### PR TITLE
Phase 1: structured error propagation, hardware-config nullability, worker error fidelity

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The server currently exposes 16 tools.
 
 The batch tools are the only path for data operations. Each `operation` name (e.g. `get_block_content`, `list_tag_tables`, `create_tag`, `update_block_logic`, `add_network_device`) carries that operation's parameters as one item; a single operation is just a one-item batch.
 
-Every operation result may carry a `warnings` array — non-fatal degradation notes captured from the TIA Openness worker (e.g. members skipped while reading a protected device). A populated `warnings` array means the payload may be partial. `read_hardware_config` additionally reports unreadable members in a payload-level `messages` array, and omits values it could not read instead of returning `0`/empty-string placeholders.
+Every operation result may carry a `warnings` array — non-fatal degradation notes captured from the TIA Openness worker (e.g. members skipped while reading a protected device). A populated `warnings` array means the payload may be partial. `read_hardware_config` additionally reports unreadable members in a payload-level `messages` array; device/module name and type-identifier fields omit values that could not be read instead of returning `0`/empty-string placeholders (a few secondary name fields still fall back to an empty string, with the failure noted in `messages`).
 
 Available read operations (for `execute_read_batch`): `browse_project_tree`, `get_block_content`, `list_tag_tables`, `read_hardware_config`, `read_cross_references`, `search_equipment_catalog`, `compile_check`, `get_project_status`.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The server currently exposes 16 tools.
 
 The batch tools are the only path for data operations. Each `operation` name (e.g. `get_block_content`, `list_tag_tables`, `create_tag`, `update_block_logic`, `add_network_device`) carries that operation's parameters as one item; a single operation is just a one-item batch.
 
+Every operation result may carry a `warnings` array — non-fatal degradation notes captured from the TIA Openness worker (e.g. members skipped while reading a protected device). A populated `warnings` array means the payload may be partial. `read_hardware_config` additionally reports unreadable members in a payload-level `messages` array, and omits values it could not read instead of returning `0`/empty-string placeholders.
+
 Available read operations (for `execute_read_batch`): `browse_project_tree`, `get_block_content`, `list_tag_tables`, `read_hardware_config`, `read_cross_references`, `search_equipment_catalog`, `compile_check`, `get_project_status`.
 
 Available write operations (for `preview_write_batch` / `apply_write_batch`): `update_block_logic`, `create_block` / `delete_block`, `create_block_group` / `delete_block_group`, `create_tag_table` / `delete_tag_table`, `create_tag` / `update_tag` / `delete_tag`, `create_user_constant` / `update_user_constant` / `delete_user_constant`, `add_network_device`, `configure_network_device`, `start_plc` / `stop_plc`.

--- a/TiaMcpServer.Contracts/DeviceInfo.cs
+++ b/TiaMcpServer.Contracts/DeviceInfo.cs
@@ -4,9 +4,9 @@ namespace TiaMcpServer.Contracts;
 
 public class DeviceInfo
 {
-    public string Name { get; set; } = string.Empty;
+    public string? Name { get; set; }
 
-    public string TypeIdentifier { get; set; } = string.Empty;
+    public string? TypeIdentifier { get; set; }
 
     public List<DeviceItemInfo> Items { get; set; } = new List<DeviceItemInfo>();
 }

--- a/TiaMcpServer.Contracts/DeviceItemInfo.cs
+++ b/TiaMcpServer.Contracts/DeviceItemInfo.cs
@@ -4,11 +4,11 @@ namespace TiaMcpServer.Contracts;
 
 public class DeviceItemInfo
 {
-    public string Name { get; set; } = string.Empty;
+    public string? Name { get; set; }
 
-    public string TypeIdentifier { get; set; } = string.Empty;
+    public string? TypeIdentifier { get; set; }
 
-    public int PositionNumber { get; set; } = 0;
+    public int? PositionNumber { get; set; }
 
     public string? Address { get; set; }
 

--- a/TiaMcpServer.Contracts/HardwareConfigInfo.cs
+++ b/TiaMcpServer.Contracts/HardwareConfigInfo.cs
@@ -7,4 +7,7 @@ public class HardwareConfigInfo
     public List<DeviceInfo> Devices { get; set; } = new List<DeviceInfo>();
 
     public List<SubnetInfo> Subnets { get; set; } = new List<SubnetInfo>();
+
+    /// <summary>Non-fatal degradation notes: members that could not be read and were omitted.</summary>
+    public List<string> Messages { get; set; } = new List<string>();
 }

--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+
+// Scripted stand-in for TiaMcpServer.OpennessWorker used by IPC integration tests.
+// The test encodes the scenario in the request's projectPath field.
+var line = Console.In.ReadLine();
+if (line is null)
+{
+    return;
+}
+
+string? scenario = null;
+try
+{
+    using var doc = JsonDocument.Parse(line);
+    if (doc.RootElement.TryGetProperty("projectPath", out var p))
+    {
+        scenario = p.GetString();
+    }
+}
+catch (JsonException)
+{
+    scenario = "malformed-request";
+}
+
+switch (scenario)
+{
+    case "ok":
+        Respond("""{"success":true,"payload":"{\"hello\":true}"}""");
+        break;
+    case "ok-with-stderr":
+        Console.Error.WriteLine("Skipping device 'X' while reading hardware configuration: access denied.");
+        Console.Error.WriteLine("Skipping subnet 'Y' while reading hardware configuration: not supported.");
+        Respond("""{"success":true,"payload":"{\"hello\":true}"}""");
+        break;
+    case "error-prefix-payload":
+        Respond("""{"success":true,"payload":"Error: literal payload text, not a failure"}""");
+        break;
+    case "worker-error":
+        Respond("""{"success":false,"error":"boom"}""");
+        break;
+    case "malformed":
+        Console.Out.WriteLine("this is not json");
+        Console.Out.Flush();
+        break;
+    case "silent-exit":
+        Console.Error.WriteLine("worker crashed during attach");
+        break;
+    default:
+        Respond($$"""{"success":false,"error":"unknown scenario '{{scenario}}'"}""");
+        break;
+}
+
+void Respond(string json)
+{
+    Console.Out.WriteLine(json);
+    Console.Out.Flush();
+}

--- a/TiaMcpServer.FakeWorker/TiaMcpServer.FakeWorker.csproj
+++ b/TiaMcpServer.FakeWorker/TiaMcpServer.FakeWorker.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -45,11 +44,7 @@ public static class EquipmentCatalogSearcher
             {
                 Traverse(catalog, string.Empty, query, results, seenEntries, visited);
             }
-            catch (EngineeringException ex)
-            {
-                Console.Error.WriteLine($"Skipping hardware catalog root while searching equipment catalog: {ex.Message}");
-            }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is EngineeringException or TargetInvocationException)
             {
                 Console.Error.WriteLine($"Skipping hardware catalog root while searching equipment catalog: {ex.Message}");
             }
@@ -83,20 +78,20 @@ public static class EquipmentCatalogSearcher
         // UNVERIFIED SDK CALL: TIA Portal V21 catalog root property name varies across SDK references.
         foreach (var propertyName in new[] { "HardwareCatalog", "GlobalHardwareCatalog" })
         {
-            var catalog = ReadProperty(tiaPortal, propertyName, $"TIA Portal {propertyName}");
+            var catalog = OpennessReflection.ReadProperty(tiaPortal, propertyName, $"TIA Portal {propertyName}");
             if (catalog is not null)
             {
                 yield return catalog;
             }
         }
 
-        var projects = ReadProperty(tiaPortal, "Projects", "TIA Portal projects"); // UNVERIFIED SDK CALL
-        foreach (var project in Enumerate(projects, "TIA Portal projects"))
+        var projects = OpennessReflection.ReadProperty(tiaPortal, "Projects", "TIA Portal projects"); // UNVERIFIED SDK CALL
+        foreach (var project in OpennessReflection.Enumerate(projects, "TIA Portal projects"))
         {
             // UNVERIFIED SDK CALL: project-specific hardware catalog availability is not confirmed in V21 stubs.
             foreach (var propertyName in new[] { "HardwareCatalog", "GlobalHardwareCatalog" })
             {
-                var catalog = ReadProperty(project, propertyName, $"project {propertyName}");
+                var catalog = OpennessReflection.ReadProperty(project, propertyName, $"project {propertyName}");
                 if (catalog is not null)
                 {
                     yield return catalog;
@@ -137,8 +132,8 @@ public static class EquipmentCatalogSearcher
         foreach (var propertyName in FolderCollectionNames.Concat(ItemCollectionNames))
         {
             // UNVERIFIED SDK CALL: catalog tree collection property names are reflection-discovered.
-            var collection = ReadProperty(node, propertyName, $"catalog node {propertyName}");
-            foreach (var child in Enumerate(collection, $"catalog node {propertyName}"))
+            var collection = OpennessReflection.ReadProperty(node, propertyName, $"catalog node {propertyName}");
+            foreach (var child in OpennessReflection.Enumerate(collection, $"catalog node {propertyName}"))
             {
                 Traverse(child, childPath, query, results, seenEntries, visited);
             }
@@ -217,104 +212,6 @@ public static class EquipmentCatalogSearcher
 
     private static string? ReadStringProperty(object instance, string propertyName, string description)
     {
-        return ReadProperty(instance, propertyName, description)?.ToString();
-    }
-
-    private static object? ReadProperty(object? instance, string propertyName, string description)
-    {
-        if (instance is null)
-        {
-            return null;
-        }
-
-        try
-        {
-            return instance.GetType()
-                .GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public)
-                ?.GetValue(instance); // UNVERIFIED SDK CALL
-        }
-        catch (TargetInvocationException ex) when (ex.InnerException is EngineeringException engineeringException)
-        {
-            Console.Error.WriteLine($"Skipping {description}: {engineeringException.Message}");
-            return null;
-        }
-        catch (TargetInvocationException ex)
-        {
-            Console.Error.WriteLine($"Skipping {description}: {ex.InnerException?.Message ?? ex.Message}");
-            return null;
-        }
-        catch (EngineeringException ex)
-        {
-            Console.Error.WriteLine($"Skipping {description}: {ex.Message}");
-            return null;
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"Skipping {description}: {ex.Message}");
-            return null;
-        }
-    }
-
-    private static IEnumerable<object> Enumerate(object? collection, string description)
-    {
-        if (collection is null)
-        {
-            yield break;
-        }
-
-        if (collection is string)
-        {
-            yield break;
-        }
-
-        if (collection is not IEnumerable enumerable)
-        {
-            yield break;
-        }
-
-        IEnumerator enumerator;
-        try
-        {
-            enumerator = enumerable.GetEnumerator(); // UNVERIFIED SDK CALL
-        }
-        catch (EngineeringException ex)
-        {
-            Console.Error.WriteLine($"Skipping {description}: {ex.Message}");
-            yield break;
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"Skipping {description}: {ex.Message}");
-            yield break;
-        }
-
-        while (true)
-        {
-            object? current;
-            try
-            {
-                if (!enumerator.MoveNext()) // UNVERIFIED SDK CALL
-                {
-                    yield break;
-                }
-
-                current = enumerator.Current; // UNVERIFIED SDK CALL
-            }
-            catch (EngineeringException ex)
-            {
-                Console.Error.WriteLine($"Skipping an entry while reading {description}: {ex.Message}");
-                yield break;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"Skipping an entry while reading {description}: {ex.Message}");
-                yield break;
-            }
-
-            if (current is not null)
-            {
-                yield return current;
-            }
-        }
+        return OpennessReflection.ReadProperty(instance, propertyName, description)?.ToString();
     }
 }

--- a/TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs
@@ -15,11 +15,11 @@ public static class HardwareConfigReader
         {
             try
             {
-                result.Devices.Add(ReadDevice(device));
+                result.Devices.Add(ReadDevice(device, result.Messages));
             }
             catch (EngineeringException ex)
             {
-                Console.Error.WriteLine($"Skipping device while reading hardware configuration: {ex.Message}");
+                result.Messages.Add($"Skipped a device while reading hardware configuration: {ex.Message}");
             }
         }
 
@@ -27,31 +27,32 @@ public static class HardwareConfigReader
         {
             try
             {
-                result.Subnets.Add(ReadSubnet(subnet));
+                result.Subnets.Add(ReadSubnet(subnet, result.Messages));
             }
             catch (EngineeringException ex)
             {
-                Console.Error.WriteLine($"Skipping subnet while reading hardware configuration: {ex.Message}");
+                result.Messages.Add($"Skipped a subnet while reading hardware configuration: {ex.Message}");
             }
         }
 
         return result;
     }
 
-    private static DeviceInfo ReadDevice(Device device)
+    private static DeviceInfo ReadDevice(Device device, List<string> messages)
     {
         var deviceInfo = new DeviceInfo
         {
-            Name = ReadString(() => device.Name, "device name"),
-            TypeIdentifier = ReadString(() => device.TypeIdentifier, $"device '{device.Name}' type identifier")
+            Name = ReadString(() => device.Name, "device name", messages)
         };
+        var deviceDescription = deviceInfo.Name ?? "(unnamed)";
+        deviceInfo.TypeIdentifier = ReadString(() => device.TypeIdentifier, $"device '{deviceDescription}' type identifier", messages);
 
-        deviceInfo.Items = ReadDeviceItems(device.DeviceItems, $"device '{deviceInfo.Name}'");
+        deviceInfo.Items = ReadDeviceItems(device.DeviceItems, $"device '{deviceDescription}'", messages);
 
         return deviceInfo;
     }
 
-    private static List<DeviceItemInfo> ReadDeviceItems(DeviceItemComposition items, string ownerDescription)
+    private static List<DeviceItemInfo> ReadDeviceItems(DeviceItemComposition items, string ownerDescription, List<string> messages)
     {
         var result = new List<DeviceItemInfo>();
 
@@ -59,35 +60,36 @@ public static class HardwareConfigReader
         {
             try
             {
-                result.Add(ReadDeviceItem(item));
+                result.Add(ReadDeviceItem(item, messages));
             }
             catch (EngineeringException ex)
             {
-                Console.Error.WriteLine($"Skipping a device item while reading {ownerDescription}: {ex.Message}");
+                messages.Add($"Skipped a device item while reading {ownerDescription}: {ex.Message}");
             }
         }
 
         return result;
     }
 
-    private static DeviceItemInfo ReadDeviceItem(DeviceItem item)
+    private static DeviceItemInfo ReadDeviceItem(DeviceItem item, List<string> messages)
     {
-        var itemName = ReadString(() => item.Name, "device item name");
+        var itemName = ReadString(() => item.Name, "device item name", messages);
+        var itemDescription = itemName ?? "(unnamed)";
         var itemInfo = new DeviceItemInfo
         {
             Name = itemName,
-            TypeIdentifier = ReadString(() => item.TypeIdentifier, $"device item '{itemName}' type identifier"),
-            PositionNumber = ReadInt(() => item.PositionNumber, $"device item '{itemName}' position number"),
-            Address = ReadAttribute((IEngineeringObject)item, "Address", $"device item '{itemName}' address")
+            TypeIdentifier = ReadString(() => item.TypeIdentifier, $"device item '{itemDescription}' type identifier", messages),
+            PositionNumber = ReadInt(() => item.PositionNumber, $"device item '{itemDescription}' position number", messages),
+            Address = ReadAttribute((IEngineeringObject)item, "Address", $"device item '{itemDescription}' address", messages)
         };
 
-        var networkInterfaces = ReadNetworkInterfaces(item, itemName);
+        var networkInterfaces = ReadNetworkInterfaces(item, itemDescription, messages);
         if (networkInterfaces.Count > 0)
         {
             itemInfo.NetworkInterfaces = networkInterfaces;
         }
 
-        var children = ReadDeviceItems(item.DeviceItems, $"device item '{itemName}'");
+        var children = ReadDeviceItems(item.DeviceItems, $"device item '{itemDescription}'", messages);
         if (children.Count > 0)
         {
             itemInfo.Items = children;
@@ -96,7 +98,7 @@ public static class HardwareConfigReader
         return itemInfo;
     }
 
-    private static List<NetworkInterfaceInfo> ReadNetworkInterfaces(DeviceItem item, string itemName)
+    private static List<NetworkInterfaceInfo> ReadNetworkInterfaces(DeviceItem item, string itemDescription, List<string> messages)
     {
         var result = new List<NetworkInterfaceInfo>();
 
@@ -105,20 +107,20 @@ public static class HardwareConfigReader
             var networkInterface = ((IEngineeringServiceProvider)item).GetService<NetworkInterface>();
             if (networkInterface is not null)
             {
-                result.Add(ReadNetworkInterface(networkInterface));
+                result.Add(ReadNetworkInterface(networkInterface, messages));
             }
         }
         catch (EngineeringException ex)
         {
-            Console.Error.WriteLine($"Skipping network interface while reading device item '{itemName}': {ex.Message}");
+            messages.Add($"Could not read network interface while reading device item '{itemDescription}': {ex.Message}");
         }
 
         return result;
     }
 
-    private static NetworkInterfaceInfo ReadNetworkInterface(NetworkInterface networkInterface)
+    private static NetworkInterfaceInfo ReadNetworkInterface(NetworkInterface networkInterface, List<string> messages)
     {
-        var interfaceName = ReadPropertyOrAttribute(networkInterface, "Name", "network interface name") ?? string.Empty;
+        var interfaceName = ReadPropertyOrAttribute(networkInterface, "Name", "network interface name", messages) ?? string.Empty;
         var interfaceInfo = new NetworkInterfaceInfo
         {
             Name = interfaceName
@@ -128,78 +130,80 @@ public static class HardwareConfigReader
         {
             try
             {
-                interfaceInfo.Nodes.Add(ReadNode(node, networkInterface));
+                interfaceInfo.Nodes.Add(ReadNode(node, networkInterface, messages));
             }
             catch (EngineeringException ex)
             {
-                Console.Error.WriteLine($"Skipping a node while reading network interface '{interfaceName}': {ex.Message}");
+                messages.Add($"Skipped a node while reading network interface '{interfaceName}': {ex.Message}");
             }
         }
 
         return interfaceInfo;
     }
 
-    private static NodeInfo ReadNode(Node node, NetworkInterface networkInterface)
+    private static NodeInfo ReadNode(Node node, NetworkInterface networkInterface, List<string> messages)
     {
-        var nodeName = ReadString(() => node.Name, "node name");
+        var nodeName = ReadString(() => node.Name, "node name", messages);
+        var nodeDescription = nodeName ?? "(unnamed)";
         return new NodeInfo
         {
-            Name = nodeName,
-            IpAddress = ReadAttribute((IEngineeringObject)node, "Address", $"node '{nodeName}' IP address"),
-            SubnetMask = ReadAttribute((IEngineeringObject)node, "SubnetMask", $"node '{nodeName}' subnet mask"),
-            PnDeviceName = ReadAttribute((IEngineeringObject)node, "PnDeviceName", $"node '{nodeName}' PROFINET device name"),
-            SubnetName = ReadConnectedSubnetName(node, nodeName),
-            IoSystemName = ReadIoSystemName(networkInterface, nodeName)
+            Name = nodeName ?? string.Empty,
+            IpAddress = ReadAttribute((IEngineeringObject)node, "Address", $"node '{nodeDescription}' IP address", messages),
+            SubnetMask = ReadAttribute((IEngineeringObject)node, "SubnetMask", $"node '{nodeDescription}' subnet mask", messages),
+            PnDeviceName = ReadAttribute((IEngineeringObject)node, "PnDeviceName", $"node '{nodeDescription}' PROFINET device name", messages),
+            SubnetName = ReadConnectedSubnetName(node, nodeDescription, messages),
+            IoSystemName = ReadIoSystemName(networkInterface, nodeDescription, messages)
         };
     }
 
-    private static SubnetInfo ReadSubnet(Subnet subnet)
+    private static SubnetInfo ReadSubnet(Subnet subnet, List<string> messages)
     {
-        var subnetName = ReadString(() => subnet.Name, "subnet name");
+        var subnetName = ReadString(() => subnet.Name, "subnet name", messages);
+        var subnetDescription = subnetName ?? "(unnamed)";
         var subnetInfo = new SubnetInfo
         {
-            Name = subnetName,
-            TypeIdentifier = ReadAttribute((IEngineeringObject)subnet, "TypeIdentifier", $"subnet '{subnetName}' type identifier") ??
-                ReadPropertyOrAttribute(subnet, "NetType", $"subnet '{subnetName}' network type")
+            Name = subnetName ?? string.Empty,
+            TypeIdentifier = ReadAttribute((IEngineeringObject)subnet, "TypeIdentifier", $"subnet '{subnetDescription}' type identifier", messages) ??
+                ReadPropertyOrAttribute(subnet, "NetType", $"subnet '{subnetDescription}' network type", messages)
         };
 
-        foreach (var node in ReadEnumerableProperty(subnet, "Nodes", $"subnet '{subnetName}' nodes"))
+        foreach (var node in ReadEnumerableProperty(subnet, "Nodes", $"subnet '{subnetDescription}' nodes"))
         {
-            var connectedNodeName = ReadPropertyOrAttribute(node, "Name", $"subnet '{subnetName}' connected node");
+            var connectedNodeName = ReadPropertyOrAttribute(node, "Name", $"subnet '{subnetDescription}' connected node", messages);
             if (!string.IsNullOrWhiteSpace(connectedNodeName))
             {
                 subnetInfo.ConnectedNodeNames.Add(connectedNodeName!);
             }
         }
 
-        foreach (var ioSystem in ReadEnumerableProperty(subnet, "IoSystems", $"subnet '{subnetName}' IO systems"))
+        foreach (var ioSystem in ReadEnumerableProperty(subnet, "IoSystems", $"subnet '{subnetDescription}' IO systems"))
         {
             try
             {
-                subnetInfo.IoSystems.Add(ReadIoSystem(ioSystem));
+                subnetInfo.IoSystems.Add(ReadIoSystem(ioSystem, messages));
             }
             catch (EngineeringException ex)
             {
-                Console.Error.WriteLine($"Skipping an IO system while reading subnet '{subnetName}': {ex.Message}");
+                messages.Add($"Skipped an IO system while reading subnet '{subnetDescription}': {ex.Message}");
             }
         }
 
         return subnetInfo;
     }
 
-    private static IoSystemInfo ReadIoSystem(object ioSystem)
+    private static IoSystemInfo ReadIoSystem(object ioSystem, List<string> messages)
     {
-        var ioSystemName = ReadPropertyOrAttribute(ioSystem, "Name", "IO system name") ?? string.Empty;
+        var ioSystemName = ReadPropertyOrAttribute(ioSystem, "Name", "IO system name", messages) ?? string.Empty;
         var ioSystemInfo = new IoSystemInfo
         {
             Name = ioSystemName,
-            IoControllerName = FindParentDeviceName(ReadProperty(ioSystem, "IoController"))
+            IoControllerName = FindParentDeviceName(ReadProperty(ioSystem, "IoController"), messages)
         };
 
         foreach (var connectedDevice in ReadEnumerableProperty(ioSystem, "ConnectedIoDevices", $"IO system '{ioSystemName}' connected IO devices"))
         {
-            var connectedDeviceName = FindParentDeviceName(connectedDevice) ??
-                ReadPropertyOrAttribute(connectedDevice, "Name", $"IO system '{ioSystemName}' connected IO device");
+            var connectedDeviceName = FindParentDeviceName(connectedDevice, messages) ??
+                ReadPropertyOrAttribute(connectedDevice, "Name", $"IO system '{ioSystemName}' connected IO device", messages);
             if (!string.IsNullOrWhiteSpace(connectedDeviceName))
             {
                 ioSystemInfo.ConnectedDeviceNames.Add(connectedDeviceName!);
@@ -209,22 +213,22 @@ public static class HardwareConfigReader
         return ioSystemInfo;
     }
 
-    private static string? ReadConnectedSubnetName(Node node, string nodeName)
+    private static string? ReadConnectedSubnetName(Node node, string nodeDescription, List<string> messages)
     {
         var connectedSubnet = ReadProperty(node, "ConnectedSubnet");
         return connectedSubnet is null
             ? null
-            : ReadPropertyOrAttribute(connectedSubnet, "Name", $"node '{nodeName}' connected subnet");
+            : ReadPropertyOrAttribute(connectedSubnet, "Name", $"node '{nodeDescription}' connected subnet", messages);
     }
 
-    private static string? ReadIoSystemName(NetworkInterface networkInterface, string nodeName)
+    private static string? ReadIoSystemName(NetworkInterface networkInterface, string nodeDescription, List<string> messages)
     {
         foreach (var ownerProperty in new[] { "IoControllers", "IoConnectors" })
         {
-            foreach (var item in ReadEnumerableProperty(networkInterface, ownerProperty, $"node '{nodeName}' {ownerProperty}"))
+            foreach (var item in ReadEnumerableProperty(networkInterface, ownerProperty, $"node '{nodeDescription}' {ownerProperty}"))
             {
                 var ioSystem = ReadProperty(item, "IoSystem") ?? item;
-                var name = ReadPropertyOrAttribute(ioSystem, "Name", $"node '{nodeName}' IO system");
+                var name = ReadPropertyOrAttribute(ioSystem, "Name", $"node '{nodeDescription}' IO system", messages);
                 if (!string.IsNullOrWhiteSpace(name))
                 {
                     return name;
@@ -235,17 +239,17 @@ public static class HardwareConfigReader
         return null;
     }
 
-    private static string? FindParentDeviceName(object? candidate)
+    private static string? FindParentDeviceName(object? candidate, List<string> messages)
     {
         var current = candidate;
         while (current is not null)
         {
             if (current is Device device)
             {
-                return ReadString(() => device.Name, "device name");
+                return ReadString(() => device.Name, "device name", messages);
             }
 
-            var name = ReadPropertyOrAttribute(current, "DeviceName", "parent device name");
+            var name = ReadPropertyOrAttribute(current, "DeviceName", "parent device name", messages);
             if (!string.IsNullOrWhiteSpace(name))
             {
                 return name;
@@ -257,7 +261,7 @@ public static class HardwareConfigReader
         return null;
     }
 
-    private static string ReadString(Func<string> read, string description)
+    private static string? ReadString(Func<string> read, string description, List<string> messages)
     {
         try
         {
@@ -265,12 +269,12 @@ public static class HardwareConfigReader
         }
         catch (EngineeringException ex)
         {
-            Console.Error.WriteLine($"Skipping {description}: {ex.Message}");
-            return string.Empty;
+            messages.Add($"Could not read {description}: {ex.Message}");
+            return null;
         }
     }
 
-    private static int ReadInt(Func<int> read, string description)
+    private static int? ReadInt(Func<int> read, string description, List<string> messages)
     {
         try
         {
@@ -278,12 +282,12 @@ public static class HardwareConfigReader
         }
         catch (EngineeringException ex)
         {
-            Console.Error.WriteLine($"Skipping {description}: {ex.Message}");
-            return 0;
+            messages.Add($"Could not read {description}: {ex.Message}");
+            return null;
         }
     }
 
-    private static string? ReadAttribute(IEngineeringObject engineeringObject, string attributeName, string description)
+    private static string? ReadAttribute(IEngineeringObject engineeringObject, string attributeName, string description, List<string> messages)
     {
         try
         {
@@ -291,12 +295,12 @@ public static class HardwareConfigReader
         }
         catch (EngineeringException ex)
         {
-            Console.Error.WriteLine($"Skipping {description}: {ex.Message}");
+            messages.Add($"Could not read {description}: {ex.Message}");
             return null;
         }
     }
 
-    private static string? ReadPropertyOrAttribute(object instance, string name, string description)
+    private static string? ReadPropertyOrAttribute(object instance, string name, string description, List<string> messages)
     {
         var value = ReadProperty(instance, name);
         if (value is not null)
@@ -305,7 +309,7 @@ public static class HardwareConfigReader
         }
 
         return instance is IEngineeringObject engineeringObject
-            ? ReadAttribute(engineeringObject, name, description)
+            ? ReadAttribute(engineeringObject, name, description, messages)
             : null;
     }
 

--- a/TiaMcpServer.OpennessWorker/Openness/OpennessReflection.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/OpennessReflection.cs
@@ -10,8 +10,8 @@ namespace TiaMcpServer.OpennessWorker.Openness;
 /// to stderr and degrade to null / an empty sequence so a single bad member does not abort a read.
 /// </summary>
 /// <remarks>
-/// Uses the narrow <see cref="EngineeringException"/> guard. Call sites that reflect over unverified
-/// SDK surfaces and need to swallow arbitrary exceptions per-member keep their own broader helpers.
+/// Uses the narrow <see cref="EngineeringException"/> guard. Reflection over unverified SDK surfaces
+/// uses the description-taking ReadProperty overload below.
 /// </remarks>
 internal static class OpennessReflection
 {
@@ -31,6 +31,36 @@ internal static class OpennessReflection
         catch (TargetInvocationException ex) when (ex.InnerException is EngineeringException engineeringException)
         {
             Console.Error.WriteLine($"Skipping property '{propertyName}': {engineeringException.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Broad-but-bounded variant for reflection over unverified SDK surfaces: additionally
+    /// swallows <see cref="TargetInvocationException"/> regardless of inner type. Anything
+    /// else (e.g. AmbiguousMatchException) is a bug and must propagate.
+    /// </summary>
+    public static object? ReadProperty(object? instance, string propertyName, string description)
+    {
+        if (instance is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return instance.GetType()
+                .GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public)
+                ?.GetValue(instance);
+        }
+        catch (TargetInvocationException ex)
+        {
+            Console.Error.WriteLine($"Skipping {description}: {ex.InnerException?.Message ?? ex.Message}");
+            return null;
+        }
+        catch (EngineeringException ex)
+        {
+            Console.Error.WriteLine($"Skipping {description}: {ex.Message}");
             return null;
         }
     }

--- a/TiaMcpServer.OpennessWorker/Program.cs
+++ b/TiaMcpServer.OpennessWorker/Program.cs
@@ -92,7 +92,7 @@ internal static class Program
         catch (Exception ex)
         {
             Console.Error.WriteLine(ex);
-            return Failure(ex.Message);
+            return Failure($"{ex.GetType().Name}: {ex.Message}");
         }
     }
 

--- a/TiaMcpServer.Tests/BatchExecutionEngineTests.cs
+++ b/TiaMcpServer.Tests/BatchExecutionEngineTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using TiaMcpServer.Batch;
+using TiaMcpServer.Worker;
 using Xunit;
 
 namespace TiaMcpServer.Tests;
@@ -18,7 +19,7 @@ public class BatchExecutionEngineTests
 
         var results = await BatchExecutionEngine.ExecuteReadsAsync(
             operations,
-            op => Task.FromResult($"payload-{op.OperationId}"));
+            op => Task.FromResult(WorkerCallResult.Ok($"payload-{op.OperationId}")));
 
         Assert.Equal(new[] { "a", "b" }, results.Select(r => r.OperationId).ToArray());
         Assert.All(results, r => Assert.Equal(BatchOperationStatus.Succeeded, r.Status));
@@ -37,7 +38,7 @@ public class BatchExecutionEngineTests
 
         var results = await BatchExecutionEngine.ExecuteReadsAsync(
             operations,
-            op => Task.FromResult(op.OperationId == "b" ? "Error: not found" : "ok"));
+            op => Task.FromResult(op.OperationId == "b" ? WorkerCallResult.Fail("not found") : WorkerCallResult.Ok("ok")));
 
         Assert.Equal(BatchOperationStatus.Succeeded, results[0].Status);
         Assert.Equal(BatchOperationStatus.Failed, results[1].Status);
@@ -52,7 +53,7 @@ public class BatchExecutionEngineTests
 
         var results = await BatchExecutionEngine.ApplyWritesAsync(
             operations,
-            op => Task.FromResult("done"));
+            op => Task.FromResult(WorkerCallResult.Ok("done")));
 
         Assert.All(results, r => Assert.Equal(BatchOperationStatus.Succeeded, r.Status));
     }
@@ -73,7 +74,7 @@ public class BatchExecutionEngineTests
             op =>
             {
                 invoked.Add(op.OperationId);
-                return Task.FromResult(op.OperationId == "b" ? "Error: boom" : "done");
+                return Task.FromResult(op.OperationId == "b" ? WorkerCallResult.Fail("boom") : WorkerCallResult.Ok("done"));
             });
 
         Assert.Equal(BatchOperationStatus.Succeeded, results[0].Status);
@@ -83,5 +84,30 @@ public class BatchExecutionEngineTests
 
         // The item after the failure must never be invoked.
         Assert.Equal(new[] { "a", "b" }, invoked.ToArray());
+    }
+
+    [Fact]
+    public async Task ExecuteReadsAsync_PayloadStartingWithErrorPrefix_IsNotAFailure()
+    {
+        var operations = new[] { Op("a", "get_block_content") };
+
+        var results = await BatchExecutionEngine.ExecuteReadsAsync(
+            operations,
+            op => Task.FromResult(WorkerCallResult.Ok("Error: literal SCL comment text")));
+
+        Assert.Equal(BatchOperationStatus.Succeeded, results[0].Status);
+    }
+
+    [Fact]
+    public async Task ExecuteReadsAsync_CopiesWarningsOntoResult()
+    {
+        var operations = new[] { Op("a", "browse_project_tree") };
+
+        var results = await BatchExecutionEngine.ExecuteReadsAsync(
+            operations,
+            op => Task.FromResult(WorkerCallResult.Ok("[]", new[] { "Skipping device 'X'." })));
+
+        Assert.NotNull(results[0].Warnings);
+        Assert.Single(results[0].Warnings!);
     }
 }

--- a/TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs
+++ b/TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+public class BatchOperationRequestJsonTests
+{
+    // Mirrors the camelCase + case-insensitive binding the MCP SDK uses for tool arguments.
+    private static readonly JsonSerializerOptions WebOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void MisspelledOptionalProperty_IsRejectedNotSilentlyDropped()
+    {
+        // "ip_adress" is the exact trap from the audit: a typo that previously succeeded
+        // silently and left the device unconfigured while reporting success.
+        var json = """{"operationId":"op1","operation":"configure_network_device","deviceName":"IO_Device_1","ip_adress":"192.168.0.10"}""";
+
+        var ex = Assert.Throws<JsonException>(
+            () => JsonSerializer.Deserialize<BatchOperationRequest>(json, WebOptions));
+
+        Assert.Contains("ip_adress", ex.Message);
+    }
+
+    [Fact]
+    public void KnownCamelCaseProperties_StillDeserialize()
+    {
+        var json = """{"operationId":"op1","operation":"configure_network_device","deviceName":"IO_Device_1","ipAddress":"192.168.0.10"}""";
+
+        var request = JsonSerializer.Deserialize<BatchOperationRequest>(json, WebOptions);
+
+        Assert.NotNull(request);
+        Assert.Equal("192.168.0.10", request!.IpAddress);
+    }
+}

--- a/TiaMcpServer.Tests/BatchResultFormatterTests.cs
+++ b/TiaMcpServer.Tests/BatchResultFormatterTests.cs
@@ -33,6 +33,7 @@ public class BatchResultFormatterTests
         Assert.Equal(2, root.GetProperty("operationCount").GetInt32());
         Assert.Equal(2, root.GetProperty("succeeded").GetInt32());
         Assert.Equal(2, root.GetProperty("operations").GetArrayLength());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("operations")[0].GetProperty("warnings").ValueKind);
     }
 
     [Fact]
@@ -67,5 +68,22 @@ public class BatchResultFormatterTests
         Assert.Equal(1, root.GetProperty("failed").GetInt32());
         Assert.Equal(1, root.GetProperty("skipped").GetInt32());
         Assert.Equal("apply_write_batch", root.GetProperty("tool").GetString());
+    }
+
+    [Fact]
+    public void ReadBatch_IncludesWarningsWhenPresent()
+    {
+        var results = new[]
+        {
+            new BatchOperationResult("a", "browse_project_tree", BatchOperationStatus.Succeeded, "[]",
+                new[] { "Skipping device 'X'." }),
+        };
+
+        var root = Parse(BatchResultFormatter.ReadBatch(results));
+        var warnings = root.GetProperty("operations")[0].GetProperty("warnings");
+
+        Assert.Equal(JsonValueKind.Array, warnings.ValueKind);
+        Assert.Equal(1, warnings.GetArrayLength());
+        Assert.Equal("Skipping device 'X'.", warnings[0].GetString());
     }
 }

--- a/TiaMcpServer.Tests/HardwareConfigInfoTests.cs
+++ b/TiaMcpServer.Tests/HardwareConfigInfoTests.cs
@@ -164,6 +164,32 @@ public class HardwareConfigInfoTests
         Assert.Null(roundTripped.NetworkInterfaces);
     }
 
