### PR TITLE
fix: use PLC software name instead of device name in block/tag/type paths

### DIFF
--- a/TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs
@@ -27,13 +27,15 @@ public static class PlcSoftwareLocator
     {
         foreach (Device device in project.Devices)
         {
-            if (plcName is not null && !string.Equals(device.Name, plcName, StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
             foreach (var plcSoftware in FindInDevice(device))
             {
+                if (plcName is not null &&
+                    !string.Equals(plcSoftware.Name, plcName, StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(device.Name, plcName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
                 yield return new DiscoveredPlcSoftware(device.Name, plcSoftware);
             }
         }

--- a/TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs
@@ -43,14 +43,15 @@ public class ProjectTreeWalker
 
     private static ProjectTreeNode WalkPlcSoftware(string deviceName, PlcSoftware plcSoftware)
     {
+        var softwareName = plcSoftware.Name;
         var children = new List<ProjectTreeNode>
         {
-            WalkBlockGroup(plcSoftware.BlockGroup, CombinePath(deviceName, "Blocks"), softwareUnitName: null),
-            WalkTagTableGroup(plcSoftware.TagTableGroup, CombinePath(deviceName, "TagTables")),
-            WalkTypeGroup(plcSoftware.TypeGroup, CombinePath(deviceName, "Types"))
+            WalkBlockGroup(plcSoftware.BlockGroup, CombinePath(softwareName, "Blocks"), softwareUnitName: null),
+            WalkTagTableGroup(plcSoftware.TagTableGroup, CombinePath(softwareName, "TagTables")),
+            WalkTypeGroup(plcSoftware.TypeGroup, CombinePath(softwareName, "Types"))
         };
 
-        children.AddRange(WalkSoftwareUnits(deviceName, plcSoftware));
+        children.AddRange(WalkSoftwareUnits(softwareName, plcSoftware));
 
         return new ProjectTreeNode
         {
@@ -64,7 +65,7 @@ public class ProjectTreeWalker
         };
     }
 
-    private static IEnumerable<ProjectTreeNode> WalkSoftwareUnits(string deviceName, PlcSoftware plcSoftware)
+    private static IEnumerable<ProjectTreeNode> WalkSoftwareUnits(string softwareName, PlcSoftware plcSoftware)
     {
         PlcUnitProvider? unitProvider = null;
 
@@ -84,7 +85,7 @@ public class ProjectTreeWalker
 
         foreach (PlcUnit unit in unitProvider.UnitGroup.Units)
         {
-            var unitPath = CombinePath(deviceName, "Units", unit.Name);
+            var unitPath = CombinePath(softwareName, "Units", unit.Name);
 
             yield return new ProjectTreeNode
             {


### PR DESCRIPTION
## Summary

- `browse_project_tree` emitted block/tag/type paths prefixed with `device.Name` (e.g. `S7-1500/ET200MP station_3/Blocks/Main`). Device names can contain `/`, which caused `BlockAddress.Parse()` to misparse the path — making `get_block_content` always fail with a path format error.
- `PlcSoftwareLocator.FindAll` matched the `plcName` parameter against `device.Name` only, so `read_cross_references` and `list_tag_tables` returned "not found" when called with the PLC software name shown in TIA Portal (e.g. `PLC_3`).

## Changes

- **`ProjectTreeWalker`**: use `plcSoftware.Name` (e.g. `PLC_3`) instead of `device.Name` as the prefix for block, tag table, and type paths returned by `browse_project_tree`.
- **`PlcSoftwareLocator.FindAll`**: match `plcName` against `plcSoftware.Name` first, falling back to `device.Name` for backwards compatibility.

## Test plan

- [ ] `browse_project_tree` returns block paths like `PLC_3/Blocks/Main` (no device name prefix)
- [ ] `get_block_content` with a path returned by `browse_project_tree` succeeds
- [ ] `read_cross_references` with `plcName: "PLC_3"` succeeds
- [ ] `list_tag_tables` with `plcName: "PLC_3"` succeeds
- [ ] Passing the full device name as `plcName` still works (backwards compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