+    [Fact]
+    public void MessagesRoundTrip()
+    {
+        var config = new HardwareConfigInfo
+        {
+            Messages = { "Could not read device 'X' type identifier: access denied." }
+        };
+
+        var json = JsonSerializer.Serialize(config);
+        var roundTripped = JsonSerializer.Deserialize<HardwareConfigInfo>(json)!;
+
+        Assert.Equal(
+            "Could not read device 'X' type identifier: access denied.",
+            Assert.Single(roundTripped.Messages));
+    }
+
+    [Fact]
+    public void UnreadableValues_AreNullNotFallbackDefaults()
+    {
+        var item = new DeviceItemInfo();
+
+        Assert.Null(item.Name);
+        Assert.Null(item.TypeIdentifier);
+        Assert.Null(item.PositionNumber);
+    }
+
     private static HardwareConfigInfo RoundTrip(HardwareConfigInfo config)
     {
         var json = JsonSerializer.Serialize(config, JsonOptions);

--- a/TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs
+++ b/TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs
@@ -1,0 +1,116 @@
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+/// <summary>
+/// Spawns the real IPC pipeline against TiaMcpServer.FakeWorker. One class so xunit
+/// runs these sequentially; the client's static WorkerGate serializes sends anyway.
+/// </summary>
+public class OpennessWorkerClientIntegrationTests
+{
+    private static string LocateFakeWorker()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (var configuration in new[] { "Debug", "Release" })
+            {
+                var candidate = Path.Combine(
+                    directory.FullName,
+                    "TiaMcpServer.FakeWorker", "bin", configuration, "net8.0",
+                    "TiaMcpServer.FakeWorker.exe");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent!;
+        }
+
+        throw new FileNotFoundException("TiaMcpServer.FakeWorker.exe not found; build the solution first.");
+    }
+
+    private static OpennessWorkerClient CreateClient(string? workerPath = null)
+        => new(new ProjectSessionBinding(null), logger: null, workerExecutablePath: workerPath ?? LocateFakeWorker());
+
+    [Fact]
+    public async Task Success_ReturnsStructuredPayload()
+    {
+        var result = await CreateClient().GetProjectStatusAsync("ok");
+
+        Assert.True(result.Success);
+        Assert.Equal("{\"hello\":true}", result.Payload);
+        Assert.Null(result.Error);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public async Task StderrLines_SurfaceAsWarnings()
+    {
+        var result = await CreateClient().GetProjectStatusAsync("ok-with-stderr");
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.Warnings.Count);
+        Assert.Contains(result.Warnings, w => w.Contains("Skipping device 'X'"));
+    }
+
+    [Fact]
+    public async Task PayloadStartingWithErrorPrefix_IsNotMisclassified()
+    {
+        // Regression test for item 1.1: before WorkerCallResult this payload was treated as failure.
+        var result = await CreateClient().GetProjectStatusAsync("error-prefix-payload");
+
+        Assert.True(result.Success);
+        Assert.StartsWith("Error:", result.Payload);
+    }
+
+    [Fact]
+    public async Task WorkerReportedError_IsStructuredFailure()
+    {
+        var result = await CreateClient().GetProjectStatusAsync("worker-error");
+
+        Assert.False(result.Success);
+        Assert.Equal("boom", result.Error);
+        Assert.Equal("Error: boom", result.ToText());
+    }
+
+    [Fact]
+    public async Task MalformedResponse_IsFailureNotCrash()
+    {
+        var result = await CreateClient().GetProjectStatusAsync("malformed");
+
+        Assert.False(result.Success);
+        Assert.NotNull(result.Error);
+    }
+
+    [Fact]
+    public async Task SilentExit_SurfacesStderrDetailInError()
+    {
+        var result = await CreateClient().GetProjectStatusAsync("silent-exit");
+
+        Assert.False(result.Success);
+        Assert.Contains("worker crashed during attach", result.Error);
+    }
+
+    [Fact]
+    public async Task NonExecutableWorkerPath_ProducesActionableWin32Message()
+    {
+        var bogus = Path.Combine(Path.GetTempPath(), $"tia-fake-{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(bogus, "not an executable");
+        try
+        {
+            var result = await CreateClient(workerPath: bogus).GetProjectStatusAsync("ok");
+
+            Assert.False(result.Success);
+            Assert.Contains(".NET Framework 4.8", result.Error);
+            Assert.Contains("openness-worker", result.Error);
+        }
+        finally
+        {
+            File.Delete(bogus);
+        }
+    }
+}

--- a/TiaMcpServer.Tests/ProjectLifecycleToolTests.cs
+++ b/TiaMcpServer.Tests/ProjectLifecycleToolTests.cs
@@ -50,7 +50,7 @@ public class ProjectLifecycleToolTests
         var method = typeof(OpennessWorkerClient).GetMethod(methodName);
 
         Assert.NotNull(method);
-        Assert.Equal(typeof(Task<string>), method.ReturnType);
+        Assert.Equal(typeof(Task<WorkerCallResult>), method.ReturnType);
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\TiaMcpServer.Contracts\TiaMcpServer.Contracts.csproj" />
     <Compile Include="..\TiaMcpServer\Worker\OpennessWorkerClient.cs" Link="Host\OpennessWorkerClient.cs" />
+    <Compile Include="..\TiaMcpServer\Worker\WorkerCallResult.cs" Link="Host\WorkerCallResult.cs" />
     <Compile Include="..\TiaMcpServer\Safety\WriteSafetyService.cs" Link="Host\WriteSafetyService.cs" />
     <Compile Include="..\TiaMcpServer\Safety\WriteSafetyTooling.cs" Link="Host\WriteSafetyTooling.cs" />
     <Compile Include="..\TiaMcpServer\Tools\ProjectLifecycleTools.cs" Link="Host\ProjectLifecycleTools.cs" />

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="xunit" Version="2.9.0" />

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TiaMcpServer.Contracts\TiaMcpServer.Contracts.csproj" />
+    <ProjectReference Include="..\TiaMcpServer.FakeWorker\TiaMcpServer.FakeWorker.csproj" ReferenceOutputAssembly="false" />
     <Compile Include="..\TiaMcpServer\Worker\OpennessWorkerClient.cs" Link="Host\OpennessWorkerClient.cs" />
     <Compile Include="..\TiaMcpServer\Worker\WorkerCallResult.cs" Link="Host\WorkerCallResult.cs" />
     <Compile Include="..\TiaMcpServer\Safety\WriteSafetyService.cs" Link="Host\WriteSafetyService.cs" />

--- a/TiaMcpServer.Tests/WorkerCallResultTests.cs
+++ b/TiaMcpServer.Tests/WorkerCallResultTests.cs
@@ -1,0 +1,56 @@
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+public class WorkerCallResultTests
+{
+    [Fact]
+    public void Ok_CarriesPayloadWithoutError()
+    {
+        var result = WorkerCallResult.Ok("{\"a\":1}");
+
+        Assert.True(result.Success);
+        Assert.Equal("{\"a\":1}", result.Payload);
+        Assert.Null(result.Error);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Fail_CarriesErrorAndEmptyPayload()
+    {
+        var result = WorkerCallResult.Fail("boom");
+
+        Assert.False(result.Success);
+        Assert.Equal(string.Empty, result.Payload);
+        Assert.Equal("boom", result.Error);
+    }
+
+    [Fact]
+    public void ToText_RendersPayloadOnSuccess()
+    {
+        Assert.Equal("data", WorkerCallResult.Ok("data").ToText());
+    }
+
+    [Fact]
+    public void ToText_RendersErrorPrefixOnFailure()
+    {
+        Assert.Equal("Error: boom", WorkerCallResult.Fail("boom").ToText());
+    }
+
+    [Fact]
+    public void Ok_PayloadStartingWithErrorPrefixStaysSuccessful()
+    {
+        // The whole point of item 1.1: payload text must never drive classification.
+        var result = WorkerCallResult.Ok("Error: literal block comment content, not a failure");
+
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public void Warnings_AreAttachedToBothShapes()
+    {
+        Assert.Single(WorkerCallResult.Ok("x", new[] { "w1" }).Warnings);
+        Assert.Single(WorkerCallResult.Fail("e", new[] { "w1" }).Warnings);
+    }
+}

--- a/TiaMcpServer.sln
+++ b/TiaMcpServer.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -10,28 +11,78 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TiaMcpServer.OpennessWorker
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TiaMcpServer.Tests", "TiaMcpServer.Tests\TiaMcpServer.Tests.csproj", "{BCAB91F2-4572-4C73-B415-46C76E21C093}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TiaMcpServer.FakeWorker", "TiaMcpServer.FakeWorker\TiaMcpServer.FakeWorker.csproj", "{A79BBD97-54DE-415B-9F51-38989EB0FF20}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E7CC35A6-2C38-4AAE-9E86-AED05601B370}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E7CC35A6-2C38-4AAE-9E86-AED05601B370}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7CC35A6-2C38-4AAE-9E86-AED05601B370}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E7CC35A6-2C38-4AAE-9E86-AED05601B370}.Debug|x64.Build.0 = Debug|Any CPU
+		{E7CC35A6-2C38-4AAE-9E86-AED05601B370}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E7CC35A6-2C38-4AAE-9E86-AED05601B370}.Debug|x86.Build.0 = Debug|Any CPU
 		{E7CC35A6-2C38-4AAE-9E86-AED05601B370}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E7CC35A6-2C38-4AAE-9E86-AED05601B370}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7CC35A6-2C38-4AAE-9E86-AED05601B370}.Release|x64.ActiveCfg = Release|Any CPU
+		{E7CC35A6-2C38-4AAE-9E86-AED05601B370}.Release|x64.Build.0 = Release|Any CPU
+		{E7CC35A6-2C38-4AAE-9E86-AED05601B370}.Release|x86.ActiveCfg = Release|Any CPU
+		{E7CC35A6-2C38-4AAE-9E86-AED05601B370}.Release|x86.Build.0 = Release|Any CPU
 		{1C2E58BE-B5F5-4FD7-8B90-5D8EAC4DF3D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1C2E58BE-B5F5-4FD7-8B90-5D8EAC4DF3D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1C2E58BE-B5F5-4FD7-8B90-5D8EAC4DF3D2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1C2E58BE-B5F5-4FD7-8B90-5D8EAC4DF3D2}.Debug|x64.Build.0 = Debug|Any CPU
+		{1C2E58BE-B5F5-4FD7-8B90-5D8EAC4DF3D2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1C2E58BE-B5F5-4FD7-8B90-5D8EAC4DF3D2}.Debug|x86.Build.0 = Debug|Any CPU
 		{1C2E58BE-B5F5-4FD7-8B90-5D8EAC4DF3D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1C2E58BE-B5F5-4FD7-8B90-5D8EAC4DF3D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1C2E58BE-B5F5-4FD7-8B90-5D8EAC4DF3D2}.Release|x64.ActiveCfg = Release|Any CPU
+		{1C2E58BE-B5F5-4FD7-8B90-5D8EAC4DF3D2}.Release|x64.Build.0 = Release|Any CPU
+		{1C2E58BE-B5F5-4FD7-8B90-5D8EAC4DF3D2}.Release|x86.ActiveCfg = Release|Any CPU
+		{1C2E58BE-B5F5-4FD7-8B90-5D8EAC4DF3D2}.Release|x86.Build.0 = Release|Any CPU
 		{87A8D3DA-F0ED-4D39-9D46-45210CC4BD59}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{87A8D3DA-F0ED-4D39-9D46-45210CC4BD59}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87A8D3DA-F0ED-4D39-9D46-45210CC4BD59}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{87A8D3DA-F0ED-4D39-9D46-45210CC4BD59}.Debug|x64.Build.0 = Debug|Any CPU
+		{87A8D3DA-F0ED-4D39-9D46-45210CC4BD59}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{87A8D3DA-F0ED-4D39-9D46-45210CC4BD59}.Debug|x86.Build.0 = Debug|Any CPU
 		{87A8D3DA-F0ED-4D39-9D46-45210CC4BD59}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{87A8D3DA-F0ED-4D39-9D46-45210CC4BD59}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87A8D3DA-F0ED-4D39-9D46-45210CC4BD59}.Release|x64.ActiveCfg = Release|Any CPU
+		{87A8D3DA-F0ED-4D39-9D46-45210CC4BD59}.Release|x64.Build.0 = Release|Any CPU
+		{87A8D3DA-F0ED-4D39-9D46-45210CC4BD59}.Release|x86.ActiveCfg = Release|Any CPU
+		{87A8D3DA-F0ED-4D39-9D46-45210CC4BD59}.Release|x86.Build.0 = Release|Any CPU
 		{BCAB91F2-4572-4C73-B415-46C76E21C093}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BCAB91F2-4572-4C73-B415-46C76E21C093}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BCAB91F2-4572-4C73-B415-46C76E21C093}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BCAB91F2-4572-4C73-B415-46C76E21C093}.Debug|x64.Build.0 = Debug|Any CPU
+		{BCAB91F2-4572-4C73-B415-46C76E21C093}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BCAB91F2-4572-4C73-B415-46C76E21C093}.Debug|x86.Build.0 = Debug|Any CPU
 		{BCAB91F2-4572-4C73-B415-46C76E21C093}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BCAB91F2-4572-4C73-B415-46C76E21C093}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BCAB91F2-4572-4C73-B415-46C76E21C093}.Release|x64.ActiveCfg = Release|Any CPU
+		{BCAB91F2-4572-4C73-B415-46C76E21C093}.Release|x64.Build.0 = Release|Any CPU
+		{BCAB91F2-4572-4C73-B415-46C76E21C093}.Release|x86.ActiveCfg = Release|Any CPU
+		{BCAB91F2-4572-4C73-B415-46C76E21C093}.Release|x86.Build.0 = Release|Any CPU
+		{A79BBD97-54DE-415B-9F51-38989EB0FF20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A79BBD97-54DE-415B-9F51-38989EB0FF20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A79BBD97-54DE-415B-9F51-38989EB0FF20}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A79BBD97-54DE-415B-9F51-38989EB0FF20}.Debug|x64.Build.0 = Debug|Any CPU
+		{A79BBD97-54DE-415B-9F51-38989EB0FF20}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A79BBD97-54DE-415B-9F51-38989EB0FF20}.Debug|x86.Build.0 = Debug|Any CPU
+		{A79BBD97-54DE-415B-9F51-38989EB0FF20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A79BBD97-54DE-415B-9F51-38989EB0FF20}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A79BBD97-54DE-415B-9F51-38989EB0FF20}.Release|x64.ActiveCfg = Release|Any CPU
+		{A79BBD97-54DE-415B-9F51-38989EB0FF20}.Release|x64.Build.0 = Release|Any CPU
+		{A79BBD97-54DE-415B-9F51-38989EB0FF20}.Release|x86.ActiveCfg = Release|Any CPU
+		{A79BBD97-54DE-415B-9F51-38989EB0FF20}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TiaMcpServer/Batch/BatchExecutionEngine.cs
+++ b/TiaMcpServer/Batch/BatchExecutionEngine.cs
@@ -1,3 +1,5 @@
+using TiaMcpServer.Worker;
+
 namespace TiaMcpServer.Batch;
 
 /// <summary>
@@ -7,20 +9,16 @@ namespace TiaMcpServer.Batch;
 /// </summary>
 public static class BatchExecutionEngine
 {
-    private static bool IsFailure(string result)
-        => result.StartsWith("Error:", StringComparison.OrdinalIgnoreCase);
-
     /// <summary>Reads run independently; a failing item is recorded but never stops the others.</summary>
     public static async Task<IReadOnlyList<BatchOperationResult>> ExecuteReadsAsync(
         IReadOnlyList<BatchOperationRequest> operations,
-        Func<BatchOperationRequest, Task<string>> invoke)
+        Func<BatchOperationRequest, Task<WorkerCallResult>> invoke)
     {
         var results = new List<BatchOperationResult>(operations.Count);
         foreach (var op in operations)
         {
             var result = await invoke(op).ConfigureAwait(false);
-            var status = IsFailure(result) ? BatchOperationStatus.Failed : BatchOperationStatus.Succeeded;
-            results.Add(new BatchOperationResult(op.OperationId, op.Operation, status, result));
+            results.Add(ToOperationResult(op, result));
         }
 
         return results;
@@ -29,7 +27,7 @@ public static class BatchExecutionEngine
     /// <summary>Writes run sequentially and stop on the first failure; later items are skipped.</summary>
     public static async Task<IReadOnlyList<BatchOperationResult>> ApplyWritesAsync(
         IReadOnlyList<BatchOperationRequest> operations,
-        Func<BatchOperationRequest, Task<string>> invoke)
+        Func<BatchOperationRequest, Task<WorkerCallResult>> invoke)
     {
         var results = new List<BatchOperationResult>(operations.Count);
         var stopped = false;
@@ -42,17 +40,18 @@ public static class BatchExecutionEngine
             }
 
             var result = await invoke(op).ConfigureAwait(false);
-            if (IsFailure(result))
-            {
-                stopped = true;
-                results.Add(new BatchOperationResult(op.OperationId, op.Operation, BatchOperationStatus.Failed, result));
-            }
-            else
-            {
-                results.Add(new BatchOperationResult(op.OperationId, op.Operation, BatchOperationStatus.Succeeded, result));
-            }
+            stopped = !result.Success;
+            results.Add(ToOperationResult(op, result));
         }
 
         return results;
     }
+
+    private static BatchOperationResult ToOperationResult(BatchOperationRequest op, WorkerCallResult result)
+        => new(
+            op.OperationId,
+            op.Operation,
+            result.Success ? BatchOperationStatus.Succeeded : BatchOperationStatus.Failed,
+            result.ToText(),
+            result.Warnings.Count > 0 ? result.Warnings : null);
 }

--- a/TiaMcpServer/Batch/BatchOperationRequest.cs
+++ b/TiaMcpServer/Batch/BatchOperationRequest.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text.Json.Serialization;
 
 namespace TiaMcpServer.Batch;
 
@@ -7,6 +8,7 @@ namespace TiaMcpServer.Batch;
 /// scalar parameters of the existing single MCP tools; only the fields relevant to the
 /// chosen <see cref="Operation"/> are read.
 /// </summary>
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
 public sealed class BatchOperationRequest
 {
     [Description("Client-supplied unique identifier for this item within the batch; the result is keyed by it.")]

--- a/TiaMcpServer/Batch/BatchOperationResult.cs
+++ b/TiaMcpServer/Batch/BatchOperationResult.cs
@@ -14,4 +14,5 @@ public sealed record BatchOperationResult(
     string OperationId,
     string Operation,
     string Status,
-    string? Result);
+    string? Result,
+    IReadOnlyList<string>? Warnings = null);

--- a/TiaMcpServer/Batch/BatchResultFormatter.cs
+++ b/TiaMcpServer/Batch/BatchResultFormatter.cs
@@ -58,7 +58,8 @@ public static class BatchResultFormatter
                 operationId = r.OperationId,
                 operation = r.Operation,
                 status = r.Status,
-                result = r.Result
+                result = r.Result,
+                warnings = r.Warnings
             })
             .ToArray();
 }

--- a/TiaMcpServer/Batch/BatchTools.cs
+++ b/TiaMcpServer/Batch/BatchTools.cs
@@ -31,7 +31,7 @@ public static class BatchTools
 
         var results = await BatchExecutionEngine.ExecuteReadsAsync(
             operations,
-            async op => (await BatchWorkerInvoker.InvokeAsync(workerClient, op).ConfigureAwait(false)).ToText()).ConfigureAwait(false);
+            op => BatchWorkerInvoker.InvokeAsync(workerClient, op)).ConfigureAwait(false);
 
         return BatchResultFormatter.ReadBatch(results);
     }
@@ -122,7 +122,7 @@ public static class BatchTools
 
         var results = await BatchExecutionEngine.ApplyWritesAsync(
             operations,
-            async op => (await BatchWorkerInvoker.InvokeAsync(workerClient, op).ConfigureAwait(false)).ToText()).ConfigureAwait(false);
+            op => BatchWorkerInvoker.InvokeAsync(workerClient, op)).ConfigureAwait(false);
 
         var resultJson = BatchResultFormatter.ApplyBatch(results);
         WriteSafetyService.Shared.AppendAudit(ApplyToolName, projectPath, targets, operations, snapshot.CombinedState, resultJson);

--- a/TiaMcpServer/Batch/BatchTools.cs
+++ b/TiaMcpServer/Batch/BatchTools.cs
@@ -31,7 +31,7 @@ public static class BatchTools
 
         var results = await BatchExecutionEngine.ExecuteReadsAsync(
             operations,
-            op => BatchWorkerInvoker.InvokeAsync(workerClient, op)).ConfigureAwait(false);
+            async op => (await BatchWorkerInvoker.InvokeAsync(workerClient, op).ConfigureAwait(false)).ToText()).ConfigureAwait(false);
 
         return BatchResultFormatter.ReadBatch(results);
     }
@@ -122,7 +122,7 @@ public static class BatchTools
 
         var results = await BatchExecutionEngine.ApplyWritesAsync(
             operations,
-            op => BatchWorkerInvoker.InvokeAsync(workerClient, op)).ConfigureAwait(false);
+            async op => (await BatchWorkerInvoker.InvokeAsync(workerClient, op).ConfigureAwait(false)).ToText()).ConfigureAwait(false);
 
         var resultJson = BatchResultFormatter.ApplyBatch(results);
         WriteSafetyService.Shared.AppendAudit(ApplyToolName, projectPath, targets, operations, snapshot.CombinedState, resultJson);
@@ -137,12 +137,12 @@ public static class BatchTools
         foreach (var op in operations)
         {
             var state = await BatchWorkerInvoker.ReadCurrentStateAsync(workerClient, op).ConfigureAwait(false);
-            if (state.StartsWith("Error:", StringComparison.OrdinalIgnoreCase))
+            if (!state.Success)
             {
-                return (string.Empty, $"Could not read current state for operationId '{op.OperationId}' ({op.Operation}). {state}");
+                return (string.Empty, $"Could not read current state for operationId '{op.OperationId}' ({op.Operation}). Error: {state.Error}");
             }
 
-            states.Add(new BatchCurrentState(op.OperationId, op.Operation, state));
+            states.Add(new BatchCurrentState(op.OperationId, op.Operation, state.Payload));
         }
 
         return (BatchSafetySnapshot.CombineCurrentState(states), null);

--- a/TiaMcpServer/Batch/BatchWorkerInvoker.cs
+++ b/TiaMcpServer/Batch/BatchWorkerInvoker.cs
@@ -10,7 +10,7 @@ namespace TiaMcpServer.Batch;
 public static class BatchWorkerInvoker
 {
     /// <summary>Reads the current state a write item's safety token binds to.</summary>
-    public static Task<string> ReadCurrentStateAsync(OpennessWorkerClient client, BatchOperationRequest op) => op.Operation switch
+    public static Task<WorkerCallResult> ReadCurrentStateAsync(OpennessWorkerClient client, BatchOperationRequest op) => op.Operation switch
     {
         "update_block_logic" => client.GetBlockContentAsync(op.BlockPath!, op.ProjectPath),
         "create_tag_table" or "delete_tag_table"
@@ -25,11 +25,11 @@ public static class BatchWorkerInvoker
             => client.GetBlockContentAsync(op.BlockPath!, op.ProjectPath),
         "start_plc" or "stop_plc"
             => client.GetProjectStatusAsync(op.ProjectPath),
-        _ => Task.FromResult($"Error: Unsupported batch write operation '{op.Operation}'."),
+        _ => Task.FromResult(WorkerCallResult.Fail($"Unsupported batch write operation '{op.Operation}'.")),
     };
 
     /// <summary>Executes a single read or write item against the worker.</summary>
-    public static Task<string> InvokeAsync(OpennessWorkerClient client, BatchOperationRequest op) => op.Operation switch
+    public static Task<WorkerCallResult> InvokeAsync(OpennessWorkerClient client, BatchOperationRequest op) => op.Operation switch
     {
         // Reads
         "browse_project_tree" => client.BrowseProjectTreeAsync(op.ProjectPath),
@@ -60,7 +60,7 @@ public static class BatchWorkerInvoker
         "start_plc" => client.StartPlcAsync(op.PlcName, op.ProjectPath),
         "stop_plc" => client.StopPlcAsync(op.PlcName, op.ProjectPath),
 
-        _ => Task.FromResult($"Error: Unsupported batch operation '{op.Operation}'."),
+        _ => Task.FromResult(WorkerCallResult.Fail($"Unsupported batch operation '{op.Operation}'.")),
     };
 
     private static string ResolveDeviceItemName(BatchOperationRequest op)

--- a/TiaMcpServer/Program.cs
+++ b/TiaMcpServer/Program.cs
@@ -16,7 +16,9 @@ namespace TiaMcpServer
             builder.Logging.AddConsole(opts => opts.LogToStandardErrorThreshold = LogLevel.Trace);
             builder.Services.AddSingleton(new ProjectSessionBinding(ResolveStartupProjectPath(args)));
             builder.Services.AddSingleton(WriteSafetyService.Shared);
-            builder.Services.AddSingleton<OpennessWorkerClient>();
+            builder.Services.AddSingleton(sp => new OpennessWorkerClient(
+                sp.GetRequiredService<ProjectSessionBinding>(),
+                sp.GetRequiredService<ILogger<OpennessWorkerClient>>()));
             builder.Services.AddMcpServer().WithStdioServerTransport().WithToolsFromAssembly();
             await builder.Build().RunAsync();
         }

--- a/TiaMcpServer/Safety/WriteSafetyTooling.cs
+++ b/TiaMcpServer/Safety/WriteSafetyTooling.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using TiaMcpServer.Worker;
 
 namespace TiaMcpServer.Safety;
 
@@ -18,7 +19,7 @@ public static class WriteSafetyTooling
         string? projectPath,
         object target,
         object requestedInput,
-        Func<Task<string>> readCurrentState)
+        Func<Task<WorkerCallResult>> readCurrentState)
     {
         if (string.IsNullOrWhiteSpace(safetyToken))
         {
@@ -27,10 +28,10 @@ public static class WriteSafetyTooling
         }
 
         var currentState = await readCurrentState().ConfigureAwait(false);
-        if (currentState.StartsWith("Error:", StringComparison.OrdinalIgnoreCase))
+        if (!currentState.Success)
         {
             return WriteSafetyApplyContext.Invalid(
-                $"Could not read current state before write. {currentState}");
+                $"Could not read current state before write. Error: {currentState.Error}");
         }
 
         var validation = WriteSafetyService.Shared.ValidateAndConsume(
@@ -39,11 +40,11 @@ public static class WriteSafetyTooling
             projectPath,
             target,
             requestedInput,
-            currentState,
+            currentState.Payload,
             previewToolName);
 
         return validation.IsValid
-            ? WriteSafetyApplyContext.Valid(currentState)
+            ? WriteSafetyApplyContext.Valid(currentState.Payload)
             : WriteSafetyApplyContext.Invalid(validation.Error);
     }
 
@@ -53,12 +54,12 @@ public static class WriteSafetyTooling
         object target,
         string summary,
         object requestedInput,
-        string currentState,
+        WorkerCallResult currentState,
         string? diff = null)
     {
-        if (currentState.StartsWith("Error:", StringComparison.OrdinalIgnoreCase))
+        if (!currentState.Success)
         {
-            return $"Could not read current state before preview. {currentState}";
+            return $"Could not read current state before preview. Error: {currentState.Error}";
         }
 
         return WriteSafetyService.Shared.CreatePreview(
@@ -67,13 +68,13 @@ public static class WriteSafetyTooling
             target,
             summary,
             requestedInput,
-            currentState,
+            currentState.Payload,
             diff);
     }
 
     public static string BuildApplyResult(
         string toolName,
-        string operationResult,
+        WorkerCallResult operationResult,
         string? verificationName = null,
         string? verificationResult = null)
     {
@@ -81,8 +82,9 @@ public static class WriteSafetyTooling
             new
             {
                 toolName,
-                success = !operationResult.StartsWith("Error:", StringComparison.OrdinalIgnoreCase),
-                operationResult,
+                success = operationResult.Success,
+                operationResult = operationResult.ToText(),
+                warnings = operationResult.Warnings.Count > 0 ? operationResult.Warnings : null,
                 verification = verificationName is null
                     ? null
                     : new

--- a/TiaMcpServer/Tools/ProjectLifecycleTools.cs
+++ b/TiaMcpServer/Tools/ProjectLifecycleTools.cs
@@ -14,7 +14,7 @@ namespace TiaMcpServer.Tools
             OpennessWorkerClient workerClient,
             [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null)
         {
-            return await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false);
+            return (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
         }
 
         [McpServerTool(Name = "preview_open_project")]
@@ -63,10 +63,10 @@ namespace TiaMcpServer.Tools
                 return safety.Error!;
             }
 
-            var result = await workerClient.OpenProjectAsync(projectPath, forceRebind).ConfigureAwait(false);
+            var result = (await workerClient.OpenProjectAsync(projectPath, forceRebind).ConfigureAwait(false)).ToText();
             var status = result.StartsWith("Error:", StringComparison.OrdinalIgnoreCase)
                 ? null
-                : await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false);
+                : (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
 
             WriteSafetyService.Shared.AppendAudit("open_project", projectPath, target, requestedInput, safety.CurrentState, result);
             return WriteSafetyTooling.BuildApplyResult("open_project", result, "get_project_status", status);
@@ -122,11 +122,11 @@ namespace TiaMcpServer.Tools
                 return safety.Error!;
             }
 
-            var result = await workerClient.CreateProjectAsync(projectDirectory, projectName, author, comment)
-                .ConfigureAwait(false);
+            var result = (await workerClient.CreateProjectAsync(projectDirectory, projectName, author, comment)
+                .ConfigureAwait(false)).ToText();
             var status = result.StartsWith("Error:", StringComparison.OrdinalIgnoreCase)
                 ? null
-                : await workerClient.GetProjectStatusAsync(null).ConfigureAwait(false);
+                : (await workerClient.GetProjectStatusAsync(null).ConfigureAwait(false)).ToText();
 
             WriteSafetyService.Shared.AppendAudit("create_project", null, target, requestedInput, safety.CurrentState, result);
             return WriteSafetyTooling.BuildApplyResult("create_project", result, "get_project_status", status);
@@ -138,7 +138,7 @@ namespace TiaMcpServer.Tools
             OpennessWorkerClient workerClient,
             [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null)
         {
-            var currentState = await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false);
+            var currentState = (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
             var target = new { projectPath };
             var requestedInput = new { projectPath };
             return WriteSafetyTooling.CreatePreview(
@@ -172,16 +172,16 @@ namespace TiaMcpServer.Tools
                 projectPath,
                 target,
                 requestedInput,
-                () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
+                async () => (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText()).ConfigureAwait(false);
             if (!safety.IsValid)
             {
                 return safety.Error!;
             }
 
-            var result = await workerClient.SaveProjectAsync(projectPath).ConfigureAwait(false);
+            var result = (await workerClient.SaveProjectAsync(projectPath).ConfigureAwait(false)).ToText();
             var status = result.StartsWith("Error:", StringComparison.OrdinalIgnoreCase)
                 ? null
-                : await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false);
+                : (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
 
             WriteSafetyService.Shared.AppendAudit("save_project", projectPath, target, requestedInput, safety.CurrentState, result);
             return WriteSafetyTooling.BuildApplyResult("save_project", result, "get_project_status", status);
@@ -196,7 +196,7 @@ namespace TiaMcpServer.Tools
             [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null,
             [Description("Set true to bind this MCP session to the copied project path after save-as.")] bool rebind = true)
         {
-            var currentState = await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false);
+            var currentState = (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
             var target = new { projectPath, targetDirectory, targetName };
             var requestedInput = new { projectPath, targetDirectory, targetName, rebind };
             return WriteSafetyTooling.CreatePreview(
@@ -233,17 +233,17 @@ namespace TiaMcpServer.Tools
                 projectPath,
                 target,
                 requestedInput,
-                () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
+                async () => (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText()).ConfigureAwait(false);
             if (!safety.IsValid)
             {
                 return safety.Error!;
             }
 
-            var result = await workerClient.SaveProjectAsAsync(projectPath, targetDirectory, targetName, rebind)
-                .ConfigureAwait(false);
+            var result = (await workerClient.SaveProjectAsAsync(projectPath, targetDirectory, targetName, rebind)
+                .ConfigureAwait(false)).ToText();
             var status = result.StartsWith("Error:", StringComparison.OrdinalIgnoreCase)
                 ? null
-                : await workerClient.GetProjectStatusAsync(rebind ? null : projectPath).ConfigureAwait(false);
+                : (await workerClient.GetProjectStatusAsync(rebind ? null : projectPath).ConfigureAwait(false)).ToText();
 
             WriteSafetyService.Shared.AppendAudit("save_project_as", projectPath, target, requestedInput, safety.CurrentState, result);
             return WriteSafetyTooling.BuildApplyResult("save_project_as", result, "get_project_status", status);
@@ -259,7 +259,7 @@ namespace TiaMcpServer.Tools
             [Description("Save the project before archiving.")] bool saveBeforeArchive = true,
             [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null)
         {
-            var currentState = await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false);
+            var currentState = (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
             var target = new { projectPath, archiveDirectory, archiveName };
             var requestedInput = new { projectPath, archiveDirectory, archiveName, mode, saveBeforeArchive };
             return WriteSafetyTooling.CreatePreview(
@@ -297,21 +297,21 @@ namespace TiaMcpServer.Tools
                 projectPath,
                 target,
                 requestedInput,
-                () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
+                async () => (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText()).ConfigureAwait(false);
             if (!safety.IsValid)
             {
                 return safety.Error!;
             }
 
-            var result = await workerClient.ArchiveProjectAsync(
+            var result = (await workerClient.ArchiveProjectAsync(
                 projectPath,
                 archiveDirectory,
                 archiveName,
                 mode,
-                saveBeforeArchive).ConfigureAwait(false);
+                saveBeforeArchive).ConfigureAwait(false)).ToText();
             var status = result.StartsWith("Error:", StringComparison.OrdinalIgnoreCase)
                 ? null
-                : await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false);
+                : (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
 
             WriteSafetyService.Shared.AppendAudit("archive_project", projectPath, target, requestedInput, safety.CurrentState, result);
             return WriteSafetyTooling.BuildApplyResult("archive_project", result, "get_project_status", status);
@@ -324,7 +324,7 @@ namespace TiaMcpServer.Tools
             [Description("Optional path to a .ap21 project file. If omitted, closes the currently bound/open project.")] string? projectPath = null,
             [Description("Save the project before closing it.")] bool saveBeforeClose = true)
         {
-            var currentState = await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false);
+            var currentState = (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
             var target = new { projectPath };
             var requestedInput = new { projectPath, saveBeforeClose };
             return WriteSafetyTooling.CreatePreview(
@@ -359,13 +359,13 @@ namespace TiaMcpServer.Tools
                 projectPath,
                 target,
                 requestedInput,
-                () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
+                async () => (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText()).ConfigureAwait(false);
             if (!safety.IsValid)
             {
                 return safety.Error!;
             }
 
-            var result = await workerClient.CloseProjectAsync(projectPath, saveBeforeClose).ConfigureAwait(false);
+            var result = (await workerClient.CloseProjectAsync(projectPath, saveBeforeClose).ConfigureAwait(false)).ToText();
 
             WriteSafetyService.Shared.AppendAudit("close_project", projectPath, target, requestedInput, safety.CurrentState, result);
             return WriteSafetyTooling.BuildApplyResult("close_project", result, "get_project_status", null);

--- a/TiaMcpServer/Tools/ProjectLifecycleTools.cs
+++ b/TiaMcpServer/Tools/ProjectLifecycleTools.cs
@@ -31,7 +31,7 @@ namespace TiaMcpServer.Tools
                 target,
                 $"Open and bind TIA Portal project '{projectPath}'.",
                 requestedInput,
-                WriteSafetyTooling.DescribePathState(projectPath)));
+                WorkerCallResult.Ok(WriteSafetyTooling.DescribePathState(projectPath))));
         }
 
         [McpServerTool(Name = "open_project")]
@@ -57,18 +57,18 @@ namespace TiaMcpServer.Tools
                 projectPath,
                 target,
                 requestedInput,
-                () => Task.FromResult(WriteSafetyTooling.DescribePathState(projectPath))).ConfigureAwait(false);
+                () => Task.FromResult(WorkerCallResult.Ok(WriteSafetyTooling.DescribePathState(projectPath)))).ConfigureAwait(false);
             if (!safety.IsValid)
             {
                 return safety.Error!;
             }
 
-            var result = (await workerClient.OpenProjectAsync(projectPath, forceRebind).ConfigureAwait(false)).ToText();
-            var status = result.StartsWith("Error:", StringComparison.OrdinalIgnoreCase)
-                ? null
-                : (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
+            var result = await workerClient.OpenProjectAsync(projectPath, forceRebind).ConfigureAwait(false);
+            var status = result.Success
+                ? (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText()
+                : null;
 
-            WriteSafetyService.Shared.AppendAudit("open_project", projectPath, target, requestedInput, safety.CurrentState, result);
+            WriteSafetyService.Shared.AppendAudit("open_project", projectPath, target, requestedInput, safety.CurrentState, result.ToText());
             return WriteSafetyTooling.BuildApplyResult("open_project", result, "get_project_status", status);
         }
 
@@ -88,7 +88,7 @@ namespace TiaMcpServer.Tools
                 target,
                 $"Create TIA Portal project '{projectName}' in '{projectDirectory}'.",
                 requestedInput,
-                WriteSafetyTooling.DescribeProjectCreationState(projectDirectory, projectName)));
+                WorkerCallResult.Ok(WriteSafetyTooling.DescribeProjectCreationState(projectDirectory, projectName))));
         }
 
         [McpServerTool(Name = "create_project")]
@@ -116,19 +116,19 @@ namespace TiaMcpServer.Tools
                 null,
                 target,
                 requestedInput,
-                () => Task.FromResult(WriteSafetyTooling.DescribeProjectCreationState(projectDirectory, projectName))).ConfigureAwait(false);
+                () => Task.FromResult(WorkerCallResult.Ok(WriteSafetyTooling.DescribeProjectCreationState(projectDirectory, projectName)))).ConfigureAwait(false);
             if (!safety.IsValid)
             {
                 return safety.Error!;
             }
 
-            var result = (await workerClient.CreateProjectAsync(projectDirectory, projectName, author, comment)
-                .ConfigureAwait(false)).ToText();
-            var status = result.StartsWith("Error:", StringComparison.OrdinalIgnoreCase)
-                ? null
-                : (await workerClient.GetProjectStatusAsync(null).ConfigureAwait(false)).ToText();
+            var result = await workerClient.CreateProjectAsync(projectDirectory, projectName, author, comment)
+                .ConfigureAwait(false);
+            var status = result.Success
+                ? (await workerClient.GetProjectStatusAsync(null).ConfigureAwait(false)).ToText()
+                : null;
 
-            WriteSafetyService.Shared.AppendAudit("create_project", null, target, requestedInput, safety.CurrentState, result);
+            WriteSafetyService.Shared.AppendAudit("create_project", null, target, requestedInput, safety.CurrentState, result.ToText());
             return WriteSafetyTooling.BuildApplyResult("create_project", result, "get_project_status", status);
         }
 
@@ -138,7 +138,7 @@ namespace TiaMcpServer.Tools
             OpennessWorkerClient workerClient,
             [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null)
         {
-            var currentState = (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
+            var currentState = await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false);
             var target = new { projectPath };
             var requestedInput = new { projectPath };
             return WriteSafetyTooling.CreatePreview(
@@ -172,18 +172,18 @@ namespace TiaMcpServer.Tools
                 projectPath,
                 target,
                 requestedInput,
-                async () => (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText()).ConfigureAwait(false);
+                () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
             if (!safety.IsValid)
             {
                 return safety.Error!;
             }
 
-            var result = (await workerClient.SaveProjectAsync(projectPath).ConfigureAwait(false)).ToText();
-            var status = result.StartsWith("Error:", StringComparison.OrdinalIgnoreCase)
-                ? null
-                : (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
+            var result = await workerClient.SaveProjectAsync(projectPath).ConfigureAwait(false);
+            var status = result.Success
+                ? (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText()
+                : null;
 
-            WriteSafetyService.Shared.AppendAudit("save_project", projectPath, target, requestedInput, safety.CurrentState, result);
+            WriteSafetyService.Shared.AppendAudit("save_project", projectPath, target, requestedInput, safety.CurrentState, result.ToText());
             return WriteSafetyTooling.BuildApplyResult("save_project", result, "get_project_status", status);
         }
 
@@ -196,7 +196,7 @@ namespace TiaMcpServer.Tools
             [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null,
             [Description("Set true to bind this MCP session to the copied project path after save-as.")] bool rebind = true)
         {
-            var currentState = (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
+            var currentState = await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false);
             var target = new { projectPath, targetDirectory, targetName };
             var requestedInput = new { projectPath, targetDirectory, targetName, rebind };
             return WriteSafetyTooling.CreatePreview(
@@ -233,19 +233,19 @@ namespace TiaMcpServer.Tools
                 projectPath,
                 target,
                 requestedInput,
-                async () => (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText()).ConfigureAwait(false);
+                () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
             if (!safety.IsValid)
             {
                 return safety.Error!;
             }
 
-            var result = (await workerClient.SaveProjectAsAsync(projectPath, targetDirectory, targetName, rebind)
-                .ConfigureAwait(false)).ToText();
-            var status = result.StartsWith("Error:", StringComparison.OrdinalIgnoreCase)
-                ? null
-                : (await workerClient.GetProjectStatusAsync(rebind ? null : projectPath).ConfigureAwait(false)).ToText();
+            var result = await workerClient.SaveProjectAsAsync(projectPath, targetDirectory, targetName, rebind)
+                .ConfigureAwait(false);
+            var status = result.Success
+                ? (await workerClient.GetProjectStatusAsync(rebind ? null : projectPath).ConfigureAwait(false)).ToText()
+                : null;
 
-            WriteSafetyService.Shared.AppendAudit("save_project_as", projectPath, target, requestedInput, safety.CurrentState, result);
+            WriteSafetyService.Shared.AppendAudit("save_project_as", projectPath, target, requestedInput, safety.CurrentState, result.ToText());
             return WriteSafetyTooling.BuildApplyResult("save_project_as", result, "get_project_status", status);
         }
 
@@ -259,7 +259,7 @@ namespace TiaMcpServer.Tools
             [Description("Save the project before archiving.")] bool saveBeforeArchive = true,
             [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null)
         {
-            var currentState = (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
+            var currentState = await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false);
             var target = new { projectPath, archiveDirectory, archiveName };
             var requestedInput = new { projectPath, archiveDirectory, archiveName, mode, saveBeforeArchive };
             return WriteSafetyTooling.CreatePreview(
@@ -297,23 +297,23 @@ namespace TiaMcpServer.Tools
                 projectPath,
                 target,
                 requestedInput,
-                async () => (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText()).ConfigureAwait(false);
+                () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
             if (!safety.IsValid)
             {
                 return safety.Error!;
             }
 
-            var result = (await workerClient.ArchiveProjectAsync(
+            var result = await workerClient.ArchiveProjectAsync(
                 projectPath,
                 archiveDirectory,
                 archiveName,
                 mode,
-                saveBeforeArchive).ConfigureAwait(false)).ToText();
-            var status = result.StartsWith("Error:", StringComparison.OrdinalIgnoreCase)
-                ? null
-                : (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
+                saveBeforeArchive).ConfigureAwait(false);
+            var status = result.Success
+                ? (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText()
+                : null;
 
-            WriteSafetyService.Shared.AppendAudit("archive_project", projectPath, target, requestedInput, safety.CurrentState, result);
+            WriteSafetyService.Shared.AppendAudit("archive_project", projectPath, target, requestedInput, safety.CurrentState, result.ToText());
             return WriteSafetyTooling.BuildApplyResult("archive_project", result, "get_project_status", status);
         }
 
@@ -324,7 +324,7 @@ namespace TiaMcpServer.Tools
             [Description("Optional path to a .ap21 project file. If omitted, closes the currently bound/open project.")] string? projectPath = null,
             [Description("Save the project before closing it.")] bool saveBeforeClose = true)
         {
-            var currentState = (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText();
+            var currentState = await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false);
             var target = new { projectPath };
             var requestedInput = new { projectPath, saveBeforeClose };
             return WriteSafetyTooling.CreatePreview(
@@ -359,15 +359,15 @@ namespace TiaMcpServer.Tools
                 projectPath,
                 target,
                 requestedInput,
-                async () => (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText()).ConfigureAwait(false);
+                () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
             if (!safety.IsValid)
             {
                 return safety.Error!;
             }
 
-            var result = (await workerClient.CloseProjectAsync(projectPath, saveBeforeClose).ConfigureAwait(false)).ToText();
+            var result = await workerClient.CloseProjectAsync(projectPath, saveBeforeClose).ConfigureAwait(false);
 
-            WriteSafetyService.Shared.AppendAudit("close_project", projectPath, target, requestedInput, safety.CurrentState, result);
+            WriteSafetyService.Shared.AppendAudit("close_project", projectPath, target, requestedInput, safety.CurrentState, result.ToText());
             return WriteSafetyTooling.BuildApplyResult("close_project", result, "get_project_status", null);
         }
     }

--- a/TiaMcpServer/Worker/OpennessWorkerClient.cs
+++ b/TiaMcpServer/Worker/OpennessWorkerClient.cs
@@ -1,6 +1,8 @@
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using TiaMcpServer.Contracts;
 
 namespace TiaMcpServer.Worker;
@@ -16,23 +18,30 @@ public class OpennessWorkerClient
     private static readonly TimeSpan WorkerTimeout = TimeSpan.FromMinutes(5);
 
     private readonly ProjectSessionBinding _projectSessionBinding;
+    private readonly ILogger<OpennessWorkerClient>? _logger;
+    private readonly string? _workerExecutablePathOverride;
 
-    public OpennessWorkerClient(ProjectSessionBinding projectSessionBinding)
+    public OpennessWorkerClient(
+        ProjectSessionBinding projectSessionBinding,
+        ILogger<OpennessWorkerClient>? logger = null,
+        string? workerExecutablePath = null)
     {
         _projectSessionBinding = projectSessionBinding;
+        _logger = logger;
+        _workerExecutablePathOverride = workerExecutablePath;
     }
 
-    public Task<string> BrowseProjectTreeAsync(string? projectPath)
+    public Task<WorkerCallResult> BrowseProjectTreeAsync(string? projectPath)
     {
         return SendBoundProjectRequestAsync("browse_project_tree", projectPath, _ => { }, "[]");
     }
 
-    public Task<string> ReadHardwareConfigAsync(string? projectPath)
+    public Task<WorkerCallResult> ReadHardwareConfigAsync(string? projectPath)
     {
         return SendBoundProjectRequestAsync("read_hardware_config", projectPath, _ => { }, "{}");
     }
 
-    public Task<string> SearchEquipmentCatalogAsync(string query, string? projectPath)
+    public Task<WorkerCallResult> SearchEquipmentCatalogAsync(string query, string? projectPath)
     {
         return SendBoundProjectRequestAsync(
             "search_equipment_catalog",
@@ -41,7 +50,7 @@ public class OpennessWorkerClient
             "[]");
     }
 
-    public Task<string> AddNetworkDeviceAsync(
+    public Task<WorkerCallResult> AddNetworkDeviceAsync(
         string typeIdentifier,
         string deviceName,
         string deviceItemName,
@@ -61,7 +70,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> ConfigureNetworkDeviceAsync(
+    public Task<WorkerCallResult> ConfigureNetworkDeviceAsync(
         string deviceName,
         string? ipAddress,
         string? subnetMask,
@@ -87,12 +96,12 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> ReadCrossReferencesAsync(string? projectPath, string? plcName, string? filter)
+    public Task<WorkerCallResult> ReadCrossReferencesAsync(string? projectPath, string? plcName, string? filter)
     {
         // Validate the filter before TryResolve so an invalid filter does not bind the session.
         if (!CrossReferenceFilterNames.TryNormalize(filter, out var normalizedFilter, out var filterError))
         {
-            return Task.FromResult($"Error: {filterError}");
+            return Task.FromResult(WorkerCallResult.Fail(filterError!));
         }
 
         return SendBoundProjectRequestAsync(
@@ -106,7 +115,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> GetBlockContentAsync(string blockPath, string? projectPath)
+    public Task<WorkerCallResult> GetBlockContentAsync(string blockPath, string? projectPath)
     {
         return SendBoundProjectRequestAsync(
             "get_block_content",
@@ -115,7 +124,7 @@ public class OpennessWorkerClient
             string.Empty);
     }
 
-    public Task<string> UpdateBlockLogicAsync(string blockPath, string yamlContent, string? projectPath)
+    public Task<WorkerCallResult> UpdateBlockLogicAsync(string blockPath, string yamlContent, string? projectPath)
     {
         return SendBoundProjectRequestAsync(
             "update_block_logic",
@@ -129,7 +138,7 @@ public class OpennessWorkerClient
             string.Empty);
     }
 
-    public Task<string> ListTagTablesAsync(string? plcName, string? projectPath)
+    public Task<WorkerCallResult> ListTagTablesAsync(string? plcName, string? projectPath)
     {
         return SendBoundProjectRequestAsync(
             "list_tag_tables",
@@ -138,7 +147,7 @@ public class OpennessWorkerClient
             "[]");
     }
 
-    public Task<string> CompileCheckAsync(string? blockPath, string? plcName, string? projectPath)
+    public Task<WorkerCallResult> CompileCheckAsync(string? blockPath, string? plcName, string? projectPath)
     {
         return SendBoundProjectRequestAsync(
             "compile_check",
@@ -151,7 +160,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> CreateTagTableAsync(
+    public Task<WorkerCallResult> CreateTagTableAsync(
         string? plcName,
         string tableName,
         string? folderPath,
@@ -171,7 +180,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> DeleteTagTableAsync(
+    public Task<WorkerCallResult> DeleteTagTableAsync(
         string? plcName,
         string tableName,
         string? folderPath,
@@ -191,7 +200,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> CreateTagAsync(
+    public Task<WorkerCallResult> CreateTagAsync(
         string? plcName,
         string tableName,
         string? folderPath,
@@ -217,7 +226,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> UpdateTagAsync(
+    public Task<WorkerCallResult> UpdateTagAsync(
         string? plcName,
         string tableName,
         string? folderPath,
@@ -253,7 +262,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> DeleteTagAsync(
+    public Task<WorkerCallResult> DeleteTagAsync(
         string? plcName,
         string tableName,
         string? folderPath,
@@ -275,7 +284,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> CreateUserConstantAsync(
+    public Task<WorkerCallResult> CreateUserConstantAsync(
         string? plcName,
         string tableName,
         string? folderPath,
@@ -301,7 +310,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> UpdateUserConstantAsync(
+    public Task<WorkerCallResult> UpdateUserConstantAsync(
         string? plcName,
         string tableName,
         string? folderPath,
@@ -327,7 +336,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> DeleteUserConstantAsync(
+    public Task<WorkerCallResult> DeleteUserConstantAsync(
         string? plcName,
         string tableName,
         string? folderPath,
@@ -349,7 +358,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> CreateBlockAsync(
+    public Task<WorkerCallResult> CreateBlockAsync(
         string blockPath,
         string blockType,
         string? language,
@@ -371,7 +380,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> DeleteBlockAsync(string blockPath, string? projectPath)
+    public Task<WorkerCallResult> DeleteBlockAsync(string blockPath, string? projectPath)
     {
         return SendBoundProjectRequestAsync(
             "delete_block",
@@ -385,7 +394,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> CreateBlockGroupAsync(string blockPath, string? projectPath)
+    public Task<WorkerCallResult> CreateBlockGroupAsync(string blockPath, string? projectPath)
     {
         return SendBoundProjectRequestAsync(
             "create_block_group",
@@ -399,7 +408,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> DeleteBlockGroupAsync(string blockPath, string? projectPath)
+    public Task<WorkerCallResult> DeleteBlockGroupAsync(string blockPath, string? projectPath)
     {
         return SendBoundProjectRequestAsync(
             "delete_block_group",
@@ -413,7 +422,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> StartPlcAsync(string? plcName, string? projectPath)
+    public Task<WorkerCallResult> StartPlcAsync(string? plcName, string? projectPath)
     {
         return SendBoundProjectRequestAsync(
             "start_plc",
@@ -427,7 +436,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> StopPlcAsync(string? plcName, string? projectPath)
+    public Task<WorkerCallResult> StopPlcAsync(string? plcName, string? projectPath)
     {
         return SendBoundProjectRequestAsync(
             "stop_plc",
@@ -441,7 +450,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public Task<string> GetProjectStatusAsync(string? projectPath)
+    public Task<WorkerCallResult> GetProjectStatusAsync(string? projectPath)
     {
         return SendBoundProjectRequestAsync(
             "get_project_status",
@@ -450,83 +459,69 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public async Task<string> OpenProjectAsync(string projectPath, bool forceRebind)
+    public async Task<WorkerCallResult> OpenProjectAsync(string projectPath, bool forceRebind)
     {
         if (!CanBind(projectPath, forceRebind, out var bindingError))
         {
-            return $"Error: {bindingError}";
+            return WorkerCallResult.Fail(bindingError!);
         }
 
-        try
-        {
-            var response = await SendAsync(
-                new WorkerRequest
-                {
-                    Method = "open_project",
-                    ProjectPath = projectPath,
-                    Confirm = true,
-                    ForceRebind = forceRebind,
-                    AllowTiaConfirmations = true
-                }).ConfigureAwait(false);
-
-            if (!response.Success)
+        var result = await InvokeWorkerAsync(
+            new WorkerRequest
             {
-                return FormatWorkerError(response);
-            }
+                Method = "open_project",
+                ProjectPath = projectPath,
+                Confirm = true,
+                ForceRebind = forceRebind,
+                AllowTiaConfirmations = true
+            }).ConfigureAwait(false);
 
-            if (!_projectSessionBinding.Bind(projectPath, forceRebind, out var bindError))
-            {
-                return $"Error: {bindError}";
-            }
-
-            return response.Payload ?? "{}";
-        }
-        catch (Exception ex) when (ex is IOException or InvalidOperationException or TimeoutException or JsonException)
+        if (!result.Success)
         {
-            return $"Error: {ex.Message}";
+            return result;
         }
+
+        if (!_projectSessionBinding.Bind(projectPath, forceRebind, out var bindError))
+        {
+            return WorkerCallResult.Fail(bindError!, result.Warnings);
+        }
+
+        return string.IsNullOrEmpty(result.Payload) ? result with { Payload = "{}" } : result;
     }
 
-    public async Task<string> CreateProjectAsync(
+    public async Task<WorkerCallResult> CreateProjectAsync(
         string projectDirectory,
         string projectName,
         string? author,
         string? comment)
     {
-        try
-        {
-            var response = await SendAsync(
-                new WorkerRequest
-                {
-                    Method = "create_project",
-                    ProjectDirectory = projectDirectory,
-                    ProjectName = projectName,
-                    Author = author,
-                    Comment = comment,
-                    Confirm = true,
-                    AllowTiaConfirmations = true
-                }).ConfigureAwait(false);
-
-            if (!response.Success)
+        var result = await InvokeWorkerAsync(
+            new WorkerRequest
             {
-                return FormatWorkerError(response);
-            }
+                Method = "create_project",
+                ProjectDirectory = projectDirectory,
+                ProjectName = projectName,
+                Author = author,
+                Comment = comment,
+                Confirm = true,
+                AllowTiaConfirmations = true
+            }).ConfigureAwait(false);
 
-            var projectPath = TryReadProjectPath(response.Payload);
-            if (!string.IsNullOrWhiteSpace(projectPath))
-            {
-                _projectSessionBinding.Bind(projectPath!, forceRebind: true, out _);
-            }
-
-            return response.Payload ?? "{}";
-        }
-        catch (Exception ex) when (ex is IOException or InvalidOperationException or TimeoutException or JsonException)
+        if (!result.Success)
         {
-            return $"Error: {ex.Message}";
+            return result;
         }
+
+        var projectPath = TryReadProjectPath(result.Payload);
+        if (!string.IsNullOrWhiteSpace(projectPath))
+        {
+            _projectSessionBinding.Bind(projectPath!, forceRebind: true, out _);
+        }
+
+        return string.IsNullOrEmpty(result.Payload) ? result with { Payload = "{}" } : result;
     }
 
-    public Task<string> SaveProjectAsync(string? projectPath)
+    public Task<WorkerCallResult> SaveProjectAsync(string? projectPath)
     {
         return SendBoundProjectRequestAsync(
             "save_project",
@@ -539,7 +534,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public async Task<string> SaveProjectAsAsync(
+    public async Task<WorkerCallResult> SaveProjectAsAsync(
         string? projectPath,
         string targetDirectory,
         string targetName,
@@ -558,9 +553,9 @@ public class OpennessWorkerClient
             },
             "{}").ConfigureAwait(false);
 
-        if (rebind && !result.StartsWith("Error:", StringComparison.OrdinalIgnoreCase))
+        if (rebind && result.Success)
         {
-            var copiedProjectPath = TryReadProjectPath(result);
+            var copiedProjectPath = TryReadProjectPath(result.Payload);
             if (!string.IsNullOrWhiteSpace(copiedProjectPath))
             {
                 _projectSessionBinding.Bind(copiedProjectPath!, forceRebind: true, out _);
@@ -570,7 +565,7 @@ public class OpennessWorkerClient
         return result;
     }
 
-    public Task<string> ArchiveProjectAsync(
+    public Task<WorkerCallResult> ArchiveProjectAsync(
         string? projectPath,
         string archiveDirectory,
         string archiveName,
@@ -579,7 +574,7 @@ public class OpennessWorkerClient
     {
         if (!ArchiveModeNames.TryNormalize(mode, out var normalizedMode, out var modeError))
         {
-            return Task.FromResult($"Error: {modeError}");
+            return Task.FromResult(WorkerCallResult.Fail(modeError!));
         }
 
         return SendBoundProjectRequestAsync(
@@ -597,7 +592,7 @@ public class OpennessWorkerClient
             "{}");
     }
 
-    public async Task<string> CloseProjectAsync(string? projectPath, bool saveBeforeClose)
+    public async Task<WorkerCallResult> CloseProjectAsync(string? projectPath, bool saveBeforeClose)
     {
         var result = await SendBoundProjectRequestAsync(
             "close_project",
@@ -610,8 +605,7 @@ public class OpennessWorkerClient
             },
             "{}").ConfigureAwait(false);
 
-        if (!result.StartsWith("Error:", StringComparison.OrdinalIgnoreCase) &&
-            _projectSessionBinding.Clear(projectPath, out _) is false)
+        if (result.Success && _projectSessionBinding.Clear(projectPath, out _) is false)
         {
             _projectSessionBinding.Clear(null, out _);
         }
@@ -619,35 +613,56 @@ public class OpennessWorkerClient
         return result;
     }
 
-    private async Task<string> SendBoundProjectRequestAsync(
+    private async Task<WorkerCallResult> SendBoundProjectRequestAsync(
         string method,
         string? projectPath,
         Action<WorkerRequest> configure,
         string emptyPayload)
     {
+        if (!_projectSessionBinding.TryResolve(projectPath, out var effectiveProjectPath, out var bindingError))
+        {
+            return WorkerCallResult.Fail(bindingError!);
+        }
+
+        var request = new WorkerRequest
+        {
+            Method = method,
+            ProjectPath = effectiveProjectPath
+        };
+        configure(request);
+
+        var result = await InvokeWorkerAsync(request).ConfigureAwait(false);
+        return result.Success && string.IsNullOrEmpty(result.Payload)
+            ? result with { Payload = emptyPayload }
+            : result;
+    }
+
+    private async Task<WorkerCallResult> InvokeWorkerAsync(WorkerRequest request)
+    {
         try
         {
-            if (!_projectSessionBinding.TryResolve(projectPath, out var effectiveProjectPath, out var bindingError))
+            var (response, stderrWarnings) = await SendAsync(request).ConfigureAwait(false);
+            foreach (var warning in stderrWarnings)
             {
-                return $"Error: {bindingError}";
+                _logger?.LogWarning("TIA Openness worker stderr: {Line}", warning);
             }
 
-            var request = new WorkerRequest
-            {
-                Method = method,
-                ProjectPath = effectiveProjectPath
-            };
-            configure(request);
-
-            var response = await SendAsync(request).ConfigureAwait(false);
-
             return response.Success
-                ? response.Payload ?? emptyPayload
-                : FormatWorkerError(response);
+                ? WorkerCallResult.Ok(response.Payload ?? string.Empty, stderrWarnings)
+                : WorkerCallResult.Fail(
+                    response.Error ?? "The TIA Openness worker failed without an error message.",
+                    stderrWarnings);
+        }
+        catch (Win32Exception ex)
+        {
+            return WorkerCallResult.Fail(
+                $"Failed to launch the TIA Openness worker process ({ex.Message}). "
+                + "Verify that .NET Framework 4.8 is installed and that the 'openness-worker' folder "
+                + "beside the MCP server executable is complete; rebuild or reinstall if files are missing.");
         }
         catch (Exception ex) when (ex is IOException or InvalidOperationException or TimeoutException or JsonException)
         {
-            return $"Error: {ex.Message}";
+            return WorkerCallResult.Fail(ex.Message);
         }
     }
 
@@ -673,11 +688,6 @@ public class OpennessWorkerClient
         return false;
     }
 
-    private static string FormatWorkerError(WorkerResponse response)
-    {
-        return $"Error: {response.Error ?? "The TIA Openness worker failed without an error message."}";
-    }
-
     private static string? TryReadProjectPath(string? payload)
     {
         if (string.IsNullOrWhiteSpace(payload))
@@ -685,29 +695,36 @@ public class OpennessWorkerClient
             return null;
         }
 
-        using var document = JsonDocument.Parse(payload);
-        if (document.RootElement.TryGetProperty("projectPath", out var projectPath) &&
-            projectPath.ValueKind == JsonValueKind.String)
+        try
         {
-            return projectPath.GetString();
-        }
+            using var document = JsonDocument.Parse(payload);
+            if (document.RootElement.TryGetProperty("projectPath", out var projectPath) &&
+                projectPath.ValueKind == JsonValueKind.String)
+            {
+                return projectPath.GetString();
+            }
 
-        if (document.RootElement.TryGetProperty("project", out var project) &&
-            project.ValueKind == JsonValueKind.Object &&
-            project.TryGetProperty("path", out var statusPath) &&
-            statusPath.ValueKind == JsonValueKind.String)
+            if (document.RootElement.TryGetProperty("project", out var project) &&
+                project.ValueKind == JsonValueKind.Object &&
+                project.TryGetProperty("path", out var statusPath) &&
+                statusPath.ValueKind == JsonValueKind.String)
+            {
+                return statusPath.GetString();
+            }
+
+            return null;
+        }
+        catch (JsonException)
         {
-            return statusPath.GetString();
+            return null;
         }
-
-        return null;
     }
 
     // Siemens Openness is not safe for concurrent multi-process access to one TIA Portal
     // instance; serialize every worker invocation until the persistent-worker rework lands.
     private static readonly SemaphoreSlim WorkerGate = new(1, 1);
 
-    private static async Task<WorkerResponse> SendAsync(WorkerRequest request)
+    private async Task<(WorkerResponse Response, IReadOnlyList<string> StderrLines)> SendAsync(WorkerRequest request)
     {
         await WorkerGate.WaitAsync().ConfigureAwait(false);
         try
@@ -720,9 +737,9 @@ public class OpennessWorkerClient
         }
     }
 
-    private static async Task<WorkerResponse> SendUnguardedAsync(WorkerRequest request)
+    private async Task<(WorkerResponse Response, IReadOnlyList<string> StderrLines)> SendUnguardedAsync(WorkerRequest request)
     {
-        var workerPath = LocateWorkerExecutable();
+        var workerPath = _workerExecutablePathOverride ?? LocateWorkerExecutable();
         var startInfo = new ProcessStartInfo
         {
             FileName = workerPath,
@@ -757,6 +774,7 @@ public class OpennessWorkerClient
         var responseLine = await responseLineTask.ConfigureAwait(false);
         await process.WaitForExitAsync(timeout.Token).ConfigureAwait(false);
         var stderr = await stderrTask.ConfigureAwait(false);
+        var stderrLines = SplitStderrLines(stderr);
 
         if (string.IsNullOrWhiteSpace(responseLine))
         {
@@ -765,7 +783,33 @@ public class OpennessWorkerClient
         }
 
         var response = JsonSerializer.Deserialize<WorkerResponse>(responseLine, JsonOptions);
-        return response ?? throw new InvalidOperationException("TIA Openness worker returned an empty response.");
+        return (response ?? throw new InvalidOperationException("TIA Openness worker returned an empty response."), stderrLines);
+    }
+
+    // A degraded read of a large project can emit hundreds of "Skipping X" lines; cap what
+    // reaches the agent so warnings cannot flood a small model's context.
+    private const int MaxStderrWarningLines = 20;
+
+    private static IReadOnlyList<string> SplitStderrLines(string stderr)
+    {
+        if (string.IsNullOrWhiteSpace(stderr))
+        {
+            return Array.Empty<string>();
+        }
+
+        var lines = stderr.Replace("\r\n", "\n").Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0)
+            .ToList();
+
+        if (lines.Count > MaxStderrWarningLines)
+        {
+            var dropped = lines.Count - MaxStderrWarningLines;
+            lines = lines.Take(MaxStderrWarningLines).ToList();
+            lines.Add($"(+{dropped} more worker warnings truncated)");
+        }
+
+        return lines;
     }
 
     private static string LocateWorkerExecutable()

--- a/TiaMcpServer/Worker/WorkerCallResult.cs
+++ b/TiaMcpServer/Worker/WorkerCallResult.cs
@@ -1,0 +1,24 @@
+namespace TiaMcpServer.Worker;
+
+/// <summary>
+/// Structured outcome of one TIA Openness worker invocation. Replaces the "Error:"
+/// string-prefix convention: success/failure is carried structurally and payload text
+/// never drives classification. <see cref="Warnings"/> carries non-fatal degradation
+/// notes captured from the worker's stderr.
+/// </summary>
+public sealed record WorkerCallResult(
+    bool Success,
+    string Payload,
+    string? Error,
+    IReadOnlyList<string> Warnings)
+{
+    public static WorkerCallResult Ok(string payload, IReadOnlyList<string>? warnings = null)
+        => new(true, payload, null, warnings ?? Array.Empty<string>());
+
+    public static WorkerCallResult Fail(string error, IReadOnlyList<string>? warnings = null)
+        => new(false, string.Empty, error, warnings ?? Array.Empty<string>());
+
+    /// <summary>Agent-facing text for boundaries where an MCP tool returns a plain string.</summary>
+    public string ToText()
+        => Success ? Payload : $"Error: {Error}";
+}

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -37,13 +37,13 @@ well-designed. The three biggest problems, in order of impact:
 
 | # | Change | Where | Why |
 |---|--------|-------|-----|
-| 1.1 | Replace the `"Error:"` string-prefix convention with a structured result record (`Success`, `Payload`, `Error`) threaded through client → batch → safety → tools | `OpennessWorkerClient.cs:552`, `BatchExecutionEngine.cs:10`, `WriteSafetyTooling.cs:30,58,83`, `ProjectLifecycleTools.cs` (5 sites), `BatchTools.cs:139` | Any payload legitimately starting with "Error:" is misclassified; false-success bugs become structurally impossible |
+| 1.1 | Replace the `"Error:"` string-prefix convention with a structured result record (`Success`, `Payload`, `Error`) threaded through client → batch → safety → tools | `OpennessWorkerClient.cs:552`, `BatchExecutionEngine.cs:10`, `WriteSafetyTooling.cs:30,58,83`, `ProjectLifecycleTools.cs` (5 sites), `BatchTools.cs:139` | Any payload legitimately starting with "Error:" is misclassified; false-success bugs become structurally impossible — DONE 2026-07-16 |
 | 1.2 | **False-success writes**: `NetworkDeviceCreator.cs:23-31` must fail the response when `CreateWithItem` throws (today: buried warning + `Success=true`, and batch stop-on-failure doesn't stop). `NetworkDeviceConfigurator.cs:71-74` must fail when ALL requested settings were skipped | worker Openness/ | CRITICAL: agent believes a device exists that doesn't; audit log records success — DONE 2026-07-15 |
-| 1.3 | Surface worker stderr: attach non-empty stderr as `warnings` on `WorkerResponse` and/or log via host ILogger; route per-item "Skipping X" degradation messages into `messages` arrays on the payload DTOs (pattern already used correctly by `CrossReferenceReader` and `CompileChecker`) | `OpennessWorkerClient.cs:633-656`, ~20 catch sites in worker readers | `browse_project_tree`/`read_hardware_config` can silently return partial trees today |
-| 1.4 | `HardwareConfigReader` fallback defaults (`0`/`""`/`null`) indistinguishable from real values → nullable + `messages` marker | `HardwareConfigReader.cs:260-297` | Agent can't tell "read failed" from "actual value" |
-| 1.5 | Add `Win32Exception` to the client catch filters with an actionable message (missing .NET FX 4.8 / corrupt openness-worker folder); include exception type name in the worker's catch-all error; wrap `SaveProjectAsAsync` like its siblings | `OpennessWorkerClient.cs:392,431,556,630`, worker `Program.cs:86-90` | The one prerequisite failure that surfaces as a raw protocol error today |
-| 1.6 | Reject unknown JSON properties on batch items (`JsonUnmappedMemberHandling.Disallow` or equivalent SDK option) | host serializer config | Misspelled OPTIONAL params (`ip_adress`) currently succeed silently — the most dangerous trap found |
-| 1.7 | Narrow bare `catch (Exception)` in `EquipmentCatalogSearcher.cs` reflection helpers to `EngineeringException`/`TargetInvocationException`, merging with the existing `OpennessReflection` helpers | worker Openness/ | Bugs currently masquerade as empty search results |
+| 1.3 | Surface worker stderr: attach non-empty stderr as `warnings` on `WorkerResponse` and/or log via host ILogger; route per-item "Skipping X" degradation messages into `messages` arrays on the payload DTOs (pattern already used correctly by `CrossReferenceReader` and `CompileChecker`) | `OpennessWorkerClient.cs:633-656`, ~20 catch sites in worker readers | `browse_project_tree`/`read_hardware_config` can silently return partial trees today — DONE 2026-07-16 |
+| 1.4 | `HardwareConfigReader` fallback defaults (`0`/`""`/`null`) indistinguishable from real values → nullable + `messages` marker | `HardwareConfigReader.cs:260-297` | Agent can't tell "read failed" from "actual value" — DONE 2026-07-16 |
+| 1.5 | Add `Win32Exception` to the client catch filters with an actionable message (missing .NET FX 4.8 / corrupt openness-worker folder); include exception type name in the worker's catch-all error; wrap `SaveProjectAsAsync` like its siblings | `OpennessWorkerClient.cs:392,431,556,630`, worker `Program.cs:86-90` | The one prerequisite failure that surfaces as a raw protocol error today — DONE 2026-07-16 |
+| 1.6 | Reject unknown JSON properties on batch items (`JsonUnmappedMemberHandling.Disallow` or equivalent SDK option) | host serializer config | Misspelled OPTIONAL params (`ip_adress`) currently succeed silently — the most dangerous trap found — DONE 2026-07-16 |
+| 1.7 | Narrow bare `catch (Exception)` in `EquipmentCatalogSearcher.cs` reflection helpers to `EngineeringException`/`TargetInvocationException`, merging with the existing `OpennessReflection` helpers | worker Openness/ | Bugs currently masquerade as empty search results — DONE 2026-07-16 |
 
 ## Phase 2 — Structural (the big wins; ~1-2 weeks)
 
@@ -77,7 +77,10 @@ well-designed. The three biggest problems, in order of impact:
 
 - Zero integration coverage of `OpennessWorkerClient` ↔ worker IPC. Add a **fake worker executable**
   test harness (echoes scripted JSON) to cover: timeout path, stderr propagation, malformed JSON,
-  Win32Exception launch failure, persistent-worker restart logic (once 2.1 lands).
+  Win32Exception launch failure, persistent-worker restart logic (once 2.1 lands). Stderr propagation,
+  malformed JSON, and Win32Exception launch failure are now covered by
+  `OpennessWorkerClientIntegrationTests` — DONE 2026-07-16. The timeout path and persistent-worker
+  restart logic remain open, deferred to a future phase 2.1 item.
 - Batch validation aggregation (0.2) and unknown-property rejection (1.6) are pure-logic → plain xunit.
 - The 146 existing tests are contract/formatting tests; none exercise a worker process.
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,24 +1,20 @@
-# Graph Report - tia-portal-mcp  (2026-07-15)
+# Graph Report - tia-portal-mcp  (2026-07-16)
 
 ## Corpus Check
-
-- 87 files · ~28,506 words
+- 92 files · ~29,601 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-
-- 865 nodes · 1315 edges · 100 communities (9 shown, 91 thin omitted)
+- 902 nodes · 1370 edges · 102 communities (10 shown, 92 thin omitted)
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS · INFERRED: 2 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-
-- Built from commit: `af470a92`
+- Built from commit: `fdb62210`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
 ## Community Hubs (Navigation)
-
 - [[_COMMUNITY_Community 0|Community 0]]
 - [[_COMMUNITY_Community 1|Community 1]]
 - [[_COMMUNITY_Community 2|Community 2]]
@@ -85,7 +81,6 @@
 - [[_COMMUNITY_Community 63|Community 63]]
 - [[_COMMUNITY_Community 64|Community 64]]
 - [[_COMMUNITY_Community 65|Community 65]]
-- [[_COMMUNITY_Community 66|Community 66]]
 - [[_COMMUNITY_Community 67|Community 67]]
 - [[_COMMUNITY_Community 68|Community 68]]
 - [[_COMMUNITY_Community 69|Community 69]]
@@ -118,11 +113,11 @@
 - [[_COMMUNITY_Community 96|Community 96]]
 - [[_COMMUNITY_Community 97|Community 97]]
 - [[_COMMUNITY_Community 98|Community 98]]
-- [[_COMMUNITY_Community 99|Community 99]]
+- [[_COMMUNITY_Community 100|Community 100]]
+- [[_COMMUNITY_Community 101|Community 101]]
 
 ## God Nodes (most connected - your core abstractions)
-
-1. `OpennessWorkerClient` - 44 edges
+1. `OpennessWorkerClient` - 49 edges
 2. `Program` - 44 edges
 3. `BatchOperationCatalogTests` - 24 edges
 4. `HardwareConfigReader` - 20 edges
@@ -134,86 +129,70 @@
 10. `ProjectLifecycleTools` - 14 edges
 
 ## Surprising Connections (you probably didn't know these)
-
 - `BatchOperationStatus` --references--> `string`  [EXTRACTED]
   TiaMcpServer/Batch/BatchOperationResult.cs → TiaMcpServer.Tests/BatchSafetyTokenTests.cs
 - `WriteSafetyService` --references--> `string`  [EXTRACTED]
   TiaMcpServer/Safety/WriteSafetyService.cs → TiaMcpServer.Tests/BatchSafetyTokenTests.cs
-- `WriteSafetyService` --references--> `JsonSerializerOptions`  [EXTRACTED]
-  TiaMcpServer/Safety/WriteSafetyService.cs → TiaMcpServer.OpennessWorker/Program.cs
+- `OpennessWorkerClient` --references--> `string`  [EXTRACTED]
+  TiaMcpServer/Worker/OpennessWorkerClient.cs → TiaMcpServer.Tests/BatchSafetyTokenTests.cs
+- `EquipmentCatalogSearcher` --references--> `string`  [EXTRACTED]
+  TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs → TiaMcpServer.Tests/BatchSafetyTokenTests.cs
 - `OpennessWorkerClient` --references--> `JsonSerializerOptions`  [EXTRACTED]
-  TiaMcpServer/Worker/OpennessWorkerClient.cs → TiaMcpServer.OpennessWorker/Program.cs
-- `BatchSafetySnapshot` --references--> `string`  [EXTRACTED]
-  TiaMcpServer/Batch/BatchSafetySnapshot.cs → TiaMcpServer.Tests/BatchSafetyTokenTests.cs
+  TiaMcpServer/Worker/OpennessWorkerClient.cs → TiaMcpServer.Tests/HardwareConfigInfoTests.cs
 
-## Communities (100 total, 91 thin omitted)
+## Communities (102 total, 92 thin omitted)
 
 ### Community 0 - "Community 0"
+Cohesion: 0.06
+Nodes (13): BatchResultFormatter, ConcurrentDictionary, Func, JsonSerializerOptions, Invalid(), Valid(), WriteSafetyService, Invalid() (+5 more)
 
+### Community 1 - "Community 1"
+Cohesion: 0.1
+Nodes (4): ILogger, ProjectSessionBinding, SemaphoreSlim, OpennessWorkerClient
+
+### Community 2 - "Community 2"
 Cohesion: 0.08
 Nodes (8): BatchOperationStatus, BatchSafetySnapshot, BatchTools, BlockImporter, string, ArchiveModeNames, ProjectSessionBinding, BatchSafetyTokenTests
 
-### Community 1 - "Community 1"
-
+### Community 3 - "Community 3"
 Cohesion: 0.04
 Nodes (45): Architecture, Block Paths, Build From Source, code:text (C:\Program Files\Siemens\Automation\Portal V21\PublicAPI\V21), code:powershell (dotnet run --project TiaMcpServer), code:powershell ('{ "method": "browse_project_tree", "projectPath": null }' |), code:json ({"success":true,"payload":"[...]"}), code:json ({"success":false,"error":"No running TIA Portal V21 instance) (+37 more)
 
-### Community 3 - "Community 3"
-
-Cohesion: 0.11
-Nodes (3): ProjectSessionBinding, SemaphoreSlim, OpennessWorkerClient
-
-### Community 6 - "Community 6"
-
+### Community 7 - "Community 7"
 Cohesion: 0.1
 Nodes (4): TagOperationsTool, TagTableOperationsTool, TiaMcpServer.Tools, UserConstantOperationsTool
 
-### Community 7 - "Community 7"
-
-Cohesion: 0.15
-Nodes (5): BatchResultFormatter, JsonSerializerOptions, Invalid(), Valid(), WriteSafetyTooling
-
 ### Community 10 - "Community 10"
-
 Cohesion: 0.19
 Nodes (7): BatchOperationCatalog, Invalid(), Valid(), int, IReadOnlyDictionary, IReadOnlyList, IReadOnlySet
 
-### Community 15 - "Community 15"
-
-Cohesion: 0.27
-Nodes (6): ConcurrentDictionary, Func, Invalid(), Valid(), WriteSafetyService, TimeSpan
-
-### Community 20 - "Community 20"
-
+### Community 19 - "Community 19"
 Cohesion: 0.22
 Nodes (4): bool, IDisposable, TiaPortalSession, TiaPortal
 
 ### Community 40 - "Community 40"
-
 Cohesion: 0.29
 Nodes (7): Model Context Protocol, Siemens TIA Openness User Group, Phase 1: Implementation, Phase 2: Universal Block Support, Phase 3: Hardware and Network Discovery, Phase 4: Advanced Diagnostics, tia-portal-mcp
 
 ## Knowledge Gaps
-
-- **66 isolated node(s):** `int`, `IReadOnlyList`, `IReadOnlyDictionary`, `IReadOnlySet`, `BatchOperationRequest` (+61 more)
+- **66 isolated node(s):** `IReadOnlyList`, `IReadOnlyDictionary`, `IReadOnlySet`, `BatchOperationRequest`, `ConcurrentDictionary` (+61 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **91 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **92 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
-
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `JsonSerializerOptions` connect `Community 7` to `Community 2`, `Community 3`, `Community 15`?**
-  _High betweenness centrality (0.027) - this node is a cross-community bridge._
-- **Why does `WriteSafetyService` connect `Community 15` to `Community 0`, `Community 7`?**
-  _High betweenness centrality (0.021) - this node is a cross-community bridge._
-- **Why does `OpennessWorkerClient` connect `Community 3` to `Community 15`, `Community 7`?**
-  _High betweenness centrality (0.021) - this node is a cross-community bridge._
-- **What connects `int`, `IReadOnlyList`, `IReadOnlyDictionary` to the rest of the system?**
+- **Why does `OpennessWorkerClient` connect `Community 1` to `Community 0`, `Community 2`, `Community 10`?**
+  _High betweenness centrality (0.039) - this node is a cross-community bridge._
+- **Why does `JsonSerializerOptions` connect `Community 0` to `Community 1`, `Community 4`?**
+  _High betweenness centrality (0.033) - this node is a cross-community bridge._
+- **Why does `string` connect `Community 2` to `Community 0`, `Community 1`, `Community 15`?**
+  _High betweenness centrality (0.029) - this node is a cross-community bridge._
+- **What connects `IReadOnlyList`, `IReadOnlyDictionary`, `IReadOnlySet` to the rest of the system?**
   _66 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.08 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.04 - nodes in this community are weakly interconnected._
-- **Should `Community 3` be split into smaller, more focused modules?**
-  _Cohesion score 0.11 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.1 - nodes in this community are weakly interconnected._
+- **Should `Community 2` be split into smaller, more focused modules?**
+  _Cohesion score 0.08 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "TiaMcpServer/Program.cs",
       "source_location": "L1",
       "id": "tiamcpserver_program_cs",
-      "community": 31,
+      "community": 33,
       "norm_label": "program.cs"
     },
     {
@@ -18,7 +18,7 @@
       "source_file": "TiaMcpServer/Program.cs",
       "source_location": "L9",
       "id": "tiamcpserver_program_tiamcpserver",
-      "community": 31,
+      "community": 33,
       "norm_label": "tiamcpserver"
     },
     {
@@ -27,7 +27,7 @@
       "source_file": "TiaMcpServer/Program.cs",
       "source_location": "L11",
       "id": "tiamcpserver_program_program",
-      "community": 31,
+      "community": 33,
       "norm_label": "program"
     },
     {
@@ -36,16 +36,16 @@
       "source_file": "TiaMcpServer/Program.cs",
       "source_location": "L13",
       "id": "tiamcpserver_program_program_main",
-      "community": 31,
+      "community": 33,
       "norm_label": ".main()"
     },
     {
       "label": ".ResolveStartupProjectPath()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Program.cs",
-      "source_location": "L24",
+      "source_location": "L26",
       "id": "tiamcpserver_program_program_resolvestartupprojectpath",
-      "community": 31,
+      "community": 33,
       "norm_label": ".resolvestartupprojectpath()"
     },
     {
@@ -54,44 +54,44 @@
       "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
       "source_location": "L1",
       "id": "tiamcpserver_batch_batchexecutionengine_cs",
-      "community": 51,
+      "community": 41,
       "norm_label": "batchexecutionengine.cs"
     },
     {
       "label": "BatchExecutionEngine",
       "file_type": "code",
       "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
-      "source_location": "L8",
-      "id": "batch_batchexecutionengine_batchexecutionengine",
-      "community": 51,
-      "norm_label": "batchexecutionengine"
-    },
-    {
-      "label": ".IsFailure()",
-      "file_type": "code",
-      "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
       "source_location": "L10",
-      "id": "batch_batchexecutionengine_batchexecutionengine_isfailure",
-      "community": 51,
-      "norm_label": ".isfailure()"
+      "id": "batch_batchexecutionengine_batchexecutionengine",
+      "community": 41,
+      "norm_label": "batchexecutionengine"
     },
     {
       "label": ".ExecuteReadsAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
-      "source_location": "L14",
+      "source_location": "L13",
       "id": "batch_batchexecutionengine_batchexecutionengine_executereadsasync",
-      "community": 51,
+      "community": 41,
       "norm_label": ".executereadsasync()"
     },
     {
       "label": ".ApplyWritesAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
-      "source_location": "L30",
+      "source_location": "L28",
       "id": "batch_batchexecutionengine_batchexecutionengine_applywritesasync",
-      "community": 51,
+      "community": 41,
       "norm_label": ".applywritesasync()"
+    },
+    {
+      "label": ".ToOperationResult()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
+      "source_location": "L50",
+      "id": "batch_batchexecutionengine_batchexecutionengine_tooperationresult",
+      "community": 41,
+      "norm_label": ".tooperationresult()"
     },
     {
       "label": "BatchOperationCatalog.cs",
@@ -132,8 +132,8 @@
     {
       "label": "int",
       "file_type": "code",
-      "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
-      "source_location": "L30",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L791",
       "id": "int",
       "community": 10,
       "norm_label": "int"
@@ -243,16 +243,16 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationRequest.cs",
       "source_location": "L1",
       "id": "tiamcpserver_batch_batchoperationrequest_cs",
-      "community": 90,
+      "community": 91,
       "norm_label": "batchoperationrequest.cs"
     },
     {
       "label": "BatchOperationRequest",
       "file_type": "code",
       "source_file": "TiaMcpServer/Batch/BatchOperationRequest.cs",
-      "source_location": "L10",
+      "source_location": "L11",
       "id": "batch_batchoperationrequest_batchoperationrequest",
-      "community": 90,
+      "community": 91,
       "norm_label": "batchoperationrequest"
     },
     {
@@ -261,7 +261,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationResult.cs",
       "source_location": "L1",
       "id": "tiamcpserver_batch_batchoperationresult_cs",
-      "community": 0,
+      "community": 2,
       "norm_label": "batchoperationresult.cs"
     },
     {
@@ -270,7 +270,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationResult.cs",
       "source_location": "L4",
       "id": "batch_batchoperationresult_batchoperationstatus",
-      "community": 0,
+      "community": 2,
       "norm_label": "batchoperationstatus"
     },
     {
@@ -279,7 +279,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L16",
       "id": "string",
-      "community": 0,
+      "community": 2,
       "norm_label": "string"
     },
     {
@@ -288,7 +288,7 @@
       "source_file": "TiaMcpServer/Batch/BatchResultFormatter.cs",
       "source_location": "L1",
       "id": "tiamcpserver_batch_batchresultformatter_cs",
-      "community": 7,
+      "community": 0,
       "norm_label": "batchresultformatter.cs"
     },
     {
@@ -297,16 +297,16 @@
       "source_file": "TiaMcpServer/Batch/BatchResultFormatter.cs",
       "source_location": "L6",
       "id": "batch_batchresultformatter_batchresultformatter",
-      "community": 7,
+      "community": 0,
       "norm_label": "batchresultformatter"
     },
     {
       "label": "JsonSerializerOptions",
       "file_type": "code",
-      "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
-      "source_location": "L12",
+      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_location": "L10",
       "id": "jsonserializeroptions",
-      "community": 7,
+      "community": 0,
       "norm_label": "jsonserializeroptions"
     },
     {
@@ -315,7 +315,7 @@
       "source_file": "TiaMcpServer/Batch/BatchResultFormatter.cs",
       "source_location": "L14",
       "id": "batch_batchresultformatter_batchresultformatter_error",
-      "community": 7,
+      "community": 0,
       "norm_label": ".error()"
     },
     {
@@ -324,7 +324,7 @@
       "source_file": "TiaMcpServer/Batch/BatchResultFormatter.cs",
       "source_location": "L17",
       "id": "batch_batchresultformatter_batchresultformatter_readbatch",
-      "community": 7,
+      "community": 0,
       "norm_label": ".readbatch()"
     },
     {
@@ -333,7 +333,7 @@
       "source_file": "TiaMcpServer/Batch/BatchResultFormatter.cs",
       "source_location": "L33",
       "id": "batch_batchresultformatter_batchresultformatter_applybatch",
-      "community": 7,
+      "community": 0,
       "norm_label": ".applybatch()"
     },
     {
@@ -342,7 +342,7 @@
       "source_file": "TiaMcpServer/Batch/BatchResultFormatter.cs",
       "source_location": "L51",
       "id": "batch_batchresultformatter_batchresultformatter_count",
-      "community": 7,
+      "community": 0,
       "norm_label": ".count()"
     },
     {
@@ -351,7 +351,7 @@
       "source_file": "TiaMcpServer/Batch/BatchResultFormatter.cs",
       "source_location": "L54",
       "id": "batch_batchresultformatter_batchresultformatter_project",
-      "community": 7,
+      "community": 0,
       "norm_label": ".project()"
     },
     {
@@ -360,7 +360,7 @@
       "source_file": "TiaMcpServer/Batch/BatchSafetySnapshot.cs",
       "source_location": "L1",
       "id": "tiamcpserver_batch_batchsafetysnapshot_cs",
-      "community": 0,
+      "community": 2,
       "norm_label": "batchsafetysnapshot.cs"
     },
     {
@@ -369,7 +369,7 @@
       "source_file": "TiaMcpServer/Batch/BatchSafetySnapshot.cs",
       "source_location": "L15",
       "id": "batch_batchsafetysnapshot_batchsafetysnapshot",
-      "community": 0,
+      "community": 2,
       "norm_label": "batchsafetysnapshot"
     },
     {
@@ -378,7 +378,7 @@
       "source_file": "TiaMcpServer/Batch/BatchSafetySnapshot.cs",
       "source_location": "L19",
       "id": "batch_batchsafetysnapshot_batchsafetysnapshot_buildtargets",
-      "community": 0,
+      "community": 2,
       "norm_label": ".buildtargets()"
     },
     {
@@ -387,7 +387,7 @@
       "source_file": "TiaMcpServer/Batch/BatchSafetySnapshot.cs",
       "source_location": "L24",
       "id": "batch_batchsafetysnapshot_batchsafetysnapshot_describeoperation",
-      "community": 0,
+      "community": 2,
       "norm_label": ".describeoperation()"
     },
     {
@@ -396,7 +396,7 @@
       "source_file": "TiaMcpServer/Batch/BatchSafetySnapshot.cs",
       "source_location": "L40",
       "id": "batch_batchsafetysnapshot_batchsafetysnapshot_combinecurrentstate",
-      "community": 0,
+      "community": 2,
       "norm_label": ".combinecurrentstate()"
     },
     {
@@ -405,7 +405,7 @@
       "source_file": "TiaMcpServer/Batch/BatchSafetySnapshot.cs",
       "source_location": "L57",
       "id": "batch_batchsafetysnapshot_batchsafetysnapshot_resolveprojectpath",
-      "community": 0,
+      "community": 2,
       "norm_label": ".resolveprojectpath()"
     },
     {
@@ -414,7 +414,7 @@
       "source_file": "TiaMcpServer/Batch/BatchTools.cs",
       "source_location": "L1",
       "id": "tiamcpserver_batch_batchtools_cs",
-      "community": 0,
+      "community": 2,
       "norm_label": "batchtools.cs"
     },
     {
@@ -423,7 +423,7 @@
       "source_file": "TiaMcpServer/Batch/BatchTools.cs",
       "source_location": "L13",
       "id": "batch_batchtools_batchtools",
-      "community": 0,
+      "community": 2,
       "norm_label": "batchtools"
     },
     {
@@ -432,7 +432,7 @@
       "source_file": "TiaMcpServer/Batch/BatchTools.cs",
       "source_location": "L19",
       "id": "batch_batchtools_batchtools_executereadbatch",
-      "community": 0,
+      "community": 2,
       "norm_label": ".executereadbatch()"
     },
     {
@@ -441,7 +441,7 @@
       "source_file": "TiaMcpServer/Batch/BatchTools.cs",
       "source_location": "L39",
       "id": "batch_batchtools_batchtools_previewwritebatch",
-      "community": 0,
+      "community": 2,
       "norm_label": ".previewwritebatch()"
     },
     {
@@ -450,7 +450,7 @@
       "source_file": "TiaMcpServer/Batch/BatchTools.cs",
       "source_location": "L72",
       "id": "batch_batchtools_batchtools_applywritebatch",
-      "community": 0,
+      "community": 2,
       "norm_label": ".applywritebatch()"
     },
     {
@@ -459,7 +459,7 @@
       "source_file": "TiaMcpServer/Batch/BatchTools.cs",
       "source_location": "L132",
       "id": "batch_batchtools_batchtools_readcombinedcurrentstateasync",
-      "community": 0,
+      "community": 2,
       "norm_label": ".readcombinedcurrentstateasync()"
     },
     {
@@ -513,7 +513,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L1",
       "id": "tiamcpserver_safety_writesafetyservice_cs",
-      "community": 15,
+      "community": 0,
       "norm_label": "writesafetyservice.cs"
     },
     {
@@ -522,7 +522,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L8",
       "id": "safety_writesafetyservice_writesafetyservice",
-      "community": 15,
+      "community": 0,
       "norm_label": "writesafetyservice"
     },
     {
@@ -531,7 +531,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L18",
       "id": "concurrentdictionary",
-      "community": 15,
+      "community": 0,
       "norm_label": "concurrentdictionary"
     },
     {
@@ -540,16 +540,16 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L19",
       "id": "func",
-      "community": 15,
+      "community": 0,
       "norm_label": "func"
     },
     {
       "label": "TimeSpan",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L16",
+      "source_location": "L18",
       "id": "timespan",
-      "community": 15,
+      "community": 0,
       "norm_label": "timespan"
     },
     {
@@ -558,7 +558,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L43",
       "id": "safety_writesafetyservice_writesafetyservice_createpreview",
-      "community": 15,
+      "community": 0,
       "norm_label": ".createpreview()"
     },
     {
@@ -567,7 +567,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L82",
       "id": "safety_writesafetyservice_writesafetyservice_validateandconsume",
-      "community": 15,
+      "community": 0,
       "norm_label": ".validateandconsume()"
     },
     {
@@ -576,7 +576,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L136",
       "id": "safety_writesafetyservice_writesafetyservice_rejected",
-      "community": 15,
+      "community": 0,
       "norm_label": ".rejected()"
     },
     {
@@ -585,7 +585,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L144",
       "id": "safety_writesafetyservice_writesafetyservice_appendaudit",
-      "community": 15,
+      "community": 0,
       "norm_label": ".appendaudit()"
     },
     {
@@ -594,7 +594,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L186",
       "id": "safety_writesafetyservice_writesafetyservice_normalizeprojectpath",
-      "community": 15,
+      "community": 0,
       "norm_label": ".normalizeprojectpath()"
     },
     {
@@ -603,7 +603,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L203",
       "id": "safety_writesafetyservice_writesafetyservice_hashtext",
-      "community": 15,
+      "community": 0,
       "norm_label": ".hashtext()"
     },
     {
@@ -612,7 +612,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L209",
       "id": "safety_writesafetyservice_writesafetyservice_tostablejson",
-      "community": 15,
+      "community": 0,
       "norm_label": ".tostablejson()"
     },
     {
@@ -621,7 +621,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L214",
       "id": "safety_writesafetyservice_writesafetyservice_createtoken",
-      "community": 15,
+      "community": 0,
       "norm_label": ".createtoken()"
     },
     {
@@ -630,7 +630,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L237",
       "id": "safety_writesafetyservice_valid",
-      "community": 15,
+      "community": 0,
       "norm_label": "valid()"
     },
     {
@@ -639,7 +639,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L242",
       "id": "safety_writesafetyservice_invalid",
-      "community": 15,
+      "community": 0,
       "norm_label": "invalid()"
     },
     {
@@ -648,88 +648,88 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
       "source_location": "L1",
       "id": "tiamcpserver_safety_writesafetytooling_cs",
-      "community": 7,
+      "community": 0,
       "norm_label": "writesafetytooling.cs"
     },
     {
       "label": "WriteSafetyTooling",
       "file_type": "code",
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
-      "source_location": "L6",
+      "source_location": "L7",
       "id": "safety_writesafetytooling_writesafetytooling",
-      "community": 7,
+      "community": 0,
       "norm_label": "writesafetytooling"
     },
     {
       "label": ".ValidateForApplyAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
-      "source_location": "L14",
+      "source_location": "L15",
       "id": "safety_writesafetytooling_writesafetytooling_validateforapplyasync",
-      "community": 7,
+      "community": 0,
       "norm_label": ".validateforapplyasync()"
     },
     {
       "label": ".CreatePreview()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
-      "source_location": "L50",
+      "source_location": "L51",
       "id": "safety_writesafetytooling_writesafetytooling_createpreview",
-      "community": 7,
+      "community": 0,
       "norm_label": ".createpreview()"
     },
     {
       "label": ".BuildApplyResult()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
-      "source_location": "L74",
+      "source_location": "L75",
       "id": "safety_writesafetytooling_writesafetytooling_buildapplyresult",
-      "community": 7,
+      "community": 0,
       "norm_label": ".buildapplyresult()"
     },
     {
       "label": ".CreateLineDiff()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
-      "source_location": "L97",
+      "source_location": "L99",
       "id": "safety_writesafetytooling_writesafetytooling_createlinediff",
-      "community": 7,
+      "community": 0,
       "norm_label": ".createlinediff()"
     },
     {
       "label": ".DescribePathState()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
-      "source_location": "L129",
+      "source_location": "L131",
       "id": "safety_writesafetytooling_writesafetytooling_describepathstate",
-      "community": 7,
+      "community": 0,
       "norm_label": ".describepathstate()"
     },
     {
       "label": ".DescribeProjectCreationState()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
-      "source_location": "L163",
+      "source_location": "L165",
       "id": "safety_writesafetytooling_writesafetytooling_describeprojectcreationstate",
-      "community": 7,
+      "community": 0,
       "norm_label": ".describeprojectcreationstate()"
     },
     {
       "label": "Valid()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
-      "source_location": "L179",
+      "source_location": "L181",
       "id": "safety_writesafetytooling_valid",
-      "community": 7,
+      "community": 0,
       "norm_label": "valid()"
     },
     {
       "label": "Invalid()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
-      "source_location": "L184",
+      "source_location": "L186",
       "id": "safety_writesafetytooling_invalid",
-      "community": 7,
+      "community": 0,
       "norm_label": "invalid()"
     },
     {
@@ -882,386 +882,440 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L1",
       "id": "tiamcpserver_worker_opennessworkerclient_cs",
-      "community": 3,
+      "community": 1,
       "norm_label": "opennessworkerclient.cs"
     },
     {
       "label": "OpennessWorkerClient",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L8",
+      "source_location": "L10",
       "id": "worker_opennessworkerclient_opennessworkerclient",
-      "community": 3,
+      "community": 1,
       "norm_label": "opennessworkerclient"
     },
     {
       "label": "ProjectSessionBinding",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L18",
+      "source_location": "L20",
       "id": "projectsessionbinding",
-      "community": 3,
+      "community": 1,
       "norm_label": "projectsessionbinding"
+    },
+    {
+      "label": "ILogger",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L21",
+      "id": "ilogger",
+      "community": 1,
+      "norm_label": "ilogger"
     },
     {
       "label": ".BrowseProjectTreeAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L25",
+      "source_location": "L34",
       "id": "worker_opennessworkerclient_opennessworkerclient_browseprojecttreeasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".browseprojecttreeasync()"
     },
     {
       "label": ".ReadHardwareConfigAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L30",
+      "source_location": "L39",
       "id": "worker_opennessworkerclient_opennessworkerclient_readhardwareconfigasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".readhardwareconfigasync()"
     },
     {
       "label": ".SearchEquipmentCatalogAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L35",
+      "source_location": "L44",
       "id": "worker_opennessworkerclient_opennessworkerclient_searchequipmentcatalogasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".searchequipmentcatalogasync()"
     },
     {
       "label": ".AddNetworkDeviceAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L44",
+      "source_location": "L53",
       "id": "worker_opennessworkerclient_opennessworkerclient_addnetworkdeviceasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".addnetworkdeviceasync()"
     },
     {
       "label": ".ConfigureNetworkDeviceAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L64",
+      "source_location": "L73",
       "id": "worker_opennessworkerclient_opennessworkerclient_configurenetworkdeviceasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".configurenetworkdeviceasync()"
     },
     {
       "label": ".ReadCrossReferencesAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L90",
+      "source_location": "L99",
       "id": "worker_opennessworkerclient_opennessworkerclient_readcrossreferencesasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".readcrossreferencesasync()"
     },
     {
       "label": ".GetBlockContentAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L109",
+      "source_location": "L118",
       "id": "worker_opennessworkerclient_opennessworkerclient_getblockcontentasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".getblockcontentasync()"
     },
     {
       "label": ".UpdateBlockLogicAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L118",
+      "source_location": "L127",
       "id": "worker_opennessworkerclient_opennessworkerclient_updateblocklogicasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".updateblocklogicasync()"
     },
     {
       "label": ".ListTagTablesAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L132",
+      "source_location": "L141",
       "id": "worker_opennessworkerclient_opennessworkerclient_listtagtablesasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".listtagtablesasync()"
     },
     {
       "label": ".CompileCheckAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L141",
+      "source_location": "L150",
       "id": "worker_opennessworkerclient_opennessworkerclient_compilecheckasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".compilecheckasync()"
     },
     {
       "label": ".CreateTagTableAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L154",
+      "source_location": "L163",
       "id": "worker_opennessworkerclient_opennessworkerclient_createtagtableasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".createtagtableasync()"
     },
     {
       "label": ".DeleteTagTableAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L174",
+      "source_location": "L183",
       "id": "worker_opennessworkerclient_opennessworkerclient_deletetagtableasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".deletetagtableasync()"
     },
     {
       "label": ".CreateTagAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L194",
+      "source_location": "L203",
       "id": "worker_opennessworkerclient_opennessworkerclient_createtagasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".createtagasync()"
     },
     {
       "label": ".UpdateTagAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L220",
+      "source_location": "L229",
       "id": "worker_opennessworkerclient_opennessworkerclient_updatetagasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".updatetagasync()"
     },
     {
       "label": ".DeleteTagAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L256",
+      "source_location": "L265",
       "id": "worker_opennessworkerclient_opennessworkerclient_deletetagasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".deletetagasync()"
     },
     {
       "label": ".CreateUserConstantAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L278",
+      "source_location": "L287",
       "id": "worker_opennessworkerclient_opennessworkerclient_createuserconstantasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".createuserconstantasync()"
     },
     {
       "label": ".UpdateUserConstantAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L304",
+      "source_location": "L313",
       "id": "worker_opennessworkerclient_opennessworkerclient_updateuserconstantasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".updateuserconstantasync()"
     },
     {
       "label": ".DeleteUserConstantAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L330",
+      "source_location": "L339",
       "id": "worker_opennessworkerclient_opennessworkerclient_deleteuserconstantasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".deleteuserconstantasync()"
     },
     {
       "label": ".CreateBlockAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L352",
+      "source_location": "L361",
       "id": "worker_opennessworkerclient_opennessworkerclient_createblockasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".createblockasync()"
     },
     {
       "label": ".DeleteBlockAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L374",
+      "source_location": "L383",
       "id": "worker_opennessworkerclient_opennessworkerclient_deleteblockasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".deleteblockasync()"
     },
     {
       "label": ".CreateBlockGroupAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L388",
+      "source_location": "L397",
       "id": "worker_opennessworkerclient_opennessworkerclient_createblockgroupasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".createblockgroupasync()"
     },
     {
       "label": ".DeleteBlockGroupAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L402",
+      "source_location": "L411",
       "id": "worker_opennessworkerclient_opennessworkerclient_deleteblockgroupasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".deleteblockgroupasync()"
     },
     {
       "label": ".StartPlcAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L416",
+      "source_location": "L425",
       "id": "worker_opennessworkerclient_opennessworkerclient_startplcasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".startplcasync()"
     },
     {
       "label": ".StopPlcAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L430",
+      "source_location": "L439",
       "id": "worker_opennessworkerclient_opennessworkerclient_stopplcasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".stopplcasync()"
     },
     {
       "label": ".GetProjectStatusAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L444",
+      "source_location": "L453",
       "id": "worker_opennessworkerclient_opennessworkerclient_getprojectstatusasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".getprojectstatusasync()"
     },
     {
       "label": ".OpenProjectAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L453",
+      "source_location": "L462",
       "id": "worker_opennessworkerclient_opennessworkerclient_openprojectasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".openprojectasync()"
     },
     {
       "label": ".CreateProjectAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L490",
+      "source_location": "L492",
       "id": "worker_opennessworkerclient_opennessworkerclient_createprojectasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".createprojectasync()"
     },
     {
       "label": ".SaveProjectAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L529",
+      "source_location": "L524",
       "id": "worker_opennessworkerclient_opennessworkerclient_saveprojectasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".saveprojectasync()"
     },
     {
       "label": ".SaveProjectAsAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L542",
+      "source_location": "L537",
       "id": "worker_opennessworkerclient_opennessworkerclient_saveprojectasasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".saveprojectasasync()"
     },
     {
       "label": ".ArchiveProjectAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L573",
+      "source_location": "L568",
       "id": "worker_opennessworkerclient_opennessworkerclient_archiveprojectasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".archiveprojectasync()"
     },
     {
       "label": ".CloseProjectAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L600",
+      "source_location": "L595",
       "id": "worker_opennessworkerclient_opennessworkerclient_closeprojectasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".closeprojectasync()"
     },
     {
       "label": ".SendBoundProjectRequestAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L622",
+      "source_location": "L616",
       "id": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".sendboundprojectrequestasync()"
+    },
+    {
+      "label": ".InvokeWorkerAsync()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L640",
+      "id": "worker_opennessworkerclient_opennessworkerclient_invokeworkerasync",
+      "community": 1,
+      "norm_label": ".invokeworkerasync()"
     },
     {
       "label": ".CanBind()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L654",
+      "source_location": "L669",
       "id": "worker_opennessworkerclient_opennessworkerclient_canbind",
-      "community": 3,
+      "community": 1,
       "norm_label": ".canbind()"
-    },
-    {
-      "label": ".FormatWorkerError()",
-      "file_type": "code",
-      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L676",
-      "id": "worker_opennessworkerclient_opennessworkerclient_formatworkererror",
-      "community": 3,
-      "norm_label": ".formatworkererror()"
     },
     {
       "label": ".TryReadProjectPath()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L681",
+      "source_location": "L691",
       "id": "worker_opennessworkerclient_opennessworkerclient_tryreadprojectpath",
-      "community": 3,
+      "community": 1,
       "norm_label": ".tryreadprojectpath()"
     },
     {
       "label": "SemaphoreSlim",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L708",
+      "source_location": "L725",
       "id": "semaphoreslim",
-      "community": 3,
+      "community": 1,
       "norm_label": "semaphoreslim"
     },
     {
       "label": ".SendAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L710",
+      "source_location": "L727",
       "id": "worker_opennessworkerclient_opennessworkerclient_sendasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".sendasync()"
     },
     {
       "label": ".SendUnguardedAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L723",
+      "source_location": "L740",
       "id": "worker_opennessworkerclient_opennessworkerclient_sendunguardedasync",
-      "community": 3,
+      "community": 1,
       "norm_label": ".sendunguardedasync()"
+    },
+    {
+      "label": ".SplitStderrLines()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L793",
+      "id": "worker_opennessworkerclient_opennessworkerclient_splitstderrlines",
+      "community": 1,
+      "norm_label": ".splitstderrlines()"
     },
     {
       "label": ".LocateWorkerExecutable()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L771",
+      "source_location": "L815",
       "id": "worker_opennessworkerclient_opennessworkerclient_locateworkerexecutable",
-      "community": 3,
+      "community": 1,
       "norm_label": ".locateworkerexecutable()"
     },
     {
       "label": ".TryKill()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L806",
+      "source_location": "L850",
       "id": "worker_opennessworkerclient_opennessworkerclient_trykill",
-      "community": 3,
+      "community": 1,
       "norm_label": ".trykill()"
+    },
+    {
+      "label": "WorkerCallResult.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/WorkerCallResult.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_worker_workercallresult_cs",
+      "community": 66,
+      "norm_label": "workercallresult.cs"
+    },
+    {
+      "label": "Ok()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/WorkerCallResult.cs",
+      "source_location": "L15",
+      "id": "worker_workercallresult_ok",
+      "community": 66,
+      "norm_label": "ok()"
+    },
+    {
+      "label": "Fail()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/WorkerCallResult.cs",
+      "source_location": "L18",
+      "id": "worker_workercallresult_fail",
+      "community": 66,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "ToText()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/WorkerCallResult.cs",
+      "source_location": "L22",
+      "id": "worker_workercallresult_totext",
+      "community": 66,
+      "norm_label": "totext()"
     },
     {
       "label": "AddDeviceResultInfo.cs",
@@ -1269,7 +1323,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/AddDeviceResultInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_adddeviceresultinfo_cs",
-      "community": 67,
+      "community": 68,
       "norm_label": "adddeviceresultinfo.cs"
     },
     {
@@ -1278,7 +1332,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/AddDeviceResultInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_adddeviceresultinfo_adddeviceresultinfo",
-      "community": 67,
+      "community": 68,
       "norm_label": "adddeviceresultinfo"
     },
     {
@@ -1287,7 +1341,7 @@
       "source_file": "TiaMcpServer.Contracts/ArchiveModeNames.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_archivemodenames_cs",
-      "community": 0,
+      "community": 2,
       "norm_label": "archivemodenames.cs"
     },
     {
@@ -1296,7 +1350,7 @@
       "source_file": "TiaMcpServer.Contracts/ArchiveModeNames.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_archivemodenames_archivemodenames",
-      "community": 0,
+      "community": 2,
       "norm_label": "archivemodenames"
     },
     {
@@ -1305,7 +1359,7 @@
       "source_file": "TiaMcpServer.Contracts/ArchiveModeNames.cs",
       "source_location": "L10",
       "id": "tiamcpserver_contracts_archivemodenames_archivemodenames_trynormalize",
-      "community": 0,
+      "community": 2,
       "norm_label": ".trynormalize()"
     },
     {
@@ -1386,7 +1440,7 @@
       "source_file": "TiaMcpServer.Contracts/BlockMutationResultInfo.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_blockmutationresultinfo_cs",
-      "community": 91,
+      "community": 92,
       "norm_label": "blockmutationresultinfo.cs"
     },
     {
@@ -1395,7 +1449,7 @@
       "source_file": "TiaMcpServer.Contracts/BlockMutationResultInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_blockmutationresultinfo_blockmutationresultinfo",
-      "community": 91,
+      "community": 92,
       "norm_label": "blockmutationresultinfo"
     },
     {
@@ -1404,7 +1458,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CatalogEntryInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_catalogentryinfo_cs",
-      "community": 68,
+      "community": 69,
       "norm_label": "catalogentryinfo.cs"
     },
     {
@@ -1413,7 +1467,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CatalogEntryInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_catalogentryinfo_catalogentryinfo",
-      "community": 68,
+      "community": 69,
       "norm_label": "catalogentryinfo"
     },
     {
@@ -1458,7 +1512,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CompileCheckReport.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_compilecheckreport_cs",
-      "community": 69,
+      "community": 70,
       "norm_label": "compilecheckreport.cs"
     },
     {
@@ -1467,7 +1521,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CompileCheckReport.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_compilecheckreport_compilecheckreport",
-      "community": 69,
+      "community": 70,
       "norm_label": "compilecheckreport"
     },
     {
@@ -1476,7 +1530,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CompileMessageInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_compilemessageinfo_cs",
-      "community": 70,
+      "community": 71,
       "norm_label": "compilemessageinfo.cs"
     },
     {
@@ -1485,7 +1539,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CompileMessageInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_compilemessageinfo_compilemessageinfo",
-      "community": 70,
+      "community": 71,
       "norm_label": "compilemessageinfo"
     },
     {
@@ -1494,7 +1548,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/ConfigureNetworkDeviceResultInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_configurenetworkdeviceresultinfo_cs",
-      "community": 71,
+      "community": 72,
       "norm_label": "configurenetworkdeviceresultinfo.cs"
     },
     {
@@ -1503,7 +1557,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/ConfigureNetworkDeviceResultInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_configurenetworkdeviceresultinfo_configurenetworkdeviceresultinfo",
-      "community": 71,
+      "community": 72,
       "norm_label": "configurenetworkdeviceresultinfo"
     },
     {
@@ -1512,7 +1566,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceFilterNames.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_crossreferencefilternames_cs",
-      "community": 66,
+      "community": 67,
       "norm_label": "crossreferencefilternames.cs"
     },
     {
@@ -1521,7 +1575,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceFilterNames.cs",
       "source_location": "L6",
       "id": "tiamcpserver_contracts_crossreferencefilternames_crossreferencefilternames",
-      "community": 66,
+      "community": 67,
       "norm_label": "crossreferencefilternames"
     },
     {
@@ -1530,7 +1584,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceFilterNames.cs",
       "source_location": "L23",
       "id": "tiamcpserver_contracts_crossreferencefilternames_crossreferencefilternames_trynormalize",
-      "community": 66,
+      "community": 67,
       "norm_label": ".trynormalize()"
     },
     {
@@ -1539,7 +1593,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceLocationInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_crossreferencelocationinfo_cs",
-      "community": 72,
+      "community": 73,
       "norm_label": "crossreferencelocationinfo.cs"
     },
     {
@@ -1548,7 +1602,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceLocationInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_crossreferencelocationinfo_crossreferencelocationinfo",
-      "community": 72,
+      "community": 73,
       "norm_label": "crossreferencelocationinfo"
     },
     {
@@ -1557,7 +1611,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceReport.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_crossreferencereport_cs",
-      "community": 73,
+      "community": 74,
       "norm_label": "crossreferencereport.cs"
     },
     {
@@ -1566,7 +1620,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceReport.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_crossreferencereport_crossreferencereport",
-      "community": 73,
+      "community": 74,
       "norm_label": "crossreferencereport"
     },
     {
@@ -1575,7 +1629,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceSourceInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_crossreferencesourceinfo_cs",
-      "community": 74,
+      "community": 75,
       "norm_label": "crossreferencesourceinfo.cs"
     },
     {
@@ -1584,7 +1638,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceSourceInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_crossreferencesourceinfo_crossreferencesourceinfo",
-      "community": 74,
+      "community": 75,
       "norm_label": "crossreferencesourceinfo"
     },
     {
@@ -1593,7 +1647,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceTargetInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_crossreferencetargetinfo_cs",
-      "community": 75,
+      "community": 76,
       "norm_label": "crossreferencetargetinfo.cs"
     },
     {
@@ -1602,61 +1656,61 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceTargetInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_crossreferencetargetinfo_crossreferencetargetinfo",
-      "community": 75,
+      "community": 76,
       "norm_label": "crossreferencetargetinfo"
     },
     {
       "label": "DeviceInfo.cs",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/DeviceInfo.cs",
+      "source_file": "TiaMcpServer.Contracts/DeviceInfo.cs",
       "source_location": "L1",
-      "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_deviceinfo_cs",
-      "community": 76,
+      "id": "tiamcpserver_contracts_deviceinfo_cs",
+      "community": 77,
       "norm_label": "deviceinfo.cs"
     },
     {
       "label": "DeviceInfo",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/DeviceInfo.cs",
+      "source_file": "TiaMcpServer.Contracts/DeviceInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_deviceinfo_deviceinfo",
-      "community": 76,
+      "community": 77,
       "norm_label": "deviceinfo"
     },
     {
       "label": "DeviceItemInfo.cs",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/DeviceItemInfo.cs",
+      "source_file": "TiaMcpServer.Contracts/DeviceItemInfo.cs",
       "source_location": "L1",
-      "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_deviceiteminfo_cs",
-      "community": 77,
+      "id": "tiamcpserver_contracts_deviceiteminfo_cs",
+      "community": 78,
       "norm_label": "deviceiteminfo.cs"
     },
     {
       "label": "DeviceItemInfo",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/DeviceItemInfo.cs",
+      "source_file": "TiaMcpServer.Contracts/DeviceItemInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_deviceiteminfo_deviceiteminfo",
-      "community": 77,
+      "community": 78,
       "norm_label": "deviceiteminfo"
     },
     {
       "label": "HardwareConfigInfo.cs",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/HardwareConfigInfo.cs",
+      "source_file": "TiaMcpServer.Contracts/HardwareConfigInfo.cs",
       "source_location": "L1",
-      "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_hardwareconfiginfo_cs",
-      "community": 78,
+      "id": "tiamcpserver_contracts_hardwareconfiginfo_cs",
+      "community": 79,
       "norm_label": "hardwareconfiginfo.cs"
     },
     {
       "label": "HardwareConfigInfo",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/HardwareConfigInfo.cs",
+      "source_file": "TiaMcpServer.Contracts/HardwareConfigInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_hardwareconfiginfo_hardwareconfiginfo",
-      "community": 78,
+      "community": 79,
       "norm_label": "hardwareconfiginfo"
     },
     {
@@ -1665,7 +1719,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/IoSystemInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_iosysteminfo_cs",
-      "community": 79,
+      "community": 80,
       "norm_label": "iosysteminfo.cs"
     },
     {
@@ -1674,7 +1728,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/IoSystemInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_iosysteminfo_iosysteminfo",
-      "community": 79,
+      "community": 80,
       "norm_label": "iosysteminfo"
     },
     {
@@ -1683,7 +1737,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/NetworkInterfaceInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_networkinterfaceinfo_cs",
-      "community": 80,
+      "community": 81,
       "norm_label": "networkinterfaceinfo.cs"
     },
     {
@@ -1692,7 +1746,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/NetworkInterfaceInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_networkinterfaceinfo_networkinterfaceinfo",
-      "community": 80,
+      "community": 81,
       "norm_label": "networkinterfaceinfo"
     },
     {
@@ -1701,7 +1755,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/NodeInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_nodeinfo_cs",
-      "community": 81,
+      "community": 82,
       "norm_label": "nodeinfo.cs"
     },
     {
@@ -1710,7 +1764,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/NodeInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_nodeinfo_nodeinfo",
-      "community": 81,
+      "community": 82,
       "norm_label": "nodeinfo"
     },
     {
@@ -1719,7 +1773,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/PlcCompileInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_plccompileinfo_cs",
-      "community": 82,
+      "community": 83,
       "norm_label": "plccompileinfo.cs"
     },
     {
@@ -1728,7 +1782,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/PlcCompileInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_plccompileinfo_plccompileinfo",
-      "community": 82,
+      "community": 83,
       "norm_label": "plccompileinfo"
     },
     {
@@ -1737,7 +1791,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/PlcCrossReferenceInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_plccrossreferenceinfo_cs",
-      "community": 83,
+      "community": 84,
       "norm_label": "plccrossreferenceinfo.cs"
     },
     {
@@ -1746,7 +1800,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/PlcCrossReferenceInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_plccrossreferenceinfo_plccrossreferenceinfo",
-      "community": 83,
+      "community": 84,
       "norm_label": "plccrossreferenceinfo"
     },
     {
@@ -1755,7 +1809,7 @@
       "source_file": "TiaMcpServer.Contracts/PlcOnlineResultInfo.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_plconlineresultinfo_cs",
-      "community": 92,
+      "community": 93,
       "norm_label": "plconlineresultinfo.cs"
     },
     {
@@ -1764,7 +1818,7 @@
       "source_file": "TiaMcpServer.Contracts/PlcOnlineResultInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_plconlineresultinfo_plconlineresultinfo",
-      "community": 92,
+      "community": 93,
       "norm_label": "plconlineresultinfo"
     },
     {
@@ -1773,7 +1827,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectLifecycleResultInfo.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_projectlifecycleresultinfo_cs",
-      "community": 93,
+      "community": 94,
       "norm_label": "projectlifecycleresultinfo.cs"
     },
     {
@@ -1782,7 +1836,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectLifecycleResultInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_projectlifecycleresultinfo_projectlifecycleresultinfo",
-      "community": 93,
+      "community": 94,
       "norm_label": "projectlifecycleresultinfo"
     },
     {
@@ -1791,7 +1845,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectSessionBinding.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_projectsessionbinding_cs",
-      "community": 0,
+      "community": 2,
       "norm_label": "projectsessionbinding.cs"
     },
     {
@@ -1800,7 +1854,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectSessionBinding.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_projectsessionbinding_projectsessionbinding",
-      "community": 0,
+      "community": 2,
       "norm_label": "projectsessionbinding"
     },
     {
@@ -1809,7 +1863,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectSessionBinding.cs",
       "source_location": "L16",
       "id": "tiamcpserver_contracts_projectsessionbinding_projectsessionbinding_tryresolve",
-      "community": 0,
+      "community": 2,
       "norm_label": ".tryresolve()"
     },
     {
@@ -1818,7 +1872,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectSessionBinding.cs",
       "source_location": "L46",
       "id": "tiamcpserver_contracts_projectsessionbinding_projectsessionbinding_bind",
-      "community": 0,
+      "community": 2,
       "norm_label": ".bind()"
     },
     {
@@ -1827,7 +1881,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectSessionBinding.cs",
       "source_location": "L70",
       "id": "tiamcpserver_contracts_projectsessionbinding_projectsessionbinding_clear",
-      "community": 0,
+      "community": 2,
       "norm_label": ".clear()"
     },
     {
@@ -1836,7 +1890,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectSessionBinding.cs",
       "source_location": "L87",
       "id": "tiamcpserver_contracts_projectsessionbinding_projectsessionbinding_normalize",
-      "community": 0,
+      "community": 2,
       "norm_label": ".normalize()"
     },
     {
@@ -1845,7 +1899,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectStatusInfo.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_projectstatusinfo_cs",
-      "community": 94,
+      "community": 95,
       "norm_label": "projectstatusinfo.cs"
     },
     {
@@ -1854,7 +1908,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectStatusInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_projectstatusinfo_projectstatusinfo",
-      "community": 94,
+      "community": 95,
       "norm_label": "projectstatusinfo"
     },
     {
@@ -1863,7 +1917,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/ProjectTreeNode.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_projecttreenode_cs",
-      "community": 84,
+      "community": 85,
       "norm_label": "projecttreenode.cs"
     },
     {
@@ -1872,7 +1926,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/ProjectTreeNode.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_projecttreenode_projecttreenode",
-      "community": 84,
+      "community": 85,
       "norm_label": "projecttreenode"
     },
     {
@@ -1881,7 +1935,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/SubnetInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_subnetinfo_cs",
-      "community": 85,
+      "community": 86,
       "norm_label": "subnetinfo.cs"
     },
     {
@@ -1890,7 +1944,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/SubnetInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_subnetinfo_subnetinfo",
-      "community": 85,
+      "community": 86,
       "norm_label": "subnetinfo"
     },
     {
@@ -1899,7 +1953,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/TagInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_taginfo_cs",
-      "community": 86,
+      "community": 87,
       "norm_label": "taginfo.cs"
     },
     {
@@ -1908,7 +1962,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/TagInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_taginfo_taginfo",
-      "community": 86,
+      "community": 87,
       "norm_label": "taginfo"
     },
     {
@@ -1917,7 +1971,7 @@
       "source_file": "TiaMcpServer.Contracts/TagMutationResultInfo.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_tagmutationresultinfo_cs",
-      "community": 95,
+      "community": 96,
       "norm_label": "tagmutationresultinfo.cs"
     },
     {
@@ -1926,7 +1980,7 @@
       "source_file": "TiaMcpServer.Contracts/TagMutationResultInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_tagmutationresultinfo_tagmutationresultinfo",
-      "community": 95,
+      "community": 96,
       "norm_label": "tagmutationresultinfo"
     },
     {
@@ -1935,7 +1989,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/TagTableInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_tagtableinfo_cs",
-      "community": 87,
+      "community": 88,
       "norm_label": "tagtableinfo.cs"
     },
     {
@@ -1944,7 +1998,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/TagTableInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_tagtableinfo_tagtableinfo",
-      "community": 87,
+      "community": 88,
       "norm_label": "tagtableinfo"
     },
     {
@@ -1953,7 +2007,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/UserConstantInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_userconstantinfo_cs",
-      "community": 88,
+      "community": 89,
       "norm_label": "userconstantinfo.cs"
     },
     {
@@ -1962,7 +2016,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/UserConstantInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_userconstantinfo_userconstantinfo",
-      "community": 88,
+      "community": 89,
       "norm_label": "userconstantinfo"
     },
     {
@@ -1971,7 +2025,7 @@
       "source_file": "TiaMcpServer.Contracts/WorkerRequest.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_workerrequest_cs",
-      "community": 96,
+      "community": 97,
       "norm_label": "workerrequest.cs"
     },
     {
@@ -1980,7 +2034,7 @@
       "source_file": "TiaMcpServer.Contracts/WorkerRequest.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_workerrequest_workerrequest",
-      "community": 96,
+      "community": 97,
       "norm_label": "workerrequest"
     },
     {
@@ -1989,7 +2043,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/WorkerResponse.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_workerresponse_cs",
-      "community": 89,
+      "community": 90,
       "norm_label": "workerresponse.cs"
     },
     {
@@ -1998,8 +2052,17 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/WorkerResponse.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_workerresponse_workerresponse",
-      "community": 89,
+      "community": 90,
       "norm_label": "workerresponse"
+    },
+    {
+      "label": "Program.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.FakeWorker/Program.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_fakeworker_program_cs",
+      "community": 99,
+      "norm_label": "program.cs"
     },
     {
       "label": "Program.cs",
@@ -2007,7 +2070,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_program_cs",
-      "community": 2,
+      "community": 4,
       "norm_label": "program.cs"
     },
     {
@@ -2016,7 +2079,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L10",
       "id": "tiamcpserver_opennessworker_program_program",
-      "community": 2,
+      "community": 4,
       "norm_label": "program"
     },
     {
@@ -2025,7 +2088,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L21",
       "id": "workertiaportalsession",
-      "community": 2,
+      "community": 4,
       "norm_label": "workertiaportalsession"
     },
     {
@@ -2034,7 +2097,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L28",
       "id": "tiamcpserver_opennessworker_program_program_main",
-      "community": 2,
+      "community": 4,
       "norm_label": ".main()"
     },
     {
@@ -2043,7 +2106,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L42",
       "id": "tiamcpserver_opennessworker_program_program_handleline",
-      "community": 2,
+      "community": 4,
       "norm_label": ".handleline()"
     },
     {
@@ -2052,7 +2115,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L99",
       "id": "tiamcpserver_opennessworker_program_program_browseprojecttree",
-      "community": 2,
+      "community": 4,
       "norm_label": ".browseprojecttree()"
     },
     {
@@ -2061,7 +2124,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L104",
       "id": "tiamcpserver_opennessworker_program_program_readhardwareconfig",
-      "community": 2,
+      "community": 4,
       "norm_label": ".readhardwareconfig()"
     },
     {
@@ -2070,7 +2133,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L109",
       "id": "tiamcpserver_opennessworker_program_program_searchequipmentcatalog",
-      "community": 2,
+      "community": 4,
       "norm_label": ".searchequipmentcatalog()"
     },
     {
@@ -2079,7 +2142,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L134",
       "id": "tiamcpserver_opennessworker_program_program_addnetworkdevice",
-      "community": 2,
+      "community": 4,
       "norm_label": ".addnetworkdevice()"
     },
     {
@@ -2088,7 +2151,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L158",
       "id": "tiamcpserver_opennessworker_program_program_configurenetworkdevice",
-      "community": 2,
+      "community": 4,
       "norm_label": ".configurenetworkdevice()"
     },
     {
@@ -2097,7 +2160,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L180",
       "id": "tiamcpserver_opennessworker_program_program_readcrossreferences",
-      "community": 2,
+      "community": 4,
       "norm_label": ".readcrossreferences()"
     },
     {
@@ -2106,7 +2169,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L193",
       "id": "tiamcpserver_opennessworker_program_program_getblockcontent",
-      "community": 2,
+      "community": 4,
       "norm_label": ".getblockcontent()"
     },
     {
@@ -2115,7 +2178,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L203",
       "id": "tiamcpserver_opennessworker_program_program_updateblocklogic",
-      "community": 2,
+      "community": 4,
       "norm_label": ".updateblocklogic()"
     },
     {
@@ -2124,7 +2187,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L218",
       "id": "tiamcpserver_opennessworker_program_program_listtagtables",
-      "community": 2,
+      "community": 4,
       "norm_label": ".listtagtables()"
     },
     {
@@ -2133,7 +2196,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L223",
       "id": "tiamcpserver_opennessworker_program_program_compilecheck",
-      "community": 2,
+      "community": 4,
       "norm_label": ".compilecheck()"
     },
     {
@@ -2142,7 +2205,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L228",
       "id": "tiamcpserver_opennessworker_program_program_createtagtable",
-      "community": 2,
+      "community": 4,
       "norm_label": ".createtagtable()"
     },
     {
@@ -2151,7 +2214,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L234",
       "id": "tiamcpserver_opennessworker_program_program_deletetagtable",
-      "community": 2,
+      "community": 4,
       "norm_label": ".deletetagtable()"
     },
     {
@@ -2160,7 +2223,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L240",
       "id": "tiamcpserver_opennessworker_program_program_createtag",
-      "community": 2,
+      "community": 4,
       "norm_label": ".createtag()"
     },
     {
@@ -2169,7 +2232,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L253",
       "id": "tiamcpserver_opennessworker_program_program_updatetag",
-      "community": 2,
+      "community": 4,
       "norm_label": ".updatetag()"
     },
     {
@@ -2178,7 +2241,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L271",
       "id": "tiamcpserver_opennessworker_program_program_deletetag",
-      "community": 2,
+      "community": 4,
       "norm_label": ".deletetag()"
     },
     {
@@ -2187,7 +2250,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L282",
       "id": "tiamcpserver_opennessworker_program_program_createuserconstant",
-      "community": 2,
+      "community": 4,
       "norm_label": ".createuserconstant()"
     },
     {
@@ -2196,7 +2259,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L295",
       "id": "tiamcpserver_opennessworker_program_program_updateuserconstant",
-      "community": 2,
+      "community": 4,
       "norm_label": ".updateuserconstant()"
     },
     {
@@ -2205,7 +2268,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L308",
       "id": "tiamcpserver_opennessworker_program_program_deleteuserconstant",
-      "community": 2,
+      "community": 4,
       "norm_label": ".deleteuserconstant()"
     },
     {
@@ -2214,7 +2277,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L319",
       "id": "tiamcpserver_opennessworker_program_program_createblock",
-      "community": 2,
+      "community": 4,
       "norm_label": ".createblock()"
     },
     {
@@ -2223,7 +2286,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L345",
       "id": "tiamcpserver_opennessworker_program_program_deleteblock",
-      "community": 2,
+      "community": 4,
       "norm_label": ".deleteblock()"
     },
     {
@@ -2232,7 +2295,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L361",
       "id": "tiamcpserver_opennessworker_program_program_createblockgroup",
-      "community": 2,
+      "community": 4,
       "norm_label": ".createblockgroup()"
     },
     {
@@ -2241,7 +2304,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L377",
       "id": "tiamcpserver_opennessworker_program_program_deleteblockgroup",
-      "community": 2,
+      "community": 4,
       "norm_label": ".deleteblockgroup()"
     },
     {
@@ -2250,7 +2313,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L393",
       "id": "tiamcpserver_opennessworker_program_program_startplc",
-      "community": 2,
+      "community": 4,
       "norm_label": ".startplc()"
     },
     {
@@ -2259,7 +2322,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L404",
       "id": "tiamcpserver_opennessworker_program_program_stopplc",
-      "community": 2,
+      "community": 4,
       "norm_label": ".stopplc()"
     },
     {
@@ -2268,7 +2331,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L415",
       "id": "tiamcpserver_opennessworker_program_program_getprojectstatus",
-      "community": 2,
+      "community": 4,
       "norm_label": ".getprojectstatus()"
     },
     {
@@ -2277,7 +2340,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L429",
       "id": "tiamcpserver_opennessworker_program_program_openproject",
-      "community": 2,
+      "community": 4,
       "norm_label": ".openproject()"
     },
     {
@@ -2286,7 +2349,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L442",
       "id": "tiamcpserver_opennessworker_program_program_createproject",
-      "community": 2,
+      "community": 4,
       "norm_label": ".createproject()"
     },
     {
@@ -2295,7 +2358,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L455",
       "id": "tiamcpserver_opennessworker_program_program_saveproject",
-      "community": 2,
+      "community": 4,
       "norm_label": ".saveproject()"
     },
     {
@@ -2304,7 +2367,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L463",
       "id": "tiamcpserver_opennessworker_program_program_saveprojectas",
-      "community": 2,
+      "community": 4,
       "norm_label": ".saveprojectas()"
     },
     {
@@ -2313,7 +2376,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L476",
       "id": "tiamcpserver_opennessworker_program_program_archiveproject",
-      "community": 2,
+      "community": 4,
       "norm_label": ".archiveproject()"
     },
     {
@@ -2322,7 +2385,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L490",
       "id": "tiamcpserver_opennessworker_program_program_closeproject",
-      "community": 2,
+      "community": 4,
       "norm_label": ".closeproject()"
     },
     {
@@ -2331,7 +2394,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L498",
       "id": "tiamcpserver_opennessworker_program_program_tagmutation",
-      "community": 2,
+      "community": 4,
       "norm_label": ".tagmutation()"
     },
     {
@@ -2340,7 +2403,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L508",
       "id": "tiamcpserver_opennessworker_program_program_projectlifecycle",
-      "community": 2,
+      "community": 4,
       "norm_label": ".projectlifecycle()"
     },
     {
@@ -2349,7 +2412,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L522",
       "id": "tiamcpserver_opennessworker_program_program_withproject",
-      "community": 2,
+      "community": 4,
       "norm_label": ".withproject()"
     },
     {
@@ -2358,7 +2421,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L543",
       "id": "tiamcpserver_opennessworker_program_program_withsession",
-      "community": 2,
+      "community": 4,
       "norm_label": ".withsession()"
     },
     {
@@ -2367,7 +2430,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L549",
       "id": "tiamcpserver_opennessworker_program_program_execute",
-      "community": 2,
+      "community": 4,
       "norm_label": ".execute()"
     },
     {
@@ -2376,7 +2439,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L573",
       "id": "tiamcpserver_opennessworker_program_program_success",
-      "community": 2,
+      "community": 4,
       "norm_label": ".success()"
     },
     {
@@ -2385,7 +2448,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L582",
       "id": "tiamcpserver_opennessworker_program_program_rawpayload",
-      "community": 2,
+      "community": 4,
       "norm_label": ".rawpayload()"
     },
     {
@@ -2394,7 +2457,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L591",
       "id": "tiamcpserver_opennessworker_program_program_failure",
-      "community": 2,
+      "community": 4,
       "norm_label": ".failure()"
     },
     {
@@ -2403,7 +2466,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_assemblyresolver_cs",
-      "community": 32,
+      "community": 34,
       "norm_label": "assemblyresolver.cs"
     },
     {
@@ -2412,7 +2475,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
       "source_location": "L10",
       "id": "openness_assemblyresolver_assemblyresolver",
-      "community": 32,
+      "community": 34,
       "norm_label": "assemblyresolver"
     },
     {
@@ -2421,7 +2484,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
       "source_location": "L24",
       "id": "openness_assemblyresolver_assemblyresolver_register",
-      "community": 32,
+      "community": 34,
       "norm_label": ".register()"
     },
     {
@@ -2430,7 +2493,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
       "source_location": "L30",
       "id": "openness_assemblyresolver_assemblyresolver_onassemblyresolve",
-      "community": 32,
+      "community": 34,
       "norm_label": ".onassemblyresolve()"
     },
     {
@@ -2439,7 +2502,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
       "source_location": "L58",
       "id": "openness_assemblyresolver_assemblyresolver_getopennessinstallpath",
-      "community": 32,
+      "community": 34,
       "norm_label": ".getopennessinstallpath()"
     },
     {
@@ -2448,7 +2511,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
       "source_location": "L115",
       "id": "openness_assemblyresolver_assemblyresolver_containsrequiredassemblies",
-      "community": 32,
+      "community": 34,
       "norm_label": ".containsrequiredassemblies()"
     },
     {
@@ -2493,7 +2556,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_blockimporter_cs",
-      "community": 0,
+      "community": 2,
       "norm_label": "blockimporter.cs"
     },
     {
@@ -2502,7 +2565,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L8",
       "id": "openness_blockimporter_blockimporter",
-      "community": 0,
+      "community": 2,
       "norm_label": "blockimporter"
     },
     {
@@ -2511,7 +2574,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L12",
       "id": "openness_blockimporter_blockimporter_import",
-      "community": 0,
+      "community": 2,
       "norm_label": ".import()"
     },
     {
@@ -2520,7 +2583,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L77",
       "id": "openness_blockimporter_blockimporter_isxmlcontent",
-      "community": 0,
+      "community": 2,
       "norm_label": ".isxmlcontent()"
     },
     {
@@ -2529,7 +2592,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L85",
       "id": "openness_blockimporter_blockimporter_writecontenttotempdir",
-      "community": 0,
+      "community": 2,
       "norm_label": ".writecontenttotempdir()"
     },
     {
@@ -2538,7 +2601,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L115",
       "id": "openness_blockimporter_blockimporter_extractfilename",
-      "community": 0,
+      "community": 2,
       "norm_label": ".extractfilename()"
     },
     {
@@ -2547,7 +2610,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L127",
       "id": "openness_blockimporter_blockimporter_flushsection",
-      "community": 0,
+      "community": 2,
       "norm_label": ".flushsection()"
     },
     {
@@ -2556,7 +2619,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_blockmutationservice_cs",
-      "community": 18,
+      "community": 17,
       "norm_label": "blockmutationservice.cs"
     },
     {
@@ -2565,7 +2628,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L11",
       "id": "openness_blockmutationservice_blockmutationservice",
-      "community": 18,
+      "community": 17,
       "norm_label": "blockmutationservice"
     },
     {
@@ -2574,7 +2637,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L13",
       "id": "openness_blockmutationservice_blockmutationservice_createblock",
-      "community": 18,
+      "community": 17,
       "norm_label": ".createblock()"
     },
     {
@@ -2583,7 +2646,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L49",
       "id": "openness_blockmutationservice_blockmutationservice_deleteblock",
-      "community": 18,
+      "community": 17,
       "norm_label": ".deleteblock()"
     },
     {
@@ -2592,7 +2655,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L72",
       "id": "openness_blockmutationservice_blockmutationservice_createblockgroup",
-      "community": 18,
+      "community": 17,
       "norm_label": ".createblockgroup()"
     },
     {
@@ -2601,7 +2664,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L89",
       "id": "openness_blockmutationservice_blockmutationservice_deleteblockgroup",
-      "community": 18,
+      "community": 17,
       "norm_label": ".deleteblockgroup()"
     },
     {
@@ -2610,7 +2673,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L112",
       "id": "openness_blockmutationservice_blockmutationservice_resolvegroupfromaddress",
-      "community": 18,
+      "community": 17,
       "norm_label": ".resolvegroupfromaddress()"
     },
     {
@@ -2619,7 +2682,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L124",
       "id": "openness_blockmutationservice_blockmutationservice_findgroupbypath",
-      "community": 18,
+      "community": 17,
       "norm_label": ".findgroupbypath()"
     },
     {
@@ -2628,7 +2691,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L151",
       "id": "openness_blockmutationservice_blockmutationservice_findusergroupbypath",
-      "community": 18,
+      "community": 17,
       "norm_label": ".findusergroupbypath()"
     },
     {
@@ -2637,7 +2700,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L179",
       "id": "openness_blockmutationservice_blockmutationservice_importblockfromxml",
-      "community": 18,
+      "community": 17,
       "norm_label": ".importblockfromxml()"
     },
     {
@@ -2646,7 +2709,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L205",
       "id": "openness_blockmutationservice_blockmutationservice_generateblockxml",
-      "community": 18,
+      "community": 17,
       "norm_label": ".generateblockxml()"
     },
     {
@@ -2655,7 +2718,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L290",
       "id": "openness_blockmutationservice_blockmutationservice_generatefbxml",
-      "community": 18,
+      "community": 17,
       "norm_label": ".generatefbxml()"
     },
     {
@@ -2664,7 +2727,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L334",
       "id": "openness_blockmutationservice_blockmutationservice_toprogramminglanguagexml",
-      "community": 18,
+      "community": 17,
       "norm_label": ".toprogramminglanguagexml()"
     },
     {
@@ -2673,7 +2736,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_blocktargetresolver_cs",
-      "community": 19,
+      "community": 18,
       "norm_label": "blocktargetresolver.cs"
     },
     {
@@ -2682,7 +2745,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L11",
       "id": "openness_blocktargetresolver_blocktargetresolver",
-      "community": 19,
+      "community": 18,
       "norm_label": "blocktargetresolver"
     },
     {
@@ -2691,7 +2754,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L13",
       "id": "openness_blocktargetresolver_blocktargetresolver_resolveforexport",
-      "community": 19,
+      "community": 18,
       "norm_label": ".resolveforexport()"
     },
     {
@@ -2700,7 +2763,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L41",
       "id": "openness_blocktargetresolver_blocktargetresolver_resolveforimport",
-      "community": 19,
+      "community": 18,
       "norm_label": ".resolveforimport()"
     },
     {
@@ -2709,7 +2772,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L64",
       "id": "openness_blocktargetresolver_blocktargetresolver_resolvedeterministicblockgroup",
-      "community": 19,
+      "community": 18,
       "norm_label": ".resolvedeterministicblockgroup()"
     },
     {
@@ -2718,7 +2781,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L73",
       "id": "openness_blocktargetresolver_blocktargetresolver_findsoftwareunit",
-      "community": 19,
+      "community": 18,
       "norm_label": ".findsoftwareunit()"
     },
     {
@@ -2727,7 +2790,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L92",
       "id": "openness_blocktargetresolver_blocktargetresolver_findblockgroup",
-      "community": 19,
+      "community": 18,
       "norm_label": ".findblockgroup()"
     },
     {
@@ -2736,7 +2799,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L114",
       "id": "openness_blocktargetresolver_blocktargetresolver_findlegacymatches",
-      "community": 19,
+      "community": 18,
       "norm_label": ".findlegacymatches()"
     },
     {
@@ -2745,7 +2808,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L131",
       "id": "openness_blocktargetresolver_blocktargetresolver_collectmatches",
-      "community": 19,
+      "community": 18,
       "norm_label": ".collectmatches()"
     },
     {
@@ -2754,7 +2817,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L146",
       "id": "openness_blocktargetresolver_resolvedblocktarget",
-      "community": 19,
+      "community": 18,
       "norm_label": "resolvedblocktarget"
     },
     {
@@ -2994,119 +3057,101 @@
     {
       "label": "EquipmentCatalogSearcher.cs",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L1",
-      "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_equipmentcatalogsearcher_cs",
-      "community": 16,
+      "id": "tiamcpserver_opennessworker_openness_equipmentcatalogsearcher_cs",
+      "community": 15,
       "norm_label": "equipmentcatalogsearcher.cs"
     },
     {
       "label": "EquipmentCatalogSearcher",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
-      "source_location": "L11",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L10",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher",
-      "community": 16,
+      "community": 15,
       "norm_label": "equipmentcatalogsearcher"
     },
     {
       "label": ".Search()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
-      "source_location": "L28",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L27",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_search",
-      "community": 16,
+      "community": 15,
       "norm_label": ".search()"
     },
     {
       "label": ".AddMatchesFromHardwareCatalogFind()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
-      "source_location": "L61",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L56",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_addmatchesfromhardwarecatalogfind",
-      "community": 16,
+      "community": 15,
       "norm_label": ".addmatchesfromhardwarecatalogfind()"
     },
     {
       "label": ".FindCatalogRoots()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
-      "source_location": "L81",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L76",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_findcatalogroots",
-      "community": 16,
+      "community": 15,
       "norm_label": ".findcatalogroots()"
     },
     {
       "label": ".Traverse()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
-      "source_location": "L108",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L103",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_traverse",
-      "community": 16,
+      "community": 15,
       "norm_label": ".traverse()"
     },
     {
       "label": ".AddMatch()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
-      "source_location": "L148",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L143",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_addmatch",
-      "community": 16,
+      "community": 15,
       "norm_label": ".addmatch()"
     },
     {
       "label": ".HasReadableProperty()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
-      "source_location": "L201",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L196",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_hasreadableproperty",
-      "community": 16,
+      "community": 15,
       "norm_label": ".hasreadableproperty()"
     },
     {
       "label": ".AppendPath()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
-      "source_location": "L206",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L201",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_appendpath",
-      "community": 16,
+      "community": 15,
       "norm_label": ".appendpath()"
     },
     {
       "label": ".Contains()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
-      "source_location": "L213",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L208",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_contains",
-      "community": 16,
+      "community": 15,
       "norm_label": ".contains()"
     },
     {
       "label": ".ReadStringProperty()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
-      "source_location": "L218",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L213",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_readstringproperty",
-      "community": 16,
+      "community": 15,
       "norm_label": ".readstringproperty()"
-    },
-    {
-      "label": ".ReadProperty()",
-      "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
-      "source_location": "L223",
-      "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_readproperty",
-      "community": 16,
-      "norm_label": ".readproperty()"
-    },
-    {
-      "label": ".Enumerate()",
-      "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
-      "source_location": "L258",
-      "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_enumerate",
-      "community": 16,
-      "norm_label": ".enumerate()"
     },
     {
       "label": "HardwareConfigReader.cs",
@@ -3114,7 +3159,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_hardwareconfigreader_cs",
-      "community": 4,
+      "community": 5,
       "norm_label": "hardwareconfigreader.cs"
     },
     {
@@ -3123,7 +3168,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L8",
       "id": "openness_hardwareconfigreader_hardwareconfigreader",
-      "community": 4,
+      "community": 5,
       "norm_label": "hardwareconfigreader"
     },
     {
@@ -3132,7 +3177,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L10",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_read",
-      "community": 4,
+      "community": 5,
       "norm_label": ".read()"
     },
     {
@@ -3141,151 +3186,151 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L41",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readdevice",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readdevice()"
     },
     {
       "label": ".ReadDeviceItems()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L54",
+      "source_location": "L55",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readdeviceitems",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readdeviceitems()"
     },
     {
       "label": ".ReadDeviceItem()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L73",
+      "source_location": "L74",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readdeviceitem",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readdeviceitem()"
     },
     {
       "label": ".ReadNetworkInterfaces()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L99",
+      "source_location": "L101",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readnetworkinterfaces",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readnetworkinterfaces()"
     },
     {
       "label": ".ReadNetworkInterface()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L119",
+      "source_location": "L121",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readnetworkinterface",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readnetworkinterface()"
     },
     {
       "label": ".ReadNode()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L142",
+      "source_location": "L144",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readnode",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readnode()"
     },
     {
       "label": ".ReadSubnet()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L156",
+      "source_location": "L159",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readsubnet",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readsubnet()"
     },
     {
       "label": ".ReadIoSystem()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L190",
+      "source_location": "L194",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readiosystem",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readiosystem()"
     },
     {
       "label": ".ReadConnectedSubnetName()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L212",
+      "source_location": "L216",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readconnectedsubnetname",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readconnectedsubnetname()"
     },
     {
       "label": ".ReadIoSystemName()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L220",
+      "source_location": "L224",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readiosystemname",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readiosystemname()"
     },
     {
       "label": ".FindParentDeviceName()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L238",
+      "source_location": "L242",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_findparentdevicename",
-      "community": 4,
+      "community": 5,
       "norm_label": ".findparentdevicename()"
     },
     {
       "label": ".ReadString()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L260",
+      "source_location": "L264",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readstring",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readstring()"
     },
     {
       "label": ".ReadInt()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L273",
+      "source_location": "L277",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readint",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readint()"
     },
     {
       "label": ".ReadAttribute()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L286",
+      "source_location": "L290",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readattribute",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readattribute()"
     },
     {
       "label": ".ReadPropertyOrAttribute()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L299",
+      "source_location": "L303",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readpropertyorattribute",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readpropertyorattribute()"
     },
     {
       "label": ".ReadProperty()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L312",
+      "source_location": "L316",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readproperty",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readproperty()"
     },
     {
       "label": ".ReadEnumerableProperty()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
-      "source_location": "L317",
+      "source_location": "L321",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readenumerableproperty",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readenumerableproperty()"
     },
     {
@@ -3429,7 +3474,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/NetworkDeviceCreator.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_networkdevicecreator_cs",
-      "community": 4,
+      "community": 5,
       "norm_label": "networkdevicecreator.cs"
     },
     {
@@ -3438,7 +3483,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/NetworkDeviceCreator.cs",
       "source_location": "L7",
       "id": "openness_networkdevicecreator_networkdevicecreator",
-      "community": 4,
+      "community": 5,
       "norm_label": "networkdevicecreator"
     },
     {
@@ -3447,7 +3492,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/NetworkDeviceCreator.cs",
       "source_location": "L9",
       "id": "openness_networkdevicecreator_networkdevicecreator_create",
-      "community": 4,
+      "community": 5,
       "norm_label": ".create()"
     },
     {
@@ -3456,7 +3501,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/NetworkDeviceCreator.cs",
       "source_location": "L52",
       "id": "openness_networkdevicecreator_networkdevicecreator_getfirstdeviceitem",
-      "community": 4,
+      "community": 5,
       "norm_label": ".getfirstdeviceitem()"
     },
     {
@@ -3465,7 +3510,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/NetworkDeviceCreator.cs",
       "source_location": "L69",
       "id": "openness_networkdevicecreator_networkdevicecreator_readstring",
-      "community": 4,
+      "community": 5,
       "norm_label": ".readstring()"
     },
     {
@@ -3499,7 +3544,7 @@
       "label": ".ReadEnumerableProperty()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/OpennessReflection.cs",
-      "source_location": "L38",
+      "source_location": "L68",
       "id": "openness_opennessreflection_opennessreflection_readenumerableproperty",
       "community": 55,
       "norm_label": ".readenumerableproperty()"
@@ -3508,7 +3553,7 @@
       "label": ".Enumerate()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/OpennessReflection.cs",
-      "source_location": "L48",
+      "source_location": "L78",
       "id": "openness_opennessreflection_opennessreflection_enumerate",
       "community": 55,
       "norm_label": ".enumerate()"
@@ -3519,7 +3564,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_plconlineservice_cs",
-      "community": 41,
+      "community": 42,
       "norm_label": "plconlineservice.cs"
     },
     {
@@ -3528,7 +3573,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L10",
       "id": "openness_plconlineservice_plconlineservice",
-      "community": 41,
+      "community": 42,
       "norm_label": "plconlineservice"
     },
     {
@@ -3537,7 +3582,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L12",
       "id": "openness_plconlineservice_plconlineservice_start",
-      "community": 41,
+      "community": 42,
       "norm_label": ".start()"
     },
     {
@@ -3546,7 +3591,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L15",
       "id": "openness_plconlineservice_plconlineservice_stop",
-      "community": 41,
+      "community": 42,
       "norm_label": ".stop()"
     },
     {
@@ -3555,7 +3600,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L18",
       "id": "openness_plconlineservice_plconlineservice_controlplc",
-      "community": 41,
+      "community": 42,
       "norm_label": ".controlplc()"
     },
     {
@@ -3564,7 +3609,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L55",
       "id": "openness_plconlineservice_plconlineservice_invokecontrolmethod",
-      "community": 41,
+      "community": 42,
       "norm_label": ".invokecontrolmethod()"
     },
     {
@@ -3573,7 +3618,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_plcsoftwarelocator_cs",
-      "community": 33,
+      "community": 35,
       "norm_label": "plcsoftwarelocator.cs"
     },
     {
@@ -3582,7 +3627,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs",
       "source_location": "L8",
       "id": "openness_plcsoftwarelocator_plcsoftwarelocator",
-      "community": 33,
+      "community": 35,
       "norm_label": "plcsoftwarelocator"
     },
     {
@@ -3591,7 +3636,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs",
       "source_location": "L11",
       "id": "openness_plcsoftwarelocator_plcsoftwarelocator_find",
-      "community": 33,
+      "community": 35,
       "norm_label": ".find()"
     },
     {
@@ -3600,7 +3645,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs",
       "source_location": "L26",
       "id": "openness_plcsoftwarelocator_plcsoftwarelocator_findall",
-      "community": 33,
+      "community": 35,
       "norm_label": ".findall()"
     },
     {
@@ -3609,7 +3654,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs",
       "source_location": "L45",
       "id": "openness_plcsoftwarelocator_plcsoftwarelocator_findindevice",
-      "community": 33,
+      "community": 35,
       "norm_label": ".findindevice()"
     },
     {
@@ -3618,7 +3663,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs",
       "source_location": "L50",
       "id": "openness_plcsoftwarelocator_plcsoftwarelocator_findindeviceitems",
-      "community": 33,
+      "community": 35,
       "norm_label": ".findindeviceitems()"
     },
     {
@@ -3627,7 +3672,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs",
       "source_location": "L78",
       "id": "openness_plcsoftwarelocator_discoveredplcsoftware",
-      "community": 33,
+      "community": 35,
       "norm_label": "discoveredplcsoftware"
     },
     {
@@ -3789,7 +3834,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_projecttreewalker_cs",
-      "community": 21,
+      "community": 20,
       "norm_label": "projecttreewalker.cs"
     },
     {
@@ -3798,7 +3843,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L14",
       "id": "openness_projecttreewalker_projecttreewalker",
-      "community": 21,
+      "community": 20,
       "norm_label": "projecttreewalker"
     },
     {
@@ -3807,7 +3852,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L16",
       "id": "openness_projecttreewalker_projecttreewalker_walk",
-      "community": 21,
+      "community": 20,
       "norm_label": ".walk()"
     },
     {
@@ -3816,7 +3861,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L44",
       "id": "openness_projecttreewalker_projecttreewalker_walkplcsoftware",
-      "community": 21,
+      "community": 20,
       "norm_label": ".walkplcsoftware()"
     },
     {
@@ -3825,7 +3870,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L68",
       "id": "openness_projecttreewalker_projecttreewalker_walksoftwareunits",
-      "community": 21,
+      "community": 20,
       "norm_label": ".walksoftwareunits()"
     },
     {
@@ -3834,7 +3879,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L108",
       "id": "openness_projecttreewalker_projecttreewalker_walkblockgroup",
-      "community": 21,
+      "community": 20,
       "norm_label": ".walkblockgroup()"
     },
     {
@@ -3843,7 +3888,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L174",
       "id": "openness_projecttreewalker_projecttreewalker_walktagtablegroup",
-      "community": 21,
+      "community": 20,
       "norm_label": ".walktagtablegroup()"
     },
     {
@@ -3852,7 +3897,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L222",
       "id": "openness_projecttreewalker_projecttreewalker_walktypegroup",
-      "community": 21,
+      "community": 20,
       "norm_label": ".walktypegroup()"
     },
     {
@@ -3861,7 +3906,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L270",
       "id": "openness_projecttreewalker_projecttreewalker_combinepath",
-      "community": 21,
+      "community": 20,
       "norm_label": ".combinepath()"
     },
     {
@@ -4014,7 +4059,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_tagtablereader_cs",
-      "community": 29,
+      "community": 28,
       "norm_label": "tagtablereader.cs"
     },
     {
@@ -4023,7 +4068,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L7",
       "id": "openness_tagtablereader_tagtablereader",
-      "community": 29,
+      "community": 28,
       "norm_label": "tagtablereader"
     },
     {
@@ -4032,7 +4077,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L9",
       "id": "openness_tagtablereader_tagtablereader_readall",
-      "community": 29,
+      "community": 28,
       "norm_label": ".readall()"
     },
     {
@@ -4041,7 +4086,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L20",
       "id": "openness_tagtablereader_tagtablereader_collecttablesfromgroup",
-      "community": 29,
+      "community": 28,
       "norm_label": ".collecttablesfromgroup()"
     },
     {
@@ -4050,7 +4095,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L56",
       "id": "openness_tagtablereader_tagtablereader_readtagtable",
-      "community": 29,
+      "community": 28,
       "norm_label": ".readtagtable()"
     },
     {
@@ -4059,7 +4104,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L70",
       "id": "openness_tagtablereader_tagtablereader_readtags",
-      "community": 29,
+      "community": 28,
       "norm_label": ".readtags()"
     },
     {
@@ -4068,7 +4113,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L95",
       "id": "openness_tagtablereader_tagtablereader_readuserconstants",
-      "community": 29,
+      "community": 28,
       "norm_label": ".readuserconstants()"
     },
     {
@@ -4077,7 +4122,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_tiaportalsession_cs",
-      "community": 20,
+      "community": 19,
       "norm_label": "tiaportalsession.cs"
     },
     {
@@ -4086,7 +4131,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L8",
       "id": "openness_tiaportalsession_tiaportalsession",
-      "community": 20,
+      "community": 19,
       "norm_label": "tiaportalsession"
     },
     {
@@ -4095,7 +4140,7 @@
       "source_file": "",
       "source_location": "",
       "id": "idisposable",
-      "community": 20,
+      "community": 19,
       "norm_label": "idisposable"
     },
     {
@@ -4104,7 +4149,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L10",
       "id": "bool",
-      "community": 20,
+      "community": 19,
       "norm_label": "bool"
     },
     {
@@ -4113,7 +4158,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L11",
       "id": "tiaportal",
-      "community": 20,
+      "community": 19,
       "norm_label": "tiaportal"
     },
     {
@@ -4122,7 +4167,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L25",
       "id": "openness_tiaportalsession_tiaportalsession_connect",
-      "community": 20,
+      "community": 19,
       "norm_label": ".connect()"
     },
     {
@@ -4131,7 +4176,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L49",
       "id": "openness_tiaportalsession_tiaportalsession_openproject",
-      "community": 20,
+      "community": 19,
       "norm_label": ".openproject()"
     },
     {
@@ -4140,7 +4185,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L66",
       "id": "openness_tiaportalsession_tiaportalsession_ensureconnected",
-      "community": 20,
+      "community": 19,
       "norm_label": ".ensureconnected()"
     },
     {
@@ -4149,7 +4194,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L76",
       "id": "openness_tiaportalsession_tiaportalsession_onnotification",
-      "community": 20,
+      "community": 19,
       "norm_label": ".onnotification()"
     },
     {
@@ -4158,7 +4203,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L81",
       "id": "openness_tiaportalsession_tiaportalsession_onconfirmation",
-      "community": 20,
+      "community": 19,
       "norm_label": ".onconfirmation()"
     },
     {
@@ -4167,7 +4212,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L88",
       "id": "openness_tiaportalsession_tiaportalsession_ondisposed",
-      "community": 20,
+      "community": 19,
       "norm_label": ".ondisposed()"
     },
     {
@@ -4176,7 +4221,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L95",
       "id": "openness_tiaportalsession_tiaportalsession_dispose",
-      "community": 20,
+      "community": 19,
       "norm_label": ".dispose()"
     },
     {
@@ -4185,7 +4230,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L122",
       "id": "openness_tiaportalsession_tiaportalsession_throwifdisposed",
-      "community": 20,
+      "community": 19,
       "norm_label": ".throwifdisposed()"
     },
     {
@@ -4194,7 +4239,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddDeviceResultInfoTests.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_adddeviceresultinfotests_cs",
-      "community": 42,
+      "community": 43,
       "norm_label": "adddeviceresultinfotests.cs"
     },
     {
@@ -4203,7 +4248,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddDeviceResultInfoTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_adddeviceresultinfotests_adddeviceresultinfotests",
-      "community": 42,
+      "community": 43,
       "norm_label": "adddeviceresultinfotests"
     },
     {
@@ -4212,7 +4257,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddDeviceResultInfoTests.cs",
       "source_location": "L17",
       "id": "tiamcpserver_tests_adddeviceresultinfotests_adddeviceresultinfotests_serializesemptyresult",
-      "community": 42,
+      "community": 43,
       "norm_label": ".serializesemptyresult()"
     },
     {
@@ -4221,7 +4266,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddDeviceResultInfoTests.cs",
       "source_location": "L31",
       "id": "tiamcpserver_tests_adddeviceresultinfotests_adddeviceresultinfotests_roundtripsresultwithwarnings",
-      "community": 42,
+      "community": 43,
       "norm_label": ".roundtripsresultwithwarnings()"
     },
     {
@@ -4230,7 +4275,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddDeviceResultInfoTests.cs",
       "source_location": "L50",
       "id": "tiamcpserver_tests_adddeviceresultinfotests_adddeviceresultinfotests_roundtrip",
-      "community": 42,
+      "community": 43,
       "norm_label": ".roundtrip()"
     },
     {
@@ -4284,62 +4329,80 @@
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_batchexecutionenginetests_cs",
-      "community": 34,
+      "community": 29,
       "norm_label": "batchexecutionenginetests.cs"
     },
     {
       "label": "BatchExecutionEngineTests",
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
-      "source_location": "L9",
+      "source_location": "L10",
       "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests",
-      "community": 34,
+      "community": 29,
       "norm_label": "batchexecutionenginetests"
     },
     {
       "label": ".Op()",
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
-      "source_location": "L11",
+      "source_location": "L12",
       "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_op",
-      "community": 34,
+      "community": 29,
       "norm_label": ".op()"
     },
     {
       "label": ".ExecuteReadsAsync_AllSucceed_PreservesOrderAndResults()",
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
-      "source_location": "L14",
+      "source_location": "L15",
       "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_executereadsasync_allsucceed_preservesorderandresults",
-      "community": 34,
+      "community": 29,
       "norm_label": ".executereadsasync_allsucceed_preservesorderandresults()"
     },
     {
       "label": ".ExecuteReadsAsync_PerItemFailureDoesNotStopOthers()",
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
-      "source_location": "L28",
+      "source_location": "L29",
       "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_executereadsasync_peritemfailuredoesnotstopothers",
-      "community": 34,
+      "community": 29,
       "norm_label": ".executereadsasync_peritemfailuredoesnotstopothers()"
     },
     {
       "label": ".ApplyWritesAsync_AllSucceed_MarksAllSucceeded()",
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
-      "source_location": "L48",
+      "source_location": "L49",
       "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_applywritesasync_allsucceed_marksallsucceeded",
-      "community": 34,
+      "community": 29,
       "norm_label": ".applywritesasync_allsucceed_marksallsucceeded()"
     },
     {
       "label": ".ApplyWritesAsync_StopsOnFirstFailureAndSkipsRest()",
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
-      "source_location": "L60",
+      "source_location": "L61",
       "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_applywritesasync_stopsonfirstfailureandskipsrest",
-      "community": 34,
+      "community": 29,
       "norm_label": ".applywritesasync_stopsonfirstfailureandskipsrest()"
+    },
+    {
+      "label": ".ExecuteReadsAsync_PayloadStartingWithErrorPrefix_IsNotAFailure()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
+      "source_location": "L89",
+      "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_executereadsasync_payloadstartingwitherrorprefix_isnotafailure",
+      "community": 29,
+      "norm_label": ".executereadsasync_payloadstartingwitherrorprefix_isnotafailure()"
+    },
+    {
+      "label": ".ExecuteReadsAsync_CopiesWarningsOntoResult()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
+      "source_location": "L101",
+      "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_executereadsasync_copieswarningsontoresult",
+      "community": 29,
+      "norm_label": ".executereadsasync_copieswarningsontoresult()"
     },
     {
       "label": "BatchOperationCatalogTests.cs",
@@ -4347,7 +4410,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_cs",
-      "community": 5,
+      "community": 6,
       "norm_label": "batchoperationcatalogtests.cs"
     },
     {
@@ -4356,7 +4419,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L7",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests",
-      "community": 5,
+      "community": 6,
       "norm_label": "batchoperationcatalogtests"
     },
     {
@@ -4365,7 +4428,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L9",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_op",
-      "community": 5,
+      "community": 6,
       "norm_label": ".op()"
     },
     {
@@ -4374,7 +4437,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L16",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_acceptsknownreadswithrequiredfields",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatereadbatch_acceptsknownreadswithrequiredfields()"
     },
     {
@@ -4383,7 +4446,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L31",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectsemptybatch",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatereadbatch_rejectsemptybatch()"
     },
     {
@@ -4392,7 +4455,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L40",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectsnullbatch",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatereadbatch_rejectsnullbatch()"
     },
     {
@@ -4401,7 +4464,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L48",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectsbatchoverfiftyitems",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatereadbatch_rejectsbatchoverfiftyitems()"
     },
     {
@@ -4410,7 +4473,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L63",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectsunknownoperation",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatereadbatch_rejectsunknownoperation()"
     },
     {
@@ -4419,7 +4482,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L72",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectswriteoperation",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatereadbatch_rejectswriteoperation()"
     },
     {
@@ -4428,7 +4491,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L83",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectsduplicateoperationid",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatereadbatch_rejectsduplicateoperationid()"
     },
     {
@@ -4437,7 +4500,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L93",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectsmissingoperationid",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatereadbatch_rejectsmissingoperationid()"
     },
     {
@@ -4446,7 +4509,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L102",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectsmissingrequiredfield",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatereadbatch_rejectsmissingrequiredfield()"
     },
     {
@@ -4455,7 +4518,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L111",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_acceptsknowndatawrites",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatewritebatch_acceptsknowndatawrites()"
     },
     {
@@ -4464,7 +4527,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L126",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_rejectsreadoperation",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatewritebatch_rejectsreadoperation()"
     },
     {
@@ -4473,7 +4536,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L137",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_rejectsprojectlifecycleoperation",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatewritebatch_rejectsprojectlifecycleoperation()"
     },
     {
@@ -4482,7 +4545,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L147",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_rejectsmissingrequiredfield",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatewritebatch_rejectsmissingrequiredfield()"
     },
     {
@@ -4491,7 +4554,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L157",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_rejectsunknownoperation",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatewritebatch_rejectsunknownoperation()"
     },
     {
@@ -4500,7 +4563,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L166",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_rejectsmixedprojectpaths",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatewritebatch_rejectsmixedprojectpaths()"
     },
     {
@@ -4509,7 +4572,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L181",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_allowssameprojectpathoneveryitem",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatewritebatch_allowssameprojectpathoneveryitem()"
     },
     {
@@ -4518,7 +4581,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L195",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_allwriteoperations_acceptafullypopulatedrequest",
-      "community": 5,
+      "community": 6,
       "norm_label": ".allwriteoperations_acceptafullypopulatedrequest()"
     },
     {
@@ -4527,7 +4590,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L205",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_allreadoperations_acceptafullypopulatedrequest",
-      "community": 5,
+      "community": 6,
       "norm_label": ".allreadoperations_acceptafullypopulatedrequest()"
     },
     {
@@ -4536,7 +4599,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L215",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_unknownoperationerrorlistsvalidreadoperations",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatereadbatch_unknownoperationerrorlistsvalidreadoperations()"
     },
     {
@@ -4545,7 +4608,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L226",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_unknownoperationerrorlistsvalidwriteoperations",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatewritebatch_unknownoperationerrorlistsvalidwriteoperations()"
     },
     {
@@ -4554,7 +4617,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L237",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_reportsallinvaliditemsatonce",
-      "community": 5,
+      "community": 6,
       "norm_label": ".validatewritebatch_reportsallinvaliditemsatonce()"
     },
     {
@@ -4563,8 +4626,44 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L255",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_fullypopulated",
-      "community": 5,
+      "community": 6,
       "norm_label": ".fullypopulated()"
+    },
+    {
+      "label": "BatchOperationRequestJsonTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_batchoperationrequestjsontests_cs",
+      "community": 0,
+      "norm_label": "batchoperationrequestjsontests.cs"
+    },
+    {
+      "label": "BatchOperationRequestJsonTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs",
+      "source_location": "L7",
+      "id": "tiamcpserver_tests_batchoperationrequestjsontests_batchoperationrequestjsontests",
+      "community": 0,
+      "norm_label": "batchoperationrequestjsontests"
+    },
+    {
+      "label": ".MisspelledOptionalProperty_IsRejectedNotSilentlyDropped()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs",
+      "source_location": "L12",
+      "id": "tiamcpserver_tests_batchoperationrequestjsontests_batchoperationrequestjsontests_misspelledoptionalproperty_isrejectednotsilentlydropped",
+      "community": 0,
+      "norm_label": ".misspelledoptionalproperty_isrejectednotsilentlydropped()"
+    },
+    {
+      "label": ".KnownCamelCaseProperties_StillDeserialize()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs",
+      "source_location": "L25",
+      "id": "tiamcpserver_tests_batchoperationrequestjsontests_batchoperationrequestjsontests_knowncamelcaseproperties_stilldeserialize",
+      "community": 0,
+      "norm_label": ".knowncamelcaseproperties_stilldeserialize()"
     },
     {
       "label": "BatchResultFormatterTests.cs",
@@ -4572,7 +4671,7 @@
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_batchresultformattertests_cs",
-      "community": 35,
+      "community": 31,
       "norm_label": "batchresultformattertests.cs"
     },
     {
@@ -4581,7 +4680,7 @@
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
       "source_location": "L7",
       "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests",
-      "community": 35,
+      "community": 31,
       "norm_label": "batchresultformattertests"
     },
     {
@@ -4590,7 +4689,7 @@
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
       "source_location": "L9",
       "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_parse",
-      "community": 35,
+      "community": 31,
       "norm_label": ".parse()"
     },
     {
@@ -4599,7 +4698,7 @@
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
       "source_location": "L11",
       "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_error_producesunsuccessfulenvelopewithmessage",
-      "community": 35,
+      "community": 31,
       "norm_label": ".error_producesunsuccessfulenvelopewithmessage()"
     },
     {
@@ -4608,26 +4707,35 @@
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
       "source_location": "L21",
       "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_readbatch_allsucceeded_issuccesswithcounts",
-      "community": 35,
+      "community": 31,
       "norm_label": ".readbatch_allsucceeded_issuccesswithcounts()"
     },
     {
       "label": ".ReadBatch_AnyFailure_IsNotSuccess()",
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
-      "source_location": "L38",
+      "source_location": "L39",
       "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_readbatch_anyfailure_isnotsuccess",
-      "community": 35,
+      "community": 31,
       "norm_label": ".readbatch_anyfailure_isnotsuccess()"
     },
     {
       "label": ".ApplyBatch_CountsSucceededFailedAndSkipped()",
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
-      "source_location": "L53",
+      "source_location": "L54",
       "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_applybatch_countssucceededfailedandskipped",
-      "community": 35,
+      "community": 31,
       "norm_label": ".applybatch_countssucceededfailedandskipped()"
+    },
+    {
+      "label": ".ReadBatch_IncludesWarningsWhenPresent()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
+      "source_location": "L73",
+      "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_readbatch_includeswarningswhenpresent",
+      "community": 31,
+      "norm_label": ".readbatch_includeswarningswhenpresent()"
     },
     {
       "label": "BatchSafetySnapshotTests.cs",
@@ -4725,7 +4833,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_batchsafetytokentests_cs",
-      "community": 0,
+      "community": 2,
       "norm_label": "batchsafetytokentests.cs"
     },
     {
@@ -4734,7 +4842,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L14",
       "id": "tiamcpserver_tests_batchsafetytokentests_batchsafetytokentests",
-      "community": 0,
+      "community": 2,
       "norm_label": "batchsafetytokentests"
     },
     {
@@ -4743,7 +4851,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L18",
       "id": "tiamcpserver_tests_batchsafetytokentests_batchsafetytokentests_op",
-      "community": 0,
+      "community": 2,
       "norm_label": ".op()"
     },
     {
@@ -4752,7 +4860,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L25",
       "id": "tiamcpserver_tests_batchsafetytokentests_batchsafetytokentests_createpreview",
-      "community": 0,
+      "community": 2,
       "norm_label": ".createpreview()"
     },
     {
@@ -4761,7 +4869,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L35",
       "id": "tiamcpserver_tests_batchsafetytokentests_batchsafetytokentests_consume",
-      "community": 0,
+      "community": 2,
       "norm_label": ".consume()"
     },
     {
@@ -4770,7 +4878,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L49",
       "id": "tiamcpserver_tests_batchsafetytokentests_batchsafetytokentests_twoitembatch",
-      "community": 0,
+      "community": 2,
       "norm_label": ".twoitembatch()"
     },
     {
@@ -4779,7 +4887,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L59",
       "id": "tiamcpserver_tests_batchsafetytokentests_batchsafetytokentests_unchangedbatchvalidates",
-      "community": 0,
+      "community": 2,
       "norm_label": ".unchangedbatchvalidates()"
     },
     {
@@ -4788,7 +4896,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L71",
       "id": "tiamcpserver_tests_batchsafetytokentests_batchsafetytokentests_reorderedoperationsarerejected",
-      "community": 0,
+      "community": 2,
       "norm_label": ".reorderedoperationsarerejected()"
     },
     {
@@ -4797,7 +4905,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L85",
       "id": "tiamcpserver_tests_batchsafetytokentests_batchsafetytokentests_changedinputisrejected",
-      "community": 0,
+      "community": 2,
       "norm_label": ".changedinputisrejected()"
     },
     {
@@ -4806,7 +4914,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L102",
       "id": "tiamcpserver_tests_batchsafetytokentests_batchsafetytokentests_changedcurrentstateisrejected",
-      "community": 0,
+      "community": 2,
       "norm_label": ".changedcurrentstateisrejected()"
     },
     {
@@ -4815,7 +4923,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L114",
       "id": "tiamcpserver_tests_batchsafetytokentests_batchsafetytokentests_differentprojectpathisrejected",
-      "community": 0,
+      "community": 2,
       "norm_label": ".differentprojectpathisrejected()"
     },
     {
@@ -4824,7 +4932,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L131",
       "id": "tiamcpserver_tests_batchsafetytokentests_batchsafetytokentests_wrongtoolnameisrejected",
-      "community": 0,
+      "community": 2,
       "norm_label": ".wrongtoolnameisrejected()"
     },
     {
@@ -4833,7 +4941,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L143",
       "id": "tiamcpserver_tests_batchsafetytokentests_batchsafetytokentests_tokenissingleuse",
-      "community": 0,
+      "community": 2,
       "norm_label": ".tokenissingleuse()"
     },
     {
@@ -4842,7 +4950,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
       "source_location": "L154",
       "id": "tiamcpserver_tests_batchsafetytokentests_batchsafetytokentests_unknowntokenisrejected",
-      "community": 0,
+      "community": 2,
       "norm_label": ".unknowntokenisrejected()"
     },
     {
@@ -4851,7 +4959,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_cs",
-      "community": 17,
+      "community": 16,
       "norm_label": "batchtoolmetadatatests.cs"
     },
     {
@@ -4860,7 +4968,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L11",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests",
-      "community": 17,
+      "community": 16,
       "norm_label": "batchtoolmetadatatests"
     },
     {
@@ -4869,7 +4977,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L13",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_methoddescription",
-      "community": 17,
+      "community": 16,
       "norm_label": ".methoddescription()"
     },
     {
@@ -4878,7 +4986,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L22",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_executereadbatchdescription_listseveryreadoperation",
-      "community": 17,
+      "community": 16,
       "norm_label": ".executereadbatchdescription_listseveryreadoperation()"
     },
     {
@@ -4887,7 +4995,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L32",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_previewwritebatchdescription_listseverywriteoperation",
-      "community": 17,
+      "community": 16,
       "norm_label": ".previewwritebatchdescription_listseverywriteoperation()"
     },
     {
@@ -4896,7 +5004,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L42",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_applywritebatchdescription_listseverywriteoperation",
-      "community": 17,
+      "community": 16,
       "norm_label": ".applywritebatchdescription_listseverywriteoperation()"
     },
     {
@@ -4905,7 +5013,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L52",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_operationpropertydescription_listseverybatchableoperation",
-      "community": 17,
+      "community": 16,
       "norm_label": ".operationpropertydescription_listseverybatchableoperation()"
     },
     {
@@ -4914,7 +5022,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L68",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_previewwritebatchdescription_statestheactualtokenlifetime",
-      "community": 17,
+      "community": 16,
       "norm_label": ".previewwritebatchdescription_statestheactualtokenlifetime()"
     },
     {
@@ -4923,7 +5031,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L75",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_propertydescription",
-      "community": 17,
+      "community": 16,
       "norm_label": ".propertydescription()"
     },
     {
@@ -4932,7 +5040,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L84",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_filterdescription_namesitsoperationandlistsallvalues",
-      "community": 17,
+      "community": 16,
       "norm_label": ".filterdescription_namesitsoperationandlistsallvalues()"
     },
     {
@@ -4941,7 +5049,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L95",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_blockpathdescription_coversallblockoperationsandcompilecheck",
-      "community": 17,
+      "community": 16,
       "norm_label": ".blockpathdescription_coversallblockoperationsandcompilecheck()"
     },
     {
@@ -4950,7 +5058,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L104",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_newnamedescription_doesnotclaimuserconstantrename",
-      "community": 17,
+      "community": 16,
       "norm_label": ".newnamedescription_doesnotclaimuserconstantrename()"
     },
     {
@@ -4959,7 +5067,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L115",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_plcnamedescription_namestheoperationsthathonorit",
-      "community": 17,
+      "community": 16,
       "norm_label": ".plcnamedescription_namestheoperationsthathonorit()"
     },
     {
@@ -4968,7 +5076,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L123",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_keyrequestfieldshavedescriptions",
-      "community": 17,
+      "community": 16,
       "norm_label": ".keyrequestfieldshavedescriptions()"
     },
     {
@@ -4977,7 +5085,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_batchtoolstests_cs",
-      "community": 23,
+      "community": 22,
       "norm_label": "batchtoolstests.cs"
     },
     {
@@ -4986,7 +5094,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L9",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests",
-      "community": 23,
+      "community": 22,
       "norm_label": "batchtoolstests"
     },
     {
@@ -4995,7 +5103,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L11",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_op",
-      "community": 23,
+      "community": 22,
       "norm_label": ".op()"
     },
     {
@@ -5004,7 +5112,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L18",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_batchtoolshavemcpmetadata",
-      "community": 23,
+      "community": 22,
       "norm_label": ".batchtoolshavemcpmetadata()"
     },
     {
@@ -5013,7 +5121,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L34",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_executereadbatch_rejectswriteoperation",
-      "community": 23,
+      "community": 22,
       "norm_label": ".executereadbatch_rejectswriteoperation()"
     },
     {
@@ -5022,7 +5130,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L46",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_executereadbatch_rejectsemptybatch",
-      "community": 23,
+      "community": 22,
       "norm_label": ".executereadbatch_rejectsemptybatch()"
     },
     {
@@ -5031,7 +5139,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L56",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_previewwritebatch_rejectsreadoperation",
-      "community": 23,
+      "community": 22,
       "norm_label": ".previewwritebatch_rejectsreadoperation()"
     },
     {
@@ -5040,7 +5148,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L68",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_previewwritebatch_rejectsprojectlifecycleoperation",
-      "community": 23,
+      "community": 22,
       "norm_label": ".previewwritebatch_rejectsprojectlifecycleoperation()"
     },
     {
@@ -5049,7 +5157,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L80",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_applywritebatch_rejectsunconfirmedrequests",
-      "community": 23,
+      "community": 22,
       "norm_label": ".applywritebatch_rejectsunconfirmedrequests()"
     },
     {
@@ -5058,7 +5166,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L93",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_applywritebatch_rejectsinvalidbatchbeforeworker",
-      "community": 23,
+      "community": 22,
       "norm_label": ".applywritebatch_rejectsinvalidbatchbeforeworker()"
     },
     {
@@ -5067,7 +5175,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L107",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_applywritebatch_rejectsmissingsafetytoken",
-      "community": 23,
+      "community": 22,
       "norm_label": ".applywritebatch_rejectsmissingsafetytoken()"
     },
     {
@@ -5076,7 +5184,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_blockaddresstests_cs",
-      "community": 28,
+      "community": 30,
       "norm_label": "blockaddresstests.cs"
     },
     {
@@ -5085,7 +5193,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L6",
       "id": "tiamcpserver_tests_blockaddresstests_blockaddresstests",
-      "community": 28,
+      "community": 30,
       "norm_label": "blockaddresstests"
     },
     {
@@ -5094,7 +5202,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_blockaddresstests_blockaddresstests_parsesupportslegacyblockonly",
-      "community": 28,
+      "community": 30,
       "norm_label": ".parsesupportslegacyblockonly()"
     },
     {
@@ -5103,7 +5211,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L21",
       "id": "tiamcpserver_tests_blockaddresstests_blockaddresstests_parsesupportslegacyplcqualifiedblock",
-      "community": 28,
+      "community": 30,
       "norm_label": ".parsesupportslegacyplcqualifiedblock()"
     },
     {
@@ -5112,7 +5220,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L33",
       "id": "tiamcpserver_tests_blockaddresstests_blockaddresstests_parsesupportsnestedblockfolderpath",
-      "community": 28,
+      "community": 30,
       "norm_label": ".parsesupportsnestedblockfolderpath()"
     },
     {
@@ -5121,7 +5229,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L46",
       "id": "tiamcpserver_tests_blockaddresstests_blockaddresstests_parsesupportssoftwareunitblockpath",
-      "community": 28,
+      "community": 30,
       "norm_label": ".parsesupportssoftwareunitblockpath()"
     },
     {
@@ -5130,7 +5238,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L59",
       "id": "tiamcpserver_tests_blockaddresstests_blockaddresstests_parsestripsblocksuffixfromfinalsegment",
-      "community": 28,
+      "community": 30,
       "norm_label": ".parsestripsblocksuffixfromfinalsegment()"
     },
     {
@@ -5139,7 +5247,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L67",
       "id": "tiamcpserver_tests_blockaddresstests_blockaddresstests_parserejectsinvalidpaths",
-      "community": 28,
+      "community": 30,
       "norm_label": ".parserejectsinvalidpaths()"
     },
     {
@@ -5202,7 +5310,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogTypeIdentifierTests.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_catalogtypeidentifiertests_cs",
-      "community": 43,
+      "community": 44,
       "norm_label": "catalogtypeidentifiertests.cs"
     },
     {
@@ -5211,7 +5319,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogTypeIdentifierTests.cs",
       "source_location": "L6",
       "id": "tiamcpserver_tests_catalogtypeidentifiertests_catalogtypeidentifiertests",
-      "community": 43,
+      "community": 44,
       "norm_label": "catalogtypeidentifiertests"
     },
     {
@@ -5220,7 +5328,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogTypeIdentifierTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_catalogtypeidentifiertests_catalogtypeidentifiertests_creatableidentifiersusesupportedprefixes",
-      "community": 43,
+      "community": 44,
       "norm_label": ".creatableidentifiersusesupportedprefixes()"
     },
     {
@@ -5229,7 +5337,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogTypeIdentifierTests.cs",
       "source_location": "L17",
       "id": "tiamcpserver_tests_catalogtypeidentifiertests_catalogtypeidentifiertests_noncreatableidentifiersarerejected",
-      "community": 43,
+      "community": 44,
       "norm_label": ".noncreatableidentifiersarerejected()"
     },
     {
@@ -5238,7 +5346,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogTypeIdentifierTests.cs",
       "source_location": "L27",
       "id": "tiamcpserver_tests_catalogtypeidentifiertests_catalogtypeidentifiertests_validationmessagepointsuserbacktocatalogtypeidentifierfield",
-      "community": 43,
+      "community": 44,
       "norm_label": ".validationmessagepointsuserbacktocatalogtypeidentifierfield()"
     },
     {
@@ -5301,7 +5409,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceResultInfoTests.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_configurenetworkdeviceresultinfotests_cs",
-      "community": 44,
+      "community": 45,
       "norm_label": "configurenetworkdeviceresultinfotests.cs"
     },
     {
@@ -5310,7 +5418,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceResultInfoTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_configurenetworkdeviceresultinfotests_configurenetworkdeviceresultinfotests",
-      "community": 44,
+      "community": 45,
       "norm_label": "configurenetworkdeviceresultinfotests"
     },
     {
@@ -5319,7 +5427,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceResultInfoTests.cs",
       "source_location": "L17",
       "id": "tiamcpserver_tests_configurenetworkdeviceresultinfotests_configurenetworkdeviceresultinfotests_serializesemptyresult",
-      "community": 44,
+      "community": 45,
       "norm_label": ".serializesemptyresult()"
     },
     {
@@ -5328,7 +5436,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceResultInfoTests.cs",
       "source_location": "L33",
       "id": "tiamcpserver_tests_configurenetworkdeviceresultinfotests_configurenetworkdeviceresultinfotests_roundtripsresultwithsettingsandmessages",
-      "community": 44,
+      "community": 45,
       "norm_label": ".roundtripsresultwithsettingsandmessages()"
     },
     {
@@ -5337,7 +5445,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceResultInfoTests.cs",
       "source_location": "L60",
       "id": "tiamcpserver_tests_configurenetworkdeviceresultinfotests_configurenetworkdeviceresultinfotests_roundtrip",
-      "community": 44,
+      "community": 45,
       "norm_label": ".roundtrip()"
     },
     {
@@ -5346,7 +5454,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_crossreferenceinfotests_cs",
-      "community": 24,
+      "community": 23,
       "norm_label": "crossreferenceinfotests.cs"
     },
     {
@@ -5355,7 +5463,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests",
-      "community": 24,
+      "community": 23,
       "norm_label": "crossreferenceinfotests"
     },
     {
@@ -5364,7 +5472,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L17",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_emptyreportserializeswithemptyplclist",
-      "community": 24,
+      "community": 23,
       "norm_label": ".emptyreportserializeswithemptyplclist()"
     },
     {
@@ -5373,7 +5481,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L32",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_fullreportroundtripssourcereferenceandlocation",
-      "community": 24,
+      "community": 23,
       "norm_label": ".fullreportroundtripssourcereferenceandlocation()"
     },
     {
@@ -5382,7 +5490,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L123",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_unusedobjectreportroundtripssourceswithemptyreferences",
-      "community": 24,
+      "community": 23,
       "norm_label": ".unusedobjectreportroundtripssourceswithemptyreferences()"
     },
     {
@@ -5391,7 +5499,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L156",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_plcmessagesroundtrip",
-      "community": 24,
+      "community": 23,
       "norm_label": ".plcmessagesroundtrip()"
     },
     {
@@ -5400,7 +5508,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L177",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_nulloremptyfilterdefaultstoobjectswithreferences",
-      "community": 24,
+      "community": 23,
       "norm_label": ".nulloremptyfilterdefaultstoobjectswithreferences()"
     },
     {
@@ -5409,7 +5517,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L189",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_validfilternamesparsecaseinsensitively",
-      "community": 24,
+      "community": 23,
       "norm_label": ".validfilternamesparsecaseinsensitively()"
     },
     {
@@ -5418,7 +5526,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L198",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_invalidfilterreturnsallowedvalues",
-      "community": 24,
+      "community": 23,
       "norm_label": ".invalidfilterreturnsallowedvalues()"
     },
     {
@@ -5427,71 +5535,188 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L212",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_roundtrip",
-      "community": 24,
+      "community": 23,
       "norm_label": ".roundtrip()"
     },
     {
       "label": "HardwareConfigInfoTests.cs",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
       "source_location": "L1",
-      "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_hardwareconfiginfotests_cs",
-      "community": 30,
+      "id": "tiamcpserver_tests_hardwareconfiginfotests_cs",
+      "community": 0,
       "norm_label": "hardwareconfiginfotests.cs"
     },
     {
       "label": "HardwareConfigInfoTests",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests",
-      "community": 30,
+      "community": 0,
       "norm_label": "hardwareconfiginfotests"
     },
     {
       "label": ".SerializesEmptyConfig()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
       "source_location": "L17",
       "id": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests_serializesemptyconfig",
-      "community": 30,
+      "community": 0,
       "norm_label": ".serializesemptyconfig()"
     },
     {
       "label": ".RoundTripsFullDeviceTree()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
       "source_location": "L30",
       "id": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests_roundtripsfulldevicetree",
-      "community": 30,
+      "community": 0,
       "norm_label": ".roundtripsfulldevicetree()"
     },
     {
       "label": ".RoundTripsSubnetWithIoSystem()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
       "source_location": "L109",
       "id": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests_roundtripssubnetwithiosystem",
-      "community": 30,
+      "community": 0,
       "norm_label": ".roundtripssubnetwithiosystem()"
     },
     {
       "label": ".NullableFieldsSerializeAsNull()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
       "source_location": "L146",
       "id": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests_nullablefieldsserializeasnull",
-      "community": 30,
+      "community": 0,
       "norm_label": ".nullablefieldsserializeasnull()"
+    },
+    {
+      "label": ".MessagesRoundTrip()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_location": "L167",
+      "id": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests_messagesroundtrip",
+      "community": 0,
+      "norm_label": ".messagesroundtrip()"
+    },
+    {
+      "label": ".UnreadableValues_AreNullNotFallbackDefaults()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_location": "L183",
+      "id": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests_unreadablevalues_arenullnotfallbackdefaults",
+      "community": 0,
+      "norm_label": ".unreadablevalues_arenullnotfallbackdefaults()"
     },
     {
       "label": ".RoundTrip()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
-      "source_location": "L167",
+      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_location": "L193",
       "id": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests_roundtrip",
-      "community": 30,
+      "community": 0,
       "norm_label": ".roundtrip()"
+    },
+    {
+      "label": "OpennessWorkerClientIntegrationTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_cs",
+      "community": 24,
+      "norm_label": "opennessworkerclientintegrationtests.cs"
+    },
+    {
+      "label": "OpennessWorkerClientIntegrationTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L11",
+      "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests",
+      "community": 24,
+      "norm_label": "opennessworkerclientintegrationtests"
+    },
+    {
+      "label": ".LocateFakeWorker()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L13",
+      "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_locatefakeworker",
+      "community": 24,
+      "norm_label": ".locatefakeworker()"
+    },
+    {
+      "label": ".CreateClient()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L36",
+      "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_createclient",
+      "community": 24,
+      "norm_label": ".createclient()"
+    },
+    {
+      "label": ".Success_ReturnsStructuredPayload()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L39",
+      "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_success_returnsstructuredpayload",
+      "community": 24,
+      "norm_label": ".success_returnsstructuredpayload()"
+    },
+    {
+      "label": ".StderrLines_SurfaceAsWarnings()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L50",
+      "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_stderrlines_surfaceaswarnings",
+      "community": 24,
+      "norm_label": ".stderrlines_surfaceaswarnings()"
+    },
+    {
+      "label": ".PayloadStartingWithErrorPrefix_IsNotMisclassified()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L60",
+      "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_payloadstartingwitherrorprefix_isnotmisclassified",
+      "community": 24,
+      "norm_label": ".payloadstartingwitherrorprefix_isnotmisclassified()"
+    },
+    {
+      "label": ".WorkerReportedError_IsStructuredFailure()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L70",
+      "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_workerreportederror_isstructuredfailure",
+      "community": 24,
+      "norm_label": ".workerreportederror_isstructuredfailure()"
+    },
+    {
+      "label": ".MalformedResponse_IsFailureNotCrash()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L80",
+      "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_malformedresponse_isfailurenotcrash",
+      "community": 24,
+      "norm_label": ".malformedresponse_isfailurenotcrash()"
+    },
+    {
+      "label": ".SilentExit_SurfacesStderrDetailInError()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L89",
+      "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_silentexit_surfacesstderrdetailinerror",
+      "community": 24,
+      "norm_label": ".silentexit_surfacesstderrdetailinerror()"
+    },
+    {
+      "label": ".NonExecutableWorkerPath_ProducesActionableWin32Message()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L98",
+      "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_nonexecutableworkerpath_producesactionablewin32message",
+      "community": 24,
+      "norm_label": ".nonexecutableworkerpath_producesactionablewin32message()"
     },
     {
       "label": "ProjectLifecycleToolTests.cs",
@@ -5499,7 +5724,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectLifecycleToolTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_projectlifecycletooltests_cs",
-      "community": 45,
+      "community": 46,
       "norm_label": "projectlifecycletooltests.cs"
     },
     {
@@ -5508,7 +5733,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectLifecycleToolTests.cs",
       "source_location": "L10",
       "id": "tiamcpserver_tests_projectlifecycletooltests_projectlifecycletooltests",
-      "community": 45,
+      "community": 46,
       "norm_label": "projectlifecycletooltests"
     },
     {
@@ -5517,7 +5742,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectLifecycleToolTests.cs",
       "source_location": "L12",
       "id": "tiamcpserver_tests_projectlifecycletooltests_projectlifecycletooltests_projectlifecycletoolshavemcpmetadata",
-      "community": 45,
+      "community": 46,
       "norm_label": ".projectlifecycletoolshavemcpmetadata()"
     },
     {
@@ -5526,7 +5751,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectLifecycleToolTests.cs",
       "source_location": "L40",
       "id": "tiamcpserver_tests_projectlifecycletooltests_projectlifecycletooltests_opennessworkerclientexposesprojectlifecyclemethods",
-      "community": 45,
+      "community": 46,
       "norm_label": ".opennessworkerclientexposesprojectlifecyclemethods()"
     },
     {
@@ -5535,7 +5760,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectLifecycleToolTests.cs",
       "source_location": "L56",
       "id": "tiamcpserver_tests_projectlifecycletooltests_projectlifecycletooltests_openprojectrejectsunconfirmedrequests",
-      "community": 45,
+      "community": 46,
       "norm_label": ".openprojectrejectsunconfirmedrequests()"
     },
     {
@@ -5544,7 +5769,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectLifecycleToolTests.cs",
       "source_location": "L67",
       "id": "tiamcpserver_tests_projectlifecycletooltests_projectlifecycletooltests_saveprojectasrejectsunconfirmedrequests",
-      "community": 45,
+      "community": 46,
       "norm_label": ".saveprojectasrejectsunconfirmedrequests()"
     },
     {
@@ -5553,7 +5778,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_projectsessionbindingtests_cs",
-      "community": 22,
+      "community": 21,
       "norm_label": "projectsessionbindingtests.cs"
     },
     {
@@ -5562,7 +5787,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L6",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests",
-      "community": 22,
+      "community": 21,
       "norm_label": "projectsessionbindingtests"
     },
     {
@@ -5571,7 +5796,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_firstexplicitprojectpathbindssession",
-      "community": 22,
+      "community": 21,
       "norm_label": ".firstexplicitprojectpathbindssession()"
     },
     {
@@ -5580,7 +5805,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L20",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_repeatedsameprojectpathisaccepted",
-      "community": 22,
+      "community": 21,
       "norm_label": ".repeatedsameprojectpathisaccepted()"
     },
     {
@@ -5589,7 +5814,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L32",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_differentprojectpathisrejectedafterbinding",
-      "community": 22,
+      "community": 21,
       "norm_label": ".differentprojectpathisrejectedafterbinding()"
     },
     {
@@ -5598,7 +5823,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L44",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_omittedprojectpathusesstartupprojectpath",
-      "community": 22,
+      "community": 21,
       "norm_label": ".omittedprojectpathusesstartupprojectpath()"
     },
     {
@@ -5607,7 +5832,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L55",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_bindsetsunboundprojectpath",
-      "community": 22,
+      "community": 21,
       "norm_label": ".bindsetsunboundprojectpath()"
     },
     {
@@ -5616,7 +5841,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L66",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_bindrejectsdifferentprojectpathwithoutforce",
-      "community": 22,
+      "community": 21,
       "norm_label": ".bindrejectsdifferentprojectpathwithoutforce()"
     },
     {
@@ -5625,7 +5850,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L77",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_bindforcerebindsdifferentprojectpath",
-      "community": 22,
+      "community": 21,
       "norm_label": ".bindforcerebindsdifferentprojectpath()"
     },
     {
@@ -5634,7 +5859,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L88",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_clearremovesmatchingprojectbinding",
-      "community": 22,
+      "community": 21,
       "norm_label": ".clearremovesmatchingprojectbinding()"
     },
     {
@@ -5643,7 +5868,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L99",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_clearrejectsdifferentprojectpath",
-      "community": 22,
+      "community": 21,
       "norm_label": ".clearrejectsdifferentprojectpath()"
     },
     {
@@ -5652,8 +5877,80 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L110",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_tryresolve_rejectionmentionsforcerebindescapehatch",
-      "community": 22,
+      "community": 21,
       "norm_label": ".tryresolve_rejectionmentionsforcerebindescapehatch()"
+    },
+    {
+      "label": "WorkerCallResultTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_workercallresulttests_cs",
+      "community": 32,
+      "norm_label": "workercallresulttests.cs"
+    },
+    {
+      "label": "WorkerCallResultTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L6",
+      "id": "tiamcpserver_tests_workercallresulttests_workercallresulttests",
+      "community": 32,
+      "norm_label": "workercallresulttests"
+    },
+    {
+      "label": ".Ok_CarriesPayloadWithoutError()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L8",
+      "id": "tiamcpserver_tests_workercallresulttests_workercallresulttests_ok_carriespayloadwithouterror",
+      "community": 32,
+      "norm_label": ".ok_carriespayloadwithouterror()"
+    },
+    {
+      "label": ".Fail_CarriesErrorAndEmptyPayload()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L19",
+      "id": "tiamcpserver_tests_workercallresulttests_workercallresulttests_fail_carrieserrorandemptypayload",
+      "community": 32,
+      "norm_label": ".fail_carrieserrorandemptypayload()"
+    },
+    {
+      "label": ".ToText_RendersPayloadOnSuccess()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L29",
+      "id": "tiamcpserver_tests_workercallresulttests_workercallresulttests_totext_renderspayloadonsuccess",
+      "community": 32,
+      "norm_label": ".totext_renderspayloadonsuccess()"
+    },
+    {
+      "label": ".ToText_RendersErrorPrefixOnFailure()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L35",
+      "id": "tiamcpserver_tests_workercallresulttests_workercallresulttests_totext_renderserrorprefixonfailure",
+      "community": 32,
+      "norm_label": ".totext_renderserrorprefixonfailure()"
+    },
+    {
+      "label": ".Ok_PayloadStartingWithErrorPrefixStaysSuccessful()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L41",
+      "id": "tiamcpserver_tests_workercallresulttests_workercallresulttests_ok_payloadstartingwitherrorprefixstayssuccessful",
+      "community": 32,
+      "norm_label": ".ok_payloadstartingwitherrorprefixstayssuccessful()"
+    },
+    {
+      "label": ".Warnings_AreAttachedToBothShapes()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L50",
+      "id": "tiamcpserver_tests_workercallresulttests_workercallresulttests_warnings_areattachedtobothshapes",
+      "community": 32,
+      "norm_label": ".warnings_areattachedtobothshapes()"
     },
     {
       "label": "WriteSafetyServiceTests.cs",
@@ -5791,6 +6088,87 @@
       "norm_label": ".confirmedprojectcloserejectsmissingsafetytoken()"
     },
     {
+      "label": ".IsFailure()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
+      "source_location": "L10",
+      "community": 41,
+      "norm_label": ".isfailure()",
+      "id": "batch_batchexecutionengine_batchexecutionengine_isfailure"
+    },
+    {
+      "label": ".FormatWorkerError()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L676",
+      "community": 1,
+      "norm_label": ".formatworkererror()",
+      "id": "worker_opennessworkerclient_opennessworkerclient_formatworkererror"
+    },
+    {
+      "label": "DeviceInfo.cs",
+      "file_type": "code",
+      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/DeviceInfo.cs",
+      "source_location": "L1",
+      "community": 77,
+      "norm_label": "deviceinfo.cs",
+      "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_deviceinfo_cs"
+    },
+    {
+      "label": "DeviceItemInfo.cs",
+      "file_type": "code",
+      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/DeviceItemInfo.cs",
+      "source_location": "L1",
+      "community": 78,
+      "norm_label": "deviceiteminfo.cs",
+      "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_deviceiteminfo_cs"
+    },
+    {
+      "label": "HardwareConfigInfo.cs",
+      "file_type": "code",
+      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/HardwareConfigInfo.cs",
+      "source_location": "L1",
+      "community": 79,
+      "norm_label": "hardwareconfiginfo.cs",
+      "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_hardwareconfiginfo_cs"
+    },
+    {
+      "label": "EquipmentCatalogSearcher.cs",
+      "file_type": "code",
+      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L1",
+      "community": 15,
+      "norm_label": "equipmentcatalogsearcher.cs",
+      "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_equipmentcatalogsearcher_cs"
+    },
+    {
+      "label": ".ReadProperty()",
+      "file_type": "code",
+      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L223",
+      "community": 15,
+      "norm_label": ".readproperty()",
+      "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_readproperty"
+    },
+    {
+      "label": ".Enumerate()",
+      "file_type": "code",
+      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L258",
+      "community": 15,
+      "norm_label": ".enumerate()",
+      "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_enumerate"
+    },
+    {
+      "label": "HardwareConfigInfoTests.cs",
+      "file_type": "code",
+      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_location": "L1",
+      "community": 0,
+      "norm_label": "hardwareconfiginfotests.cs",
+      "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_hardwareconfiginfotests_cs"
+    },
+    {
       "label": "BlockExporter.cs",
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/BlockExporter.cs",
@@ -5804,7 +6182,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L1",
-      "community": 0,
+      "community": 2,
       "norm_label": "blockimporter.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_blockimporter_cs"
     },
@@ -5813,7 +6191,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/NetworkDeviceCreator.cs",
       "source_location": "L1",
-      "community": 4,
+      "community": 5,
       "norm_label": "networkdevicecreator.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_networkdevicecreator_cs"
     },
@@ -5822,7 +6200,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/AddNetworkDeviceTool.cs",
       "source_location": "L1",
-      "community": 46,
+      "community": 47,
       "norm_label": "addnetworkdevicetool.cs",
       "id": "tiamcpserver_tools_addnetworkdevicetool_cs"
     },
@@ -5831,7 +6209,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/AddNetworkDeviceTool.cs",
       "source_location": "L6",
-      "community": 46,
+      "community": 47,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_addnetworkdevicetool_tiamcpserver_tools"
     },
@@ -5840,7 +6218,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/AddNetworkDeviceTool.cs",
       "source_location": "L8",
-      "community": 46,
+      "community": 47,
       "norm_label": "addnetworkdevicetool",
       "id": "tools_addnetworkdevicetool_addnetworkdevicetool"
     },
@@ -5849,7 +6227,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/AddNetworkDeviceTool.cs",
       "source_location": "L11",
-      "community": 46,
+      "community": 47,
       "norm_label": ".previewaddnetworkdevice()",
       "id": "tools_addnetworkdevicetool_addnetworkdevicetool_previewaddnetworkdevice"
     },
@@ -5858,7 +6236,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/AddNetworkDeviceTool.cs",
       "source_location": "L36",
-      "community": 46,
+      "community": 47,
       "norm_label": ".addnetworkdevice()",
       "id": "tools_addnetworkdevicetool_addnetworkdevicetool_addnetworkdevice"
     },
@@ -5939,7 +6317,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ConfigureNetworkDeviceTool.cs",
       "source_location": "L1",
-      "community": 47,
+      "community": 48,
       "norm_label": "configurenetworkdevicetool.cs",
       "id": "tiamcpserver_tools_configurenetworkdevicetool_cs"
     },
@@ -5948,7 +6326,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ConfigureNetworkDeviceTool.cs",
       "source_location": "L6",
-      "community": 47,
+      "community": 48,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_configurenetworkdevicetool_tiamcpserver_tools"
     },
@@ -5957,7 +6335,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ConfigureNetworkDeviceTool.cs",
       "source_location": "L8",
-      "community": 47,
+      "community": 48,
       "norm_label": "configurenetworkdevicetool",
       "id": "tools_configurenetworkdevicetool_configurenetworkdevicetool"
     },
@@ -5966,7 +6344,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ConfigureNetworkDeviceTool.cs",
       "source_location": "L11",
-      "community": 47,
+      "community": 48,
       "norm_label": ".previewconfigurenetworkdevice()",
       "id": "tools_configurenetworkdevicetool_configurenetworkdevicetool_previewconfigurenetworkdevice"
     },
@@ -5975,7 +6353,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ConfigureNetworkDeviceTool.cs",
       "source_location": "L36",
-      "community": 47,
+      "community": 48,
       "norm_label": ".configurenetworkdevice()",
       "id": "tools_configurenetworkdevicetool_configurenetworkdevicetool_configurenetworkdevice"
     },
@@ -6164,7 +6542,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L1",
-      "community": 6,
+      "community": 7,
       "norm_label": "tagoperationstools.cs",
       "id": "tiamcpserver_tools_tagoperationstools_cs"
     },
@@ -6173,7 +6551,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L6",
-      "community": 6,
+      "community": 7,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_tagoperationstools_tiamcpserver_tools"
     },
@@ -6182,7 +6560,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L8",
-      "community": 6,
+      "community": 7,
       "norm_label": "tagtableoperationstool",
       "id": "tools_tagoperationstools_tagtableoperationstool"
     },
@@ -6191,7 +6569,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L11",
-      "community": 6,
+      "community": 7,
       "norm_label": ".previewcreatetagtable()",
       "id": "tools_tagoperationstools_tagtableoperationstool_previewcreatetagtable"
     },
@@ -6200,7 +6578,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L32",
-      "community": 6,
+      "community": 7,
       "norm_label": ".createtagtable()",
       "id": "tools_tagoperationstools_tagtableoperationstool_createtagtable"
     },
@@ -6209,7 +6587,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L76",
-      "community": 6,
+      "community": 7,
       "norm_label": ".previewdeletetagtable()",
       "id": "tools_tagoperationstools_tagtableoperationstool_previewdeletetagtable"
     },
@@ -6218,7 +6596,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L97",
-      "community": 6,
+      "community": 7,
       "norm_label": ".deletetagtable()",
       "id": "tools_tagoperationstools_tagtableoperationstool_deletetagtable"
     },
@@ -6227,7 +6605,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L142",
-      "community": 6,
+      "community": 7,
       "norm_label": "tagoperationstool",
       "id": "tools_tagoperationstools_tagoperationstool"
     },
@@ -6236,7 +6614,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L145",
-      "community": 6,
+      "community": 7,
       "norm_label": ".previewcreatetag()",
       "id": "tools_tagoperationstools_tagoperationstool_previewcreatetag"
     },
@@ -6245,7 +6623,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L169",
-      "community": 6,
+      "community": 7,
       "norm_label": ".createtag()",
       "id": "tools_tagoperationstools_tagoperationstool_createtag"
     },
@@ -6254,7 +6632,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L219",
-      "community": 6,
+      "community": 7,
       "norm_label": ".previewupdatetag()",
       "id": "tools_tagoperationstools_tagoperationstool_previewupdatetag"
     },
@@ -6263,7 +6641,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L248",
-      "community": 6,
+      "community": 7,
       "norm_label": ".updatetag()",
       "id": "tools_tagoperationstools_tagoperationstool_updatetag"
     },
@@ -6272,7 +6650,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L308",
-      "community": 6,
+      "community": 7,
       "norm_label": ".previewdeletetag()",
       "id": "tools_tagoperationstools_tagoperationstool_previewdeletetag"
     },
@@ -6281,7 +6659,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L330",
-      "community": 6,
+      "community": 7,
       "norm_label": ".deletetag()",
       "id": "tools_tagoperationstools_tagoperationstool_deletetag"
     },
@@ -6290,7 +6668,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L377",
-      "community": 6,
+      "community": 7,
       "norm_label": "userconstantoperationstool",
       "id": "tools_tagoperationstools_userconstantoperationstool"
     },
@@ -6299,7 +6677,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L380",
-      "community": 6,
+      "community": 7,
       "norm_label": ".previewcreateuserconstant()",
       "id": "tools_tagoperationstools_userconstantoperationstool_previewcreateuserconstant"
     },
@@ -6308,7 +6686,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L404",
-      "community": 6,
+      "community": 7,
       "norm_label": ".createuserconstant()",
       "id": "tools_tagoperationstools_userconstantoperationstool_createuserconstant"
     },
@@ -6317,7 +6695,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L454",
-      "community": 6,
+      "community": 7,
       "norm_label": ".previewupdateuserconstant()",
       "id": "tools_tagoperationstools_userconstantoperationstool_previewupdateuserconstant"
     },
@@ -6326,7 +6704,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L478",
-      "community": 6,
+      "community": 7,
       "norm_label": ".updateuserconstant()",
       "id": "tools_tagoperationstools_userconstantoperationstool_updateuserconstant"
     },
@@ -6335,7 +6713,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L528",
-      "community": 6,
+      "community": 7,
       "norm_label": ".previewdeleteuserconstant()",
       "id": "tools_tagoperationstools_userconstantoperationstool_previewdeleteuserconstant"
     },
@@ -6344,7 +6722,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L550",
-      "community": 6,
+      "community": 7,
       "norm_label": ".deleteuserconstant()",
       "id": "tools_tagoperationstools_userconstantoperationstool_deleteuserconstant"
     },
@@ -6353,7 +6731,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/UpdateBlockLogicTool.cs",
       "source_location": "L1",
-      "community": 48,
+      "community": 49,
       "norm_label": "updateblocklogictool.cs",
       "id": "tiamcpserver_tools_updateblocklogictool_cs"
     },
@@ -6362,7 +6740,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/UpdateBlockLogicTool.cs",
       "source_location": "L6",
-      "community": 48,
+      "community": 49,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_updateblocklogictool_tiamcpserver_tools"
     },
@@ -6371,7 +6749,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/UpdateBlockLogicTool.cs",
       "source_location": "L8",
-      "community": 48,
+      "community": 49,
       "norm_label": "updateblocklogictool",
       "id": "tools_updateblocklogictool_updateblocklogictool"
     },
@@ -6380,7 +6758,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/UpdateBlockLogicTool.cs",
       "source_location": "L11",
-      "community": 48,
+      "community": 49,
       "norm_label": ".previewupdateblocklogic()",
       "id": "tools_updateblocklogictool_updateblocklogictool_previewupdateblocklogic"
     },
@@ -6389,7 +6767,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/UpdateBlockLogicTool.cs",
       "source_location": "L33",
-      "community": 48,
+      "community": 49,
       "norm_label": ".updateblocklogic()",
       "id": "tools_updateblocklogictool_updateblocklogictool_updateblocklogic"
     },
@@ -6398,7 +6776,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddNetworkDeviceToolTests.cs",
       "source_location": "L1",
-      "community": 49,
+      "community": 50,
       "norm_label": "addnetworkdevicetooltests.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_addnetworkdevicetooltests_cs"
     },
@@ -6407,7 +6785,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddNetworkDeviceToolTests.cs",
       "source_location": "L10",
-      "community": 49,
+      "community": 50,
       "norm_label": "addnetworkdevicetooltests",
       "id": "tiamcpserver_tests_addnetworkdevicetooltests_addnetworkdevicetooltests"
     },
@@ -6416,7 +6794,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddNetworkDeviceToolTests.cs",
       "source_location": "L12",
-      "community": 49,
+      "community": 50,
       "norm_label": ".addnetworkdevicetoolhasmcpmetadata()",
       "id": "tiamcpserver_tests_addnetworkdevicetooltests_addnetworkdevicetooltests_addnetworkdevicetoolhasmcpmetadata"
     },
@@ -6425,7 +6803,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddNetworkDeviceToolTests.cs",
       "source_location": "L34",
-      "community": 49,
+      "community": 50,
       "norm_label": ".addnetworkdevicerejectsunconfirmedrequests()",
       "id": "tiamcpserver_tests_addnetworkdevicetooltests_addnetworkdevicetooltests_addnetworkdevicerejectsunconfirmedrequests"
     },
@@ -6434,7 +6812,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddNetworkDeviceToolTests.cs",
       "source_location": "L46",
-      "community": 49,
+      "community": 50,
       "norm_label": ".opennessworkerclientexposesaddnetworkdeviceasync()",
       "id": "tiamcpserver_tests_addnetworkdevicetooltests_addnetworkdevicetooltests_opennessworkerclientexposesaddnetworkdeviceasync"
     },
@@ -6479,7 +6857,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceToolTests.cs",
       "source_location": "L1",
-      "community": 50,
+      "community": 51,
       "norm_label": "configurenetworkdevicetooltests.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_configurenetworkdevicetooltests_cs"
     },
@@ -6488,7 +6866,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceToolTests.cs",
       "source_location": "L10",
-      "community": 50,
+      "community": 51,
       "norm_label": "configurenetworkdevicetooltests",
       "id": "tiamcpserver_tests_configurenetworkdevicetooltests_configurenetworkdevicetooltests"
     },
@@ -6497,7 +6875,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceToolTests.cs",
       "source_location": "L12",
-      "community": 50,
+      "community": 51,
       "norm_label": ".configurenetworkdevicetoolhasmcpmetadata()",
       "id": "tiamcpserver_tests_configurenetworkdevicetooltests_configurenetworkdevicetooltests_configurenetworkdevicetoolhasmcpmetadata"
     },
@@ -6506,7 +6884,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceToolTests.cs",
       "source_location": "L34",
-      "community": 50,
+      "community": 51,
       "norm_label": ".configurenetworkdevicerejectsunconfirmedrequests()",
       "id": "tiamcpserver_tests_configurenetworkdevicetooltests_configurenetworkdevicetooltests_configurenetworkdevicerejectsunconfirmedrequests"
     },
@@ -6515,7 +6893,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceToolTests.cs",
       "source_location": "L46",
-      "community": 50,
+      "community": 51,
       "norm_label": ".opennessworkerclientexposesconfigurenetworkdeviceasync()",
       "id": "tiamcpserver_tests_configurenetworkdevicetooltests_configurenetworkdevicetooltests_opennessworkerclientexposesconfigurenetworkdeviceasync"
     },
@@ -6713,7 +7091,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Program.cs",
       "source_location": "L1",
-      "community": 31,
+      "community": 33,
       "norm_label": "program.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_program_cs"
     },
@@ -6722,7 +7100,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Program.cs",
       "source_location": "L17",
-      "community": 31,
+      "community": 33,
       "norm_label": ".currentdomain_assemblyresolve()",
       "id": "tiamcpserver_program_program_currentdomain_assemblyresolve"
     },
@@ -6731,7 +7109,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Tools/AddNetworkDeviceTool.cs",
       "source_location": "L1",
-      "community": 46,
+      "community": 47,
       "norm_label": "addnetworkdevicetool.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tools_addnetworkdevicetool_cs"
     },
@@ -6740,7 +7118,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Tools/ConfigureNetworkDeviceTool.cs",
       "source_location": "L1",
-      "community": 47,
+      "community": 48,
       "norm_label": "configurenetworkdevicetool.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tools_configurenetworkdevicetool_cs"
     },
@@ -6749,7 +7127,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Tools/UpdateBlockLogicTool.cs",
       "source_location": "L1",
-      "community": 48,
+      "community": 49,
       "norm_label": "updateblocklogictool.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tools_updateblocklogictool_cs"
     },
@@ -6758,7 +7136,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L1",
-      "community": 19,
+      "community": 18,
       "norm_label": "blocktargetresolver.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_blocktargetresolver_cs"
     },
@@ -6767,7 +7145,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L75",
-      "community": 19,
+      "community": 18,
       "norm_label": ".findplcsoftware()",
       "id": "openness_blocktargetresolver_blocktargetresolver_findplcsoftware"
     },
@@ -6776,7 +7154,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L95",
-      "community": 19,
+      "community": 18,
       "norm_label": ".findplcsoftwareindeviceitems()",
       "id": "openness_blocktargetresolver_blocktargetresolver_findplcsoftwareindeviceitems"
     },
@@ -6857,7 +7235,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L1",
-      "community": 4,
+      "community": 5,
       "norm_label": "hardwareconfigreader.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_hardwareconfigreader_cs"
     },
@@ -6875,7 +7253,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L1",
-      "community": 21,
+      "community": 20,
       "norm_label": "projecttreewalker.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_projecttreewalker_cs"
     },
@@ -6884,7 +7262,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L45",
-      "community": 21,
+      "community": 20,
       "norm_label": ".findplcsoftwareindevice()",
       "id": "openness_projecttreewalker_projecttreewalker_findplcsoftwareindevice"
     },
@@ -6893,7 +7271,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L50",
-      "community": 21,
+      "community": 20,
       "norm_label": ".findplcsoftwareindeviceitems()",
       "id": "openness_projecttreewalker_projecttreewalker_findplcsoftwareindeviceitems"
     },
@@ -6902,7 +7280,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L1",
-      "community": 1,
+      "community": 3,
       "norm_label": "readme.md",
       "id": "readme_md"
     },
@@ -6911,7 +7289,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L1",
-      "community": 1,
+      "community": 3,
       "norm_label": "tia-portal-mcp",
       "id": "tia_portal_mcp_readme_tia_portal_mcp"
     },
@@ -6920,7 +7298,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L29",
-      "community": 1,
+      "community": 3,
       "norm_label": "architecture",
       "id": "tia_portal_mcp_readme_architecture"
     },
@@ -6929,7 +7307,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L40",
-      "community": 1,
+      "community": 3,
       "norm_label": "requirements",
       "id": "tia_portal_mcp_readme_requirements"
     },
@@ -6938,7 +7316,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L56",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:text (c:\\program files\\siemens\\automation\\portal v21\\publicapi\\v21)",
       "id": "tia_portal_mcp_readme_codeblock_1"
     },
@@ -6947,7 +7325,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L64",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell (dotnet build tiamcpserver.sln -m:1 /p:usetiaportalreferences)",
       "id": "tia_portal_mcp_readme_codeblock_2"
     },
@@ -6956,7 +7334,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L70",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell (dotnet build tiamcpserver.sln -m:1 /p:usetiaportalreferences)",
       "id": "tia_portal_mcp_readme_codeblock_3"
     },
@@ -6965,7 +7343,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L76",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:text (tia openness compile references: c:\\program files\\siemens\\au)",
       "id": "tia_portal_mcp_readme_codeblock_4"
     },
@@ -6974,7 +7352,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L80",
-      "community": 1,
+      "community": 3,
       "norm_label": "install",
       "id": "tia_portal_mcp_readme_install"
     },
@@ -6983,7 +7361,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L82",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell (dotnet tool install -g tiamcpserver)",
       "id": "tia_portal_mcp_readme_codeblock_5"
     },
@@ -6992,7 +7370,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L88",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell (tia-mcp)",
       "id": "tia_portal_mcp_readme_codeblock_6"
     },
@@ -7001,7 +7379,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L94",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell (tia-mcp --project c:\\projects\\line.ap21)",
       "id": "tia_portal_mcp_readme_codeblock_7"
     },
@@ -7010,7 +7388,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L104",
-      "community": 1,
+      "community": 3,
       "norm_label": "build from source",
       "id": "tia_portal_mcp_readme_build_from_source"
     },
@@ -7019,7 +7397,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L106",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell (dotnet restore tiamcpserver.sln)",
       "id": "tia_portal_mcp_readme_codeblock_8"
     },
@@ -7028,7 +7406,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L115",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:text (tiamcpserver\\bin\\debug\\net8.0\\openness-worker)",
       "id": "tia_portal_mcp_readme_codeblock_9"
     },
@@ -7037,7 +7415,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L119",
-      "community": 1,
+      "community": 3,
       "norm_label": "run locally",
       "id": "tia_portal_mcp_readme_run_locally"
     },
@@ -7046,7 +7424,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L123",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell (dotnet run --project tiamcpserver)",
       "id": "tia_portal_mcp_readme_codeblock_10"
     },
@@ -7055,7 +7433,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L131",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell ('{ \"method\": \"browse_project_tree\", \"projectpath\": null }' |)",
       "id": "tia_portal_mcp_readme_codeblock_11"
     },
@@ -7064,7 +7442,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L140",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:json ({\"success\":true,\"payload\":\"[...]\"})",
       "id": "tia_portal_mcp_readme_codeblock_12"
     },
@@ -7073,7 +7451,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L146",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:json ({\"success\":false,\"error\":\"no running tia portal v21 instance)",
       "id": "tia_portal_mcp_readme_codeblock_13"
     },
@@ -7082,7 +7460,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L150",
-      "community": 1,
+      "community": 3,
       "norm_label": "local mcp sandbox testing",
       "id": "tia_portal_mcp_readme_local_mcp_sandbox_testing"
     },
@@ -7091,7 +7469,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L158",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell (dotnet restore tiamcpserver.sln)",
       "id": "tia_portal_mcp_readme_codeblock_14"
     },
@@ -7100,7 +7478,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L165",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell (npx -y @modelcontextprotocol/inspector dotnet .\\tiamcpserver)",
       "id": "tia_portal_mcp_readme_codeblock_15"
     },
@@ -7109,7 +7487,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L171",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell (npx -y @modelcontextprotocol/inspector dotnet .\\tiamcpserver)",
       "id": "tia_portal_mcp_readme_codeblock_16"
     },
@@ -7118,7 +7496,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L187",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:json ({})",
       "id": "tia_portal_mcp_readme_codeblock_17"
     },
@@ -7127,7 +7505,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L193",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:json ({)",
       "id": "tia_portal_mcp_readme_codeblock_18"
     },
@@ -7136,7 +7514,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L201",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:json ({)",
       "id": "tia_portal_mcp_readme_codeblock_19"
     },
@@ -7145,7 +7523,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L210",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:json ({)",
       "id": "tia_portal_mcp_readme_codeblock_20"
     },
@@ -7154,7 +7532,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L220",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:json ({)",
       "id": "tia_portal_mcp_readme_codeblock_21"
     },
@@ -7163,7 +7541,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L228",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:json ({)",
       "id": "tia_portal_mcp_readme_codeblock_22"
     },
@@ -7172,7 +7550,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L239",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:json ({)",
       "id": "tia_portal_mcp_readme_codeblock_23"
     },
@@ -7181,7 +7559,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L252",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:json ({)",
       "id": "tia_portal_mcp_readme_codeblock_24"
     },
@@ -7190,7 +7568,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L265",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:json ({)",
       "id": "tia_portal_mcp_readme_codeblock_25"
     },
@@ -7199,7 +7577,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L274",
-      "community": 1,
+      "community": 3,
       "norm_label": "local package build",
       "id": "tia_portal_mcp_readme_local_package_build"
     },
@@ -7208,7 +7586,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L280",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell (dotnet pack tiamcpserver\\tiamcpserver.csproj -c release)",
       "id": "tia_portal_mcp_readme_codeblock_26"
     },
@@ -7217,7 +7595,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L286",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell (dotnet tool install -g tiamcpserver --add-source .\\tiamcpser)",
       "id": "tia_portal_mcp_readme_codeblock_27"
     },
@@ -7226,7 +7604,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L292",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell (tia-mcp)",
       "id": "tia_portal_mcp_readme_codeblock_28"
     },
@@ -7235,7 +7613,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L298",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:powershell (tia-mcp --project c:\\projects\\line.ap21)",
       "id": "tia_portal_mcp_readme_codeblock_29"
     },
@@ -7244,7 +7622,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L306",
-      "community": 1,
+      "community": 3,
       "norm_label": "block paths",
       "id": "tia_portal_mcp_readme_block_paths"
     },
@@ -7253,7 +7631,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L310",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:text (blockname)",
       "id": "tia_portal_mcp_readme_codeblock_30"
     },
@@ -7262,7 +7640,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L319",
-      "community": 1,
+      "community": 3,
       "norm_label": "roadmap",
       "id": "tia_portal_mcp_readme_roadmap"
     },
@@ -7271,7 +7649,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L335",
-      "community": 1,
+      "community": 3,
       "norm_label": "mcp client configuration",
       "id": "tia_portal_mcp_readme_mcp_client_configuration"
     },
@@ -7280,7 +7658,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L339",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:json ({)",
       "id": "tia_portal_mcp_readme_codeblock_31"
     },
@@ -7289,7 +7667,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L351",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:json ({)",
       "id": "tia_portal_mcp_readme_codeblock_32"
     },
@@ -7298,7 +7676,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L364",
-      "community": 1,
+      "community": 3,
       "norm_label": "code:json ({)",
       "id": "tia_portal_mcp_readme_codeblock_33"
     },
@@ -7307,7 +7685,7 @@
       "file_type": "document",
       "source_file": "README.md",
       "source_location": "L375",
-      "community": 1,
+      "community": 3,
       "norm_label": "troubleshooting",
       "id": "tia_portal_mcp_readme_troubleshooting"
     },
@@ -7316,7 +7694,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/AddDeviceResultInfo.cs",
       "source_location": "L1",
-      "community": 67,
+      "community": 68,
       "norm_label": "adddeviceresultinfo.cs",
       "id": "tiamcpserver_contracts_adddeviceresultinfo_cs"
     },
@@ -7334,7 +7712,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CatalogEntryInfo.cs",
       "source_location": "L1",
-      "community": 68,
+      "community": 69,
       "norm_label": "catalogentryinfo.cs",
       "id": "tiamcpserver_contracts_catalogentryinfo_cs"
     },
@@ -7352,7 +7730,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CompileCheckReport.cs",
       "source_location": "L1",
-      "community": 69,
+      "community": 70,
       "norm_label": "compilecheckreport.cs",
       "id": "tiamcpserver_contracts_compilecheckreport_cs"
     },
@@ -7361,7 +7739,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CompileMessageInfo.cs",
       "source_location": "L1",
-      "community": 70,
+      "community": 71,
       "norm_label": "compilemessageinfo.cs",
       "id": "tiamcpserver_contracts_compilemessageinfo_cs"
     },
@@ -7370,7 +7748,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/ConfigureNetworkDeviceResultInfo.cs",
       "source_location": "L1",
-      "community": 71,
+      "community": 72,
       "norm_label": "configurenetworkdeviceresultinfo.cs",
       "id": "tiamcpserver_contracts_configurenetworkdeviceresultinfo_cs"
     },
@@ -7379,7 +7757,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CrossReferenceFilterNames.cs",
       "source_location": "L1",
-      "community": 66,
+      "community": 67,
       "norm_label": "crossreferencefilternames.cs",
       "id": "tiamcpserver_contracts_crossreferencefilternames_cs"
     },
@@ -7388,7 +7766,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CrossReferenceLocationInfo.cs",
       "source_location": "L1",
-      "community": 72,
+      "community": 73,
       "norm_label": "crossreferencelocationinfo.cs",
       "id": "tiamcpserver_contracts_crossreferencelocationinfo_cs"
     },
@@ -7397,7 +7775,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CrossReferenceReport.cs",
       "source_location": "L1",
-      "community": 73,
+      "community": 74,
       "norm_label": "crossreferencereport.cs",
       "id": "tiamcpserver_contracts_crossreferencereport_cs"
     },
@@ -7406,7 +7784,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CrossReferenceSourceInfo.cs",
       "source_location": "L1",
-      "community": 74,
+      "community": 75,
       "norm_label": "crossreferencesourceinfo.cs",
       "id": "tiamcpserver_contracts_crossreferencesourceinfo_cs"
     },
@@ -7415,43 +7793,16 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CrossReferenceTargetInfo.cs",
       "source_location": "L1",
-      "community": 75,
+      "community": 76,
       "norm_label": "crossreferencetargetinfo.cs",
       "id": "tiamcpserver_contracts_crossreferencetargetinfo_cs"
-    },
-    {
-      "label": "DeviceInfo.cs",
-      "file_type": "code",
-      "source_file": "TiaMcpServer.Contracts/DeviceInfo.cs",
-      "source_location": "L1",
-      "community": 76,
-      "norm_label": "deviceinfo.cs",
-      "id": "tiamcpserver_contracts_deviceinfo_cs"
-    },
-    {
-      "label": "DeviceItemInfo.cs",
-      "file_type": "code",
-      "source_file": "TiaMcpServer.Contracts/DeviceItemInfo.cs",
-      "source_location": "L1",
-      "community": 77,
-      "norm_label": "deviceiteminfo.cs",
-      "id": "tiamcpserver_contracts_deviceiteminfo_cs"
-    },
-    {
-      "label": "HardwareConfigInfo.cs",
-      "file_type": "code",
-      "source_file": "TiaMcpServer.Contracts/HardwareConfigInfo.cs",
-      "source_location": "L1",
-      "community": 78,
-      "norm_label": "hardwareconfiginfo.cs",
-      "id": "tiamcpserver_contracts_hardwareconfiginfo_cs"
     },
     {
       "label": "IoSystemInfo.cs",
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/IoSystemInfo.cs",
       "source_location": "L1",
-      "community": 79,
+      "community": 80,
       "norm_label": "iosysteminfo.cs",
       "id": "tiamcpserver_contracts_iosysteminfo_cs"
     },
@@ -7460,7 +7811,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/NetworkInterfaceInfo.cs",
       "source_location": "L1",
-      "community": 80,
+      "community": 81,
       "norm_label": "networkinterfaceinfo.cs",
       "id": "tiamcpserver_contracts_networkinterfaceinfo_cs"
     },
@@ -7469,7 +7820,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/NodeInfo.cs",
       "source_location": "L1",
-      "community": 81,
+      "community": 82,
       "norm_label": "nodeinfo.cs",
       "id": "tiamcpserver_contracts_nodeinfo_cs"
     },
@@ -7478,7 +7829,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/PlcCompileInfo.cs",
       "source_location": "L1",
-      "community": 82,
+      "community": 83,
       "norm_label": "plccompileinfo.cs",
       "id": "tiamcpserver_contracts_plccompileinfo_cs"
     },
@@ -7487,7 +7838,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/PlcCrossReferenceInfo.cs",
       "source_location": "L1",
-      "community": 83,
+      "community": 84,
       "norm_label": "plccrossreferenceinfo.cs",
       "id": "tiamcpserver_contracts_plccrossreferenceinfo_cs"
     },
@@ -7496,7 +7847,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/ProjectTreeNode.cs",
       "source_location": "L1",
-      "community": 84,
+      "community": 85,
       "norm_label": "projecttreenode.cs",
       "id": "tiamcpserver_contracts_projecttreenode_cs"
     },
@@ -7505,7 +7856,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/SubnetInfo.cs",
       "source_location": "L1",
-      "community": 85,
+      "community": 86,
       "norm_label": "subnetinfo.cs",
       "id": "tiamcpserver_contracts_subnetinfo_cs"
     },
@@ -7514,7 +7865,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/TagInfo.cs",
       "source_location": "L1",
-      "community": 86,
+      "community": 87,
       "norm_label": "taginfo.cs",
       "id": "tiamcpserver_contracts_taginfo_cs"
     },
@@ -7523,7 +7874,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/TagTableInfo.cs",
       "source_location": "L1",
-      "community": 87,
+      "community": 88,
       "norm_label": "tagtableinfo.cs",
       "id": "tiamcpserver_contracts_tagtableinfo_cs"
     },
@@ -7532,7 +7883,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/UserConstantInfo.cs",
       "source_location": "L1",
-      "community": 88,
+      "community": 89,
       "norm_label": "userconstantinfo.cs",
       "id": "tiamcpserver_contracts_userconstantinfo_cs"
     },
@@ -7541,7 +7892,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/WorkerResponse.cs",
       "source_location": "L1",
-      "community": 89,
+      "community": 90,
       "norm_label": "workerresponse.cs",
       "id": "tiamcpserver_contracts_workerresponse_cs"
     },
@@ -7550,25 +7901,16 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
       "source_location": "L1",
-      "community": 32,
+      "community": 34,
       "norm_label": "assemblyresolver.cs",
       "id": "tiamcpserver_opennessworker_openness_assemblyresolver_cs"
-    },
-    {
-      "label": "EquipmentCatalogSearcher.cs",
-      "file_type": "code",
-      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
-      "source_location": "L1",
-      "community": 16,
-      "norm_label": "equipmentcatalogsearcher.cs",
-      "id": "tiamcpserver_opennessworker_openness_equipmentcatalogsearcher_cs"
     },
     {
       "label": ".FindPlcSoftware()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L23",
-      "community": 29,
+      "community": 28,
       "norm_label": ".findplcsoftware()",
       "id": "openness_tagtablereader_tagtablereader_findplcsoftware"
     },
@@ -7577,7 +7919,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L45",
-      "community": 29,
+      "community": 28,
       "norm_label": ".findplcsoftwareindeviceitems()",
       "id": "openness_tagtablereader_tagtablereader_findplcsoftwareindeviceitems"
     },
@@ -7586,7 +7928,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/AddDeviceResultInfoTests.cs",
       "source_location": "L1",
-      "community": 42,
+      "community": 43,
       "norm_label": "adddeviceresultinfotests.cs",
       "id": "tiamcpserver_tests_adddeviceresultinfotests_cs"
     },
@@ -7595,7 +7937,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/AddNetworkDeviceToolTests.cs",
       "source_location": "L1",
-      "community": 49,
+      "community": 50,
       "norm_label": "addnetworkdevicetooltests.cs",
       "id": "tiamcpserver_tests_addnetworkdevicetooltests_cs"
     },
@@ -7604,7 +7946,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L1",
-      "community": 28,
+      "community": 30,
       "norm_label": "blockaddresstests.cs",
       "id": "tiamcpserver_tests_blockaddresstests_cs"
     },
@@ -7622,7 +7964,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/CatalogTypeIdentifierTests.cs",
       "source_location": "L1",
-      "community": 43,
+      "community": 44,
       "norm_label": "catalogtypeidentifiertests.cs",
       "id": "tiamcpserver_tests_catalogtypeidentifiertests_cs"
     },
@@ -7649,7 +7991,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/ConfigureNetworkDeviceResultInfoTests.cs",
       "source_location": "L1",
-      "community": 44,
+      "community": 45,
       "norm_label": "configurenetworkdeviceresultinfotests.cs",
       "id": "tiamcpserver_tests_configurenetworkdeviceresultinfotests_cs"
     },
@@ -7658,7 +8000,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/ConfigureNetworkDeviceToolTests.cs",
       "source_location": "L1",
-      "community": 50,
+      "community": 51,
       "norm_label": "configurenetworkdevicetooltests.cs",
       "id": "tiamcpserver_tests_configurenetworkdevicetooltests_cs"
     },
@@ -7667,18 +8009,9 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L1",
-      "community": 24,
+      "community": 23,
       "norm_label": "crossreferenceinfotests.cs",
       "id": "tiamcpserver_tests_crossreferenceinfotests_cs"
-    },
-    {
-      "label": "HardwareConfigInfoTests.cs",
-      "file_type": "code",
-      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
-      "source_location": "L1",
-      "community": 30,
-      "norm_label": "hardwareconfiginfotests.cs",
-      "id": "tiamcpserver_tests_hardwareconfiginfotests_cs"
     },
     {
       "label": "SearchEquipmentCatalogToolTests.cs",
@@ -7724,7 +8057,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 97,
+      "community": 98,
       "norm_label": "multi-process architecture rationale",
       "id": "readme_arch_rationale"
     },
@@ -7737,7 +8070,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 97,
+      "community": 98,
       "norm_label": ".net remoting incompatibility in .net 8",
       "id": "readme_remoting_limitation"
     },
@@ -7815,7 +8148,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 98,
+      "community": 100,
       "norm_label": ".net 8",
       "id": "readme_dotnet8"
     },
@@ -7828,7 +8161,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 99,
+      "community": 101,
       "norm_label": ".net framework 4.8",
       "id": "readme_dotnet48"
     }
@@ -7929,16 +8262,6 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
-      "source_location": "L10",
-      "weight": 1.0,
-      "confidence_score": 1.0,
-      "source": "batch_batchexecutionengine_batchexecutionengine",
-      "target": "batch_batchexecutionengine_batchexecutionengine_isfailure"
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
       "source_location": "L14",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -7956,6 +8279,37 @@
       "target": "batch_batchexecutionengine_batchexecutionengine_applywritesasync"
     },
     {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "batch_batchexecutionengine_batchexecutionengine",
+      "target": "batch_batchexecutionengine_batchexecutionengine_tooperationresult",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
+      "source_location": "L10",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "batch_batchexecutionengine_batchexecutionengine",
+      "target": "batch_batchexecutionengine_batchexecutionengine_isfailure"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
+      "source_location": "L21",
+      "weight": 1.0,
+      "source": "batch_batchexecutionengine_batchexecutionengine_executereadsasync",
+      "target": "batch_batchexecutionengine_batchexecutionengine_tooperationresult",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "context": "call",
       "confidence": "EXTRACTED",
@@ -7965,6 +8319,17 @@
       "confidence_score": 1.0,
       "source": "batch_batchexecutionengine_batchexecutionengine_executereadsasync",
       "target": "batch_batchexecutionengine_batchexecutionengine_isfailure"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
+      "source_location": "L44",
+      "weight": 1.0,
+      "source": "batch_batchexecutionengine_batchexecutionengine_applywritesasync",
+      "target": "batch_batchexecutionengine_batchexecutionengine_tooperationresult",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -8176,6 +8541,17 @@
       "target": "batch_batchoperationcatalog_batchoperationcatalog_buildspecs"
     },
     {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L791",
+      "weight": 1.0,
+      "context": "field",
+      "source": "worker_opennessworkerclient_opennessworkerclient",
+      "target": "int",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "context": "call",
       "confidence": "EXTRACTED",
@@ -8279,7 +8655,18 @@
       "source_location": "L22",
       "weight": 1.0,
       "context": "field",
+      "confidence_score": 1.0,
       "source": "safety_writesafetyservice_writesafetyservice",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L22",
+      "weight": 1.0,
+      "context": "field",
+      "source": "worker_opennessworkerclient_opennessworkerclient",
       "target": "string",
       "confidence_score": 1.0
     },
@@ -8312,7 +8699,18 @@
       "source_location": "L10",
       "weight": 1.0,
       "context": "field",
+      "confidence_score": 1.0,
       "source": "openness_blockimporter_blockimporter",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L20",
+      "weight": 1.0,
+      "context": "field",
+      "source": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher",
       "target": "string",
       "confidence_score": 1.0
     },
@@ -8441,6 +8839,28 @@
       "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program",
       "target": "jsonserializeroptions"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs",
+      "source_location": "L10",
+      "weight": 1.0,
+      "context": "field",
+      "source": "tiamcpserver_tests_batchoperationrequestjsontests_batchoperationrequestjsontests",
+      "target": "jsonserializeroptions",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_location": "L10",
+      "weight": 1.0,
+      "context": "field",
+      "source": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests",
+      "target": "jsonserializeroptions",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -8759,9 +9179,9 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L136",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "safety_writesafetyservice_writesafetyservice",
-      "target": "safety_writesafetyservice_writesafetyservice_rejected",
-      "confidence_score": 1.0
+      "target": "safety_writesafetyservice_writesafetyservice_rejected"
     },
     {
       "relation": "method",
@@ -8875,9 +9295,9 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L93",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "safety_writesafetyservice_writesafetyservice_validateandconsume",
-      "target": "safety_writesafetyservice_writesafetyservice_rejected",
-      "confidence_score": 1.0
+      "target": "safety_writesafetyservice_writesafetyservice_rejected"
     },
     {
       "relation": "calls",
@@ -8941,9 +9361,9 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L139",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "safety_writesafetyservice_writesafetyservice_rejected",
-      "target": "safety_writesafetyservice_invalid",
-      "confidence_score": 1.0
+      "target": "safety_writesafetyservice_invalid"
     },
     {
       "relation": "calls",
@@ -9262,6 +9682,17 @@
       "target": "projectsessionbinding"
     },
     {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L21",
+      "weight": 1.0,
+      "context": "field",
+      "source": "worker_opennessworkerclient_opennessworkerclient",
+      "target": "ilogger",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
@@ -9447,9 +9878,9 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L352",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient",
-      "target": "worker_opennessworkerclient_opennessworkerclient_createblockasync",
-      "confidence_score": 1.0
+      "target": "worker_opennessworkerclient_opennessworkerclient_createblockasync"
     },
     {
       "relation": "method",
@@ -9457,9 +9888,9 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L374",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient",
-      "target": "worker_opennessworkerclient_opennessworkerclient_deleteblockasync",
-      "confidence_score": 1.0
+      "target": "worker_opennessworkerclient_opennessworkerclient_deleteblockasync"
     },
     {
       "relation": "method",
@@ -9467,9 +9898,9 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L388",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient",
-      "target": "worker_opennessworkerclient_opennessworkerclient_createblockgroupasync",
-      "confidence_score": 1.0
+      "target": "worker_opennessworkerclient_opennessworkerclient_createblockgroupasync"
     },
     {
       "relation": "method",
@@ -9477,9 +9908,9 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L402",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient",
-      "target": "worker_opennessworkerclient_opennessworkerclient_deleteblockgroupasync",
-      "confidence_score": 1.0
+      "target": "worker_opennessworkerclient_opennessworkerclient_deleteblockgroupasync"
     },
     {
       "relation": "method",
@@ -9487,9 +9918,9 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L416",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient",
-      "target": "worker_opennessworkerclient_opennessworkerclient_startplcasync",
-      "confidence_score": 1.0
+      "target": "worker_opennessworkerclient_opennessworkerclient_startplcasync"
     },
     {
       "relation": "method",
@@ -9497,9 +9928,9 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L430",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient",
-      "target": "worker_opennessworkerclient_opennessworkerclient_stopplcasync",
-      "confidence_score": 1.0
+      "target": "worker_opennessworkerclient_opennessworkerclient_stopplcasync"
     },
     {
       "relation": "method",
@@ -9585,21 +10016,21 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L732",
+      "source_location": "L640",
       "weight": 1.0,
-      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient",
-      "target": "worker_opennessworkerclient_opennessworkerclient_canbind"
+      "target": "worker_opennessworkerclient_opennessworkerclient_invokeworkerasync",
+      "confidence_score": 1.0
     },
     {
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L754",
+      "source_location": "L732",
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient",
-      "target": "worker_opennessworkerclient_opennessworkerclient_formatworkererror"
+      "target": "worker_opennessworkerclient_opennessworkerclient_canbind"
     },
     {
       "relation": "method",
@@ -9618,9 +10049,9 @@
       "source_location": "L708",
       "weight": 1.0,
       "context": "field",
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient",
-      "target": "semaphoreslim",
-      "confidence_score": 1.0
+      "target": "semaphoreslim"
     },
     {
       "relation": "method",
@@ -9638,8 +10069,18 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L723",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient",
-      "target": "worker_opennessworkerclient_opennessworkerclient_sendunguardedasync",
+      "target": "worker_opennessworkerclient_opennessworkerclient_sendunguardedasync"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L793",
+      "weight": 1.0,
+      "source": "worker_opennessworkerclient_opennessworkerclient",
+      "target": "worker_opennessworkerclient_opennessworkerclient_splitstderrlines",
       "confidence_score": 1.0
     },
     {
@@ -9661,6 +10102,16 @@
       "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient",
       "target": "worker_opennessworkerclient_opennessworkerclient_trykill"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L754",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "worker_opennessworkerclient_opennessworkerclient",
+      "target": "worker_opennessworkerclient_opennessworkerclient_formatworkererror"
     },
     {
       "relation": "calls",
@@ -9977,9 +10428,9 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L359",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient_createblockasync",
-      "target": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync",
-      "confidence_score": 1.0
+      "target": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync"
     },
     {
       "relation": "calls",
@@ -9988,9 +10439,9 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L376",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient_deleteblockasync",
-      "target": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync",
-      "confidence_score": 1.0
+      "target": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync"
     },
     {
       "relation": "calls",
@@ -9999,9 +10450,9 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L390",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient_createblockgroupasync",
-      "target": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync",
-      "confidence_score": 1.0
+      "target": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync"
     },
     {
       "relation": "calls",
@@ -10010,9 +10461,9 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L404",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient_deleteblockgroupasync",
-      "target": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync",
-      "confidence_score": 1.0
+      "target": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync"
     },
     {
       "relation": "calls",
@@ -10021,9 +10472,9 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L418",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient_startplcasync",
-      "target": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync",
-      "confidence_score": 1.0
+      "target": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync"
     },
     {
       "relation": "calls",
@@ -10032,9 +10483,9 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L432",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient_stopplcasync",
-      "target": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync",
-      "confidence_score": 1.0
+      "target": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync"
     },
     {
       "relation": "calls",
@@ -10063,6 +10514,17 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L469",
+      "weight": 1.0,
+      "source": "worker_opennessworkerclient_opennessworkerclient_openprojectasync",
+      "target": "worker_opennessworkerclient_opennessworkerclient_invokeworkerasync",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L540",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -10085,6 +10547,28 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L498",
+      "weight": 1.0,
+      "source": "worker_opennessworkerclient_opennessworkerclient_createprojectasync",
+      "target": "worker_opennessworkerclient_opennessworkerclient_invokeworkerasync",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L593",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "worker_opennessworkerclient_opennessworkerclient_createprojectasync",
+      "target": "worker_opennessworkerclient_opennessworkerclient_tryreadprojectpath"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L576",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -10101,17 +10585,6 @@
       "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient_createprojectasync",
       "target": "worker_opennessworkerclient_opennessworkerclient_formatworkererror"
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L593",
-      "weight": 1.0,
-      "confidence_score": 1.0,
-      "source": "worker_opennessworkerclient_opennessworkerclient_createprojectasync",
-      "target": "worker_opennessworkerclient_opennessworkerclient_tryreadprojectpath"
     },
     {
       "relation": "calls",
@@ -10173,6 +10646,28 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L634",
+      "weight": 1.0,
+      "source": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync",
+      "target": "worker_opennessworkerclient_opennessworkerclient_invokeworkerasync",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L718",
+      "weight": 1.0,
+      "source": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync",
+      "target": "openness_networkdeviceconfigurator_networkdeviceconfigurator_configure"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L720",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -10193,13 +10688,13 @@
     {
       "relation": "calls",
       "context": "call",
-      "confidence": "INFERRED",
-      "confidence_score": 0.8,
+      "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L718",
+      "source_location": "L644",
       "weight": 1.0,
-      "source": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync",
-      "target": "openness_networkdeviceconfigurator_networkdeviceconfigurator_configure"
+      "source": "worker_opennessworkerclient_opennessworkerclient_invokeworkerasync",
+      "target": "worker_opennessworkerclient_opennessworkerclient_sendasync",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -10208,9 +10703,9 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L715",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient_sendasync",
-      "target": "worker_opennessworkerclient_opennessworkerclient_sendunguardedasync",
-      "confidence_score": 1.0
+      "target": "worker_opennessworkerclient_opennessworkerclient_sendunguardedasync"
     },
     {
       "relation": "calls",
@@ -10241,9 +10736,9 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L725",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient_sendunguardedasync",
-      "target": "worker_opennessworkerclient_opennessworkerclient_locateworkerexecutable",
-      "confidence_score": 1.0
+      "target": "worker_opennessworkerclient_opennessworkerclient_locateworkerexecutable"
     },
     {
       "relation": "calls",
@@ -10252,8 +10747,49 @@
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L753",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "worker_opennessworkerclient_opennessworkerclient_sendunguardedasync",
-      "target": "worker_opennessworkerclient_opennessworkerclient_trykill",
+      "target": "worker_opennessworkerclient_opennessworkerclient_trykill"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
+      "source_location": "L777",
+      "weight": 1.0,
+      "source": "worker_opennessworkerclient_opennessworkerclient_sendunguardedasync",
+      "target": "worker_opennessworkerclient_opennessworkerclient_splitstderrlines",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/WorkerCallResult.cs",
+      "source_location": "L15",
+      "weight": 1.0,
+      "source": "tiamcpserver_worker_workercallresult_cs",
+      "target": "worker_workercallresult_ok",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/WorkerCallResult.cs",
+      "source_location": "L18",
+      "weight": 1.0,
+      "source": "tiamcpserver_worker_workercallresult_cs",
+      "target": "worker_workercallresult_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/WorkerCallResult.cs",
+      "source_location": "L22",
+      "weight": 1.0,
+      "source": "tiamcpserver_worker_workercallresult_cs",
+      "target": "worker_workercallresult_totext",
       "confidence_score": 1.0
     },
     {
@@ -10432,9 +10968,9 @@
       "source_file": "TiaMcpServer.Contracts/BlockMutationResultInfo.cs",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_contracts_blockmutationresultinfo_cs",
-      "target": "tiamcpserver_contracts_blockmutationresultinfo_blockmutationresultinfo",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_contracts_blockmutationresultinfo_blockmutationresultinfo"
     },
     {
       "relation": "contains",
@@ -10669,16 +11205,6 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/DeviceInfo.cs",
-      "source_location": "L5",
-      "weight": 1.0,
-      "confidence_score": 1.0,
-      "source": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_deviceinfo_cs",
-      "target": "tiamcpserver_contracts_deviceinfo_deviceinfo"
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.Contracts/DeviceInfo.cs",
       "source_location": "L5",
       "weight": 1.0,
@@ -10689,12 +11215,12 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/DeviceItemInfo.cs",
+      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/DeviceInfo.cs",
       "source_location": "L5",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_deviceiteminfo_cs",
-      "target": "tiamcpserver_contracts_deviceiteminfo_deviceiteminfo"
+      "source": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_deviceinfo_cs",
+      "target": "tiamcpserver_contracts_deviceinfo_deviceinfo"
     },
     {
       "relation": "contains",
@@ -10709,12 +11235,12 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/HardwareConfigInfo.cs",
+      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/DeviceItemInfo.cs",
       "source_location": "L5",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_hardwareconfiginfo_cs",
-      "target": "tiamcpserver_contracts_hardwareconfiginfo_hardwareconfiginfo"
+      "source": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_deviceiteminfo_cs",
+      "target": "tiamcpserver_contracts_deviceiteminfo_deviceiteminfo"
     },
     {
       "relation": "contains",
@@ -10724,6 +11250,16 @@
       "weight": 1.0,
       "confidence_score": 1.0,
       "source": "tiamcpserver_contracts_hardwareconfiginfo_cs",
+      "target": "tiamcpserver_contracts_hardwareconfiginfo_hardwareconfiginfo"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/HardwareConfigInfo.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_hardwareconfiginfo_cs",
       "target": "tiamcpserver_contracts_hardwareconfiginfo_hardwareconfiginfo"
     },
     {
@@ -10832,9 +11368,9 @@
       "source_file": "TiaMcpServer.Contracts/PlcOnlineResultInfo.cs",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_contracts_plconlineresultinfo_cs",
-      "target": "tiamcpserver_contracts_plconlineresultinfo_plconlineresultinfo",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_contracts_plconlineresultinfo_plconlineresultinfo"
     },
     {
       "relation": "contains",
@@ -11086,9 +11622,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L6",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_cs",
-      "target": "workertiaportalsession",
-      "confidence_score": 1.0
+      "target": "workertiaportalsession"
     },
     {
       "relation": "contains",
@@ -11107,9 +11643,9 @@
       "source_location": "L21",
       "weight": 1.0,
       "context": "field",
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program",
-      "target": "workertiaportalsession",
-      "confidence_score": 1.0
+      "target": "workertiaportalsession"
     },
     {
       "relation": "method",
@@ -11317,9 +11853,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L319",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program",
-      "target": "tiamcpserver_opennessworker_program_program_createblock",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_createblock"
     },
     {
       "relation": "method",
@@ -11327,9 +11863,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L345",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program",
-      "target": "tiamcpserver_opennessworker_program_program_deleteblock",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_deleteblock"
     },
     {
       "relation": "method",
@@ -11337,9 +11873,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L361",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program",
-      "target": "tiamcpserver_opennessworker_program_program_createblockgroup",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_createblockgroup"
     },
     {
       "relation": "method",
@@ -11347,9 +11883,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L377",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program",
-      "target": "tiamcpserver_opennessworker_program_program_deleteblockgroup",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_deleteblockgroup"
     },
     {
       "relation": "method",
@@ -11357,9 +11893,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L393",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program",
-      "target": "tiamcpserver_opennessworker_program_program_startplc",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_startplc"
     },
     {
       "relation": "method",
@@ -11367,9 +11903,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L404",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program",
-      "target": "tiamcpserver_opennessworker_program_program_stopplc",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_stopplc"
     },
     {
       "relation": "method",
@@ -11759,9 +12295,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L73",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_handleline",
-      "target": "tiamcpserver_opennessworker_program_program_createblock",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_createblock"
     },
     {
       "relation": "calls",
@@ -11770,9 +12306,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L74",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_handleline",
-      "target": "tiamcpserver_opennessworker_program_program_deleteblock",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_deleteblock"
     },
     {
       "relation": "calls",
@@ -11781,9 +12317,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L75",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_handleline",
-      "target": "tiamcpserver_opennessworker_program_program_createblockgroup",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_createblockgroup"
     },
     {
       "relation": "calls",
@@ -11792,9 +12328,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L76",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_handleline",
-      "target": "tiamcpserver_opennessworker_program_program_deleteblockgroup",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_deleteblockgroup"
     },
     {
       "relation": "calls",
@@ -11803,9 +12339,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L77",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_handleline",
-      "target": "tiamcpserver_opennessworker_program_program_startplc",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_startplc"
     },
     {
       "relation": "calls",
@@ -11814,9 +12350,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L78",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_handleline",
-      "target": "tiamcpserver_opennessworker_program_program_stopplc",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_stopplc"
     },
     {
       "relation": "calls",
@@ -12419,9 +12955,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L323",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_createblock",
-      "target": "tiamcpserver_opennessworker_program_program_failure",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_failure"
     },
     {
       "relation": "calls",
@@ -12430,9 +12966,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L336",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_createblock",
-      "target": "tiamcpserver_opennessworker_program_program_withproject",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_withproject"
     },
     {
       "relation": "calls",
@@ -12441,9 +12977,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L336",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_createblock",
-      "target": "tiamcpserver_opennessworker_program_program_success",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_success"
     },
     {
       "relation": "calls",
@@ -12452,9 +12988,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L349",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_deleteblock",
-      "target": "tiamcpserver_opennessworker_program_program_failure",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_failure"
     },
     {
       "relation": "calls",
@@ -12463,9 +12999,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L357",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_deleteblock",
-      "target": "tiamcpserver_opennessworker_program_program_withproject",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_withproject"
     },
     {
       "relation": "calls",
@@ -12474,9 +13010,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L357",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_deleteblock",
-      "target": "tiamcpserver_opennessworker_program_program_success",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_success"
     },
     {
       "relation": "calls",
@@ -12485,9 +13021,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L365",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_createblockgroup",
-      "target": "tiamcpserver_opennessworker_program_program_failure",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_failure"
     },
     {
       "relation": "calls",
@@ -12496,9 +13032,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L373",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_createblockgroup",
-      "target": "tiamcpserver_opennessworker_program_program_withproject",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_withproject"
     },
     {
       "relation": "calls",
@@ -12507,9 +13043,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L373",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_createblockgroup",
-      "target": "tiamcpserver_opennessworker_program_program_success",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_success"
     },
     {
       "relation": "calls",
@@ -12518,9 +13054,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L381",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_deleteblockgroup",
-      "target": "tiamcpserver_opennessworker_program_program_failure",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_failure"
     },
     {
       "relation": "calls",
@@ -12529,9 +13065,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L389",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_deleteblockgroup",
-      "target": "tiamcpserver_opennessworker_program_program_withproject",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_withproject"
     },
     {
       "relation": "calls",
@@ -12540,9 +13076,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L389",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_deleteblockgroup",
-      "target": "tiamcpserver_opennessworker_program_program_success",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_success"
     },
     {
       "relation": "calls",
@@ -12551,9 +13087,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L397",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_startplc",
-      "target": "tiamcpserver_opennessworker_program_program_failure",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_failure"
     },
     {
       "relation": "calls",
@@ -12562,9 +13098,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L400",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_startplc",
-      "target": "tiamcpserver_opennessworker_program_program_withproject",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_withproject"
     },
     {
       "relation": "calls",
@@ -12573,9 +13109,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L400",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_startplc",
-      "target": "tiamcpserver_opennessworker_program_program_success",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_success"
     },
     {
       "relation": "calls",
@@ -12584,9 +13120,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L408",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_stopplc",
-      "target": "tiamcpserver_opennessworker_program_program_failure",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_failure"
     },
     {
       "relation": "calls",
@@ -12595,9 +13131,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L411",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_stopplc",
-      "target": "tiamcpserver_opennessworker_program_program_withproject",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_withproject"
     },
     {
       "relation": "calls",
@@ -12606,9 +13142,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Program.cs",
       "source_location": "L411",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_program_program_stopplc",
-      "target": "tiamcpserver_opennessworker_program_program_success",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_opennessworker_program_program_success"
     },
     {
       "relation": "calls",
@@ -12936,9 +13472,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockExporter.cs",
       "source_location": "L69",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockexporter_blockexporter",
-      "target": "openness_blockexporter_blockexporter_stripnondeterministic",
-      "confidence_score": 1.0
+      "target": "openness_blockexporter_blockexporter_stripnondeterministic"
     },
     {
       "relation": "contains",
@@ -12957,9 +13493,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockExporter.cs",
       "source_location": "L34",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockexporter_blockexporter_export",
-      "target": "openness_blockexporter_blockexporter_stripnondeterministic",
-      "confidence_score": 1.0
+      "target": "openness_blockexporter_blockexporter_stripnondeterministic"
     },
     {
       "relation": "contains",
@@ -12987,9 +13523,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L77",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockimporter_blockimporter",
-      "target": "openness_blockimporter_blockimporter_isxmlcontent",
-      "confidence_score": 1.0
+      "target": "openness_blockimporter_blockimporter_isxmlcontent"
     },
     {
       "relation": "method",
@@ -13038,9 +13574,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L23",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockimporter_blockimporter_import",
-      "target": "openness_blockimporter_blockimporter_isxmlcontent",
-      "confidence_score": 1.0
+      "target": "openness_blockimporter_blockimporter_isxmlcontent"
     },
     {
       "relation": "calls",
@@ -13081,9 +13617,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L11",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_openness_blockmutationservice_cs",
-      "target": "openness_blockmutationservice_blockmutationservice",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice"
     },
     {
       "relation": "method",
@@ -13091,9 +13627,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L13",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice",
-      "target": "openness_blockmutationservice_blockmutationservice_createblock",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_createblock"
     },
     {
       "relation": "method",
@@ -13101,9 +13637,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L49",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice",
-      "target": "openness_blockmutationservice_blockmutationservice_deleteblock",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_deleteblock"
     },
     {
       "relation": "method",
@@ -13111,9 +13647,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L72",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice",
-      "target": "openness_blockmutationservice_blockmutationservice_createblockgroup",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_createblockgroup"
     },
     {
       "relation": "method",
@@ -13121,9 +13657,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L89",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice",
-      "target": "openness_blockmutationservice_blockmutationservice_deleteblockgroup",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_deleteblockgroup"
     },
     {
       "relation": "method",
@@ -13131,9 +13667,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L112",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice",
-      "target": "openness_blockmutationservice_blockmutationservice_resolvegroupfromaddress",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_resolvegroupfromaddress"
     },
     {
       "relation": "method",
@@ -13141,9 +13677,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L124",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice",
-      "target": "openness_blockmutationservice_blockmutationservice_findgroupbypath",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_findgroupbypath"
     },
     {
       "relation": "method",
@@ -13151,9 +13687,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L151",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice",
-      "target": "openness_blockmutationservice_blockmutationservice_findusergroupbypath",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_findusergroupbypath"
     },
     {
       "relation": "method",
@@ -13161,9 +13697,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L179",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice",
-      "target": "openness_blockmutationservice_blockmutationservice_importblockfromxml",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_importblockfromxml"
     },
     {
       "relation": "method",
@@ -13171,9 +13707,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L205",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice",
-      "target": "openness_blockmutationservice_blockmutationservice_generateblockxml",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_generateblockxml"
     },
     {
       "relation": "method",
@@ -13181,9 +13717,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L290",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice",
-      "target": "openness_blockmutationservice_blockmutationservice_generatefbxml",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_generatefbxml"
     },
     {
       "relation": "method",
@@ -13191,9 +13727,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L334",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice",
-      "target": "openness_blockmutationservice_blockmutationservice_toprogramminglanguagexml",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_toprogramminglanguagexml"
     },
     {
       "relation": "calls",
@@ -13202,9 +13738,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L22",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice_createblock",
-      "target": "openness_blockmutationservice_blockmutationservice_resolvegroupfromaddress",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_resolvegroupfromaddress"
     },
     {
       "relation": "calls",
@@ -13213,9 +13749,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L30",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice_createblock",
-      "target": "openness_blockmutationservice_blockmutationservice_importblockfromxml",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_importblockfromxml"
     },
     {
       "relation": "calls",
@@ -13224,9 +13760,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L76",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice_createblockgroup",
-      "target": "openness_blockmutationservice_blockmutationservice_resolvegroupfromaddress",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_resolvegroupfromaddress"
     },
     {
       "relation": "calls",
@@ -13235,9 +13771,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L96",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice_deleteblockgroup",
-      "target": "openness_blockmutationservice_blockmutationservice_findusergroupbypath",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_findusergroupbypath"
     },
     {
       "relation": "calls",
@@ -13246,9 +13782,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L119",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice_resolvegroupfromaddress",
-      "target": "openness_blockmutationservice_blockmutationservice_findgroupbypath",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_findgroupbypath"
     },
     {
       "relation": "calls",
@@ -13257,9 +13793,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L186",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice_importblockfromxml",
-      "target": "openness_blockmutationservice_blockmutationservice_generateblockxml",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_generateblockxml"
     },
     {
       "relation": "calls",
@@ -13268,9 +13804,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L215",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice_generateblockxml",
-      "target": "openness_blockmutationservice_blockmutationservice_generatefbxml",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_generatefbxml"
     },
     {
       "relation": "calls",
@@ -13279,9 +13815,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L230",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice_generateblockxml",
-      "target": "openness_blockmutationservice_blockmutationservice_toprogramminglanguagexml",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_toprogramminglanguagexml"
     },
     {
       "relation": "calls",
@@ -13290,9 +13826,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L292",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_blockmutationservice_blockmutationservice_generatefbxml",
-      "target": "openness_blockmutationservice_blockmutationservice_toprogramminglanguagexml",
-      "confidence_score": 1.0
+      "target": "openness_blockmutationservice_blockmutationservice_toprogramminglanguagexml"
     },
     {
       "relation": "contains",
@@ -14138,11 +14674,11 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L11",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_equipmentcatalogsearcher_cs",
+      "source": "tiamcpserver_opennessworker_openness_equipmentcatalogsearcher_cs",
       "target": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher"
     },
     {
@@ -14236,6 +14772,16 @@
       "target": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_readstringproperty"
     },
     {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
+      "source_location": "L11",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_equipmentcatalogsearcher_cs",
+      "target": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher"
+    },
+    {
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
@@ -14256,17 +14802,8 @@
       "target": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_enumerate"
     },
     {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
-      "source_location": "L11",
-      "weight": 1.0,
-      "confidence_score": 1.0,
-      "source": "tiamcpserver_opennessworker_openness_equipmentcatalogsearcher_cs",
-      "target": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher"
-    },
-    {
       "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L39",
@@ -14277,6 +14814,7 @@
     },
     {
       "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L42",
@@ -14287,6 +14825,7 @@
     },
     {
       "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L46",
@@ -14297,6 +14836,7 @@
     },
     {
       "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L72",
@@ -14327,6 +14867,7 @@
     },
     {
       "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L121",
@@ -14337,6 +14878,7 @@
     },
     {
       "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L124",
@@ -14347,6 +14889,7 @@
     },
     {
       "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L130",
@@ -14357,6 +14900,7 @@
     },
     {
       "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L135",
@@ -14387,6 +14931,7 @@
     },
     {
       "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L155",
@@ -14397,6 +14942,7 @@
     },
     {
       "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L162",
@@ -15068,9 +15614,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/NetworkDeviceConfigurator.cs",
       "source_location": "L83",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_networkdeviceconfigurator_networkdeviceconfigurator",
-      "target": "openness_networkdeviceconfigurator_networkdeviceconfigurator_finalizeresult",
-      "confidence_score": 1.0
+      "target": "openness_networkdeviceconfigurator_networkdeviceconfigurator_finalizeresult"
     },
     {
       "relation": "method",
@@ -15254,9 +15800,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/NetworkDeviceConfigurator.cs",
       "source_location": "L55",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_networkdeviceconfigurator_networkdeviceconfigurator_configure",
-      "target": "openness_networkdeviceconfigurator_networkdeviceconfigurator_finalizeresult",
-      "confidence_score": 1.0
+      "target": "openness_networkdeviceconfigurator_networkdeviceconfigurator_finalizeresult"
     },
     {
       "relation": "calls",
@@ -15496,9 +16042,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_opennessworker_openness_plconlineservice_cs",
-      "target": "openness_plconlineservice_plconlineservice",
-      "confidence_score": 1.0
+      "target": "openness_plconlineservice_plconlineservice"
     },
     {
       "relation": "method",
@@ -15506,9 +16052,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_plconlineservice_plconlineservice",
-      "target": "openness_plconlineservice_plconlineservice_start",
-      "confidence_score": 1.0
+      "target": "openness_plconlineservice_plconlineservice_start"
     },
     {
       "relation": "method",
@@ -15516,9 +16062,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L15",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_plconlineservice_plconlineservice",
-      "target": "openness_plconlineservice_plconlineservice_stop",
-      "confidence_score": 1.0
+      "target": "openness_plconlineservice_plconlineservice_stop"
     },
     {
       "relation": "method",
@@ -15526,9 +16072,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L18",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_plconlineservice_plconlineservice",
-      "target": "openness_plconlineservice_plconlineservice_controlplc",
-      "confidence_score": 1.0
+      "target": "openness_plconlineservice_plconlineservice_controlplc"
     },
     {
       "relation": "method",
@@ -15536,9 +16082,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L55",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_plconlineservice_plconlineservice",
-      "target": "openness_plconlineservice_plconlineservice_invokecontrolmethod",
-      "confidence_score": 1.0
+      "target": "openness_plconlineservice_plconlineservice_invokecontrolmethod"
     },
     {
       "relation": "calls",
@@ -15547,9 +16093,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L13",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_plconlineservice_plconlineservice_start",
-      "target": "openness_plconlineservice_plconlineservice_controlplc",
-      "confidence_score": 1.0
+      "target": "openness_plconlineservice_plconlineservice_controlplc"
     },
     {
       "relation": "calls",
@@ -15558,9 +16104,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L16",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_plconlineservice_plconlineservice_stop",
-      "target": "openness_plconlineservice_plconlineservice_controlplc",
-      "confidence_score": 1.0
+      "target": "openness_plconlineservice_plconlineservice_controlplc"
     },
     {
       "relation": "calls",
@@ -15569,9 +16115,9 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L35",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "openness_plconlineservice_plconlineservice_controlplc",
-      "target": "openness_plconlineservice_plconlineservice_invokecontrolmethod",
-      "confidence_score": 1.0
+      "target": "openness_plconlineservice_plconlineservice_invokecontrolmethod"
     },
     {
       "relation": "contains",
@@ -17414,6 +17960,26 @@
       "target": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_applywritesasync_stopsonfirstfailureandskipsrest"
     },
     {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
+      "source_location": "L89",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests",
+      "target": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_executereadsasync_payloadstartingwitherrorprefix_isnotafailure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
+      "source_location": "L101",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests",
+      "target": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_executereadsasync_copieswarningsontoresult",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "context": "call",
       "confidence": "EXTRACTED",
@@ -17456,6 +18022,28 @@
       "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_applywritesasync_stopsonfirstfailureandskipsrest",
       "target": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_op"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
+      "source_location": "L92",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_executereadsasync_payloadstartingwitherrorprefix_isnotafailure",
+      "target": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_op",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
+      "source_location": "L104",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_executereadsasync_copieswarningsontoresult",
+      "target": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_op",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -17663,9 +18251,9 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L215",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests",
-      "target": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_unknownoperationerrorlistsvalidreadoperations",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_unknownoperationerrorlistsvalidreadoperations"
     },
     {
       "relation": "method",
@@ -17673,9 +18261,9 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L226",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests",
-      "target": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_unknownoperationerrorlistsvalidwriteoperations",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_unknownoperationerrorlistsvalidwriteoperations"
     },
     {
       "relation": "method",
@@ -17683,9 +18271,9 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L237",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests",
-      "target": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_reportsallinvaliditemsatonce",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_reportsallinvaliditemsatonce"
     },
     {
       "relation": "method",
@@ -17858,9 +18446,9 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L218",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_unknownoperationerrorlistsvalidreadoperations",
-      "target": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_op",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_op"
     },
     {
       "relation": "calls",
@@ -17869,9 +18457,9 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L229",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_unknownoperationerrorlistsvalidwriteoperations",
-      "target": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_op",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_op"
     },
     {
       "relation": "calls",
@@ -17880,9 +18468,9 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L242",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_reportsallinvaliditemsatonce",
-      "target": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_op",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_op"
     },
     {
       "relation": "calls",
@@ -17905,6 +18493,36 @@
       "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_allreadoperations_acceptafullypopulatedrequest",
       "target": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_fullypopulated"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_batchoperationrequestjsontests_cs",
+      "target": "tiamcpserver_tests_batchoperationrequestjsontests_batchoperationrequestjsontests",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs",
+      "source_location": "L12",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_batchoperationrequestjsontests_batchoperationrequestjsontests",
+      "target": "tiamcpserver_tests_batchoperationrequestjsontests_batchoperationrequestjsontests_misspelledoptionalproperty_isrejectednotsilentlydropped",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_batchoperationrequestjsontests_batchoperationrequestjsontests",
+      "target": "tiamcpserver_tests_batchoperationrequestjsontests_batchoperationrequestjsontests_knowncamelcaseproperties_stilldeserialize",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -17967,6 +18585,16 @@
       "target": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_applybatch_countssucceededfailedandskipped"
     },
     {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
+      "source_location": "L73",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests",
+      "target": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_readbatch_includeswarningswhenpresent",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "context": "call",
       "confidence": "EXTRACTED",
@@ -18009,6 +18637,17 @@
       "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_applybatch_countssucceededfailedandskipped",
       "target": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_parse"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
+      "source_location": "L82",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_readbatch_includeswarningswhenpresent",
+      "target": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_parse",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -18648,9 +19287,9 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L68",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests",
-      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_previewwritebatchdescription_statestheactualtokenlifetime",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_previewwritebatchdescription_statestheactualtokenlifetime"
     },
     {
       "relation": "method",
@@ -18658,9 +19297,9 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L75",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests",
-      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_propertydescription",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_propertydescription"
     },
     {
       "relation": "method",
@@ -18668,9 +19307,9 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L84",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests",
-      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_filterdescription_namesitsoperationandlistsallvalues",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_filterdescription_namesitsoperationandlistsallvalues"
     },
     {
       "relation": "method",
@@ -18678,9 +19317,9 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L95",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests",
-      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_blockpathdescription_coversallblockoperationsandcompilecheck",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_blockpathdescription_coversallblockoperationsandcompilecheck"
     },
     {
       "relation": "method",
@@ -18688,9 +19327,9 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L104",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests",
-      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_newnamedescription_doesnotclaimuserconstantrename",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_newnamedescription_doesnotclaimuserconstantrename"
     },
     {
       "relation": "method",
@@ -18698,9 +19337,9 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L115",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests",
-      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_plcnamedescription_namestheoperationsthathonorit",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_plcnamedescription_namestheoperationsthathonorit"
     },
     {
       "relation": "method",
@@ -18752,9 +19391,9 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L72",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_previewwritebatchdescription_statestheactualtokenlifetime",
-      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_methoddescription",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_methoddescription"
     },
     {
       "relation": "calls",
@@ -18763,9 +19402,9 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L87",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_filterdescription_namesitsoperationandlistsallvalues",
-      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_propertydescription",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_propertydescription"
     },
     {
       "relation": "calls",
@@ -18774,9 +19413,9 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L98",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_blockpathdescription_coversallblockoperationsandcompilecheck",
-      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_propertydescription",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_propertydescription"
     },
     {
       "relation": "calls",
@@ -18785,9 +19424,9 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L107",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_newnamedescription_doesnotclaimuserconstantrename",
-      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_propertydescription",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_propertydescription"
     },
     {
       "relation": "calls",
@@ -18796,9 +19435,9 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L118",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_plcnamedescription_namestheoperationsthathonorit",
-      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_propertydescription",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_propertydescription"
     },
     {
       "relation": "contains",
@@ -19479,11 +20118,11 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
       "source_location": "L8",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_hardwareconfiginfotests_cs",
+      "source": "tiamcpserver_tests_hardwareconfiginfotests_cs",
       "target": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests"
     },
     {
@@ -19532,6 +20171,26 @@
       "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
       "source_location": "L167",
       "weight": 1.0,
+      "source": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests",
+      "target": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests_messagesroundtrip",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_location": "L183",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests",
+      "target": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests_unreadablevalues_arenullnotfallbackdefaults",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_location": "L167",
+      "weight": 1.0,
       "confidence_score": 1.0,
       "source": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests",
       "target": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests_roundtrip"
@@ -19539,15 +20198,16 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
+      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
       "source_location": "L8",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "tiamcpserver_tests_hardwareconfiginfotests_cs",
+      "source": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_hardwareconfiginfotests_cs",
       "target": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests"
     },
     {
       "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
       "source_location": "L22",
@@ -19558,6 +20218,7 @@
     },
     {
       "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
       "source_location": "L84",
@@ -19568,6 +20229,7 @@
     },
     {
       "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.Tests/HardwareConfigInfoTests.cs",
       "source_location": "L134",
@@ -19575,6 +20237,194 @@
       "confidence_score": 1.0,
       "source": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests_roundtripssubnetwithiosystem",
       "target": "tiamcpserver_tests_hardwareconfiginfotests_hardwareconfiginfotests_roundtrip"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_cs",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_locatefakeworker",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L36",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_createclient",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_success_returnsstructuredpayload",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_stderrlines_surfaceaswarnings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L60",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_payloadstartingwitherrorprefix_isnotmisclassified",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L70",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_workerreportederror_isstructuredfailure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L80",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_malformedresponse_isfailurenotcrash",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L89",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_silentexit_surfacesstderrdetailinerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L98",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_nonexecutableworkerpath_producesactionablewin32message",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_createclient",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_locatefakeworker",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_success_returnsstructuredpayload",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_createclient",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L53",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_stderrlines_surfaceaswarnings",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_createclient",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L64",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_payloadstartingwitherrorprefix_isnotmisclassified",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_createclient",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L73",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_workerreportederror_isstructuredfailure",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_createclient",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L83",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_malformedresponse_isfailurenotcrash",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_createclient",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L92",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_silentexit_surfacesstderrdetailinerror",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_createclient",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
+      "source_location": "L105",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_nonexecutableworkerpath_producesactionablewin32message",
+      "target": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_createclient",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -19732,8 +20582,78 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L110",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests",
-      "target": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_tryresolve_rejectionmentionsforcerebindescapehatch",
+      "target": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_tryresolve_rejectionmentionsforcerebindescapehatch"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_workercallresulttests_cs",
+      "target": "tiamcpserver_tests_workercallresulttests_workercallresulttests",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_workercallresulttests_workercallresulttests",
+      "target": "tiamcpserver_tests_workercallresulttests_workercallresulttests_ok_carriespayloadwithouterror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L19",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_workercallresulttests_workercallresulttests",
+      "target": "tiamcpserver_tests_workercallresulttests_workercallresulttests_fail_carrieserrorandemptypayload",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L29",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_workercallresulttests_workercallresulttests",
+      "target": "tiamcpserver_tests_workercallresulttests_workercallresulttests_totext_renderspayloadonsuccess",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L35",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_workercallresulttests_workercallresulttests",
+      "target": "tiamcpserver_tests_workercallresulttests_workercallresulttests_totext_renderserrorprefixonfailure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_workercallresulttests_workercallresulttests",
+      "target": "tiamcpserver_tests_workercallresulttests_workercallresulttests_ok_payloadstartingwitherrorprefixstayssuccessful",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "tiamcpserver_tests_workercallresulttests_workercallresulttests",
+      "target": "tiamcpserver_tests_workercallresulttests_workercallresulttests_warnings_areattachedtobothshapes",
       "confidence_score": 1.0
     },
     {
@@ -19792,9 +20712,9 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L137",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests",
-      "target": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_rejectionincludesrecoveryguidancewithpreviewtoolname",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_rejectionincludesrecoveryguidancewithpreviewtoolname"
     },
     {
       "relation": "method",
@@ -19802,9 +20722,9 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L157",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests",
-      "target": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_recoveryguidanceusesconfiguredlifetime",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_recoveryguidanceusesconfiguredlifetime"
     },
     {
       "relation": "method",
@@ -19812,9 +20732,9 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L170",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests",
-      "target": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_appendaudit_writesjsonlrecordtoconfigureddirectory",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_appendaudit_writesjsonlrecordtoconfigureddirectory"
     },
     {
       "relation": "method",
@@ -19822,9 +20742,9 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L194",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests",
-      "target": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_appendaudit_logsfailuretostderrinsteadofthrowing",
-      "confidence_score": 1.0
+      "target": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_appendaudit_logsfailuretostderrinsteadofthrowing"
     },
     {
       "relation": "method",
@@ -21491,5 +22411,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "af470a92e1be8d60085e59123be155b7ba7d3f8a"
+  "built_at_commit": "fdb6221057747da8482f18fe5b51ae5f52847a81"
 }


### PR DESCRIPTION
## Summary

Implements Phase 1 of the improvement plan (`docs/superpowers/plans/2026-07-16-phase1-error-propagation.md`, covering `docs/IMPROVEMENT_PLAN.md` items 1.1, 1.3, 1.4, 1.5, 1.6, 1.7):

- **Structured worker outcomes** (`WorkerCallResult`): replaces the `"Error:"` string-prefix convention with a `Success`/`Payload`/`Error`/`Warnings` record threaded through `OpennessWorkerClient` → `BatchExecutionEngine`/`BatchWorkerInvoker` → `WriteSafetyTooling` → `ProjectLifecycleTools`/`BatchTools`. A payload that legitimately starts with `"Error:"` (e.g. literal SCL comment text) is no longer misclassified as a failure.
- **Worker stderr surfaced as warnings**: non-fatal degradation notes (capped at 20 lines) travel with the response instead of vanishing, verified end-to-end with a new fake-worker IPC integration harness (`TiaMcpServer.FakeWorker`).
- **Actionable `Win32Exception` handling**: a missing .NET FX 4.8 install or a corrupt `openness-worker` folder now produces a clear, actionable error instead of a raw protocol failure.
- **Hardware-config nullability**: `HardwareConfigInfo`/`DeviceInfo`/`DeviceItemInfo` distinguish "could not read" (`null`, omitted from JSON, noted in a `Messages` array) from real `0`/empty-string values.
- **Strict batch-item JSON**: `BatchOperationRequest` now rejects unknown/misspelled properties (`JsonUnmappedMemberHandling.Disallow`) instead of silently dropping them — closes the `ip_adress`-style silent-failure trap.
- **Worker-side error fidelity**: `EquipmentCatalogSearcher`'s bare `catch (Exception)` reflection helpers are narrowed and consolidated into the shared `OpennessReflection.ReadProperty` overload; the worker's catch-all now names the exception type.
- Docs updated (README, `docs/IMPROVEMENT_PLAN.md`) to reflect the new `warnings`/`messages` channels and mark the covered items DONE.

## Test plan

- [x] `dotnet build TiaMcpServer.sln` — clean build, 0 errors
- [x] `dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj` — 179/179 passing
- [x] `Get-ChildItem TiaMcpServer -Recurse -Filter *.cs | Select-String 'StartsWith("Error:'` — zero hits in the host project
- [x] New fake-worker IPC integration tests cover: success, stderr→warnings, error-prefix-payload regression, structured worker failure, malformed response, silent exit, non-executable worker path (Win32)
- [x] New `BatchOperationRequestJsonTests` cover misspelled-property rejection and known-property acceptance
- [x] New `HardwareConfigInfoTests` cover `Messages` round-trip and null-not-fallback-default behavior
- [x] Two independent broad reviews (opus) across the full commit range — 0 Critical/High/Medium findings; one Minor doc-wording note addressed directly

https://claude.ai/code/session_01Nq1QfDvun9V3sEse6YTNNo