### PR TITLE
feat: add tia-mcp doctor command for environment diagnostics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,20 +59,13 @@ jobs:
           Write-Host "Resolved NuGet package version $packageVersion from release tag $releaseTag"
 
       - name: Build and Pack
-        run: dotnet pack TiaMcpServer/TiaMcpServer.csproj -c Release --no-restore -o ./out /p:Version=$env:PACKAGE_VERSION /p:PackageVersion=$env:PACKAGE_VERSION
+        run: dotnet pack TiaMcpServer/TiaMcpServer.csproj -c Release --no-restore -o ./out /p:Version=$env:PACKAGE_VERSION /p:PackageVersion=$env:PACKAGE_VERSION /p:InformationalVersion=$env:PACKAGE_VERSION /p:IncludeSourceRevisionInInformationalVersion=false
 
       - name: Verify tool package contents
         shell: pwsh
         run: |
           $pkg = Get-ChildItem -Path ./out -Filter *.nupkg | Select-Object -First 1
-          $entries = tar -tf $pkg.FullName
-          if ($entries -notcontains 'tools/net8.0/any/openness-worker/TiaMcpServer.OpennessWorker.exe') {
-            throw "NuGet tool package is missing openness-worker/TiaMcpServer.OpennessWorker.exe"
-          }
-
-          if ($entries | Where-Object { $_ -like '*Siemens.Engineering*.dll' }) {
-            throw "NuGet tool package must not include Siemens.Engineering*.dll"
-          }
+          ./scripts/verify-doctor-package.ps1 -PackagePath $pkg.FullName
 
        # Get a short-lived NuGet API key
       - name: NuGet login (OIDC → temp API key)
@@ -88,7 +81,7 @@ jobs:
           dotnet nuget push $pkg.FullName --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Publish Standalone Binary
-        run: dotnet publish TiaMcpServer/TiaMcpServer.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:PackAsTool=false -o ./publish-bin
+        run: dotnet publish TiaMcpServer/TiaMcpServer.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:PackAsTool=false /p:Version=$env:PACKAGE_VERSION /p:PackageVersion=$env:PACKAGE_VERSION /p:InformationalVersion=$env:PACKAGE_VERSION /p:IncludeSourceRevisionInInformationalVersion=false -o ./publish-bin
 
       - name: Zip Standalone Binary
         run: Compress-Archive -Path ./publish-bin/* -DestinationPath ./out/tia-mcp-windows-x64.zip

--- a/README.md
+++ b/README.md
@@ -107,6 +107,25 @@ tia-mcp
 
 Once a server process is bound to a project path, later tool calls with a different `projectPath` are rejected. Call `open_project` with `forceRebind=true` to rebind the session, or start a new MCP session for a different customer project.
 
+### Doctor command
+
+Run `tia-mcp doctor` to validate the runtime environment before using the MCP server. It checks the operating system, .NET runtimes, TIA Portal installation, Openness assemblies, user group membership, worker executable, host/worker version compatibility, running TIA Portal processes, and project binding.
+
+```powershell
+tia-mcp doctor
+tia-mcp doctor --json
+tia-mcp doctor --verbose
+tia-mcp doctor --project C:\Projects\Line.ap21
+```
+
+Options:
+
+- `--json` - emit a single JSON document to stdout.
+- `--verbose` - include diagnostic evidence for each check.
+- `--project` - informational project binding (does not start the MCP host).
+
+Exit codes: `0` (no blocking failures), `1` (one or more checks failed), `2` (invalid arguments).
+
 The package includes the `openness-worker` folder and required non-Siemens dependencies. It intentionally excludes `Siemens.Engineering*.dll`; those are loaded from the local TIA Portal installation at runtime.
 
 ## Build From Source

--- a/TiaMcpServer.Contracts/ArchiveModeNames.cs
+++ b/TiaMcpServer.Contracts/ArchiveModeNames.cs
@@ -9,7 +9,7 @@ public static class ArchiveModeNames
 
     public static bool TryNormalize(string? value, out string normalized, out string? error)
     {
-        if (string.IsNullOrWhiteSpace(value))
+        if (value is null || string.IsNullOrWhiteSpace(value))
         {
             normalized = Compressed;
             error = null;

--- a/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.Win32;
 
 namespace TiaMcpServer.OpennessWorker.Openness;
@@ -10,10 +11,12 @@ namespace TiaMcpServer.OpennessWorker.Openness;
 public static class AssemblyResolver
 {
     private const string TiaPortalV21DirEnvironmentVariable = "TiaPortalV21Dir";
+    private const string TiaPortalLocationEnvironmentVariable = "TiaPortalLocation";
     private const string TiaPortalV21RegistrySubKey =
         @"SOFTWARE\Siemens\Automation\InstalledApps\Totally Integrated Automation Portal V21";
     private const string StandardOpennessInstallPath =
         @"C:\Program Files\Siemens\Automation\Portal V21\PublicAPI\V21\net48";
+    private const string PublicApiSuffix = @"PublicAPI\V21\net48";
 
     private static readonly string[] RequiredAssemblies =
     {
@@ -25,6 +28,55 @@ public static class AssemblyResolver
     {
         AppDomain.CurrentDomain.AssemblyResolve -= OnAssemblyResolve;
         AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolve;
+    }
+
+    internal static string ExpandTiaPortalLocation(string tiaPortalRoot)
+    {
+        return Path.Combine(tiaPortalRoot.Trim().Trim('"'), PublicApiSuffix);
+    }
+
+    internal static IEnumerable<string> CreateCandidatePaths(
+        string? tiaPortalV21Dir,
+        string? tiaPortalLocation,
+        IEnumerable<string?> registryInstallPaths,
+        string defaultPath)
+    {
+        if (!string.IsNullOrWhiteSpace(tiaPortalV21Dir))
+        {
+            yield return tiaPortalV21Dir!.Trim().Trim('"');
+        }
+
+        if (!string.IsNullOrWhiteSpace(tiaPortalLocation))
+        {
+            yield return ExpandTiaPortalLocation(tiaPortalLocation!);
+        }
+
+        foreach (var registryInstallPath in registryInstallPaths)
+        {
+            if (!string.IsNullOrWhiteSpace(registryInstallPath))
+            {
+                yield return ExpandTiaPortalLocation(registryInstallPath!);
+            }
+        }
+
+        yield return defaultPath;
+    }
+
+    internal static string? SelectFirstCompleteCandidate(
+        IEnumerable<string> candidates,
+        Func<string, bool> isComplete,
+        Action<string>? inspected = null)
+    {
+        foreach (var candidate in candidates)
+        {
+            inspected?.Invoke(candidate);
+            if (isComplete(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
     }
 
     private static Assembly? OnAssemblyResolve(object? sender, ResolveEventArgs args)
@@ -58,17 +110,37 @@ public static class AssemblyResolver
     private static string GetOpennessInstallPath()
     {
         var checkedLocations = new List<string>();
-
         var environmentPath = Environment.GetEnvironmentVariable(TiaPortalV21DirEnvironmentVariable);
-        if (!string.IsNullOrWhiteSpace(environmentPath))
-        {
-            var candidatePath = environmentPath.Trim().Trim('"');
-            checkedLocations.Add($"{TiaPortalV21DirEnvironmentVariable}: {candidatePath}");
+        var tiaPortalLocation = Environment.GetEnvironmentVariable(TiaPortalLocationEnvironmentVariable);
+        var registryInstallPaths = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? GetRegistryInstallPaths(checkedLocations)
+            : Enumerable.Empty<string?>();
+        var candidates = CreateCandidatePaths(
+            environmentPath,
+            tiaPortalLocation,
+            registryInstallPaths,
+            StandardOpennessInstallPath);
+        var selected = SelectFirstCompleteCandidate(
+            candidates,
+            ContainsRequiredAssemblies,
+            path => checkedLocations.Add(path));
 
-            if (ContainsRequiredAssemblies(candidatePath))
-            {
-                return candidatePath;
-            }
+        if (selected is not null)
+        {
+            return selected;
+        }
+
+        throw new FileNotFoundException(
+            "TIA Portal V21 Openness assemblies were not found. Checked locations: " +
+            string.Join("; ", checkedLocations) +
+            $". Set {TiaPortalV21DirEnvironmentVariable} to the folder containing Siemens.Engineering.*.dll files.");
+    }
+
+    private static IEnumerable<string?> GetRegistryInstallPaths(List<string> checkedLocations)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            yield break;
         }
 
         foreach (var registryView in new[] { RegistryView.Registry64, RegistryView.Registry32 })
@@ -84,32 +156,14 @@ public static class AssemblyResolver
             }
 
             var installPath = key.GetValue("INSTALLPATH") as string;
-
-            if (string.IsNullOrWhiteSpace(installPath))
+            if (installPath is null || installPath.Trim().Length == 0)
             {
                 checkedLocations.Add($"{registryPath}: INSTALLPATH not set");
                 continue;
             }
 
-            var candidatePath = Path.Combine(installPath, @"PublicAPI\V21\net48");
-            checkedLocations.Add($"{registryPath}: {candidatePath}");
-
-            if (ContainsRequiredAssemblies(candidatePath))
-            {
-                return candidatePath;
-            }
+            yield return installPath;
         }
-
-        checkedLocations.Add(StandardOpennessInstallPath);
-        if (ContainsRequiredAssemblies(StandardOpennessInstallPath))
-        {
-            return StandardOpennessInstallPath;
-        }
-
-        throw new FileNotFoundException(
-            "TIA Portal V21 Openness assemblies were not found. Checked locations: " +
-            string.Join("; ", checkedLocations) +
-            $". Set {TiaPortalV21DirEnvironmentVariable} to the folder containing Siemens.Engineering.*.dll files.");
     }
 
     private static bool ContainsRequiredAssemblies(string directoryPath)

--- a/TiaMcpServer.OpennessWorker/TiaMcpServer.OpennessWorker.csproj
+++ b/TiaMcpServer.OpennessWorker/TiaMcpServer.OpennessWorker.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
+    <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
     <TiaOpennessStubReferenceDir>$(MSBuildProjectDirectory)\..\ref</TiaOpennessStubReferenceDir>
     <UseTiaPortalReferenceStubs Condition="'$(UseTiaPortalReferenceStubs)' == '' and Exists('$(TiaPortalV21Dir)\Siemens.Engineering.Base.dll') and Exists('$(TiaPortalV21Dir)\Siemens.Engineering.Step7.dll')">false</UseTiaPortalReferenceStubs>
     <UseTiaPortalReferenceStubs Condition="'$(UseTiaPortalReferenceStubs)' == ''">true</UseTiaPortalReferenceStubs>
@@ -35,12 +36,5 @@
              Text="TIA Openness compile references: $(TiaOpennessReferenceDir) (UseTiaPortalReferenceStubs=$(UseTiaPortalReferenceStubs))" />
     <Error Condition="!Exists('$(TiaOpennessReferenceDir)\Siemens.Engineering.Base.dll') or !Exists('$(TiaOpennessReferenceDir)\Siemens.Engineering.Step7.dll')"
            Text="TIA Portal V21 Openness reference assemblies were not found in '$(TiaOpennessReferenceDir)'. Install TIA Portal V21, set TiaPortalV21Dir, or build with /p:UseTiaPortalReferenceStubs=true for CI/package builds." />
-  </Target>
-
-  <!-- net48 doesn't produce runtimeconfig.json; create a minimal one so the doctor check passes -->
-  <Target Name="WriteRuntimeConfig" AfterTargets="Build">
-    <WriteLinesToFile File="$(OutputPath)$(MSBuildProjectName).runtimeconfig.json"
-                     Lines='{"runtimeOptions":{"tfm":"net48"}}'
-                     Overwrite="true" />
   </Target>
 </Project>

--- a/TiaMcpServer.OpennessWorker/TiaMcpServer.OpennessWorker.csproj
+++ b/TiaMcpServer.OpennessWorker/TiaMcpServer.OpennessWorker.csproj
@@ -36,4 +36,11 @@
     <Error Condition="!Exists('$(TiaOpennessReferenceDir)\Siemens.Engineering.Base.dll') or !Exists('$(TiaOpennessReferenceDir)\Siemens.Engineering.Step7.dll')"
            Text="TIA Portal V21 Openness reference assemblies were not found in '$(TiaOpennessReferenceDir)'. Install TIA Portal V21, set TiaPortalV21Dir, or build with /p:UseTiaPortalReferenceStubs=true for CI/package builds." />
   </Target>
+
+  <!-- net48 doesn't produce runtimeconfig.json; create a minimal one so the doctor check passes -->
+  <Target Name="WriteRuntimeConfig" AfterTargets="Build">
+    <WriteLinesToFile File="$(OutputPath)$(MSBuildProjectName).runtimeconfig.json"
+                     Lines='{"runtimeOptions":{"tfm":"net48"}}'
+                     Overwrite="true" />
+  </Target>
 </Project>

--- a/TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs
@@ -1,0 +1,98 @@
+using Microsoft.Win32;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.Versioning;
+using TiaMcpServer.Diagnostics;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+[SupportedOSPlatform("windows")]
+public class ApplicationInfoServiceTests
+{
+    private const string CurrentVersionKey = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion";
+
+    [Fact]
+    public void HostVersion_PreservesInformationalSemVerPrerelease()
+    {
+        var assembly = CreateAssembly(
+            "PrereleaseHost",
+            new Version(1, 2, 3),
+            "1.2.3-rc.1");
+        var service = new ApplicationInfoService(
+            new FakeRegistryService(),
+            () => true,
+            () => new Version(10, 0, 22000),
+            () => assembly);
+
+        Assert.Equal("1.2.3-rc.1", service.HostVersion);
+    }
+
+    [Fact]
+    public void HostVersion_WithoutInformationalVersion_FallsBackToAssemblyVersion()
+    {
+        var assembly = CreateAssembly("AssemblyVersionHost", new Version(4, 5, 6, 7));
+        var service = new ApplicationInfoService(
+            new FakeRegistryService(),
+            () => true,
+            () => new Version(10, 0, 22000),
+            () => assembly);
+
+        Assert.Equal("4.5.6.7", service.HostVersion);
+    }
+
+    [Fact]
+    public void OsName_Windows10ProductNameAtBuild22000_ReportsWindows11()
+    {
+        var registry = CreateRegistryWithProductName("Windows 10 Pro");
+        var service = new ApplicationInfoService(registry, () => true, () => new Version(10, 0, 22000));
+
+        Assert.Equal("Windows 11 Pro", service.OsName);
+    }
+
+    [Fact]
+    public void OsName_Windows10ProductNameBelowBuild22000_RemainsWindows10()
+    {
+        var registry = CreateRegistryWithProductName("Windows 10 Pro");
+        var service = new ApplicationInfoService(registry, () => true, () => new Version(10, 0, 21999));
+
+        Assert.Equal("Windows 10 Pro", service.OsName);
+    }
+
+    [Fact]
+    public void OsName_ServerProductNameAtBuild22000_IsPreserved()
+    {
+        var registry = CreateRegistryWithProductName("Windows Server 2022 Standard");
+        var service = new ApplicationInfoService(registry, () => true, () => new Version(10, 0, 22000));
+
+        Assert.Equal("Windows Server 2022 Standard", service.OsName);
+    }
+
+    private static FakeRegistryService CreateRegistryWithProductName(string productName)
+    {
+        var registry = new FakeRegistryService();
+        registry.SetStringValue(
+            RegistryHive.LocalMachine,
+            RegistryView.Registry64,
+            CurrentVersionKey,
+            "ProductName",
+            productName);
+        return registry;
+    }
+
+    private static Assembly CreateAssembly(
+        string name,
+        Version assemblyVersion,
+        string? informationalVersion = null)
+    {
+        var assemblyName = new AssemblyName(name) { Version = assemblyVersion };
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        if (informationalVersion is not null)
+        {
+            var constructor = typeof(AssemblyInformationalVersionAttribute).GetConstructor([typeof(string)])!;
+            assembly.SetCustomAttribute(new CustomAttributeBuilder(constructor, [informationalVersion]));
+        }
+
+        return assembly;
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/AssemblyResolverTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/AssemblyResolverTests.cs
@@ -1,0 +1,64 @@
+using TiaMcpServer.OpennessWorker.Openness;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class AssemblyResolverTests
+{
+    [Fact]
+    public void TiaPortalLocationRoot_AppendsV21Net48PublicApiSuffix()
+    {
+        var path = AssemblyResolver.ExpandTiaPortalLocation(
+            @"C:\Program Files\Siemens\Automation\Portal V21");
+
+        Assert.Equal(
+            @"C:\Program Files\Siemens\Automation\Portal V21\PublicAPI\V21\net48",
+            path);
+    }
+
+    [Fact]
+    public void CandidatePaths_PreserveEnvironmentRegistryDefaultPrecedence()
+    {
+        var paths = AssemblyResolver.CreateCandidatePaths(
+            @"C:\override\net48",
+            @"C:\Portal V21",
+            new[] { @"C:\registry64", @"C:\registry32" },
+            @"C:\default\net48").ToArray();
+
+        Assert.Equal(
+            new[]
+            {
+                @"C:\override\net48",
+                @"C:\Portal V21\PublicAPI\V21\net48",
+                @"C:\registry64\PublicAPI\V21\net48",
+                @"C:\registry32\PublicAPI\V21\net48",
+                @"C:\default\net48"
+            },
+            paths);
+    }
+
+    [Fact]
+    public void FirstIncompleteCandidate_FallsThroughToNextCompleteCandidate()
+    {
+        var inspected = new List<string>();
+        var candidates = AssemblyResolver.CreateCandidatePaths(
+            @"C:\incomplete\net48",
+            @"C:\Portal V21",
+            new[] { @"C:\registry64" },
+            @"C:\default\net48");
+
+        var selected = AssemblyResolver.SelectFirstCompleteCandidate(
+            candidates,
+            path => path.Contains("Portal V21", StringComparison.Ordinal),
+            inspected.Add);
+
+        Assert.Equal(@"C:\Portal V21\PublicAPI\V21\net48", selected);
+        Assert.Equal(
+            new[]
+            {
+                @"C:\incomplete\net48",
+                @"C:\Portal V21\PublicAPI\V21\net48"
+            },
+            inspected);
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs
@@ -83,6 +83,47 @@ public class DoctorCliParserTests
     }
 
     [Fact]
+    public void Parse_ProjectFlagFollowedByAnotherFlag_ReturnsInvalid()
+    {
+        var result = DoctorCliParser.Parse(new[] { "--project", "--json" });
+
+        Assert.False(result.Valid);
+        Assert.True(result.Json);
+        Assert.Contains("requires a value", result.ParseError);
+    }
+
+    [Fact]
+    public void Parse_ProjectEqualsWithoutValue_ReturnsInvalid()
+    {
+        var result = DoctorCliParser.Parse(new[] { "--project=" });
+
+        Assert.False(result.Valid);
+        Assert.Contains("requires a value", result.ParseError);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Parse_ProjectFlagWithBlankSeparateValue_ReturnsInvalid(string projectPath)
+    {
+        var result = DoctorCliParser.Parse(new[] { "--json", "--project", projectPath });
+
+        Assert.False(result.Valid);
+        Assert.True(result.Json);
+        Assert.Null(result.ProjectPath);
+        Assert.Contains("requires a value", result.ParseError);
+    }
+
+    [Fact]
+    public void Parse_HelpFlag_ReturnsValidHelpRequest()
+    {
+        var result = DoctorCliParser.Parse(new[] { "--help" });
+
+        Assert.True(result.Valid);
+        Assert.True(result.Help);
+    }
+
+    [Fact]
     public void Parse_CaseInsensitive_FlagsWork()
     {
         var result = DoctorCliParser.Parse(new[] { "--JSON", "--VERBOSE" });

--- a/TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs
@@ -1,0 +1,94 @@
+using TiaMcpServer.Cli;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class DoctorCliParserTests
+{
+    [Fact]
+    public void Parse_EmptyArgs_ReturnsValidDefaults()
+    {
+        var result = DoctorCliParser.Parse(Array.Empty<string>());
+
+        Assert.True(result.Valid);
+        Assert.False(result.Json);
+        Assert.False(result.Verbose);
+        Assert.Null(result.ProjectPath);
+        Assert.Null(result.ParseError);
+    }
+
+    [Fact]
+    public void Parse_JsonFlag_SetsJson()
+    {
+        var result = DoctorCliParser.Parse(new[] { "--json" });
+
+        Assert.True(result.Valid);
+        Assert.True(result.Json);
+    }
+
+    [Fact]
+    public void Parse_VerboseFlag_SetsVerbose()
+    {
+        var result = DoctorCliParser.Parse(new[] { "--verbose" });
+
+        Assert.True(result.Valid);
+        Assert.True(result.Verbose);
+    }
+
+    [Fact]
+    public void Parse_ProjectFlag_SetsProjectPath()
+    {
+        var result = DoctorCliParser.Parse(new[] { "--project", @"C:\Projects\Line.ap21" });
+
+        Assert.True(result.Valid);
+        Assert.Equal(@"C:\Projects\Line.ap21", result.ProjectPath);
+    }
+
+    [Fact]
+    public void Parse_ProjectEquals_SetsProjectPath()
+    {
+        var result = DoctorCliParser.Parse(new[] { "--project=C:\\Projects\\Line.ap21" });
+
+        Assert.True(result.Valid);
+        Assert.Equal(@"C:\Projects\Line.ap21", result.ProjectPath);
+    }
+
+    [Fact]
+    public void Parse_CombinedFlags_AllSet()
+    {
+        var result = DoctorCliParser.Parse(new[] { "--json", "--verbose", "--project", "test.ap21" });
+
+        Assert.True(result.Valid);
+        Assert.True(result.Json);
+        Assert.True(result.Verbose);
+        Assert.Equal("test.ap21", result.ProjectPath);
+    }
+
+    [Fact]
+    public void Parse_UnknownArg_ReturnsInvalid()
+    {
+        var result = DoctorCliParser.Parse(new[] { "--bogus" });
+
+        Assert.False(result.Valid);
+        Assert.Contains("Unknown doctor argument", result.ParseError);
+    }
+
+    [Fact]
+    public void Parse_ProjectFlagWithoutValue_ReturnsInvalid()
+    {
+        var result = DoctorCliParser.Parse(new[] { "--project" });
+
+        Assert.False(result.Valid);
+        Assert.Contains("requires a value", result.ParseError);
+    }
+
+    [Fact]
+    public void Parse_CaseInsensitive_FlagsWork()
+    {
+        var result = DoctorCliParser.Parse(new[] { "--JSON", "--VERBOSE" });
+
+        Assert.True(result.Valid);
+        Assert.True(result.Json);
+        Assert.True(result.Verbose);
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs
@@ -1,0 +1,143 @@
+using System.Text.Json;
+using TiaMcpServer.Cli;
+using TiaMcpServer.Diagnostics;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class DoctorCommandTests
+{
+    [Fact]
+    public async Task RunAsync_Help_WritesUsageToStandardOutputAndReturnsZero()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await DoctorCommand.RunAsync(
+            new[] { "--help" },
+            _ => PassedReport(),
+            output,
+            error);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Usage: tia-mcp doctor", output.ToString());
+        Assert.Empty(error.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_JsonHelp_WritesOneParseableUsageDocumentToStandardOutput()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await DoctorCommand.RunAsync(
+            new[] { "--json", "--help" },
+            _ => PassedReport(),
+            output,
+            error);
+
+        using var document = JsonDocument.Parse(output.ToString());
+
+        Assert.Equal(0, exitCode);
+        Assert.True(document.RootElement.TryGetProperty("usage", out var usage));
+        Assert.Contains("--help", usage.GetString());
+        Assert.Empty(error.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_JsonParseError_WritesParseableErrorToStandardOutput()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await DoctorCommand.RunAsync(
+            new[] { "--json", "--project=" },
+            _ => PassedReport(),
+            output,
+            error);
+
+        using var document = JsonDocument.Parse(output.ToString());
+
+        Assert.Equal(2, exitCode);
+        Assert.True(document.RootElement.TryGetProperty("error", out var errorElement));
+        Assert.Contains("requires a value", errorElement.GetString());
+        Assert.Empty(error.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_JsonProjectWithSeparateEmptyValue_WritesOneErrorDocumentAndReturnsTwo()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await DoctorCommand.RunAsync(
+            new[] { "--json", "--project", "" },
+            _ => PassedReport(),
+            output,
+            error);
+
+        using var document = JsonDocument.Parse(output.ToString());
+
+        Assert.Equal(2, exitCode);
+        Assert.Contains("requires a value", document.RootElement.GetProperty("error").GetString());
+        Assert.Empty(error.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_ProjectThenJson_WritesParseableErrorToStandardOutput()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await DoctorCommand.RunAsync(
+            new[] { "--project", "--json" },
+            _ => PassedReport(),
+            output,
+            error);
+
+        using var document = JsonDocument.Parse(output.ToString());
+
+        Assert.Equal(2, exitCode);
+        Assert.Contains("requires a value", document.RootElement.GetProperty("error").GetString());
+        Assert.Empty(error.ToString());
+    }
+
+    [Theory]
+    [InlineData(DiagnosticStatus.Passed, false, 0)]
+    [InlineData(DiagnosticStatus.Warning, false, 0)]
+    [InlineData(DiagnosticStatus.Failed, false, 1)]
+    [InlineData(DiagnosticStatus.Failed, true, 2)]
+    public async Task RunAsync_MapsReportStateToExpectedExitCode(
+        DiagnosticStatus status,
+        bool hasUnexpectedCheckFailure,
+        int expectedExitCode)
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var report = new DoctorReport(
+            status,
+            DateTimeOffset.UtcNow,
+            "1.0.0",
+            new DoctorSummary(0, 0, status == DiagnosticStatus.Failed ? 1 : 0),
+            Array.Empty<DiagnosticCheckResult>())
+        {
+            HasUnexpectedCheckFailure = hasUnexpectedCheckFailure
+        };
+
+        var exitCode = await DoctorCommand.RunAsync(
+            Array.Empty<string>(),
+            _ => report,
+            output,
+            error);
+
+        Assert.Equal(expectedExitCode, exitCode);
+        Assert.Empty(error.ToString());
+    }
+
+    private static DoctorReport PassedReport() => new(
+        DiagnosticStatus.Passed,
+        DateTimeOffset.UtcNow,
+        "1.0.0",
+        new DoctorSummary(0, 0, 0),
+        Array.Empty<DiagnosticCheckResult>());
+}

--- a/TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using TiaMcpServer.Diagnostics;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class DoctorJsonRendererTests
+{
+    [Fact]
+    public void Render_ProducesValidJsonWithCorrectStructure()
+    {
+        var report = CreateReport(DiagnosticStatus.Passed, new[]
+        {
+            new DiagnosticCheckResult("c1", "OS", DiagnosticStatus.Passed, "Windows")
+        });
+
+        var json = DoctorJsonRenderer.Render(report, verbose: false);
+        using var doc = JsonDocument.Parse(json);
+
+        var root = doc.RootElement;
+        Assert.Equal("passed", root.GetProperty("status").GetString());
+        Assert.True(root.TryGetProperty("timestampUtc", out _));
+        Assert.Equal("1.0.0", root.GetProperty("hostVersion").GetString());
+
+        var summary = root.GetProperty("summary");
+        Assert.Equal(1, summary.GetProperty("passed").GetInt32());
+        Assert.Equal(0, summary.GetProperty("warnings").GetInt32());
+        Assert.Equal(0, summary.GetProperty("failed").GetInt32());
+
+        var checks = root.GetProperty("checks");
+        Assert.Equal(1, checks.GetArrayLength());
+        Assert.Equal("c1", checks[0].GetProperty("id").GetString());
+        Assert.Equal("passed", checks[0].GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public void Render_FailedStatus_SerializesCorrectly()
+    {
+        var report = CreateReport(DiagnosticStatus.Failed, new[]
+        {
+            new DiagnosticCheckResult("c1", "X", DiagnosticStatus.Failed, "broken")
+        });
+
+        var json = DoctorJsonRenderer.Render(report, verbose: false);
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.Equal("failed", doc.RootElement.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public void Render_Verbose_IncludesEvidence()
+    {
+        var evidence = new Dictionary<string, string?> { ["k"] = "v" };
+        var report = CreateReport(DiagnosticStatus.Passed, new[]
+        {
+            new DiagnosticCheckResult("c1", "X", DiagnosticStatus.Passed, "msg", Evidence: evidence)
+        });
+
+        var json = DoctorJsonRenderer.Render(report, verbose: true);
+        using var doc = JsonDocument.Parse(json);
+
+        var check = doc.RootElement.GetProperty("checks")[0];
+        Assert.True(check.TryGetProperty("evidence", out var ev));
+        Assert.Equal("v", ev.GetProperty("k").GetString());
+    }
+
+    [Fact]
+    public void Render_NonVerbose_OmitsEvidence()
+    {
+        var evidence = new Dictionary<string, string?> { ["k"] = "v" };
+        var report = CreateReport(DiagnosticStatus.Passed, new[]
+        {
+            new DiagnosticCheckResult("c1", "X", DiagnosticStatus.Passed, "msg", Evidence: evidence)
+        });
+
+        var json = DoctorJsonRenderer.Render(report, verbose: false);
+        using var doc = JsonDocument.Parse(json);
+
+        var check = doc.RootElement.GetProperty("checks")[0];
+        Assert.False(check.TryGetProperty("evidence", out _));
+    }
+
+    [Fact]
+    public void Render_NullRemediation_SerializesAsNull()
+    {
+        var report = CreateReport(DiagnosticStatus.Passed, new[]
+        {
+            new DiagnosticCheckResult("c1", "X", DiagnosticStatus.Passed, "msg")
+        });
+
+        var json = DoctorJsonRenderer.Render(report, verbose: false);
+        using var doc = JsonDocument.Parse(json);
+
+        var check = doc.RootElement.GetProperty("checks")[0];
+        Assert.True(check.GetProperty("remediation").ValueKind == JsonValueKind.Null);
+    }
+
+    [Fact]
+    public void Render_NonNullRemediation_SerializesAsString()
+    {
+        var report = CreateReport(DiagnosticStatus.Failed, new[]
+        {
+            new DiagnosticCheckResult("c1", "X", DiagnosticStatus.Failed, "msg", "Fix it")
+        });
+
+        var json = DoctorJsonRenderer.Render(report, verbose: false);
+        using var doc = JsonDocument.Parse(json);
+
+        var check = doc.RootElement.GetProperty("checks")[0];
+        Assert.Equal("Fix it", check.GetProperty("remediation").GetString());
+    }
+
+    [Fact]
+    public void Render_EvidenceNullValue_SerializesAsNull()
+    {
+        var evidence = new Dictionary<string, string?> { ["k"] = null };
+        var report = CreateReport(DiagnosticStatus.Passed, new[]
+        {
+            new DiagnosticCheckResult("c1", "X", DiagnosticStatus.Passed, "msg", Evidence: evidence)
+        });
+
+        var json = DoctorJsonRenderer.Render(report, verbose: true);
+        using var doc = JsonDocument.Parse(json);
+
+        var ev = doc.RootElement.GetProperty("checks")[0].GetProperty("evidence");
+        Assert.True(ev.GetProperty("k").ValueKind == JsonValueKind.Null);
+    }
+
+    private static DoctorReport CreateReport(DiagnosticStatus status, DiagnosticCheckResult[] checks)
+        => new(status, DateTimeOffset.UtcNow, "1.0.0",
+            new(checks.Count(c => c.Status == DiagnosticStatus.Passed),
+                checks.Count(c => c.Status == DiagnosticStatus.Warning),
+                checks.Count(c => c.Status == DiagnosticStatus.Failed)),
+            checks);
+}

--- a/TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs
@@ -80,6 +80,7 @@ public class DoctorRunnerTests
         Assert.Equal(3, report.Checks.Count);
         Assert.Equal(DiagnosticStatus.Failed, report.Checks[1].Status);
         Assert.Contains("Unexpected error", report.Checks[1].Message);
+        Assert.True(report.HasUnexpectedCheckFailure);
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs
@@ -1,0 +1,134 @@
+using TiaMcpServer.Diagnostics;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class DoctorRunnerTests
+{
+    [Fact]
+    public void Run_AllChecksPass_ReturnsPassedStatus()
+    {
+        var appInfo = new FakeApplicationInfoService();
+        var checks = new IDiagnosticCheck[]
+        {
+            new StubCheck("c1", "Check 1", DiagnosticStatus.Passed),
+            new StubCheck("c2", "Check 2", DiagnosticStatus.Passed)
+        };
+
+        var runner = new DoctorRunner(appInfo, checks);
+        var report = runner.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, report.Status);
+        Assert.Equal(2, report.Summary.Passed);
+        Assert.Equal(0, report.Summary.Warnings);
+        Assert.Equal(0, report.Summary.Failed);
+        Assert.Equal(2, report.Checks.Count);
+    }
+
+    [Fact]
+    public void Run_MixedResults_ReturnsFailedIfAnyFailed()
+    {
+        var appInfo = new FakeApplicationInfoService();
+        var checks = new IDiagnosticCheck[]
+        {
+            new StubCheck("c1", "Check 1", DiagnosticStatus.Passed),
+            new StubCheck("c2", "Check 2", DiagnosticStatus.Warning),
+            new StubCheck("c3", "Check 3", DiagnosticStatus.Failed)
+        };
+
+        var runner = new DoctorRunner(appInfo, checks);
+        var report = runner.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, report.Status);
+        Assert.Equal(1, report.Summary.Passed);
+        Assert.Equal(1, report.Summary.Warnings);
+        Assert.Equal(1, report.Summary.Failed);
+    }
+
+    [Fact]
+    public void Run_OnlyWarnings_ReturnsWarning()
+    {
+        var appInfo = new FakeApplicationInfoService();
+        var checks = new IDiagnosticCheck[]
+        {
+            new StubCheck("c1", "Check 1", DiagnosticStatus.Warning),
+            new StubCheck("c2", "Check 2", DiagnosticStatus.Warning)
+        };
+
+        var runner = new DoctorRunner(appInfo, checks);
+        var report = runner.Run();
+
+        Assert.Equal(DiagnosticStatus.Warning, report.Status);
+        Assert.Equal(2, report.Summary.Warnings);
+    }
+
+    [Fact]
+    public void Run_ThrowingCheck_CapturedAsFailed()
+    {
+        var appInfo = new FakeApplicationInfoService();
+        var checks = new IDiagnosticCheck[]
+        {
+            new StubCheck("c1", "Check 1", DiagnosticStatus.Passed),
+            new ThrowingCheck(),
+            new StubCheck("c3", "Check 3", DiagnosticStatus.Passed)
+        };
+
+        var runner = new DoctorRunner(appInfo, checks);
+        var report = runner.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, report.Status);
+        Assert.Equal(3, report.Checks.Count);
+        Assert.Equal(DiagnosticStatus.Failed, report.Checks[1].Status);
+        Assert.Contains("Unexpected error", report.Checks[1].Message);
+    }
+
+    [Fact]
+    public void Run_EmptyCheckList_ReturnsPassed()
+    {
+        var appInfo = new FakeApplicationInfoService();
+        var runner = new DoctorRunner(appInfo, Array.Empty<IDiagnosticCheck>());
+        var report = runner.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, report.Status);
+        Assert.Empty(report.Checks);
+        Assert.Equal(0, report.Summary.Passed);
+    }
+
+    [Fact]
+    public void Run_IncludesHostVersionFromAppInfo()
+    {
+        var appInfo = new FakeApplicationInfoService { HostVersion = "2.5.0" };
+        var runner = new DoctorRunner(appInfo, Array.Empty<IDiagnosticCheck>());
+        var report = runner.Run();
+
+        Assert.Equal("2.5.0", report.HostVersion);
+    }
+
+    [Fact]
+    public void Run_SetsTimestamp()
+    {
+        var before = DateTimeOffset.UtcNow;
+        var appInfo = new FakeApplicationInfoService();
+        var runner = new DoctorRunner(appInfo, Array.Empty<IDiagnosticCheck>());
+        var report = runner.Run();
+        var after = DateTimeOffset.UtcNow;
+
+        Assert.InRange(report.TimestampUtc, before, after);
+    }
+
+    private sealed class StubCheck : IDiagnosticCheck
+    {
+        private readonly DiagnosticStatus _status;
+        public StubCheck(string id, string name, DiagnosticStatus status) { Id = id; Name = name; _status = status; }
+        public string Id { get; }
+        public string Name { get; }
+        public DiagnosticCheckResult Run() => new(Id, Name, _status, $"{Name} message");
+    }
+
+    private sealed class ThrowingCheck : IDiagnosticCheck
+    {
+        public string Id => "throwing";
+        public string Name => "Throwing Check";
+        public DiagnosticCheckResult Run() => throw new InvalidOperationException("boom");
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs
@@ -1,0 +1,135 @@
+using TiaMcpServer.Diagnostics;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class DoctorTextRendererTests
+{
+    [Fact]
+    public void Render_AllPassed_ShowsPassTagsAndReady()
+    {
+        var report = CreateReport(DiagnosticStatus.Passed, new[]
+        {
+            new DiagnosticCheckResult("c1", "OS", DiagnosticStatus.Passed, "Windows 10"),
+            new DiagnosticCheckResult("c2", "Runtime", DiagnosticStatus.Passed, ".NET 8")
+        });
+
+        var writer = new StringWriter();
+        DoctorTextRenderer.Render(report, verbose: false, writer);
+        var output = writer.ToString();
+
+        Assert.Contains("[PASS] OS", output);
+        Assert.Contains("[PASS] Runtime", output);
+        Assert.Contains("2 passed", output);
+        Assert.Contains("Environment is ready", output);
+    }
+
+    [Fact]
+    public void Render_WithFailure_ShowsFailTagsAndNotReady()
+    {
+        var report = CreateReport(DiagnosticStatus.Failed, new[]
+        {
+            new DiagnosticCheckResult("c1", "OS", DiagnosticStatus.Passed, "Windows 10"),
+            new DiagnosticCheckResult("c2", "Install", DiagnosticStatus.Failed, "Not found", "Install TIA Portal")
+        });
+
+        var writer = new StringWriter();
+        DoctorTextRenderer.Render(report, verbose: false, writer);
+        var output = writer.ToString();
+
+        Assert.Contains("[PASS] OS", output);
+        Assert.Contains("[FAIL] Install", output);
+        Assert.Contains("Not found", output);
+        Assert.Contains("Environment is not ready", output);
+    }
+
+    [Fact]
+    public void Render_WithWarning_ShowsWarnTag()
+    {
+        var report = CreateReport(DiagnosticStatus.Passed, new[]
+        {
+            new DiagnosticCheckResult("c1", "Process", DiagnosticStatus.Warning, "No TIA running")
+        });
+
+        var writer = new StringWriter();
+        DoctorTextRenderer.Render(report, verbose: false, writer);
+        var output = writer.ToString();
+
+        Assert.Contains("[WARN] Process", output);
+        Assert.Contains("1 warning", output);
+    }
+
+    [Fact]
+    public void Render_Verbose_ShowsEvidence()
+    {
+        var evidence = new Dictionary<string, string?> { ["key1"] = "val1", ["key2"] = null };
+        var report = CreateReport(DiagnosticStatus.Passed, new[]
+        {
+            new DiagnosticCheckResult("c1", "Test", DiagnosticStatus.Passed, "msg", Evidence: evidence)
+        });
+
+        var writer = new StringWriter();
+        DoctorTextRenderer.Render(report, verbose: true, writer);
+        var output = writer.ToString();
+
+        Assert.Contains("Evidence:", output);
+        Assert.Contains("key1 = val1", output);
+        Assert.Contains("key2 = <null>", output);
+    }
+
+    [Fact]
+    public void Render_NonVerbose_HidesEvidence()
+    {
+        var evidence = new Dictionary<string, string?> { ["key1"] = "val1" };
+        var report = CreateReport(DiagnosticStatus.Passed, new[]
+        {
+            new DiagnosticCheckResult("c1", "Test", DiagnosticStatus.Passed, "msg", Evidence: evidence)
+        });
+
+        var writer = new StringWriter();
+        DoctorTextRenderer.Render(report, verbose: false, writer);
+        var output = writer.ToString();
+
+        Assert.DoesNotContain("Evidence:", output);
+        Assert.DoesNotContain("key1", output);
+    }
+
+    [Fact]
+    public void Render_WithRemediation_ShowsFix()
+    {
+        var report = CreateReport(DiagnosticStatus.Failed, new[]
+        {
+            new DiagnosticCheckResult("c1", "Install", DiagnosticStatus.Failed, "Missing", "Install TIA Portal V21.")
+        });
+
+        var writer = new StringWriter();
+        DoctorTextRenderer.Render(report, verbose: false, writer);
+        var output = writer.ToString();
+
+        Assert.Contains("Fix:", output);
+        Assert.Contains("Install TIA Portal V21.", output);
+    }
+
+    [Fact]
+    public void Render_MultiLineRemediation_IndentsEachLine()
+    {
+        var report = CreateReport(DiagnosticStatus.Failed, new[]
+        {
+            new DiagnosticCheckResult("c1", "X", DiagnosticStatus.Failed, "msg", "Line one\nLine two")
+        });
+
+        var writer = new StringWriter();
+        DoctorTextRenderer.Render(report, verbose: false, writer);
+        var output = writer.ToString();
+
+        Assert.Contains("       Line one", output);
+        Assert.Contains("       Line two", output);
+    }
+
+    private static DoctorReport CreateReport(DiagnosticStatus status, DiagnosticCheckResult[] checks)
+        => new(status, DateTimeOffset.UtcNow, "1.0.0",
+            new(checks.Count(c => c.Status == DiagnosticStatus.Passed),
+                checks.Count(c => c.Status == DiagnosticStatus.Warning),
+                checks.Count(c => c.Status == DiagnosticStatus.Failed)),
+            checks);
+}

--- a/TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs
@@ -1,10 +1,12 @@
 using Microsoft.Win32;
+using System.Runtime.Versioning;
 using TiaMcpServer.Diagnostics;
 using TiaMcpServer.Diagnostics.Checks;
 using Xunit;
 
 namespace TiaMcpServer.Tests.Diagnostics;
 
+[SupportedOSPlatform("windows")]
 public class DotNetFrameworkCheckTests
 {
     private const string NetFrameworkKey = @"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full";

--- a/TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs
@@ -1,0 +1,95 @@
+using Microsoft.Win32;
+using TiaMcpServer.Diagnostics;
+using TiaMcpServer.Diagnostics.Checks;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class DotNetFrameworkCheckTests
+{
+    private const string NetFrameworkKey = @"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full";
+
+    [Fact]
+    public void NotWindows_ReturnsFailed()
+    {
+        var registry = new FakeRegistryService();
+        var appInfo = new FakeApplicationInfoService { IsWindows = false };
+        var check = new DotNetFrameworkCheck(registry, appInfo);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("Not running on Windows", result.Message);
+    }
+
+    [Fact]
+    public void NoRegistryValue_ReturnsFailed()
+    {
+        var registry = new FakeRegistryService();
+        var appInfo = new FakeApplicationInfoService { IsWindows = true };
+        var check = new DotNetFrameworkCheck(registry, appInfo);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("was not detected", result.Message);
+    }
+
+    [Fact]
+    public void OldRelease_ReturnsFailed()
+    {
+        var registry = new FakeRegistryService();
+        registry.SetIntValue(RegistryHive.LocalMachine, RegistryView.Registry64, NetFrameworkKey, "Release", 461808); // 4.7.2
+        var appInfo = new FakeApplicationInfoService { IsWindows = true };
+        var check = new DotNetFrameworkCheck(registry, appInfo);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("4.7.2", result.Message);
+        Assert.Contains("4.8", result.Message);
+    }
+
+    [Fact]
+    public void Release48_ReturnsPassed()
+    {
+        var registry = new FakeRegistryService();
+        registry.SetIntValue(RegistryHive.LocalMachine, RegistryView.Registry64, NetFrameworkKey, "Release", 528040);
+        var appInfo = new FakeApplicationInfoService { IsWindows = true };
+        var check = new DotNetFrameworkCheck(registry, appInfo);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("4.8", result.Message);
+    }
+
+    [Fact]
+    public void Release481_ReturnsPassed()
+    {
+        var registry = new FakeRegistryService();
+        registry.SetIntValue(RegistryHive.LocalMachine, RegistryView.Registry64, NetFrameworkKey, "Release", 533320);
+        var appInfo = new FakeApplicationInfoService { IsWindows = true };
+        var check = new DotNetFrameworkCheck(registry, appInfo);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("4.8.1", result.Message);
+    }
+
+    [Fact]
+    public void FallsBackToRegistry32()
+    {
+        var registry = new FakeRegistryService();
+        // Registry64 returns null, Registry32 returns 528040
+        registry.SetIntValue(RegistryHive.LocalMachine, RegistryView.Registry32, NetFrameworkKey, "Release", 528040);
+        var appInfo = new FakeApplicationInfoService { IsWindows = true };
+        var check = new DotNetFrameworkCheck(registry, appInfo);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Equal("Registry32", result.Evidence!["registryView"]);
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/DotNetRuntimeCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/DotNetRuntimeCheckTests.cs
@@ -1,0 +1,45 @@
+using TiaMcpServer.Diagnostics;
+using TiaMcpServer.Diagnostics.Checks;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class DotNetRuntimeCheckTests
+{
+    [Fact]
+    public void AlwaysPasses_WithRuntimeDescription()
+    {
+        var appInfo = new FakeApplicationInfoService
+        {
+            RuntimeDescription = ".NET 8.0.5",
+            ProcessArchitecture = "X64",
+            HostVersion = "1.0.0"
+        };
+        var check = new DotNetRuntimeCheck(appInfo);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains(".NET 8.0.5", result.Message);
+        Assert.Contains("X64", result.Message);
+    }
+
+    [Fact]
+    public void IncludesEvidence()
+    {
+        var appInfo = new FakeApplicationInfoService
+        {
+            RuntimeDescription = ".NET 8.0.5",
+            ProcessArchitecture = "Arm64",
+            HostVersion = "2.0.0"
+        };
+        var check = new DotNetRuntimeCheck(appInfo);
+
+        var result = check.Run();
+
+        Assert.NotNull(result.Evidence);
+        Assert.Equal(".NET 8.0.5", result.Evidence!["runtimeDescription"]);
+        Assert.Equal("Arm64", result.Evidence!["processArchitecture"]);
+        Assert.Equal("2.0.0", result.Evidence!["applicationVersion"]);
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/Fakes.cs
+++ b/TiaMcpServer.Tests/Diagnostics/Fakes.cs
@@ -1,10 +1,12 @@
 using Microsoft.Win32;
+using System.Runtime.Versioning;
 using TiaMcpServer.Diagnostics;
 
 namespace TiaMcpServer.Tests.Diagnostics;
 
 public sealed class FakeApplicationInfoService : IApplicationInfoService
 {
+    [SupportedOSPlatformGuard("windows")]
     public bool IsWindows { get; set; } = true;
     public string OsName { get; set; } = "Windows";
     public string OsVersion { get; set; } = "10.0.19045";
@@ -23,6 +25,7 @@ public sealed class FakeEnvironmentVariableService : IEnvironmentVariableService
     public string? Get(string name) => _vars.TryGetValue(name, out var v) ? v : null;
 }
 
+[SupportedOSPlatform("windows")]
 public sealed class FakeRegistryService : IRegistryService
 {
     private readonly Dictionary<(RegistryHive, RegistryView, string, string), string?> _stringValues = new();

--- a/TiaMcpServer.Tests/Diagnostics/Fakes.cs
+++ b/TiaMcpServer.Tests/Diagnostics/Fakes.cs
@@ -1,0 +1,81 @@
+using Microsoft.Win32;
+using TiaMcpServer.Diagnostics;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public sealed class FakeApplicationInfoService : IApplicationInfoService
+{
+    public bool IsWindows { get; set; } = true;
+    public string OsName { get; set; } = "Windows";
+    public string OsVersion { get; set; } = "10.0.19045";
+    public string ProcessArchitecture { get; set; } = "X64";
+    public string HostVersion { get; set; } = "1.0.0";
+    public string BaseDirectory { get; set; } = "/app";
+    public string RuntimeDescription { get; set; } = ".NET 8.0.0";
+}
+
+public sealed class FakeEnvironmentVariableService : IEnvironmentVariableService
+{
+    private readonly Dictionary<string, string?> _vars = new(StringComparer.OrdinalIgnoreCase);
+
+    public void Set(string name, string? value) => _vars[name] = value;
+
+    public string? Get(string name) => _vars.TryGetValue(name, out var v) ? v : null;
+}
+
+public sealed class FakeRegistryService : IRegistryService
+{
+    private readonly Dictionary<(RegistryHive, RegistryView, string, string), string?> _stringValues = new();
+    private readonly Dictionary<(RegistryHive, RegistryView, string, string), int?> _intValues = new();
+    private readonly HashSet<(RegistryHive, RegistryView, string)> _existingKeys = new();
+
+    public void SetStringValue(RegistryHive hive, RegistryView view, string subKey, string valueName, string? value)
+        => _stringValues[(hive, view, subKey, valueName)] = value;
+
+    public void SetIntValue(RegistryHive hive, RegistryView view, string subKey, string valueName, int? value)
+        => _intValues[(hive, view, subKey, valueName)] = value;
+
+    public void SetKeyExists(RegistryHive hive, RegistryView view, string subKey)
+        => _existingKeys.Add((hive, view, subKey));
+
+    public string? GetStringValue(RegistryHive hive, RegistryView view, string subKey, string valueName)
+        => _stringValues.TryGetValue((hive, view, subKey, valueName), out var v) ? v : null;
+
+    public int? GetIntValue(RegistryHive hive, RegistryView view, string subKey, string valueName)
+        => _intValues.TryGetValue((hive, view, subKey, valueName), out var v) ? v : null;
+
+    public bool KeyExists(RegistryHive hive, RegistryView view, string subKey)
+        => _existingKeys.Contains((hive, view, subKey));
+}
+
+public sealed class FakeFileSystemService : IFileSystemService
+{
+    private readonly HashSet<string> _files = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _directories = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string?> _fileVersions = new(StringComparer.OrdinalIgnoreCase);
+
+    public void AddFile(string path) => _files.Add(path);
+    public void AddDirectory(string path) => _directories.Add(path);
+    public void SetFileVersion(string path, string? version) => _fileVersions[path] = version;
+
+    public bool FileExists(string path) => _files.Contains(path);
+    public bool DirectoryExists(string path) => _directories.Contains(path);
+    public string? GetFileVersion(string path) => _fileVersions.TryGetValue(path, out var v) ? v : null;
+}
+
+public sealed class FakeWindowsIdentityService : IWindowsIdentityService
+{
+    public bool IsWindows { get; set; } = true;
+    public WindowsUserInfo? UserInfo { get; set; } = new("DOMAIN\\user", "S-1-5-21-123");
+    public OpennessGroupMembership Membership { get; set; } = new(true, true, "S-1-5-32-544", null);
+
+    public WindowsUserInfo? GetCurrentUserInfo() => UserInfo;
+    public OpennessGroupMembership CheckGroupMembership(string groupName) => Membership;
+}
+
+public sealed class FakeProcessEnumerationService : IProcessEnumerationService
+{
+    public List<ProcessInfo> Processes { get; set; } = new();
+
+    public IReadOnlyList<ProcessInfo> ListProcesses() => Processes;
+}

--- a/TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs
@@ -1,0 +1,72 @@
+using TiaMcpServer.Diagnostics;
+using TiaMcpServer.Diagnostics.Checks;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class HostWorkerVersionCheckTests
+{
+    [Fact]
+    public void WorkerNotFound_ReturnsWarning()
+    {
+        var appInfo = new FakeApplicationInfoService { BaseDirectory = "/app", HostVersion = "1.0.0" };
+        var fileSystem = new FakeFileSystemService();
+        // No worker found
+
+        var check = new HostWorkerVersionCheck(appInfo, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Warning, result.Status);
+        Assert.Contains("not found", result.Message);
+    }
+
+    [Fact]
+    public void MatchingMajorVersions_ReturnsPassed()
+    {
+        var appInfo = new FakeApplicationInfoService { BaseDirectory = "/app", HostVersion = "1.2.3" };
+        var fileSystem = new FakeFileSystemService();
+        var workerPath = System.IO.Path.Combine("/app", "openness-worker", "TiaMcpServer.OpennessWorker.exe");
+        fileSystem.AddFile(workerPath);
+        fileSystem.SetFileVersion(workerPath, "1.5.0.0");
+
+        var check = new HostWorkerVersionCheck(appInfo, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("1.2.3", result.Message);
+        Assert.Contains("1.5.0.0", result.Message);
+    }
+
+    [Fact]
+    public void DifferentMajorVersions_ReturnsFailed()
+    {
+        var appInfo = new FakeApplicationInfoService { BaseDirectory = "/app", HostVersion = "1.0.0" };
+        var fileSystem = new FakeFileSystemService();
+        var workerPath = System.IO.Path.Combine("/app", "openness-worker", "TiaMcpServer.OpennessWorker.exe");
+        fileSystem.AddFile(workerPath);
+        fileSystem.SetFileVersion(workerPath, "2.0.0.0");
+
+        var check = new HostWorkerVersionCheck(appInfo, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("different major versions", result.Message);
+        Assert.NotNull(result.Remediation);
+    }
+
+    [Fact]
+    public void WorkerVersionNull_ReturnsWarning()
+    {
+        var appInfo = new FakeApplicationInfoService { BaseDirectory = "/app", HostVersion = "1.0.0" };
+        var fileSystem = new FakeFileSystemService();
+        var workerPath = System.IO.Path.Combine("/app", "openness-worker", "TiaMcpServer.OpennessWorker.exe");
+        fileSystem.AddFile(workerPath);
+        // No version set -> null
+
+        var check = new HostWorkerVersionCheck(appInfo, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Warning, result.Status);
+        Assert.Contains("could not be determined", result.Message);
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs
@@ -69,4 +69,40 @@ public class HostWorkerVersionCheckTests
         Assert.Equal(DiagnosticStatus.Warning, result.Status);
         Assert.Contains("could not be determined", result.Message);
     }
+
+    [Fact]
+    public void MalformedHostVersion_ReturnsWarningWithEvidence()
+    {
+        var appInfo = new FakeApplicationInfoService { BaseDirectory = "/app", HostVersion = "not-a-version" };
+        var fileSystem = new FakeFileSystemService();
+        var workerPath = System.IO.Path.Combine("/app", "openness-worker", "TiaMcpServer.OpennessWorker.exe");
+        fileSystem.AddFile(workerPath);
+        fileSystem.SetFileVersion(workerPath, "1.0.0.0");
+
+        var result = new HostWorkerVersionCheck(appInfo, fileSystem).Run();
+
+        Assert.Equal(DiagnosticStatus.Warning, result.Status);
+        Assert.Contains("host version", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("could not be parsed", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("not-a-version", result.Evidence!["hostVersion"]);
+        Assert.Contains("host", result.Evidence["versionParseError"], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MalformedWorkerVersion_ReturnsWarningWithEvidence()
+    {
+        var appInfo = new FakeApplicationInfoService { BaseDirectory = "/app", HostVersion = "1.0.0" };
+        var fileSystem = new FakeFileSystemService();
+        var workerPath = System.IO.Path.Combine("/app", "openness-worker", "TiaMcpServer.OpennessWorker.exe");
+        fileSystem.AddFile(workerPath);
+        fileSystem.SetFileVersion(workerPath, "not-a-version");
+
+        var result = new HostWorkerVersionCheck(appInfo, fileSystem).Run();
+
+        Assert.Equal(DiagnosticStatus.Warning, result.Status);
+        Assert.Contains("worker version", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("could not be parsed", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("not-a-version", result.Evidence!["workerVersion"]);
+        Assert.Contains("worker", result.Evidence["versionParseError"], StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs
@@ -1,10 +1,12 @@
 using TiaMcpServer.Diagnostics;
 using TiaMcpServer.Diagnostics.Checks;
 using TiaMcpServer.Worker;
+using System.Runtime.Versioning;
 using Xunit;
 
 namespace TiaMcpServer.Tests.Diagnostics;
 
+[SupportedOSPlatform("windows")]
 public class OpennessAssembliesCheckTests
 {
     [Fact]
@@ -26,21 +28,120 @@ public class OpennessAssembliesCheckTests
     }
 
     [Fact]
-    public void IncompleteInstallation_ReturnsFailed()
+    public void ExistingApiDirectoryWithoutAllAssemblies_ReportsMissingAssemblies()
     {
         var env = new FakeEnvironmentVariableService();
         env.Set("TiaPortalV21Dir", @"C:\TIA\api");
         var registry = new FakeRegistryService();
         var fileSystem = new FakeFileSystemService();
         fileSystem.AddDirectory(@"C:\TIA\api");
-        // Only add one of the required assemblies - locator considers this incomplete
+        // Only add one of the required assemblies.
         fileSystem.AddFile(System.IO.Path.Combine(@"C:\TIA\api", TiaPortalInstallationLocator.RequiredAssemblies[0]));
 
         var check = new OpennessAssembliesCheck(env, registry, fileSystem);
         var result = check.Run();
 
         Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("Missing Openness assemblies", result.Message);
+        Assert.Contains(TiaPortalInstallationLocator.RequiredAssemblies[1], result.Message);
+        Assert.Equal(@"C:\TIA\api", result.Evidence!["selectedPath"]);
         Assert.NotNull(result.Remediation);
+    }
+
+    [Fact]
+    public void TiaPortalLocationRootWithoutApiDirectory_ReportsMissingApiDirectory()
+    {
+        const string root = @"C:\Program Files\Siemens\Automation\Portal V21";
+        var env = new FakeEnvironmentVariableService();
+        env.Set("TiaPortalLocation", root);
+        var registry = new FakeRegistryService();
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddDirectory(root);
+
+        var result = new OpennessAssembliesCheck(env, registry, fileSystem).Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("Openness API directory", result.Message);
+        Assert.Equal(root, result.Evidence!["selectedInstallationPath"]);
+        Assert.Equal("false", result.Evidence["apiDirectoryPresent"]);
+        Assert.Contains("Openness option", result.Remediation);
+    }
+
+    [Fact]
+    public void RegistryRootWithoutApiDirectory_ReportsMissingApiDirectory()
+    {
+        const string root = @"C:\Program Files\Siemens\Automation\Portal V21";
+        var env = new FakeEnvironmentVariableService();
+        var registry = new FakeRegistryService();
+        registry.SetStringValue(
+            Microsoft.Win32.RegistryHive.LocalMachine,
+            Microsoft.Win32.RegistryView.Registry64,
+            @"SOFTWARE\Siemens\Automation\InstalledApps\Totally Integrated Automation Portal V21",
+            "INSTALLPATH",
+            root);
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddDirectory(root);
+
+        var result = new OpennessAssembliesCheck(env, registry, fileSystem).Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("Openness API directory", result.Message);
+        Assert.Equal(root, result.Evidence!["selectedInstallationPath"]);
+        Assert.Equal("registry:Registry64", result.Evidence["selectedSource"]);
+    }
+
+    [Fact]
+    public void EarlyLocationRootAndLaterCompleteRegistry_UsesCompleteRegistryApi()
+    {
+        const string locationRoot = @"C:\TIA\Portal V21";
+        const string registryRoot = @"D:\Siemens\Portal V21";
+        var env = new FakeEnvironmentVariableService();
+        env.Set("TiaPortalLocation", locationRoot);
+        var registry = new FakeRegistryService();
+        registry.SetStringValue(
+            Microsoft.Win32.RegistryHive.LocalMachine,
+            Microsoft.Win32.RegistryView.Registry64,
+            @"SOFTWARE\Siemens\Automation\InstalledApps\Totally Integrated Automation Portal V21",
+            "INSTALLPATH",
+            registryRoot);
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddDirectory(locationRoot);
+        fileSystem.AddDirectory(registryRoot);
+        var registryApi = Path.Combine(registryRoot, @"PublicAPI\V21\net48");
+        fileSystem.AddDirectory(registryApi);
+        foreach (var assembly in TiaPortalInstallationLocator.RequiredAssemblies)
+            fileSystem.AddFile(Path.Combine(registryApi, assembly));
+
+        var result = new OpennessAssembliesCheck(env, registry, fileSystem).Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Equal("registry:Registry64", result.Evidence!["selectedSource"]);
+        Assert.Equal(registryApi, result.Evidence["selectedPath"]);
+    }
+
+    [Fact]
+    public void EarlyRegistryRootAndLaterCompleteRegistry_UsesCompleteRegistryApi()
+    {
+        const string registry64Root = @"C:\Siemens\Portal V21";
+        const string registry32Root = @"D:\Siemens\Portal V21";
+        var env = new FakeEnvironmentVariableService();
+        var registry = new FakeRegistryService();
+        const string registryKey = @"SOFTWARE\Siemens\Automation\InstalledApps\Totally Integrated Automation Portal V21";
+        registry.SetStringValue(Microsoft.Win32.RegistryHive.LocalMachine, Microsoft.Win32.RegistryView.Registry64, registryKey, "INSTALLPATH", registry64Root);
+        registry.SetStringValue(Microsoft.Win32.RegistryHive.LocalMachine, Microsoft.Win32.RegistryView.Registry32, registryKey, "INSTALLPATH", registry32Root);
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddDirectory(registry64Root);
+        fileSystem.AddDirectory(registry32Root);
+        var registry32Api = Path.Combine(registry32Root, @"PublicAPI\V21\net48");
+        fileSystem.AddDirectory(registry32Api);
+        foreach (var assembly in TiaPortalInstallationLocator.RequiredAssemblies)
+            fileSystem.AddFile(Path.Combine(registry32Api, assembly));
+
+        var result = new OpennessAssembliesCheck(env, registry, fileSystem).Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Equal("registry:Registry32", result.Evidence!["selectedSource"]);
+        Assert.Equal(registry32Api, result.Evidence["selectedPath"]);
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs
@@ -1,0 +1,59 @@
+using TiaMcpServer.Diagnostics;
+using TiaMcpServer.Diagnostics.Checks;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class OpennessAssembliesCheckTests
+{
+    [Fact]
+    public void AllAssembliesPresent_ReturnsPassed()
+    {
+        var env = new FakeEnvironmentVariableService();
+        env.Set("TiaPortalV21Dir", @"C:\TIA\api");
+        var registry = new FakeRegistryService();
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddDirectory(@"C:\TIA\api");
+        foreach (var asm in TiaPortalInstallationLocator.RequiredAssemblies)
+            fileSystem.AddFile(System.IO.Path.Combine(@"C:\TIA\api", asm));
+
+        var check = new OpennessAssembliesCheck(env, registry, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("present", result.Message);
+    }
+
+    [Fact]
+    public void IncompleteInstallation_ReturnsFailed()
+    {
+        var env = new FakeEnvironmentVariableService();
+        env.Set("TiaPortalV21Dir", @"C:\TIA\api");
+        var registry = new FakeRegistryService();
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddDirectory(@"C:\TIA\api");
+        // Only add one of the required assemblies - locator considers this incomplete
+        fileSystem.AddFile(System.IO.Path.Combine(@"C:\TIA\api", TiaPortalInstallationLocator.RequiredAssemblies[0]));
+
+        var check = new OpennessAssembliesCheck(env, registry, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.NotNull(result.Remediation);
+    }
+
+    [Fact]
+    public void NoInstallationFound_ReturnsFailed()
+    {
+        var env = new FakeEnvironmentVariableService();
+        var registry = new FakeRegistryService();
+        var fileSystem = new FakeFileSystemService();
+
+        var check = new OpennessAssembliesCheck(env, registry, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("No TIA Portal", result.Message);
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs
@@ -1,0 +1,87 @@
+using TiaMcpServer.Diagnostics;
+using TiaMcpServer.Diagnostics.Checks;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class OpennessGroupCheckTests
+{
+    [Fact]
+    public void NotWindows_ReturnsFailed()
+    {
+        var identity = new FakeWindowsIdentityService { IsWindows = false };
+        var check = new OpennessGroupCheck(identity);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("Not running on Windows", result.Message);
+    }
+
+    [Fact]
+    public void GroupDoesNotExist_ReturnsFailed()
+    {
+        var identity = new FakeWindowsIdentityService
+        {
+            IsWindows = true,
+            Membership = new OpennessGroupMembership(GroupExists: false, IsMember: false, GroupSid: null, ErrorMessage: null)
+        };
+        var check = new OpennessGroupCheck(identity);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("does not exist", result.Message);
+    }
+
+    [Fact]
+    public void UserNotMember_ReturnsFailed()
+    {
+        var identity = new FakeWindowsIdentityService
+        {
+            IsWindows = true,
+            Membership = new OpennessGroupMembership(GroupExists: true, IsMember: false, GroupSid: "S-1-5-32-544", ErrorMessage: null)
+        };
+        var check = new OpennessGroupCheck(identity);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("not a member", result.Message);
+    }
+
+    [Fact]
+    public void UserIsMember_ReturnsPassed()
+    {
+        var identity = new FakeWindowsIdentityService
+        {
+            IsWindows = true,
+            UserInfo = new WindowsUserInfo("DOMAIN\\testuser", "S-1-5-21-999"),
+            Membership = new OpennessGroupMembership(GroupExists: true, IsMember: true, GroupSid: "S-1-5-32-544", ErrorMessage: null)
+        };
+        var check = new OpennessGroupCheck(identity);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("member", result.Message);
+    }
+
+    [Fact]
+    public void IncludesUserEvidence()
+    {
+        var identity = new FakeWindowsIdentityService
+        {
+            IsWindows = true,
+            UserInfo = new WindowsUserInfo("DOMAIN\\admin", "S-1-5-21-111"),
+            Membership = new OpennessGroupMembership(GroupExists: true, IsMember: true, GroupSid: "S-1-5-32-544", ErrorMessage: null)
+        };
+        var check = new OpennessGroupCheck(identity);
+
+        var result = check.Run();
+
+        Assert.Equal("DOMAIN\\admin", result.Evidence!["user"]);
+        Assert.Equal("S-1-5-21-111", result.Evidence!["userSid"]);
+        Assert.Equal("true", result.Evidence!["isMember"]);
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs
@@ -1,0 +1,81 @@
+using TiaMcpServer.Diagnostics;
+using TiaMcpServer.Diagnostics.Checks;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class OpennessWorkerCheckTests
+{
+    [Fact]
+    public void WorkerFoundWithRuntimeConfig_ReturnsPassed()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), "doctor-test-" + Guid.NewGuid().ToString("N"));
+        var workerDir = Path.Combine(baseDir, "openness-worker");
+        var workerPath = Path.Combine(workerDir, "TiaMcpServer.OpennessWorker.exe");
+        var runtimeConfigPath = Path.Combine(workerDir, "TiaMcpServer.OpennessWorker.runtimeconfig.json");
+
+        var appInfo = new FakeApplicationInfoService { BaseDirectory = baseDir };
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddFile(workerPath);
+        fileSystem.AddFile(runtimeConfigPath);
+        fileSystem.SetFileVersion(workerPath, "1.0.0.0");
+
+        var check = new OpennessWorkerCheck(appInfo, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("1.0.0.0", result.Message);
+    }
+
+    [Fact]
+    public void WorkerNotFound_ReturnsFailed()
+    {
+        var appInfo = new FakeApplicationInfoService { BaseDirectory = Path.Combine(Path.GetTempPath(), "nonexistent") };
+        var fileSystem = new FakeFileSystemService();
+
+        var check = new OpennessWorkerCheck(appInfo, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("not found", result.Message);
+        Assert.NotNull(result.Remediation);
+    }
+
+    [Fact]
+    public void WorkerFoundButRuntimeConfigMissing_ReturnsFailed()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), "doctor-test-" + Guid.NewGuid().ToString("N"));
+        var workerDir = Path.Combine(baseDir, "openness-worker");
+        var workerPath = Path.Combine(workerDir, "TiaMcpServer.OpennessWorker.exe");
+
+        var appInfo = new FakeApplicationInfoService { BaseDirectory = baseDir };
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddFile(workerPath);
+
+        var check = new OpennessWorkerCheck(appInfo, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("runtime configuration", result.Message);
+    }
+
+    [Fact]
+    public void WorkerFoundWithoutVersion_PassesWithVersionlessMessage()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), "doctor-test-" + Guid.NewGuid().ToString("N"));
+        var workerDir = Path.Combine(baseDir, "openness-worker");
+        var workerPath = Path.Combine(workerDir, "TiaMcpServer.OpennessWorker.exe");
+        var runtimeConfigPath = Path.Combine(workerDir, "TiaMcpServer.OpennessWorker.runtimeconfig.json");
+
+        var appInfo = new FakeApplicationInfoService { BaseDirectory = baseDir };
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddFile(workerPath);
+        fileSystem.AddFile(runtimeConfigPath);
+
+        var check = new OpennessWorkerCheck(appInfo, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.DoesNotContain("version", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs
@@ -1,23 +1,38 @@
 using TiaMcpServer.Diagnostics;
 using TiaMcpServer.Diagnostics.Checks;
+using System.Text.Json;
 using Xunit;
 
 namespace TiaMcpServer.Tests.Diagnostics;
 
 public class OpennessWorkerCheckTests
 {
+    private static readonly string[] RequiredCompanionFiles =
+    {
+        "TiaMcpServer.OpennessWorker.exe.config",
+        "TiaMcpServer.Contracts.dll",
+        "Microsoft.Bcl.AsyncInterfaces.dll",
+        "System.Buffers.dll",
+        "System.IO.Pipelines.dll",
+        "System.Memory.dll",
+        "System.Numerics.Vectors.dll",
+        "System.Runtime.CompilerServices.Unsafe.dll",
+        "System.Text.Encodings.Web.dll",
+        "System.Text.Json.dll",
+        "System.Threading.Tasks.Extensions.dll"
+    };
+
     [Fact]
-    public void WorkerFoundWithRuntimeConfig_ReturnsPassed()
+    public void WorkerFoundWithRequiredCompanionFiles_ReturnsPassed()
     {
         var baseDir = Path.Combine(Path.GetTempPath(), "doctor-test-" + Guid.NewGuid().ToString("N"));
         var workerDir = Path.Combine(baseDir, "openness-worker");
         var workerPath = Path.Combine(workerDir, "TiaMcpServer.OpennessWorker.exe");
-        var runtimeConfigPath = Path.Combine(workerDir, "TiaMcpServer.OpennessWorker.runtimeconfig.json");
 
         var appInfo = new FakeApplicationInfoService { BaseDirectory = baseDir };
         var fileSystem = new FakeFileSystemService();
         fileSystem.AddFile(workerPath);
-        fileSystem.AddFile(runtimeConfigPath);
+        AddRequiredCompanionFiles(fileSystem, workerDir);
         fileSystem.SetFileVersion(workerPath, "1.0.0.0");
 
         var check = new OpennessWorkerCheck(appInfo, fileSystem);
@@ -42,7 +57,7 @@ public class OpennessWorkerCheckTests
     }
 
     [Fact]
-    public void WorkerFoundButRuntimeConfigMissing_ReturnsFailed()
+    public void WorkerFoundButContractsAssemblyMissing_ReturnsFailed()
     {
         var baseDir = Path.Combine(Path.GetTempPath(), "doctor-test-" + Guid.NewGuid().ToString("N"));
         var workerDir = Path.Combine(baseDir, "openness-worker");
@@ -51,12 +66,13 @@ public class OpennessWorkerCheckTests
         var appInfo = new FakeApplicationInfoService { BaseDirectory = baseDir };
         var fileSystem = new FakeFileSystemService();
         fileSystem.AddFile(workerPath);
+        AddRequiredCompanionFiles(fileSystem, workerDir, "TiaMcpServer.Contracts.dll");
 
         var check = new OpennessWorkerCheck(appInfo, fileSystem);
         var result = check.Run();
 
         Assert.Equal(DiagnosticStatus.Failed, result.Status);
-        Assert.Contains("runtime configuration", result.Message);
+        Assert.Contains("TiaMcpServer.Contracts.dll", result.Message);
     }
 
     [Fact]
@@ -65,17 +81,96 @@ public class OpennessWorkerCheckTests
         var baseDir = Path.Combine(Path.GetTempPath(), "doctor-test-" + Guid.NewGuid().ToString("N"));
         var workerDir = Path.Combine(baseDir, "openness-worker");
         var workerPath = Path.Combine(workerDir, "TiaMcpServer.OpennessWorker.exe");
-        var runtimeConfigPath = Path.Combine(workerDir, "TiaMcpServer.OpennessWorker.runtimeconfig.json");
 
         var appInfo = new FakeApplicationInfoService { BaseDirectory = baseDir };
         var fileSystem = new FakeFileSystemService();
         fileSystem.AddFile(workerPath);
-        fileSystem.AddFile(runtimeConfigPath);
+        AddRequiredCompanionFiles(fileSystem, workerDir);
 
         var check = new OpennessWorkerCheck(appInfo, fileSystem);
         var result = check.Run();
 
         Assert.Equal(DiagnosticStatus.Passed, result.Status);
         Assert.DoesNotContain("version", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void AddRequiredCompanionFiles(
+        FakeFileSystemService fileSystem,
+        string workerDir,
+        string? excludedFile = null)
+    {
+        foreach (var companionFile in RequiredCompanionFiles)
+        {
+            if (!string.Equals(companionFile, excludedFile, StringComparison.Ordinal))
+            {
+                fileSystem.AddFile(Path.Combine(workerDir, companionFile));
+            }
+        }
+    }
+
+    [Fact]
+    public void RequiredCompanionFiles_CoverWorkerRuntimeAssets()
+    {
+        var repositoryRoot = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", ".."));
+        var assetsPath = Path.Combine(
+            repositoryRoot,
+            "TiaMcpServer.OpennessWorker",
+            "obj",
+            "project.assets.json");
+
+        using var assets = JsonDocument.Parse(File.ReadAllText(assetsPath));
+        var target = assets.RootElement.GetProperty("targets")
+            .EnumerateObject()
+            .Single(property => property.Name == ".NETFramework,Version=v4.8");
+        var runtimeDlls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var package in target.Value.EnumerateObject())
+        {
+            if (!package.Value.TryGetProperty("runtime", out var runtime))
+            {
+                continue;
+            }
+
+            foreach (var asset in runtime.EnumerateObject())
+            {
+                if (asset.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                {
+                    runtimeDlls.Add(Path.GetFileName(asset.Name));
+                }
+            }
+        }
+
+        Assert.All(
+            runtimeDlls,
+            dependency => Assert.Contains(
+                dependency,
+                OpennessWorkerCheck.RequiredCompanionFiles,
+                StringComparer.OrdinalIgnoreCase));
+        Assert.Contains(
+            "TiaMcpServer.OpennessWorker.exe.config",
+            OpennessWorkerCheck.RequiredCompanionFiles);
+        Assert.DoesNotContain(
+            OpennessWorkerCheck.RequiredCompanionFiles,
+            file => file.EndsWith("runtimeconfig.json", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void PackageLayout_ExcludesWorkerRuntimeConfigAtCopyAndPackBoundaries()
+    {
+        var repositoryRoot = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", ".."));
+        var project = File.ReadAllText(Path.Combine(
+            repositoryRoot,
+            "TiaMcpServer",
+            "TiaMcpServer.csproj"));
+
+        Assert.Equal(
+            3,
+            project.Split("**\\*.runtimeconfig.json", StringSplitOptions.None).Length);
+        Assert.Contains("RemoveStaleOpennessWorkerRuntimeConfig", project);
+        Assert.DoesNotContain("PackOpennessWorker", project);
     }
 }

--- a/TiaMcpServer.Tests/Diagnostics/OperatingSystemCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/OperatingSystemCheckTests.cs
@@ -1,0 +1,47 @@
+using TiaMcpServer.Diagnostics;
+using TiaMcpServer.Diagnostics.Checks;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class OperatingSystemCheckTests
+{
+    [Fact]
+    public void Windows_ReturnsPassed()
+    {
+        var appInfo = new FakeApplicationInfoService { IsWindows = true, OsName = "Windows", OsVersion = "10.0", ProcessArchitecture = "X64" };
+        var check = new OperatingSystemCheck(appInfo);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("Windows", result.Message);
+    }
+
+    [Fact]
+    public void NonWindows_ReturnsFailed()
+    {
+        var appInfo = new FakeApplicationInfoService { IsWindows = false, OsName = "Linux", OsVersion = "6.0" };
+        var check = new OperatingSystemCheck(appInfo);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("not supported", result.Message);
+        Assert.NotNull(result.Remediation);
+    }
+
+    [Fact]
+    public void IncludesEvidence()
+    {
+        var appInfo = new FakeApplicationInfoService { IsWindows = true, OsName = "Windows", OsVersion = "10.0", ProcessArchitecture = "Arm64" };
+        var check = new OperatingSystemCheck(appInfo);
+
+        var result = check.Run();
+
+        Assert.NotNull(result.Evidence);
+        Assert.Equal("true", result.Evidence!["isWindows"]);
+        Assert.Equal("Windows", result.Evidence!["osName"]);
+        Assert.Equal("Arm64", result.Evidence!["processArchitecture"]);
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs
@@ -1,0 +1,72 @@
+using TiaMcpServer.Diagnostics;
+using TiaMcpServer.Diagnostics.Checks;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class ProjectBindingCheckTests
+{
+    [Fact]
+    public void CliPathProvided_ReturnsPassed()
+    {
+        var env = new FakeEnvironmentVariableService();
+        var check = new ProjectBindingCheck(env, @"C:\Projects\Line.ap21");
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("--project", result.Message);
+        Assert.Contains(@"C:\Projects\Line.ap21", result.Message);
+    }
+
+    [Fact]
+    public void EnvVarProvided_ReturnsPassed()
+    {
+        var env = new FakeEnvironmentVariableService();
+        env.Set("TIA_MCP_PROJECT_PATH", @"C:\Projects\Line.ap21");
+        var check = new ProjectBindingCheck(env, null);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("TIA_MCP_PROJECT_PATH", result.Message);
+    }
+
+    [Fact]
+    public void NeitherProvided_ReturnsPassed()
+    {
+        var env = new FakeEnvironmentVariableService();
+        var check = new ProjectBindingCheck(env, null);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("No project binding", result.Message);
+    }
+
+    [Fact]
+    public void CliPathTakesPrecedence()
+    {
+        var env = new FakeEnvironmentVariableService();
+        env.Set("TIA_MCP_PROJECT_PATH", @"C:\Other.ap21");
+        var check = new ProjectBindingCheck(env, @"C:\Projects\Line.ap21");
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("--project", result.Message);
+        Assert.DoesNotContain("TIA_MCP_PROJECT_PATH", result.Message);
+    }
+
+    [Fact]
+    public void WhitespaceCliPath_TreatedAsNotProvided()
+    {
+        var env = new FakeEnvironmentVariableService();
+        var check = new ProjectBindingCheck(env, "   ");
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("No project binding", result.Message);
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/ReleaseWorkflowTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/ReleaseWorkflowTests.cs
@@ -1,0 +1,48 @@
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class ReleaseWorkflowTests
+{
+    [Fact]
+    public void StandalonePublish_UsesResolvedPackageVersion()
+    {
+        var publishStep = ReadWorkflowStep("Publish Standalone Binary", "Zip Standalone Binary");
+
+        Assert.Contains("/p:Version=$env:PACKAGE_VERSION", publishStep, StringComparison.Ordinal);
+        Assert.Contains("/p:PackageVersion=$env:PACKAGE_VERSION", publishStep, StringComparison.Ordinal);
+        Assert.Contains("/p:InformationalVersion=$env:PACKAGE_VERSION", publishStep, StringComparison.Ordinal);
+        Assert.Contains("/p:IncludeSourceRevisionInInformationalVersion=false", publishStep, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NuGetPack_UsesExactResolvedInformationalVersion()
+    {
+        var packStep = ReadWorkflowStep("Build and Pack", "Verify tool package contents");
+
+        Assert.Contains("/p:Version=$env:PACKAGE_VERSION", packStep, StringComparison.Ordinal);
+        Assert.Contains("/p:PackageVersion=$env:PACKAGE_VERSION", packStep, StringComparison.Ordinal);
+        Assert.Contains("/p:InformationalVersion=$env:PACKAGE_VERSION", packStep, StringComparison.Ordinal);
+        Assert.Contains("/p:IncludeSourceRevisionInInformationalVersion=false", packStep, StringComparison.Ordinal);
+    }
+
+    private static string ReadWorkflowStep(string stepName, string followingStepName)
+    {
+        var workflowPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            ".github",
+            "workflows",
+            "publish.yml"));
+        var workflow = File.ReadAllText(workflowPath);
+        var stepStart = workflow.IndexOf($"- name: {stepName}", StringComparison.Ordinal);
+        var stepEnd = workflow.IndexOf($"- name: {followingStepName}", stepStart, StringComparison.Ordinal);
+
+        Assert.True(stepStart >= 0, $"{stepName} step is missing.");
+        Assert.True(stepEnd > stepStart, $"{followingStepName} step must follow {stepName}.");
+        return workflow[stepStart..stepEnd];
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs
@@ -1,10 +1,12 @@
 using TiaMcpServer.Diagnostics;
 using TiaMcpServer.Diagnostics.Checks;
 using TiaMcpServer.Worker;
+using System.Runtime.Versioning;
 using Xunit;
 
 namespace TiaMcpServer.Tests.Diagnostics;
 
+[SupportedOSPlatform("windows")]
 public class TiaPortalInstallationCheckTests
 {
     [Fact]
@@ -26,6 +28,42 @@ public class TiaPortalInstallationCheckTests
     }
 
     [Fact]
+    public void ExistingApiDirectoryWithoutAssemblies_ReturnsPassed()
+    {
+        var env = new FakeEnvironmentVariableService();
+        env.Set("TiaPortalV21Dir", @"C:\TIA\PublicAPI\V21\net48");
+        var registry = new FakeRegistryService();
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddDirectory(@"C:\TIA\PublicAPI\V21\net48");
+
+        var check = new TiaPortalInstallationCheck(env, registry, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("env:TiaPortalV21Dir", result.Message);
+    }
+
+    [Fact]
+    public void TiaPortalLocationRootWithoutApiDirectory_ReturnsPassedWithRootEvidence()
+    {
+        const string root = @"C:\Program Files\Siemens\Automation\Portal V21";
+        var env = new FakeEnvironmentVariableService();
+        env.Set("TiaPortalLocation", root);
+        var registry = new FakeRegistryService();
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddDirectory(root);
+
+        var result = new TiaPortalInstallationCheck(env, registry, fileSystem).Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("env:TiaPortalLocation", result.Message);
+        Assert.Equal(root, result.Evidence!["selectedInstallationPath"]);
+        Assert.Equal(
+            Path.Combine(root, @"PublicAPI\V21\net48"),
+            result.Evidence["selectedPath"]);
+    }
+
+    [Fact]
     public void NotFound_ReturnsFailed()
     {
         var env = new FakeEnvironmentVariableService();
@@ -42,6 +80,7 @@ public class TiaPortalInstallationCheckTests
     }
 
     [Fact]
+    [SupportedOSPlatform("windows")]
     public void FoundViaRegistry_ReturnsPassed()
     {
         var env = new FakeEnvironmentVariableService();
@@ -51,6 +90,7 @@ public class TiaPortalInstallationCheckTests
             @"SOFTWARE\Siemens\Automation\InstalledApps\Totally Integrated Automation Portal V21",
             "INSTALLPATH", @"C:\Program Files\Siemens\Automation\Portal V21");
         var fileSystem = new FakeFileSystemService();
+        fileSystem.AddDirectory(@"C:\Program Files\Siemens\Automation\Portal V21");
         var apiPath = @"C:\Program Files\Siemens\Automation\Portal V21\PublicAPI\V21\net48";
         fileSystem.AddDirectory(apiPath);
         foreach (var asm in TiaPortalInstallationLocator.RequiredAssemblies)
@@ -61,6 +101,82 @@ public class TiaPortalInstallationCheckTests
 
         Assert.Equal(DiagnosticStatus.Passed, result.Status);
         Assert.Contains("registry:Registry64", result.Message);
+    }
+
+    [Fact]
+    public void RegistryRootWithoutApiDirectory_ReturnsPassedWithRootEvidence()
+    {
+        const string root = @"C:\Program Files\Siemens\Automation\Portal V21";
+        var env = new FakeEnvironmentVariableService();
+        var registry = new FakeRegistryService();
+        registry.SetStringValue(
+            Microsoft.Win32.RegistryHive.LocalMachine,
+            Microsoft.Win32.RegistryView.Registry64,
+            @"SOFTWARE\Siemens\Automation\InstalledApps\Totally Integrated Automation Portal V21",
+            "INSTALLPATH",
+            root);
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddDirectory(root);
+
+        var result = new TiaPortalInstallationCheck(env, registry, fileSystem).Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("registry:Registry64", result.Message);
+        Assert.Equal(root, result.Evidence!["selectedInstallationPath"]);
+    }
+
+    [Fact]
+    public void EarlyLocationRootAndLaterCompleteRegistry_SelectsEarlyInstallation()
+    {
+        const string locationRoot = @"C:\TIA\Portal V21";
+        const string registryRoot = @"D:\Siemens\Portal V21";
+        var env = new FakeEnvironmentVariableService();
+        env.Set("TiaPortalLocation", locationRoot);
+        var registry = new FakeRegistryService();
+        registry.SetStringValue(
+            Microsoft.Win32.RegistryHive.LocalMachine,
+            Microsoft.Win32.RegistryView.Registry64,
+            @"SOFTWARE\Siemens\Automation\InstalledApps\Totally Integrated Automation Portal V21",
+            "INSTALLPATH",
+            registryRoot);
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddDirectory(locationRoot);
+        fileSystem.AddDirectory(registryRoot);
+        var registryApi = Path.Combine(registryRoot, @"PublicAPI\V21\net48");
+        fileSystem.AddDirectory(registryApi);
+        foreach (var assembly in TiaPortalInstallationLocator.RequiredAssemblies)
+            fileSystem.AddFile(Path.Combine(registryApi, assembly));
+
+        var result = new TiaPortalInstallationCheck(env, registry, fileSystem).Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Equal("env:TiaPortalLocation", result.Evidence!["selectedSource"]);
+        Assert.Equal(locationRoot, result.Evidence["selectedInstallationPath"]);
+    }
+
+    [Fact]
+    public void EarlyRegistryRootAndLaterCompleteRegistry_SelectsEarlyInstallation()
+    {
+        const string registry64Root = @"C:\Siemens\Portal V21";
+        const string registry32Root = @"D:\Siemens\Portal V21";
+        var env = new FakeEnvironmentVariableService();
+        var registry = new FakeRegistryService();
+        const string registryKey = @"SOFTWARE\Siemens\Automation\InstalledApps\Totally Integrated Automation Portal V21";
+        registry.SetStringValue(Microsoft.Win32.RegistryHive.LocalMachine, Microsoft.Win32.RegistryView.Registry64, registryKey, "INSTALLPATH", registry64Root);
+        registry.SetStringValue(Microsoft.Win32.RegistryHive.LocalMachine, Microsoft.Win32.RegistryView.Registry32, registryKey, "INSTALLPATH", registry32Root);
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddDirectory(registry64Root);
+        fileSystem.AddDirectory(registry32Root);
+        var registry32Api = Path.Combine(registry32Root, @"PublicAPI\V21\net48");
+        fileSystem.AddDirectory(registry32Api);
+        foreach (var assembly in TiaPortalInstallationLocator.RequiredAssemblies)
+            fileSystem.AddFile(Path.Combine(registry32Api, assembly));
+
+        var result = new TiaPortalInstallationCheck(env, registry, fileSystem).Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Equal("registry:Registry64", result.Evidence!["selectedSource"]);
+        Assert.Equal(registry64Root, result.Evidence["selectedInstallationPath"]);
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs
@@ -1,0 +1,80 @@
+using TiaMcpServer.Diagnostics;
+using TiaMcpServer.Diagnostics.Checks;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class TiaPortalInstallationCheckTests
+{
+    [Fact]
+    public void FoundViaEnvVar_ReturnsPassed()
+    {
+        var env = new FakeEnvironmentVariableService();
+        env.Set("TiaPortalV21Dir", @"C:\TIA\PublicAPI\V21\net48");
+        var registry = new FakeRegistryService();
+        var fileSystem = new FakeFileSystemService();
+        fileSystem.AddDirectory(@"C:\TIA\PublicAPI\V21\net48");
+        foreach (var asm in TiaPortalInstallationLocator.RequiredAssemblies)
+            fileSystem.AddFile(System.IO.Path.Combine(@"C:\TIA\PublicAPI\V21\net48", asm));
+
+        var check = new TiaPortalInstallationCheck(env, registry, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("env:TiaPortalV21Dir", result.Message);
+    }
+
+    [Fact]
+    public void NotFound_ReturnsFailed()
+    {
+        var env = new FakeEnvironmentVariableService();
+        var registry = new FakeRegistryService();
+        var fileSystem = new FakeFileSystemService();
+        // No directories or files added - nothing will be found
+
+        var check = new TiaPortalInstallationCheck(env, registry, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Failed, result.Status);
+        Assert.Contains("not found", result.Message);
+        Assert.NotNull(result.Remediation);
+    }
+
+    [Fact]
+    public void FoundViaRegistry_ReturnsPassed()
+    {
+        var env = new FakeEnvironmentVariableService();
+        var registry = new FakeRegistryService();
+        registry.SetStringValue(Microsoft.Win32.RegistryHive.LocalMachine,
+            Microsoft.Win32.RegistryView.Registry64,
+            @"SOFTWARE\Siemens\Automation\InstalledApps\Totally Integrated Automation Portal V21",
+            "INSTALLPATH", @"C:\Program Files\Siemens\Automation\Portal V21");
+        var fileSystem = new FakeFileSystemService();
+        var apiPath = @"C:\Program Files\Siemens\Automation\Portal V21\PublicAPI\V21\net48";
+        fileSystem.AddDirectory(apiPath);
+        foreach (var asm in TiaPortalInstallationLocator.RequiredAssemblies)
+            fileSystem.AddFile(System.IO.Path.Combine(apiPath, asm));
+
+        var check = new TiaPortalInstallationCheck(env, registry, fileSystem);
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("registry:Registry64", result.Message);
+    }
+
+    [Fact]
+    public void IncludesCandidateEvidence()
+    {
+        var env = new FakeEnvironmentVariableService();
+        var registry = new FakeRegistryService();
+        var fileSystem = new FakeFileSystemService();
+
+        var check = new TiaPortalInstallationCheck(env, registry, fileSystem);
+        var result = check.Run();
+
+        Assert.NotNull(result.Evidence);
+        // Should have at least the default candidate
+        Assert.True(result.Evidence!.Count > 0);
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs
@@ -1,0 +1,93 @@
+using TiaMcpServer.Diagnostics;
+using TiaMcpServer.Diagnostics.Checks;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class TiaPortalProcessCheckTests
+{
+    [Fact]
+    public void NotWindows_ReturnsWarning()
+    {
+        var processes = new FakeProcessEnumerationService();
+        var appInfo = new FakeApplicationInfoService { IsWindows = false };
+        var check = new TiaPortalProcessCheck(processes, appInfo);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Warning, result.Status);
+        Assert.Contains("Not running on Windows", result.Message);
+    }
+
+    [Fact]
+    public void TiaProcessesFound_ReturnsPassed()
+    {
+        var processes = new FakeProcessEnumerationService
+        {
+            Processes = new()
+            {
+                new("Siemens.Automation.Portal.exe", 1234),
+                new("notepad.exe", 5678)
+            }
+        };
+        var appInfo = new FakeApplicationInfoService { IsWindows = true };
+        var check = new TiaPortalProcessCheck(processes, appInfo);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("1 process", result.Message);
+    }
+
+    [Fact]
+    public void MultipleTiaProcesses_CountsAll()
+    {
+        var processes = new FakeProcessEnumerationService
+        {
+            Processes = new()
+            {
+                new("Siemens.Automation.Portal.exe", 100),
+                new("TIA.Portal.Startcenter.exe", 200),
+                new("Siemens.Simulation.Portal.exe", 300)
+            }
+        };
+        var appInfo = new FakeApplicationInfoService { IsWindows = true };
+        var check = new TiaPortalProcessCheck(processes, appInfo);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+        Assert.Contains("3 process", result.Message);
+    }
+
+    [Fact]
+    public void NoTiaProcesses_ReturnsWarning()
+    {
+        var processes = new FakeProcessEnumerationService
+        {
+            Processes = new() { new("notepad.exe", 1234) }
+        };
+        var appInfo = new FakeApplicationInfoService { IsWindows = true };
+        var check = new TiaPortalProcessCheck(processes, appInfo);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Warning, result.Status);
+        Assert.Contains("No running TIA Portal", result.Message);
+    }
+
+    [Fact]
+    public void CaseInsensitiveMatch()
+    {
+        var processes = new FakeProcessEnumerationService
+        {
+            Processes = new() { new("siemens.automation.portal.exe", 1234) }
+        };
+        var appInfo = new FakeApplicationInfoService { IsWindows = true };
+        var check = new TiaPortalProcessCheck(processes, appInfo);
+
+        var result = check.Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+    }
+}

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
@@ -25,6 +26,11 @@
     <ProjectReference Include="..\TiaMcpServer.Contracts\TiaMcpServer.Contracts.csproj" />
     <ProjectReference Include="..\TiaMcpServer.FakeWorker\TiaMcpServer.FakeWorker.csproj" ReferenceOutputAssembly="false" />
     <Compile Include="..\TiaMcpServer\Worker\OpennessWorkerClient.cs" Link="Host\OpennessWorkerClient.cs" />
+    <Compile Include="..\TiaMcpServer\Worker\OpennessWorkerLocator.cs" Link="Host\OpennessWorkerLocator.cs" />
+    <Compile Include="..\TiaMcpServer\Worker\TiaPortalInstallationLocator.cs" Link="Host\TiaPortalInstallationLocator.cs" />
+    <Compile Include="..\TiaMcpServer\Diagnostics\*.cs" Link="Host\Diagnostics\%(Filename)%(Extension)" />
+    <Compile Include="..\TiaMcpServer\Diagnostics\Checks\*.cs" Link="Host\Diagnostics\Checks\%(Filename)%(Extension)" />
+    <Compile Include="..\TiaMcpServer\Cli\*.cs" Link="Host\Cli\%(Filename)%(Extension)" />
     <Compile Include="..\TiaMcpServer\Worker\PersistentWorkerTransport.cs" Link="Host\PersistentWorkerTransport.cs" />
     <Compile Include="..\TiaMcpServer\Worker\WorkerCallResult.cs" Link="Host\WorkerCallResult.cs" />
     <Compile Include="..\TiaMcpServer\Safety\WriteSafetyService.cs" Link="Host\WriteSafetyService.cs" />

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -46,5 +46,6 @@
     <Compile Include="..\TiaMcpServer\Batch\BatchWorkerInvoker.cs" Link="Host\Batch\BatchWorkerInvoker.cs" />
     <Compile Include="..\TiaMcpServer\Batch\BatchTools.cs" Link="Host\Batch\BatchTools.cs" />
     <Compile Include="..\TiaMcpServer.OpennessWorker\Openness\ProjectRebindCloseGuard.cs" Link="Worker\ProjectRebindCloseGuard.cs" />
+    <Compile Include="..\TiaMcpServer.OpennessWorker\Openness\AssemblyResolver.cs" Link="Worker\AssemblyResolver.cs" />
   </ItemGroup>
 </Project>

--- a/TiaMcpServer/Cli/DoctorCliParser.cs
+++ b/TiaMcpServer/Cli/DoctorCliParser.cs
@@ -1,0 +1,61 @@
+namespace TiaMcpServer.Cli;
+
+public sealed record DoctorCliOptions(
+    bool Valid,
+    bool Json,
+    bool Verbose,
+    string? ProjectPath,
+    string? ParseError);
+
+public static class DoctorCliParser
+{
+    private const string JsonFlag = "--json";
+    private const string VerboseFlag = "--verbose";
+    private const string ProjectFlag = "--project";
+    private const string ProjectPrefix = "--project=";
+
+    public static DoctorCliOptions Parse(string[] args)
+    {
+        bool json = false;
+        bool verbose = false;
+        string? projectPath = null;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+
+            if (string.Equals(arg, JsonFlag, StringComparison.OrdinalIgnoreCase))
+            {
+                json = true;
+                continue;
+            }
+
+            if (string.Equals(arg, VerboseFlag, StringComparison.OrdinalIgnoreCase))
+            {
+                verbose = true;
+                continue;
+            }
+
+            if (string.Equals(arg, ProjectFlag, StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 >= args.Length)
+                {
+                    return new DoctorCliOptions(false, json, verbose, null, $"--project requires a value.");
+                }
+
+                projectPath = args[++i];
+                continue;
+            }
+
+            if (arg.StartsWith(ProjectPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                projectPath = arg.Substring(ProjectPrefix.Length);
+                continue;
+            }
+
+            return new DoctorCliOptions(false, json, verbose, projectPath, $"Unknown doctor argument: '{arg}'.");
+        }
+
+        return new DoctorCliOptions(true, json, verbose, projectPath, null);
+    }
+}

--- a/TiaMcpServer/Cli/DoctorCliParser.cs
+++ b/TiaMcpServer/Cli/DoctorCliParser.cs
@@ -4,6 +4,7 @@ public sealed record DoctorCliOptions(
     bool Valid,
     bool Json,
     bool Verbose,
+    bool Help,
     string? ProjectPath,
     string? ParseError);
 
@@ -11,13 +12,15 @@ public static class DoctorCliParser
 {
     private const string JsonFlag = "--json";
     private const string VerboseFlag = "--verbose";
+    private const string HelpFlag = "--help";
     private const string ProjectFlag = "--project";
     private const string ProjectPrefix = "--project=";
 
     public static DoctorCliOptions Parse(string[] args)
     {
-        bool json = false;
+        bool json = args.Any(arg => string.Equals(arg, JsonFlag, StringComparison.OrdinalIgnoreCase));
         bool verbose = false;
+        bool help = false;
         string? projectPath = null;
 
         for (int i = 0; i < args.Length; i++)
@@ -36,11 +39,19 @@ public static class DoctorCliParser
                 continue;
             }
 
+            if (string.Equals(arg, HelpFlag, StringComparison.OrdinalIgnoreCase))
+            {
+                help = true;
+                continue;
+            }
+
             if (string.Equals(arg, ProjectFlag, StringComparison.OrdinalIgnoreCase))
             {
-                if (i + 1 >= args.Length)
+                if (i + 1 >= args.Length ||
+                    string.IsNullOrWhiteSpace(args[i + 1]) ||
+                    args[i + 1].StartsWith("--", StringComparison.Ordinal))
                 {
-                    return new DoctorCliOptions(false, json, verbose, null, $"--project requires a value.");
+                    return new DoctorCliOptions(false, json, verbose, help, null, $"--project requires a value.");
                 }
 
                 projectPath = args[++i];
@@ -50,12 +61,17 @@ public static class DoctorCliParser
             if (arg.StartsWith(ProjectPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 projectPath = arg.Substring(ProjectPrefix.Length);
+                if (string.IsNullOrWhiteSpace(projectPath))
+                {
+                    return new DoctorCliOptions(false, json, verbose, help, null, $"--project requires a value.");
+                }
+
                 continue;
             }
 
-            return new DoctorCliOptions(false, json, verbose, projectPath, $"Unknown doctor argument: '{arg}'.");
+            return new DoctorCliOptions(false, json, verbose, help, projectPath, $"Unknown doctor argument: '{arg}'.");
         }
 
-        return new DoctorCliOptions(true, json, verbose, projectPath, null);
+        return new DoctorCliOptions(true, json, verbose, help, projectPath, null);
     }
 }

--- a/TiaMcpServer/Cli/DoctorCommand.cs
+++ b/TiaMcpServer/Cli/DoctorCommand.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+using TiaMcpServer.Diagnostics;
+using TiaMcpServer.Diagnostics.Checks;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Cli;
+
+public static class DoctorCommand
+{
+    private const string UsageText = """
+        Usage: tia-mcp doctor [--json] [--verbose] [--project <path>]
+
+        Options:
+          --json       Emit a single JSON document to stdout.
+          --verbose    Include additional evidence.
+          --project    Informational project binding (does not start the MCP host).
+
+        Exit codes:
+          0  No blocking failures.
+          1  One or more diagnostic checks failed.
+          2  Invalid arguments or an unexpected error.
+        """;
+
+    public static Task<int> RunAsync(string[] args)
+    {
+        var options = DoctorCliParser.Parse(args);
+        if (!options.Valid)
+        {
+            Console.Error.WriteLine($"error: {options.ParseError}");
+            Console.Error.WriteLine(UsageText);
+            return Task.FromResult(2);
+        }
+
+        try
+        {
+            var runner = BuildRunner(options);
+            var report = runner.Run();
+
+            if (options.Json)
+            {
+                Console.Out.WriteLine(DoctorJsonRenderer.Render(report, options.Verbose));
+            }
+            else
+            {
+                DoctorTextRenderer.Render(report, options.Verbose, Console.Out);
+            }
+
+            return Task.FromResult(report.Status == DiagnosticStatus.Failed ? 1 : 0);
+        }
+        catch (Exception ex)
+        {
+            if (options.Json)
+            {
+                Console.Error.WriteLine(JsonSerializer.Serialize(new { error = ex.Message }));
+            }
+            else
+            {
+                Console.Error.WriteLine($"Fatal: {ex.Message}");
+            }
+
+            return Task.FromResult(2);
+        }
+    }
+
+    private static DoctorRunner BuildRunner(DoctorCliOptions options)
+    {
+        var appInfo = ApplicationInfoService.Instance;
+        var env = EnvironmentVariableService.Instance;
+        var registry = RegistryService.Instance;
+        var fileSystem = FileSystemService.Instance;
+        var processes = ProcessEnumerationService.Instance;
+        var identity = WindowsIdentityService.Instance;
+
+        var checks = new List<IDiagnosticCheck>
+        {
+            new OperatingSystemCheck(appInfo),
+            new DotNetRuntimeCheck(appInfo),
+            new DotNetFrameworkCheck(registry, appInfo),
+            new TiaPortalInstallationCheck(env, registry, fileSystem),
+            new OpennessAssembliesCheck(env, registry, fileSystem),
+            new OpennessGroupCheck(identity),
+            new OpennessWorkerCheck(appInfo, fileSystem),
+            new HostWorkerVersionCheck(appInfo, fileSystem),
+            new TiaPortalProcessCheck(processes, appInfo),
+            new ProjectBindingCheck(env, options.ProjectPath)
+        };
+
+        return new DoctorRunner(appInfo, checks);
+    }
+}

--- a/TiaMcpServer/Cli/DoctorCommand.cs
+++ b/TiaMcpServer/Cli/DoctorCommand.cs
@@ -8,12 +8,13 @@ namespace TiaMcpServer.Cli;
 public static class DoctorCommand
 {
     private const string UsageText = """
-        Usage: tia-mcp doctor [--json] [--verbose] [--project <path>]
+        Usage: tia-mcp doctor [--json] [--verbose] [--project <path>] [--help]
 
         Options:
           --json       Emit a single JSON document to stdout.
           --verbose    Include additional evidence.
           --project    Informational project binding (does not start the MCP host).
+          --help       Show command usage and exit.
 
         Exit codes:
           0  No blocking failures.
@@ -22,40 +23,62 @@ public static class DoctorCommand
         """;
 
     public static Task<int> RunAsync(string[] args)
+        => RunAsync(args, options => BuildRunner(options).Run(), Console.Out, Console.Error);
+
+    public static Task<int> RunAsync(
+        string[] args,
+        Func<DoctorCliOptions, DoctorReport> runDoctor,
+        TextWriter output,
+        TextWriter error)
     {
         var options = DoctorCliParser.Parse(args);
         if (!options.Valid)
         {
-            Console.Error.WriteLine($"error: {options.ParseError}");
-            Console.Error.WriteLine(UsageText);
+            if (options.Json)
+            {
+                output.WriteLine(JsonSerializer.Serialize(new { error = options.ParseError }));
+            }
+            else
+            {
+                error.WriteLine($"error: {options.ParseError}");
+                error.WriteLine(UsageText);
+            }
+
             return Task.FromResult(2);
+        }
+
+        if (options.Help)
+        {
+            output.WriteLine(options.Json
+                ? JsonSerializer.Serialize(new { usage = UsageText })
+                : UsageText);
+            return Task.FromResult(0);
         }
 
         try
         {
-            var runner = BuildRunner(options);
-            var report = runner.Run();
+            var report = runDoctor(options);
 
             if (options.Json)
             {
-                Console.Out.WriteLine(DoctorJsonRenderer.Render(report, options.Verbose));
+                output.WriteLine(DoctorJsonRenderer.Render(report, options.Verbose));
             }
             else
             {
-                DoctorTextRenderer.Render(report, options.Verbose, Console.Out);
+                DoctorTextRenderer.Render(report, options.Verbose, output);
             }
 
-            return Task.FromResult(report.Status == DiagnosticStatus.Failed ? 1 : 0);
+            return Task.FromResult(report.HasUnexpectedCheckFailure ? 2 : report.Status == DiagnosticStatus.Failed ? 1 : 0);
         }
         catch (Exception ex)
         {
             if (options.Json)
             {
-                Console.Error.WriteLine(JsonSerializer.Serialize(new { error = ex.Message }));
+                output.WriteLine(JsonSerializer.Serialize(new { error = ex.Message }));
             }
             else
             {
-                Console.Error.WriteLine($"Fatal: {ex.Message}");
+                error.WriteLine($"Fatal: {ex.Message}");
             }
 
             return Task.FromResult(2);

--- a/TiaMcpServer/Diagnostics/ApplicationInfoService.cs
+++ b/TiaMcpServer/Diagnostics/ApplicationInfoService.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace TiaMcpServer.Diagnostics;
+
+public sealed class ApplicationInfoService : IApplicationInfoService
+{
+    public static readonly ApplicationInfoService Instance = new();
+
+    public bool IsWindows => OperatingSystem.IsWindows();
+
+    public string OsName
+    {
+        get
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return RuntimeInformation.OSDescription;
+            }
+
+            return GetWindowsProductName();
+        }
+    }
+
+    public string OsVersion => Environment.OSVersion.Version.ToString();
+
+    public string ProcessArchitecture => RuntimeInformation.ProcessArchitecture.ToString();
+
+    public string HostVersion
+    {
+        get
+        {
+            var version = Assembly.GetEntryAssembly()?.GetName().Version;
+            return version is not null ? version.ToString() : "1.0.0";
+        }
+    }
+
+    public string BaseDirectory => AppContext.BaseDirectory;
+
+    public string RuntimeDescription => RuntimeInformation.FrameworkDescription;
+
+    private static string GetWindowsProductName()
+    {
+        try
+        {
+            using var key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
+            var productName = key?.GetValue("ProductName") as string;
+            if (!string.IsNullOrWhiteSpace(productName))
+            {
+                return productName;
+            }
+        }
+        catch
+        {
+            // Registry access may fail in restricted environments.
+        }
+
+        // Fallback: use build number heuristic (Windows 11+ has build >= 22000).
+        var version = Environment.OSVersion.Version;
+        return version.Major >= 10 && version.Build >= 22000 ? "Windows 11" : "Windows 10";
+    }
+}

--- a/TiaMcpServer/Diagnostics/ApplicationInfoService.cs
+++ b/TiaMcpServer/Diagnostics/ApplicationInfoService.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Microsoft.Win32;
 
 namespace TiaMcpServer.Diagnostics;
 
@@ -7,13 +9,48 @@ public sealed class ApplicationInfoService : IApplicationInfoService
 {
     public static readonly ApplicationInfoService Instance = new();
 
-    public bool IsWindows => OperatingSystem.IsWindows();
+    private const string CurrentVersionKey = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion";
+    private readonly IRegistryService _registry;
+    private readonly Func<bool> _isWindows;
+    private readonly Func<Version> _getOsVersion;
+    private readonly Func<Assembly?> _getEntryAssembly;
+
+    public ApplicationInfoService()
+        : this(
+            RegistryService.Instance,
+            OperatingSystem.IsWindows,
+            () => Environment.OSVersion.Version,
+            Assembly.GetEntryAssembly)
+    {
+    }
+
+    public ApplicationInfoService(
+        IRegistryService registry,
+        Func<bool> isWindows,
+        Func<Version> getOsVersion)
+        : this(registry, isWindows, getOsVersion, Assembly.GetEntryAssembly)
+    {
+    }
+
+    public ApplicationInfoService(
+        IRegistryService registry,
+        Func<bool> isWindows,
+        Func<Version> getOsVersion,
+        Func<Assembly?> getEntryAssembly)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _isWindows = isWindows ?? throw new ArgumentNullException(nameof(isWindows));
+        _getOsVersion = getOsVersion ?? throw new ArgumentNullException(nameof(getOsVersion));
+        _getEntryAssembly = getEntryAssembly ?? throw new ArgumentNullException(nameof(getEntryAssembly));
+    }
+
+    public bool IsWindows => _isWindows();
 
     public string OsName
     {
         get
         {
-            if (!OperatingSystem.IsWindows())
+            if (!IsWindows || !OperatingSystem.IsWindows())
             {
                 return RuntimeInformation.OSDescription;
             }
@@ -22,7 +59,7 @@ public sealed class ApplicationInfoService : IApplicationInfoService
         }
     }
 
-    public string OsVersion => Environment.OSVersion.Version.ToString();
+    public string OsVersion => _getOsVersion().ToString();
 
     public string ProcessArchitecture => RuntimeInformation.ProcessArchitecture.ToString();
 
@@ -30,8 +67,16 @@ public sealed class ApplicationInfoService : IApplicationInfoService
     {
         get
         {
-            var version = Assembly.GetEntryAssembly()?.GetName().Version;
-            return version is not null ? version.ToString() : "1.0.0";
+            var assembly = _getEntryAssembly();
+            var informationalVersion = assembly?
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion;
+            if (!string.IsNullOrWhiteSpace(informationalVersion))
+            {
+                return informationalVersion;
+            }
+
+            return assembly?.GetName().Version?.ToString() ?? "1.0.0";
         }
     }
 
@@ -39,15 +84,21 @@ public sealed class ApplicationInfoService : IApplicationInfoService
 
     public string RuntimeDescription => RuntimeInformation.FrameworkDescription;
 
-    private static string GetWindowsProductName()
+    [SupportedOSPlatform("windows")]
+    private string GetWindowsProductName()
     {
+        var version = _getOsVersion();
+
         try
         {
-            using var key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
-            var productName = key?.GetValue("ProductName") as string;
+            var productName = _registry.GetStringValue(
+                RegistryHive.LocalMachine,
+                RegistryView.Registry64,
+                CurrentVersionKey,
+                "ProductName");
             if (!string.IsNullOrWhiteSpace(productName))
             {
-                return productName;
+                return NormalizeWindowsProductName(productName, version);
             }
         }
         catch
@@ -56,7 +107,14 @@ public sealed class ApplicationInfoService : IApplicationInfoService
         }
 
         // Fallback: use build number heuristic (Windows 11+ has build >= 22000).
-        var version = Environment.OSVersion.Version;
-        return version.Major >= 10 && version.Build >= 22000 ? "Windows 11" : "Windows 10";
+        return IsWindows11OrLater(version) ? "Windows 11" : "Windows 10";
     }
+
+    private static string NormalizeWindowsProductName(string productName, Version version)
+        => IsWindows11OrLater(version) && !productName.Contains("Server", StringComparison.OrdinalIgnoreCase)
+            ? productName.Replace("Windows 10", "Windows 11", StringComparison.OrdinalIgnoreCase)
+            : productName;
+
+    private static bool IsWindows11OrLater(Version version)
+        => version.Major > 10 || version.Major == 10 && version.Build >= 22000;
 }

--- a/TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs
@@ -1,0 +1,118 @@
+using Microsoft.Win32;
+
+namespace TiaMcpServer.Diagnostics.Checks;
+
+public sealed class DotNetFrameworkCheck : IDiagnosticCheck
+{
+    private const string NetFrameworkFullKey = @"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full";
+    private const string ReleaseValueName = "Release";
+    private const int NetFramework48Release = 528040;
+
+    private readonly IRegistryService _registry;
+    private readonly IApplicationInfoService _appInfo;
+
+    public DotNetFrameworkCheck(IRegistryService registry, IApplicationInfoService appInfo)
+    {
+        _registry = registry;
+        _appInfo = appInfo;
+    }
+
+    public string Id => "dotnet-framework";
+    public string Name => ".NET Framework 4.8";
+
+    public DiagnosticCheckResult Run()
+    {
+        var evidence = Evidence.Empty();
+        evidence["registryKey"] = $@"HKLM\{NetFrameworkFullKey}";
+        evidence["releaseValueName"] = ReleaseValueName;
+
+        if (!_appInfo.IsWindows)
+        {
+            evidence["reason"] = "not running on Windows";
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Failed,
+                "Not running on Windows; .NET Framework 4.8 cannot be detected.",
+                "Run on Windows and install .NET Framework 4.8 Developer Pack or Runtime.",
+                evidence);
+        }
+
+        var release = _registry.GetIntValue(
+            RegistryHive.LocalMachine,
+            RegistryView.Registry64,
+            NetFrameworkFullKey,
+            ReleaseValueName);
+
+        if (release is null)
+        {
+            release = _registry.GetIntValue(
+                RegistryHive.LocalMachine,
+                RegistryView.Registry32,
+                NetFrameworkFullKey,
+                ReleaseValueName);
+            if (release is not null)
+            {
+                evidence["registryView"] = "Registry32";
+            }
+        }
+        else
+        {
+            evidence["registryView"] = "Registry64";
+        }
+
+        if (release is null)
+        {
+            evidence["release"] = null;
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Failed,
+                ".NET Framework 4.8 was not detected.",
+                "Install .NET Framework 4.8 Runtime (or Developer Pack for source builds): https://dotnet.microsoft.com/download/dotnet-framework/net48",
+                evidence);
+        }
+
+        evidence["release"] = release.Value.ToString();
+        var version = InterpretRelease(release.Value);
+        evidence["frameworkVersion"] = version;
+
+        if (release.Value < NetFramework48Release)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Failed,
+                $".NET Framework {version} detected (release {release.Value}); 4.8 or newer is required.",
+                "Install .NET Framework 4.8 Runtime (or Developer Pack for source builds): https://dotnet.microsoft.com/download/dotnet-framework/net48",
+                evidence);
+        }
+
+        return new DiagnosticCheckResult(
+            Id,
+            Name,
+            DiagnosticStatus.Passed,
+            $".NET Framework {version} detected (release {release.Value}).",
+            null,
+            evidence);
+    }
+
+    private static string InterpretRelease(int release)
+    {
+        return release switch
+        {
+            >= 533320 => "4.8.1",
+            >= 528040 => "4.8",
+            >= 461808 => "4.7.2",
+            >= 461308 => "4.7.1",
+            >= 460798 => "4.7",
+            >= 394802 => "4.6.2",
+            >= 394254 => "4.6.1",
+            >= 393295 => "4.6",
+            >= 379893 => "4.5.2",
+            >= 378675 => "4.5.1",
+            >= 378389 => "4.5",
+            _ => $"4.x (release {release})"
+        };
+    }
+}

--- a/TiaMcpServer/Diagnostics/Checks/DotNetRuntimeCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/DotNetRuntimeCheck.cs
@@ -1,0 +1,27 @@
+namespace TiaMcpServer.Diagnostics.Checks;
+
+public sealed class DotNetRuntimeCheck : IDiagnosticCheck
+{
+    private readonly IApplicationInfoService _appInfo;
+
+    public DotNetRuntimeCheck(IApplicationInfoService appInfo) => _appInfo = appInfo;
+
+    public string Id => "dotnet-runtime";
+    public string Name => ".NET runtime";
+
+    public DiagnosticCheckResult Run()
+    {
+        var evidence = Evidence.Empty();
+        evidence["runtimeDescription"] = _appInfo.RuntimeDescription;
+        evidence["processArchitecture"] = _appInfo.ProcessArchitecture;
+        evidence["applicationVersion"] = _appInfo.HostVersion;
+
+        return new DiagnosticCheckResult(
+            Id,
+            Name,
+            DiagnosticStatus.Passed,
+            $"{_appInfo.RuntimeDescription} ({_appInfo.ProcessArchitecture})",
+            null,
+            evidence);
+    }
+}

--- a/TiaMcpServer/Diagnostics/Checks/Evidence.cs
+++ b/TiaMcpServer/Diagnostics/Checks/Evidence.cs
@@ -3,14 +3,4 @@ namespace TiaMcpServer.Diagnostics.Checks;
 internal static class Evidence
 {
     public static Dictionary<string, string?> Empty() => new();
-
-    public static Dictionary<string, string?> With(string key, string? value)
-    {
-        var dict = new Dictionary<string, string?>();
-        if (!string.IsNullOrEmpty(key))
-        {
-            dict[key] = value;
-        }
-        return dict;
-    }
 }

--- a/TiaMcpServer/Diagnostics/Checks/Evidence.cs
+++ b/TiaMcpServer/Diagnostics/Checks/Evidence.cs
@@ -1,0 +1,16 @@
+namespace TiaMcpServer.Diagnostics.Checks;
+
+internal static class Evidence
+{
+    public static Dictionary<string, string?> Empty() => new();
+
+    public static Dictionary<string, string?> With(string key, string? value)
+    {
+        var dict = new Dictionary<string, string?>();
+        if (!string.IsNullOrEmpty(key))
+        {
+            dict[key] = value;
+        }
+        return dict;
+    }
+}

--- a/TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs
@@ -49,21 +49,38 @@ public sealed class HostWorkerVersionCheck : IDiagnosticCheck
                 evidence);
         }
 
-        if (TryParseMajor(hostVersion, out var hostMajor) && TryParseMajor(workerVersion, out var workerMajor))
+        var hostParsed = TryParseMajor(hostVersion, out var hostMajor);
+        var workerParsed = TryParseMajor(workerVersion, out var workerMajor);
+        if (!hostParsed || !workerParsed)
         {
-            evidence["hostMajor"] = hostMajor.ToString();
-            evidence["workerMajor"] = workerMajor.ToString();
-
-            if (hostMajor != workerMajor)
+            var invalidVersions = string.Join(" and ", new[]
             {
-                return new DiagnosticCheckResult(
-                    Id,
-                    Name,
-                    DiagnosticStatus.Failed,
-                    $"Host version {hostVersion} and worker version {workerVersion} have different major versions.",
-                    "Rebuild the solution so the host and worker share the same version, or reinstall the tia-mcp global tool.",
-                    evidence);
-            }
+                hostParsed ? null : "host",
+                workerParsed ? null : "worker"
+            }.Where(value => value is not null));
+            evidence["versionParseError"] = $"Could not parse the {invalidVersions} major version.";
+
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Warning,
+                $"The {invalidVersions} version could not be parsed; host/worker compatibility could not be verified.",
+                null,
+                evidence);
+        }
+
+        evidence["hostMajor"] = hostMajor.ToString();
+        evidence["workerMajor"] = workerMajor.ToString();
+
+        if (hostMajor != workerMajor)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Failed,
+                $"Host version {hostVersion} and worker version {workerVersion} have different major versions.",
+                "Rebuild the solution so the host and worker share the same version, or reinstall the tia-mcp global tool.",
+                evidence);
         }
 
         return new DiagnosticCheckResult(

--- a/TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs
@@ -1,0 +1,91 @@
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Diagnostics.Checks;
+
+public sealed class HostWorkerVersionCheck : IDiagnosticCheck
+{
+    private readonly IApplicationInfoService _appInfo;
+    private readonly IFileSystemService _fileSystem;
+
+    public HostWorkerVersionCheck(IApplicationInfoService appInfo, IFileSystemService fileSystem)
+    {
+        _appInfo = appInfo;
+        _fileSystem = fileSystem;
+    }
+
+    public string Id => "host-worker-version";
+    public string Name => "Host and worker compatibility";
+
+    public DiagnosticCheckResult Run()
+    {
+        var evidence = Evidence.Empty();
+        var hostVersion = _appInfo.HostVersion;
+        evidence["hostVersion"] = hostVersion;
+
+        var workerLocation = OpennessWorkerLocator.Locate(_appInfo.BaseDirectory, _fileSystem);
+        if (!workerLocation.Found || workerLocation.SelectedPath is null)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Warning,
+                "Worker executable not found; host/worker compatibility could not be checked.",
+                null,
+                evidence);
+        }
+
+        var workerVersion = _fileSystem.GetFileVersion(workerLocation.SelectedPath);
+        evidence["workerPath"] = workerLocation.SelectedPath;
+        evidence["workerVersion"] = workerVersion;
+
+        if (string.IsNullOrWhiteSpace(workerVersion))
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Warning,
+                "Worker file version could not be determined.",
+                null,
+                evidence);
+        }
+
+        if (TryParseMajor(hostVersion, out var hostMajor) && TryParseMajor(workerVersion, out var workerMajor))
+        {
+            evidence["hostMajor"] = hostMajor.ToString();
+            evidence["workerMajor"] = workerMajor.ToString();
+
+            if (hostMajor != workerMajor)
+            {
+                return new DiagnosticCheckResult(
+                    Id,
+                    Name,
+                    DiagnosticStatus.Failed,
+                    $"Host version {hostVersion} and worker version {workerVersion} have different major versions.",
+                    "Rebuild the solution so the host and worker share the same version, or reinstall the tia-mcp global tool.",
+                    evidence);
+            }
+        }
+
+        return new DiagnosticCheckResult(
+            Id,
+            Name,
+            DiagnosticStatus.Passed,
+            $"Host {hostVersion}, worker {workerVersion}.",
+            null,
+            evidence);
+    }
+
+    private static bool TryParseMajor(string? version, out int major)
+    {
+        major = 0;
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return false;
+        }
+
+        var span = version.AsSpan();
+        var dot = span.IndexOf('.');
+        var majorSpan = dot < 0 ? span : span[..dot];
+        return int.TryParse(majorSpan, out major);
+    }
+}

--- a/TiaMcpServer/Diagnostics/Checks/OpennessAssembliesCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/OpennessAssembliesCheck.cs
@@ -1,0 +1,76 @@
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Diagnostics.Checks;
+
+public sealed class OpennessAssembliesCheck : IDiagnosticCheck
+{
+    private readonly IEnvironmentVariableService _env;
+    private readonly IRegistryService _registry;
+    private readonly IFileSystemService _fileSystem;
+
+    public OpennessAssembliesCheck(
+        IEnvironmentVariableService env,
+        IRegistryService registry,
+        IFileSystemService fileSystem)
+    {
+        _env = env;
+        _registry = registry;
+        _fileSystem = fileSystem;
+    }
+
+    public string Id => "openness-assemblies";
+    public string Name => "Openness assemblies";
+
+    public DiagnosticCheckResult Run()
+    {
+        var result = TiaPortalInstallationLocator.Locate(_env, _registry, _fileSystem);
+        var evidence = Evidence.Empty();
+
+        if (!result.Found || result.SelectedPath is null)
+        {
+            evidence["selectedPath"] = null;
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Failed,
+                "No TIA Portal V21 installation with the required Openness assemblies was found.",
+                "Install TIA Portal V21 with the Openness option, or set TiaPortalV21Dir to the PublicAPI\\V21\\net48 folder.",
+                evidence);
+        }
+
+        var path = result.SelectedPath;
+        evidence["selectedPath"] = path;
+        var missing = new List<string>();
+
+        foreach (var assembly in TiaPortalInstallationLocator.RequiredAssemblies)
+        {
+            var assemblyPath = Path.Combine(path, assembly);
+            var exists = _fileSystem.FileExists(assemblyPath);
+            evidence[$"assembly.{assembly}.path"] = assemblyPath;
+            evidence[$"assembly.{assembly}.exists"] = exists.ToString().ToLowerInvariant();
+            if (!exists)
+            {
+                missing.Add(assembly);
+            }
+        }
+
+        if (missing.Count > 0)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Failed,
+                $"Missing Openness assemblies: {string.Join(", ", missing)}.",
+                "Reinstall TIA Portal V21 with the Openness option, or set TiaPortalV21Dir to a complete PublicAPI\\V21\\net48 folder.",
+                evidence);
+        }
+
+        return new DiagnosticCheckResult(
+            Id,
+            Name,
+            DiagnosticStatus.Passed,
+            $"Required Openness assemblies present in {path}.",
+            null,
+            evidence);
+    }
+}

--- a/TiaMcpServer/Diagnostics/Checks/OpennessAssembliesCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/OpennessAssembliesCheck.cs
@@ -33,13 +33,31 @@ public sealed class OpennessAssembliesCheck : IDiagnosticCheck
                 Id,
                 Name,
                 DiagnosticStatus.Failed,
-                "No TIA Portal V21 installation with the required Openness assemblies was found.",
+                "No TIA Portal V21 installation was found.",
                 "Install TIA Portal V21 with the Openness option, or set TiaPortalV21Dir to the PublicAPI\\V21\\net48 folder.",
                 evidence);
         }
 
-        var path = result.SelectedPath;
+        var path = result.SelectedOpennessPath ?? result.SelectedPath;
+        var source = result.OpennessSource ?? result.Source;
+        var selectedCandidate = result.Candidates.First(candidate =>
+            candidate.Path == path && candidate.Source == source);
         evidence["selectedPath"] = path;
+        evidence["selectedInstallationPath"] = selectedCandidate.InstallationPath;
+        evidence["selectedSource"] = selectedCandidate.Source;
+        evidence["apiDirectoryPresent"] = selectedCandidate.DirectoryPresent.ToString().ToLowerInvariant();
+
+        if (!selectedCandidate.DirectoryPresent)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Failed,
+                $"TIA Portal V21 is installed at {selectedCandidate.InstallationPath}, but its Openness API directory was not found at {path}.",
+                "Modify or reinstall TIA Portal V21 with the Openness option, or set TiaPortalV21Dir to a complete PublicAPI\\V21\\net48 folder.",
+                evidence);
+        }
+
         var missing = new List<string>();
 
         foreach (var assembly in TiaPortalInstallationLocator.RequiredAssemblies)

--- a/TiaMcpServer/Diagnostics/Checks/OpennessGroupCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/OpennessGroupCheck.cs
@@ -1,0 +1,76 @@
+namespace TiaMcpServer.Diagnostics.Checks;
+
+public sealed class OpennessGroupCheck : IDiagnosticCheck
+{
+    private const string OpennessGroupName = "Siemens TIA Openness";
+
+    private readonly IWindowsIdentityService _identity;
+
+    public OpennessGroupCheck(IWindowsIdentityService identity) => _identity = identity;
+
+    public string Id => "openness-user-group";
+    public string Name => "Siemens TIA Openness group";
+
+    public DiagnosticCheckResult Run()
+    {
+        var evidence = Evidence.Empty();
+        evidence["group"] = OpennessGroupName;
+
+        var user = _identity.GetCurrentUserInfo();
+        if (user is not null)
+        {
+            evidence["user"] = user.DomainUser;
+            evidence["userSid"] = user.Sid;
+        }
+        else
+        {
+            evidence["user"] = null;
+        }
+
+        if (!_identity.IsWindows)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Failed,
+                "Not running on Windows; group membership cannot be verified.",
+                "Run on Windows and add the current user to the local \"Siemens TIA Openness\" group, then sign out and sign in again.",
+                evidence);
+        }
+
+        var membership = _identity.CheckGroupMembership(OpennessGroupName);
+        evidence["groupExists"] = membership.GroupExists.ToString().ToLowerInvariant();
+        evidence["groupSid"] = membership.GroupSid;
+        evidence["isMember"] = membership.IsMember.ToString().ToLowerInvariant();
+
+        if (!membership.GroupExists)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Failed,
+                $"The local group \"{OpennessGroupName}\" does not exist.",
+                "Install TIA Portal V21 with the Openness option to create the group, then add the current user to it and sign out and sign in again.",
+                evidence);
+        }
+
+        if (!membership.IsMember)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Failed,
+                $"Current user is not a member of \"{OpennessGroupName}\".",
+                $"Add the current user to the local \"{OpennessGroupName}\" group, then sign out and sign in again.",
+                evidence);
+        }
+
+        return new DiagnosticCheckResult(
+            Id,
+            Name,
+            DiagnosticStatus.Passed,
+            $"Current user is a member of \"{OpennessGroupName}\".",
+            null,
+            evidence);
+    }
+}

--- a/TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs
@@ -1,0 +1,88 @@
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Diagnostics.Checks;
+
+public sealed class OpennessWorkerCheck : IDiagnosticCheck
+{
+    private readonly IApplicationInfoService _appInfo;
+    private readonly IFileSystemService _fileSystem;
+
+    public OpennessWorkerCheck(IApplicationInfoService appInfo, IFileSystemService fileSystem)
+    {
+        _appInfo = appInfo;
+        _fileSystem = fileSystem;
+    }
+
+    public string Id => "openness-worker";
+    public string Name => "Openness worker";
+
+    public DiagnosticCheckResult Run()
+    {
+        var result = OpennessWorkerLocator.Locate(_appInfo.BaseDirectory, _fileSystem);
+        var evidence = Evidence.Empty();
+
+        for (int i = 0; i < result.Candidates.Count; i++)
+        {
+            var candidate = result.Candidates[i];
+            evidence[$"candidate[{i}].path"] = candidate.Path;
+            evidence[$"candidate[{i}].exists"] = candidate.Exists.ToString().ToLowerInvariant();
+        }
+
+        if (!result.Found || result.SelectedPath is null)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Failed,
+                "TIA Openness worker executable was not found.",
+                "Build the solution and ensure the openness-worker folder is beside the MCP server executable, or reinstall the tia-mcp global tool.",
+                evidence);
+        }
+
+        var path = result.SelectedPath;
+        evidence["selectedPath"] = path;
+
+        var version = _fileSystem.GetFileVersion(path);
+        evidence["workerVersion"] = version;
+
+        var directory = Path.GetDirectoryName(path);
+        if (directory is null)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Failed,
+                $"Worker executable found at {path} but its directory could not be determined.",
+                "Rebuild the solution or reinstall the tia-mcp global tool.",
+                evidence);
+        }
+
+        var runtimeConfigPath = Path.Combine(directory, "TiaMcpServer.OpennessWorker.runtimeconfig.json");
+        var runtimeConfigExists = _fileSystem.FileExists(runtimeConfigPath);
+        evidence["runtimeConfigPath"] = runtimeConfigPath;
+        evidence["runtimeConfigExists"] = runtimeConfigExists.ToString().ToLowerInvariant();
+
+        if (!runtimeConfigExists)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Failed,
+                $"Worker executable found at {path} but its runtime configuration file is missing.",
+                "Rebuild the solution or reinstall the tia-mcp global tool; the openness-worker folder is incomplete.",
+                evidence);
+        }
+
+        var message = version is not null
+            ? $"Worker found at {path} (version {version})."
+            : $"Worker found at {path}.";
+
+        return new DiagnosticCheckResult(
+            Id,
+            Name,
+            DiagnosticStatus.Passed,
+            message,
+            null,
+            evidence);
+    }
+}

--- a/TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs
@@ -4,6 +4,21 @@ namespace TiaMcpServer.Diagnostics.Checks;
 
 public sealed class OpennessWorkerCheck : IDiagnosticCheck
 {
+    internal static readonly string[] RequiredCompanionFiles =
+    {
+        "TiaMcpServer.OpennessWorker.exe.config",
+        "TiaMcpServer.Contracts.dll",
+        "Microsoft.Bcl.AsyncInterfaces.dll",
+        "System.Buffers.dll",
+        "System.IO.Pipelines.dll",
+        "System.Memory.dll",
+        "System.Numerics.Vectors.dll",
+        "System.Runtime.CompilerServices.Unsafe.dll",
+        "System.Text.Encodings.Web.dll",
+        "System.Text.Json.dll",
+        "System.Threading.Tasks.Extensions.dll"
+    };
+
     private readonly IApplicationInfoService _appInfo;
     private readonly IFileSystemService _fileSystem;
 
@@ -57,18 +72,26 @@ public sealed class OpennessWorkerCheck : IDiagnosticCheck
                 evidence);
         }
 
-        var runtimeConfigPath = Path.Combine(directory, "TiaMcpServer.OpennessWorker.runtimeconfig.json");
-        var runtimeConfigExists = _fileSystem.FileExists(runtimeConfigPath);
-        evidence["runtimeConfigPath"] = runtimeConfigPath;
-        evidence["runtimeConfigExists"] = runtimeConfigExists.ToString().ToLowerInvariant();
+        var missingCompanionFiles = new List<string>();
+        foreach (var companionFile in RequiredCompanionFiles)
+        {
+            var companionPath = Path.Combine(directory, companionFile);
+            var exists = _fileSystem.FileExists(companionPath);
+            evidence[$"companion.{companionFile}.path"] = companionPath;
+            evidence[$"companion.{companionFile}.exists"] = exists.ToString().ToLowerInvariant();
+            if (!exists)
+            {
+                missingCompanionFiles.Add(companionFile);
+            }
+        }
 
-        if (!runtimeConfigExists)
+        if (missingCompanionFiles.Count > 0)
         {
             return new DiagnosticCheckResult(
                 Id,
                 Name,
                 DiagnosticStatus.Failed,
-                $"Worker executable found at {path} but its runtime configuration file is missing.",
+                $"Worker executable found at {path} but required companion files are missing: {string.Join(", ", missingCompanionFiles)}.",
                 "Rebuild the solution or reinstall the tia-mcp global tool; the openness-worker folder is incomplete.",
                 evidence);
         }

--- a/TiaMcpServer/Diagnostics/Checks/OperatingSystemCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/OperatingSystemCheck.cs
@@ -1,0 +1,39 @@
+namespace TiaMcpServer.Diagnostics.Checks;
+
+public sealed class OperatingSystemCheck : IDiagnosticCheck
+{
+    private readonly IApplicationInfoService _appInfo;
+
+    public OperatingSystemCheck(IApplicationInfoService appInfo) => _appInfo = appInfo;
+
+    public string Id => "operating-system";
+    public string Name => "Operating system";
+
+    public DiagnosticCheckResult Run()
+    {
+        var evidence = Evidence.Empty();
+        evidence["isWindows"] = _appInfo.IsWindows.ToString().ToLowerInvariant();
+        evidence["osName"] = _appInfo.OsName;
+        evidence["osVersion"] = _appInfo.OsVersion;
+        evidence["processArchitecture"] = _appInfo.ProcessArchitecture;
+
+        if (!_appInfo.IsWindows)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Failed,
+                $"{_appInfo.OsName} is not supported. TIA Portal MCP requires Windows.",
+                "Run on a Windows host with TIA Portal V21 installed.",
+                evidence);
+        }
+
+        return new DiagnosticCheckResult(
+            Id,
+            Name,
+            DiagnosticStatus.Passed,
+            $"{_appInfo.OsName} {_appInfo.OsVersion} {_appInfo.ProcessArchitecture}",
+            null,
+            evidence);
+    }
+}

--- a/TiaMcpServer/Diagnostics/Checks/ProjectBindingCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/ProjectBindingCheck.cs
@@ -1,0 +1,60 @@
+namespace TiaMcpServer.Diagnostics.Checks;
+
+public sealed class ProjectBindingCheck : IDiagnosticCheck
+{
+    private const string ProjectArg = "--project";
+    private const string ProjectEnvVar = "TIA_MCP_PROJECT_PATH";
+
+    private readonly IEnvironmentVariableService _env;
+    private readonly string? _cliProjectPath;
+
+    public ProjectBindingCheck(IEnvironmentVariableService env, string? cliProjectPath)
+    {
+        _env = env;
+        _cliProjectPath = cliProjectPath;
+    }
+
+    public string Id => "project-binding";
+    public string Name => "Project binding";
+
+    public DiagnosticCheckResult Run()
+    {
+        var evidence = Evidence.Empty();
+        evidence[$"arg:{ProjectArg}"] = _cliProjectPath;
+        evidence[$"env:{ProjectEnvVar}"] = _env.Get(ProjectEnvVar);
+
+        var cliPath = string.IsNullOrWhiteSpace(_cliProjectPath) ? null : _cliProjectPath!.Trim();
+        var envPath = _env.Get(ProjectEnvVar);
+        var envPathNormalized = string.IsNullOrWhiteSpace(envPath) ? null : envPath!.Trim();
+
+        if (cliPath is not null)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Passed,
+                $"Project binding configured via --project: {cliPath}",
+                null,
+                evidence);
+        }
+
+        if (envPathNormalized is not null)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Passed,
+                $"Project binding configured via {ProjectEnvVar}: {envPathNormalized}",
+                null,
+                evidence);
+        }
+
+        return new DiagnosticCheckResult(
+            Id,
+            Name,
+            DiagnosticStatus.Passed,
+            "No project binding configured. Tools will use the project currently open in TIA Portal.",
+            null,
+            evidence);
+    }
+}

--- a/TiaMcpServer/Diagnostics/Checks/TiaPortalInstallationCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/TiaPortalInstallationCheck.cs
@@ -30,19 +30,25 @@ public sealed class TiaPortalInstallationCheck : IDiagnosticCheck
         {
             var candidate = result.Candidates[i];
             evidence[$"candidate[{i}].path"] = candidate.Path;
+            evidence[$"candidate[{i}].apiPath"] = candidate.Path;
+            evidence[$"candidate[{i}].installationPath"] = candidate.InstallationPath;
             evidence[$"candidate[{i}].source"] = candidate.Source;
+            evidence[$"candidate[{i}].installationPresent"] = candidate.InstallationPresent.ToString().ToLowerInvariant();
+            evidence[$"candidate[{i}].directoryPresent"] = candidate.DirectoryPresent.ToString().ToLowerInvariant();
+            evidence[$"candidate[{i}].apiDirectoryPresent"] = candidate.DirectoryPresent.ToString().ToLowerInvariant();
             evidence[$"candidate[{i}].assembliesPresent"] = candidate.AssembliesPresent.ToString().ToLowerInvariant();
         }
 
         if (result.Found)
         {
             evidence["selectedPath"] = result.SelectedPath;
+            evidence["selectedInstallationPath"] = result.SelectedInstallationPath;
             evidence["selectedSource"] = result.Source;
             return new DiagnosticCheckResult(
                 Id,
                 Name,
                 DiagnosticStatus.Passed,
-                $"TIA Portal V21 detected via {result.Source}.",
+                $"TIA Portal V21 detected at {result.SelectedInstallationPath} via {result.Source}.",
                 null,
                 evidence);
         }
@@ -51,8 +57,8 @@ public sealed class TiaPortalInstallationCheck : IDiagnosticCheck
             Id,
             Name,
             DiagnosticStatus.Failed,
-            "TIA Portal V21 Openness assemblies were not found in any inspected location.",
-            "Install TIA Portal V21 with the Openness option, or set the TiaPortalV21Dir environment variable to the folder containing Siemens.Engineering.*.dll (PublicAPI\\V21\\net48).",
+            "TIA Portal V21 installation was not found in any inspected location.",
+            "Install TIA Portal V21, set TiaPortalV21Dir to its PublicAPI\\V21\\net48 folder, or set TiaPortalLocation to the Portal V21 installation root.",
             evidence);
     }
 }

--- a/TiaMcpServer/Diagnostics/Checks/TiaPortalInstallationCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/TiaPortalInstallationCheck.cs
@@ -1,0 +1,58 @@
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Diagnostics.Checks;
+
+public sealed class TiaPortalInstallationCheck : IDiagnosticCheck
+{
+    private readonly IEnvironmentVariableService _env;
+    private readonly IRegistryService _registry;
+    private readonly IFileSystemService _fileSystem;
+
+    public TiaPortalInstallationCheck(
+        IEnvironmentVariableService env,
+        IRegistryService registry,
+        IFileSystemService fileSystem)
+    {
+        _env = env;
+        _registry = registry;
+        _fileSystem = fileSystem;
+    }
+
+    public string Id => "tia-portal-installation";
+    public string Name => "TIA Portal installation";
+
+    public DiagnosticCheckResult Run()
+    {
+        var result = TiaPortalInstallationLocator.Locate(_env, _registry, _fileSystem);
+        var evidence = Evidence.Empty();
+
+        for (int i = 0; i < result.Candidates.Count; i++)
+        {
+            var candidate = result.Candidates[i];
+            evidence[$"candidate[{i}].path"] = candidate.Path;
+            evidence[$"candidate[{i}].source"] = candidate.Source;
+            evidence[$"candidate[{i}].assembliesPresent"] = candidate.AssembliesPresent.ToString().ToLowerInvariant();
+        }
+
+        if (result.Found)
+        {
+            evidence["selectedPath"] = result.SelectedPath;
+            evidence["selectedSource"] = result.Source;
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Passed,
+                $"TIA Portal V21 detected via {result.Source}.",
+                null,
+                evidence);
+        }
+
+        return new DiagnosticCheckResult(
+            Id,
+            Name,
+            DiagnosticStatus.Failed,
+            "TIA Portal V21 Openness assemblies were not found in any inspected location.",
+            "Install TIA Portal V21 with the Openness option, or set the TiaPortalV21Dir environment variable to the folder containing Siemens.Engineering.*.dll (PublicAPI\\V21\\net48).",
+            evidence);
+    }
+}

--- a/TiaMcpServer/Diagnostics/Checks/TiaPortalProcessCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/TiaPortalProcessCheck.cs
@@ -1,0 +1,70 @@
+namespace TiaMcpServer.Diagnostics.Checks;
+
+public sealed class TiaPortalProcessCheck : IDiagnosticCheck
+{
+    private static readonly string[] TiaPortalProcessNameFragments =
+    {
+        "Siemens.Automation.Portal",
+        "TIA.Portal",
+        "Portal.V21",
+        "Siemens.Simulation.Portal"
+    };
+
+    private readonly IProcessEnumerationService _processes;
+    private readonly IApplicationInfoService _appInfo;
+
+    public TiaPortalProcessCheck(IProcessEnumerationService processes, IApplicationInfoService appInfo)
+    {
+        _processes = processes;
+        _appInfo = appInfo;
+    }
+
+    public string Id => "tia-portal-process";
+    public string Name => "TIA Portal process";
+
+    public DiagnosticCheckResult Run()
+    {
+        var evidence = Evidence.Empty();
+
+        if (!_appInfo.IsWindows)
+        {
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Warning,
+                "Not running on Windows; TIA Portal process detection was skipped.",
+                "Start TIA Portal V21 before operations that attach to an open project.",
+                evidence);
+        }
+
+        var processes = _processes.ListProcesses();
+        var matches = processes
+            .Where(p => TiaPortalProcessNameFragments.Any(f => p.Name.IndexOf(f, StringComparison.OrdinalIgnoreCase) >= 0))
+            .ToList();
+
+        if (matches.Count > 0)
+        {
+            for (int i = 0; i < matches.Count; i++)
+            {
+                evidence[$"process[{i}].name"] = matches[i].Name;
+                evidence[$"process[{i}].id"] = matches[i].Id.ToString();
+            }
+
+            return new DiagnosticCheckResult(
+                Id,
+                Name,
+                DiagnosticStatus.Passed,
+                $"TIA Portal is running ({matches.Count} process(es) detected).",
+                null,
+                evidence);
+        }
+
+        return new DiagnosticCheckResult(
+            Id,
+            Name,
+            DiagnosticStatus.Warning,
+            "No running TIA Portal instance was detected.",
+            "Start TIA Portal V21 before operations that attach to an open project. This is informational; the installation can still be valid.",
+            evidence);
+    }
+}

--- a/TiaMcpServer/Diagnostics/DiagnosticCheckResult.cs
+++ b/TiaMcpServer/Diagnostics/DiagnosticCheckResult.cs
@@ -1,0 +1,9 @@
+namespace TiaMcpServer.Diagnostics;
+
+public sealed record DiagnosticCheckResult(
+    string Id,
+    string Name,
+    DiagnosticStatus Status,
+    string Message,
+    string? Remediation = null,
+    IReadOnlyDictionary<string, string?>? Evidence = null);

--- a/TiaMcpServer/Diagnostics/DiagnosticStatus.cs
+++ b/TiaMcpServer/Diagnostics/DiagnosticStatus.cs
@@ -1,0 +1,8 @@
+namespace TiaMcpServer.Diagnostics;
+
+public enum DiagnosticStatus
+{
+    Passed,
+    Warning,
+    Failed
+}

--- a/TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs
+++ b/TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs
@@ -1,0 +1,84 @@
+using System.Text;
+using System.Text.Json;
+
+namespace TiaMcpServer.Diagnostics;
+
+public static class DoctorJsonRenderer
+{
+    public static string Render(DoctorReport report, bool verbose)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("status", StatusString(report.Status));
+            writer.WriteString("timestampUtc", FormatTimestamp(report.TimestampUtc));
+            writer.WriteString("hostVersion", report.HostVersion);
+
+            writer.WritePropertyName("summary");
+            writer.WriteStartObject();
+            writer.WriteNumber("passed", report.Summary.Passed);
+            writer.WriteNumber("warnings", report.Summary.Warnings);
+            writer.WriteNumber("failed", report.Summary.Failed);
+            writer.WriteEndObject();
+
+            writer.WritePropertyName("checks");
+            writer.WriteStartArray();
+            foreach (var check in report.Checks)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("id", check.Id);
+                writer.WriteString("name", check.Name);
+                writer.WriteString("status", StatusString(check.Status));
+                writer.WriteString("message", check.Message);
+                if (!string.IsNullOrEmpty(check.Remediation))
+                {
+                    writer.WriteString("remediation", check.Remediation);
+                }
+                else
+                {
+                    writer.WriteNull("remediation");
+                }
+
+                if (verbose && check.Evidence is not null && check.Evidence.Count > 0)
+                {
+                    writer.WritePropertyName("evidence");
+                    writer.WriteStartObject();
+                    foreach (var kvp in check.Evidence)
+                    {
+                        if (kvp.Value is null)
+                        {
+                            writer.WriteNull(kvp.Key);
+                        }
+                        else
+                        {
+                            writer.WriteString(kvp.Key, kvp.Value);
+                        }
+                    }
+                    writer.WriteEndObject();
+                }
+
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static string StatusString(DiagnosticStatus status) => status switch
+    {
+        DiagnosticStatus.Passed => "passed",
+        DiagnosticStatus.Warning => "warning",
+        DiagnosticStatus.Failed => "failed",
+        _ => "unknown"
+    };
+
+    private static string FormatTimestamp(DateTimeOffset timestamp)
+    {
+        var utc = timestamp.ToUniversalTime();
+        return utc.ToString("yyyy-MM-ddTHH:mm:ssZ");
+    }
+}

--- a/TiaMcpServer/Diagnostics/DoctorReport.cs
+++ b/TiaMcpServer/Diagnostics/DoctorReport.cs
@@ -5,4 +5,7 @@ public sealed record DoctorReport(
     DateTimeOffset TimestampUtc,
     string HostVersion,
     DoctorSummary Summary,
-    IReadOnlyList<DiagnosticCheckResult> Checks);
+    IReadOnlyList<DiagnosticCheckResult> Checks)
+{
+    public bool HasUnexpectedCheckFailure { get; init; }
+}

--- a/TiaMcpServer/Diagnostics/DoctorReport.cs
+++ b/TiaMcpServer/Diagnostics/DoctorReport.cs
@@ -1,0 +1,8 @@
+namespace TiaMcpServer.Diagnostics;
+
+public sealed record DoctorReport(
+    DiagnosticStatus Status,
+    DateTimeOffset TimestampUtc,
+    string HostVersion,
+    DoctorSummary Summary,
+    IReadOnlyList<DiagnosticCheckResult> Checks);

--- a/TiaMcpServer/Diagnostics/DoctorRunner.cs
+++ b/TiaMcpServer/Diagnostics/DoctorRunner.cs
@@ -1,0 +1,55 @@
+namespace TiaMcpServer.Diagnostics;
+
+public sealed class DoctorRunner
+{
+    private readonly IApplicationInfoService _appInfo;
+    private readonly IReadOnlyList<IDiagnosticCheck> _checks;
+
+    public DoctorRunner(IApplicationInfoService appInfo, IReadOnlyList<IDiagnosticCheck> checks)
+    {
+        _appInfo = appInfo;
+        _checks = checks;
+    }
+
+    public DoctorReport Run()
+    {
+        var results = new List<DiagnosticCheckResult>(_checks.Count);
+
+        foreach (var check in _checks)
+        {
+            try
+            {
+                results.Add(check.Run());
+            }
+            catch (Exception ex)
+            {
+                var evidence = new Dictionary<string, string?>
+                {
+                    ["exceptionType"] = ex.GetType().FullName,
+                    ["exceptionMessage"] = ex.Message
+                };
+
+                results.Add(new DiagnosticCheckResult(
+                    check.Id,
+                    check.Name,
+                    DiagnosticStatus.Failed,
+                    $"Unexpected error during check: {ex.Message}",
+                    null,
+                    evidence));
+            }
+        }
+
+        var passed = results.Count(r => r.Status == DiagnosticStatus.Passed);
+        var warnings = results.Count(r => r.Status == DiagnosticStatus.Warning);
+        var failed = results.Count(r => r.Status == DiagnosticStatus.Failed);
+        var summary = new DoctorSummary(passed, warnings, failed);
+        var status = failed > 0 ? DiagnosticStatus.Failed : warnings > 0 ? DiagnosticStatus.Warning : DiagnosticStatus.Passed;
+
+        return new DoctorReport(
+            status,
+            DateTimeOffset.UtcNow,
+            _appInfo.HostVersion,
+            summary,
+            results);
+    }
+}

--- a/TiaMcpServer/Diagnostics/DoctorRunner.cs
+++ b/TiaMcpServer/Diagnostics/DoctorRunner.cs
@@ -14,6 +14,7 @@ public sealed class DoctorRunner
     public DoctorReport Run()
     {
         var results = new List<DiagnosticCheckResult>(_checks.Count);
+        bool hasUnexpectedCheckFailure = false;
 
         foreach (var check in _checks)
         {
@@ -23,6 +24,7 @@ public sealed class DoctorRunner
             }
             catch (Exception ex)
             {
+                hasUnexpectedCheckFailure = true;
                 var evidence = new Dictionary<string, string?>
                 {
                     ["exceptionType"] = ex.GetType().FullName,
@@ -50,6 +52,9 @@ public sealed class DoctorRunner
             DateTimeOffset.UtcNow,
             _appInfo.HostVersion,
             summary,
-            results);
+            results)
+        {
+            HasUnexpectedCheckFailure = hasUnexpectedCheckFailure
+        };
     }
 }

--- a/TiaMcpServer/Diagnostics/DoctorSummary.cs
+++ b/TiaMcpServer/Diagnostics/DoctorSummary.cs
@@ -1,0 +1,3 @@
+namespace TiaMcpServer.Diagnostics;
+
+public sealed record DoctorSummary(int Passed, int Warnings, int Failed);

--- a/TiaMcpServer/Diagnostics/DoctorTextRenderer.cs
+++ b/TiaMcpServer/Diagnostics/DoctorTextRenderer.cs
@@ -1,0 +1,72 @@
+using System.Text;
+
+namespace TiaMcpServer.Diagnostics;
+
+public static class DoctorTextRenderer
+{
+    public static void Render(DoctorReport report, bool verbose, TextWriter writer)
+    {
+        writer.WriteLine("TIA Portal MCP Environment Doctor");
+        writer.WriteLine();
+
+        foreach (var check in report.Checks)
+        {
+            RenderCheck(writer, check, verbose);
+        }
+
+        writer.WriteLine($"Summary: {report.Summary.Passed} passed, {Pluralize(report.Summary.Warnings, "warning")}, {Pluralize(report.Summary.Failed, "failure")}");
+        writer.WriteLine(report.Status == DiagnosticStatus.Failed
+            ? "Environment is not ready."
+            : report.Status == DiagnosticStatus.Warning
+                ? "Environment is ready with warnings."
+                : "Environment is ready.");
+    }
+
+    private static void RenderCheck(TextWriter writer, DiagnosticCheckResult check, bool verbose)
+    {
+        var tag = check.Status switch
+        {
+            DiagnosticStatus.Passed => "[PASS]",
+            DiagnosticStatus.Warning => "[WARN]",
+            DiagnosticStatus.Failed => "[FAIL]",
+            _ => "[????]"
+        };
+
+        writer.WriteLine($"{tag} {check.Name}");
+        writer.WriteLine($"       {check.Message}");
+
+        if (!string.IsNullOrEmpty(check.Remediation))
+        {
+            writer.WriteLine();
+            writer.WriteLine("       Fix:");
+            foreach (var line in SplitLines(check.Remediation))
+            {
+                writer.WriteLine($"       {line}");
+            }
+        }
+
+        if (verbose && check.Evidence is not null && check.Evidence.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("       Evidence:");
+            foreach (var kvp in check.Evidence)
+            {
+                writer.WriteLine($"         {kvp.Key} = {FormatValue(kvp.Value)}");
+            }
+        }
+
+        writer.WriteLine();
+    }
+
+    private static string FormatValue(string? value) => value is null ? "<null>" : value;
+
+    private static IEnumerable<string> SplitLines(string text)
+    {
+        foreach (var line in text.Replace("\r\n", "\n").Split('\n'))
+        {
+            yield return line;
+        }
+    }
+
+    private static string Pluralize(int count, string singular) => count == 1 ? $"{count} {singular}" : $"{count} {singular}s";
+}

--- a/TiaMcpServer/Diagnostics/DoctorTextRenderer.cs
+++ b/TiaMcpServer/Diagnostics/DoctorTextRenderer.cs
@@ -1,5 +1,3 @@
-using System.Text;
-
 namespace TiaMcpServer.Diagnostics;
 
 public static class DoctorTextRenderer

--- a/TiaMcpServer/Diagnostics/EnvironmentVariableService.cs
+++ b/TiaMcpServer/Diagnostics/EnvironmentVariableService.cs
@@ -1,0 +1,8 @@
+namespace TiaMcpServer.Diagnostics;
+
+public sealed class EnvironmentVariableService : IEnvironmentVariableService
+{
+    public static readonly EnvironmentVariableService Instance = new();
+
+    public string? Get(string name) => Environment.GetEnvironmentVariable(name);
+}

--- a/TiaMcpServer/Diagnostics/FileSystemService.cs
+++ b/TiaMcpServer/Diagnostics/FileSystemService.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+
+namespace TiaMcpServer.Diagnostics;
+
+public sealed class FileSystemService : IFileSystemService
+{
+    public static readonly FileSystemService Instance = new();
+
+    public bool FileExists(string path) => File.Exists(path);
+
+    public bool DirectoryExists(string path) => Directory.Exists(path);
+
+    public string? GetFileVersion(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            var info = FileVersionInfo.GetVersionInfo(path);
+            var version = !string.IsNullOrWhiteSpace(info.ProductVersion)
+                ? info.ProductVersion
+                : !string.IsNullOrWhiteSpace(info.FileVersion)
+                    ? info.FileVersion
+                    : null;
+            return version;
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException or IOException)
+        {
+            return null;
+        }
+    }
+}

--- a/TiaMcpServer/Diagnostics/IApplicationInfoService.cs
+++ b/TiaMcpServer/Diagnostics/IApplicationInfoService.cs
@@ -1,7 +1,10 @@
+using System.Runtime.Versioning;
+
 namespace TiaMcpServer.Diagnostics;
 
 public interface IApplicationInfoService
 {
+    [SupportedOSPlatformGuard("windows")]
     bool IsWindows { get; }
 
     string OsName { get; }

--- a/TiaMcpServer/Diagnostics/IApplicationInfoService.cs
+++ b/TiaMcpServer/Diagnostics/IApplicationInfoService.cs
@@ -1,0 +1,18 @@
+namespace TiaMcpServer.Diagnostics;
+
+public interface IApplicationInfoService
+{
+    bool IsWindows { get; }
+
+    string OsName { get; }
+
+    string OsVersion { get; }
+
+    string ProcessArchitecture { get; }
+
+    string HostVersion { get; }
+
+    string BaseDirectory { get; }
+
+    string RuntimeDescription { get; }
+}

--- a/TiaMcpServer/Diagnostics/IDiagnosticCheck.cs
+++ b/TiaMcpServer/Diagnostics/IDiagnosticCheck.cs
@@ -1,0 +1,10 @@
+namespace TiaMcpServer.Diagnostics;
+
+public interface IDiagnosticCheck
+{
+    string Id { get; }
+
+    string Name { get; }
+
+    DiagnosticCheckResult Run();
+}

--- a/TiaMcpServer/Diagnostics/IEnvironmentVariableService.cs
+++ b/TiaMcpServer/Diagnostics/IEnvironmentVariableService.cs
@@ -1,0 +1,6 @@
+namespace TiaMcpServer.Diagnostics;
+
+public interface IEnvironmentVariableService
+{
+    string? Get(string name);
+}

--- a/TiaMcpServer/Diagnostics/IFileSystemService.cs
+++ b/TiaMcpServer/Diagnostics/IFileSystemService.cs
@@ -1,0 +1,10 @@
+namespace TiaMcpServer.Diagnostics;
+
+public interface IFileSystemService
+{
+    bool FileExists(string path);
+
+    bool DirectoryExists(string path);
+
+    string? GetFileVersion(string path);
+}

--- a/TiaMcpServer/Diagnostics/IProcessEnumerationService.cs
+++ b/TiaMcpServer/Diagnostics/IProcessEnumerationService.cs
@@ -1,0 +1,8 @@
+namespace TiaMcpServer.Diagnostics;
+
+public sealed record ProcessInfo(string Name, int Id);
+
+public interface IProcessEnumerationService
+{
+    IReadOnlyList<ProcessInfo> ListProcesses();
+}

--- a/TiaMcpServer/Diagnostics/IRegistryService.cs
+++ b/TiaMcpServer/Diagnostics/IRegistryService.cs
@@ -1,0 +1,12 @@
+using Microsoft.Win32;
+
+namespace TiaMcpServer.Diagnostics;
+
+public interface IRegistryService
+{
+    string? GetStringValue(RegistryHive hive, RegistryView view, string subKey, string valueName);
+
+    int? GetIntValue(RegistryHive hive, RegistryView view, string subKey, string valueName);
+
+    bool KeyExists(RegistryHive hive, RegistryView view, string subKey);
+}

--- a/TiaMcpServer/Diagnostics/IWindowsIdentityService.cs
+++ b/TiaMcpServer/Diagnostics/IWindowsIdentityService.cs
@@ -1,0 +1,18 @@
+namespace TiaMcpServer.Diagnostics;
+
+public sealed record WindowsUserInfo(string DomainUser, string Sid);
+
+public sealed record OpennessGroupMembership(
+    bool GroupExists,
+    bool IsMember,
+    string? GroupSid,
+    string? ErrorMessage);
+
+public interface IWindowsIdentityService
+{
+    bool IsWindows { get; }
+
+    WindowsUserInfo? GetCurrentUserInfo();
+
+    OpennessGroupMembership CheckGroupMembership(string groupName);
+}

--- a/TiaMcpServer/Diagnostics/ProcessEnumerationService.cs
+++ b/TiaMcpServer/Diagnostics/ProcessEnumerationService.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+
+namespace TiaMcpServer.Diagnostics;
+
+public sealed class ProcessEnumerationService : IProcessEnumerationService
+{
+    public static readonly ProcessEnumerationService Instance = new();
+
+    public IReadOnlyList<ProcessInfo> ListProcesses()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return Array.Empty<ProcessInfo>();
+        }
+
+        try
+        {
+            return Process.GetProcesses()
+                .Select(p =>
+                {
+                    using (p)
+                    {
+                        try
+                        {
+                            return new ProcessInfo(p.ProcessName, p.Id);
+                        }
+                        catch
+                        {
+                            return null;
+                        }
+                    }
+                })
+                .OfType<ProcessInfo>()
+                .ToList();
+        }
+        catch
+        {
+            return Array.Empty<ProcessInfo>();
+        }
+    }
+}

--- a/TiaMcpServer/Diagnostics/RegistryService.cs
+++ b/TiaMcpServer/Diagnostics/RegistryService.cs
@@ -1,0 +1,55 @@
+using Microsoft.Win32;
+
+namespace TiaMcpServer.Diagnostics;
+
+public sealed class RegistryService : IRegistryService
+{
+    public static readonly RegistryService Instance = new();
+
+    public string? GetStringValue(RegistryHive hive, RegistryView view, string subKey, string valueName)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return null;
+        }
+
+        using var baseKey = RegistryKey.OpenBaseKey(hive, view);
+        using var key = baseKey.OpenSubKey(subKey);
+        return key?.GetValue(valueName) as string;
+    }
+
+    public int? GetIntValue(RegistryHive hive, RegistryView view, string subKey, string valueName)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return null;
+        }
+
+        using var baseKey = RegistryKey.OpenBaseKey(hive, view);
+        using var key = baseKey.OpenSubKey(subKey);
+        if (key is null)
+        {
+            return null;
+        }
+
+        var value = key.GetValue(valueName);
+        return value switch
+        {
+            int i => i,
+            long l when l >= int.MinValue && l <= int.MaxValue => (int)l,
+            _ => null
+        };
+    }
+
+    public bool KeyExists(RegistryHive hive, RegistryView view, string subKey)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        using var baseKey = RegistryKey.OpenBaseKey(hive, view);
+        using var key = baseKey.OpenSubKey(subKey);
+        return key is not null;
+    }
+}

--- a/TiaMcpServer/Diagnostics/WindowsIdentityService.cs
+++ b/TiaMcpServer/Diagnostics/WindowsIdentityService.cs
@@ -1,4 +1,5 @@
 using System.Security.Principal;
+using System.Runtime.Versioning;
 
 namespace TiaMcpServer.Diagnostics;
 
@@ -78,6 +79,7 @@ public sealed class WindowsIdentityService : IWindowsIdentityService
         }
     }
 
+    [SupportedOSPlatform("windows")]
     private static string? TryResolveGroupSid(string groupName)
     {
         try

--- a/TiaMcpServer/Diagnostics/WindowsIdentityService.cs
+++ b/TiaMcpServer/Diagnostics/WindowsIdentityService.cs
@@ -1,0 +1,124 @@
+using System.Security.Principal;
+
+namespace TiaMcpServer.Diagnostics;
+
+public sealed class WindowsIdentityService : IWindowsIdentityService
+{
+    public static readonly WindowsIdentityService Instance = new();
+
+    public bool IsWindows => OperatingSystem.IsWindows();
+
+    public WindowsUserInfo? GetCurrentUserInfo()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return null;
+        }
+
+        try
+        {
+            using var identity = WindowsIdentity.GetCurrent();
+            var sid = identity.User?.Value;
+            var name = identity.Name;
+            return new WindowsUserInfo(name, sid ?? string.Empty);
+        }
+        catch (System.Security.SecurityException)
+        {
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    public OpennessGroupMembership CheckGroupMembership(string groupName)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return new OpennessGroupMembership(
+                GroupExists: false,
+                IsMember: false,
+                GroupSid: null,
+                ErrorMessage: "Not running on Windows.");
+        }
+
+        try
+        {
+            using var identity = WindowsIdentity.GetCurrent();
+            var principal = new WindowsPrincipal(identity);
+
+            // Resolve the local group to an NTAccount to confirm it exists and to test membership by SID.
+            var groupSid = TryResolveGroupSid(groupName);
+            if (groupSid is null)
+            {
+                return new OpennessGroupMembership(
+                    GroupExists: false,
+                    IsMember: false,
+                    GroupSid: null,
+                    ErrorMessage: $"The local group \"{groupName}\" does not exist.");
+            }
+
+            var sidIdentity = new SecurityIdentifier(groupSid);
+            var isMember = principal.IsInRole(sidIdentity);
+
+            return new OpennessGroupMembership(
+                GroupExists: true,
+                IsMember: isMember,
+                GroupSid: groupSid,
+                ErrorMessage: null);
+        }
+        catch (Exception ex)
+        {
+            return new OpennessGroupMembership(
+                GroupExists: false,
+                IsMember: false,
+                GroupSid: null,
+                ErrorMessage: ex.Message);
+        }
+    }
+
+    private static string? TryResolveGroupSid(string groupName)
+    {
+        try
+        {
+            // Try as a local group first (machine\group), then as a bare name.
+            var machine = Environment.MachineName;
+            var ntAccounts = new[]
+            {
+                new NTAccount($@"{machine}\{groupName}"),
+                new NTAccount(groupName)
+            };
+
+            foreach (var account in ntAccounts)
+            {
+                try
+                {
+                    var translated = account.Translate(typeof(SecurityIdentifier));
+                    if (translated is SecurityIdentifier sid)
+                    {
+                        return sid.Value;
+                    }
+                }
+                catch (IdentityNotMappedException)
+                {
+                    // Try the next form.
+                }
+                catch (SystemException)
+                {
+                    // Try the next form.
+                }
+            }
+
+            return null;
+        }
+        catch (IdentityNotMappedException)
+        {
+            return null;
+        }
+        catch (SystemException)
+        {
+            return null;
+        }
+    }
+}

--- a/TiaMcpServer/Program.cs
+++ b/TiaMcpServer/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using TiaMcpServer.Cli;
 using TiaMcpServer.Contracts;
 using TiaMcpServer.Safety;
 using TiaMcpServer.Worker;
@@ -10,8 +11,13 @@ namespace TiaMcpServer
 {
     internal static class Program
     {
-        private static async Task Main(string[] args)
+        private static async Task<int> Main(string[] args)
         {
+            if (args.Length > 0 && string.Equals(args[0], "doctor", StringComparison.OrdinalIgnoreCase))
+            {
+                return await DoctorCommand.RunAsync(args[1..]);
+            }
+
             var builder = Host.CreateApplicationBuilder(args);
             builder.Logging.AddConsole(opts => opts.LogToStandardErrorThreshold = LogLevel.Trace);
             builder.Services.AddSingleton(new ProjectSessionBinding(ResolveStartupProjectPath(args)));
@@ -21,6 +27,7 @@ namespace TiaMcpServer
                 sp.GetRequiredService<ILogger<OpennessWorkerClient>>()));
             builder.Services.AddMcpServer().WithStdioServerTransport().WithToolsFromAssembly();
             await builder.Build().RunAsync();
+            return 0;
         }
 
         private static string? ResolveStartupProjectPath(string[] args)

--- a/TiaMcpServer/TiaMcpServer.csproj
+++ b/TiaMcpServer/TiaMcpServer.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TiaMcpServer/TiaMcpServer.csproj
+++ b/TiaMcpServer/TiaMcpServer.csproj
@@ -34,7 +34,7 @@
   <Target Name="CopyOpennessWorker" AfterTargets="Build">
     <ItemGroup>
       <OpennessWorkerFiles Include="..\TiaMcpServer.OpennessWorker\bin\$(Configuration)\net48\**\*.*"
-                           Exclude="..\TiaMcpServer.OpennessWorker\bin\$(Configuration)\net48\Siemens.Engineering*.dll" />
+                           Exclude="..\TiaMcpServer.OpennessWorker\bin\$(Configuration)\net48\Siemens.Engineering*.dll;..\TiaMcpServer.OpennessWorker\bin\$(Configuration)\net48\**\*.runtimeconfig.json" />
     </ItemGroup>
     <Copy SourceFiles="@(OpennessWorkerFiles)"
           DestinationFiles="@(OpennessWorkerFiles->'$(OutputPath)openness-worker\%(RecursiveDir)%(Filename)%(Extension)')"
@@ -44,19 +44,18 @@
   <Target Name="CopyOpennessWorkerToPublish" AfterTargets="Publish">
     <ItemGroup>
       <OpennessWorkerFiles Include="..\TiaMcpServer.OpennessWorker\bin\$(Configuration)\net48\**\*.*"
-                           Exclude="..\TiaMcpServer.OpennessWorker\bin\$(Configuration)\net48\Siemens.Engineering*.dll" />
+                           Exclude="..\TiaMcpServer.OpennessWorker\bin\$(Configuration)\net48\Siemens.Engineering*.dll;..\TiaMcpServer.OpennessWorker\bin\$(Configuration)\net48\**\*.runtimeconfig.json" />
     </ItemGroup>
     <Copy SourceFiles="@(OpennessWorkerFiles)"
           DestinationFiles="@(OpennessWorkerFiles->'$(PublishDir)openness-worker\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
 
-  <Target Name="PackOpennessWorker" AfterTargets="PackTool" Condition="'$(PackAsTool)' == 'true'">
-    <ItemGroup>
-      <OpennessWorkerPackageFiles Include="$(OutputPath)openness-worker\**\*.*" />
-      <TfmSpecificPackageFile Include="@(OpennessWorkerPackageFiles)">
-        <PackagePath>tools/$(_NuGetShortFolderName)/any/openness-worker/%(OpennessWorkerPackageFiles.RecursiveDir)%(Filename)%(Extension)</PackagePath>
-      </TfmSpecificPackageFile>
-    </ItemGroup>
+  <Target Name="RemoveStaleOpennessWorkerRuntimeConfig"
+          BeforeTargets="CopyOpennessWorker;CopyOpennessWorkerToPublish;PackTool">
+    <Delete Files="$(OutputPath)openness-worker\TiaMcpServer.OpennessWorker.runtimeconfig.json" />
+    <Delete Files="$(PublishDir)openness-worker\TiaMcpServer.OpennessWorker.runtimeconfig.json"
+            Condition="'$(PublishDir)' != ''" />
   </Target>
+
 </Project>

--- a/TiaMcpServer/Worker/OpennessWorkerClient.cs
+++ b/TiaMcpServer/Worker/OpennessWorkerClient.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using TiaMcpServer.Contracts;
+using TiaMcpServer.Diagnostics;
 
 namespace TiaMcpServer.Worker;
 
@@ -800,38 +801,6 @@ public class OpennessWorkerClient : IDisposable
     }
 
     private static string LocateWorkerExecutable()
-    {
-        var packagedPath = Path.Combine(AppContext.BaseDirectory, "openness-worker", "TiaMcpServer.OpennessWorker.exe");
-        if (File.Exists(packagedPath))
-        {
-            return packagedPath;
-        }
-
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null)
-        {
-            foreach (var configuration in new[] { "Debug", "Release" })
-            {
-                var candidatePath = Path.Combine(
-                    directory.FullName,
-                    "TiaMcpServer.OpennessWorker",
-                    "bin",
-                    configuration,
-                    "net48",
-                    "TiaMcpServer.OpennessWorker.exe");
-
-                if (File.Exists(candidatePath))
-                {
-                    return candidatePath;
-                }
-            }
-
-            directory = directory.Parent;
-        }
-
-        throw new FileNotFoundException(
-            "TIA Openness worker executable was not found. Build the solution and ensure the openness-worker folder is beside the MCP server executable.",
-            packagedPath);
-    }
+        => OpennessWorkerLocator.LocateOrThrow(AppContext.BaseDirectory, FileSystemService.Instance);
 
 }

--- a/TiaMcpServer/Worker/OpennessWorkerLocator.cs
+++ b/TiaMcpServer/Worker/OpennessWorkerLocator.cs
@@ -1,0 +1,74 @@
+using TiaMcpServer.Diagnostics;
+
+namespace TiaMcpServer.Worker;
+
+
+public sealed record WorkerCandidate(string Path, bool Exists);
+
+public sealed record WorkerLocationResult(
+    bool Found,
+    string? SelectedPath,
+    IReadOnlyList<WorkerCandidate> Candidates);
+
+/// <summary>
+/// Resolves the TIA Openness worker executable. Extracted from
+/// <see cref="OpennessWorkerClient"/> so the doctor command and the runtime share one
+/// resolution path. The runtime throws on miss; the doctor command treats a miss as a
+/// failed check.
+/// </summary>
+public static class OpennessWorkerLocator
+{
+    private const string WorkerExecutableName = "TiaMcpServer.OpennessWorker.exe";
+    private const string WorkerFolderName = "openness-worker";
+
+    public static WorkerLocationResult Locate(string baseDirectory, IFileSystemService fileSystem)
+    {
+        var candidates = new List<WorkerCandidate>();
+
+        var packagedPath = Path.Combine(baseDirectory, WorkerFolderName, WorkerExecutableName);
+        candidates.Add(new WorkerCandidate(packagedPath, fileSystem.FileExists(packagedPath)));
+        if (fileSystem.FileExists(packagedPath))
+        {
+            return new WorkerLocationResult(true, packagedPath, candidates);
+        }
+
+        var directory = new DirectoryInfo(baseDirectory);
+        while (directory is not null)
+        {
+            foreach (var configuration in new[] { "Debug", "Release" })
+            {
+                var candidatePath = Path.Combine(
+                    directory.FullName,
+                    "TiaMcpServer.OpennessWorker",
+                    "bin",
+                    configuration,
+                    "net48",
+                    WorkerExecutableName);
+
+                candidates.Add(new WorkerCandidate(candidatePath, fileSystem.FileExists(candidatePath)));
+                if (fileSystem.FileExists(candidatePath))
+                {
+                    return new WorkerLocationResult(true, candidatePath, candidates);
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return new WorkerLocationResult(false, null, candidates);
+    }
+
+    public static string LocateOrThrow(string baseDirectory, IFileSystemService fileSystem)
+    {
+        var result = Locate(baseDirectory, fileSystem);
+        if (result.Found)
+        {
+            return result.SelectedPath!;
+        }
+
+        var inspected = string.Join("; ", result.Candidates.Select(c => c.Path));
+        throw new FileNotFoundException(
+            "TIA Openness worker executable was not found. Build the solution and ensure the openness-worker folder is beside the MCP server executable. Inspected: " + inspected,
+            result.Candidates.FirstOrDefault()?.Path ?? WorkerExecutableName);
+    }
+}

--- a/TiaMcpServer/Worker/TiaPortalInstallationLocator.cs
+++ b/TiaMcpServer/Worker/TiaPortalInstallationLocator.cs
@@ -6,14 +6,21 @@ namespace TiaMcpServer.Worker;
 
 public sealed record TiaPortalCandidate(
     string Path,
+    string InstallationPath,
     string Source,
+    bool InstallationPresent,
+    bool DirectoryPresent,
     bool AssembliesPresent,
     IReadOnlyList<string> MissingAssemblies);
 
 public sealed record TiaPortalInstallationResult(
     bool Found,
     string? SelectedPath,
+    string? SelectedInstallationPath,
     string? Source,
+    bool OpennessFound,
+    string? SelectedOpennessPath,
+    string? OpennessSource,
     IReadOnlyList<TiaPortalCandidate> Candidates);
 
 /// <summary>
@@ -24,7 +31,8 @@ public sealed record TiaPortalInstallationResult(
 /// 2. <c>TiaPortalLocation</c> environment variable (Portal root; <c>PublicAPI\V21\net48</c> appended).
 /// 3. Siemens installation registry key <c>INSTALLPATH</c> (64- then 32-bit view).
 /// 4. Default install path.
-/// A candidate is only accepted when the required Openness assemblies are present.
+/// The first existing directory is selected as the installation. Assembly completeness is
+/// retained separately so the installation and Openness-assembly diagnostics stay distinct.
 /// </summary>
 public static class TiaPortalInstallationLocator
 {
@@ -40,8 +48,8 @@ public static class TiaPortalInstallationLocator
         @"SOFTWARE\Siemens\Automation\InstalledApps\Totally Integrated Automation Portal V21";
     private const string RegistryInstallValueName = "INSTALLPATH";
     private const string PublicApiSuffix = @"PublicAPI\V21\net48";
-    private const string StandardOpennessInstallPath =
-        @"C:\Program Files\Siemens\Automation\Portal V21\PublicAPI\V21\net48";
+    private const string StandardPortalInstallPath =
+        @"C:\Program Files\Siemens\Automation\Portal V21";
 
     public static TiaPortalInstallationResult Locate(
         IEnvironmentVariableService env,
@@ -54,7 +62,7 @@ public static class TiaPortalInstallationLocator
         if (!string.IsNullOrWhiteSpace(envV21Dir))
         {
             var path = envV21Dir!.Trim().Trim('"');
-            AddCandidate(candidates, fileSystem, path, $"env:{TiaPortalV21DirEnvironmentVariable}");
+            AddCandidate(candidates, fileSystem, path, path, $"env:{TiaPortalV21DirEnvironmentVariable}");
         }
 
         var envLocation = env.Get(TiaPortalLocationEnvironmentVariable);
@@ -62,58 +70,82 @@ public static class TiaPortalInstallationLocator
         {
             var root = envLocation!.Trim().Trim('"');
             var path = Path.Combine(root, PublicApiSuffix);
-            AddCandidate(candidates, fileSystem, path, $"env:{TiaPortalLocationEnvironmentVariable}");
+            AddCandidate(candidates, fileSystem, root, path, $"env:{TiaPortalLocationEnvironmentVariable}");
         }
 
-        foreach (var view in new[] { RegistryView.Registry64, RegistryView.Registry32 })
+        if (OperatingSystem.IsWindows())
         {
-            var installPath = registry.GetStringValue(
-                RegistryHive.LocalMachine,
-                view,
-                TiaPortalV21RegistrySubKey,
-                RegistryInstallValueName);
-
-            if (!string.IsNullOrWhiteSpace(installPath))
+            foreach (var view in new[] { RegistryView.Registry64, RegistryView.Registry32 })
             {
-                var path = Path.Combine(installPath!, PublicApiSuffix);
-                AddCandidate(candidates, fileSystem, path, $"registry:{view}");
+                var installPath = registry.GetStringValue(
+                    RegistryHive.LocalMachine,
+                    view,
+                    TiaPortalV21RegistrySubKey,
+                    RegistryInstallValueName);
+
+                if (!string.IsNullOrWhiteSpace(installPath))
+                {
+                    var root = installPath!.Trim().Trim('"');
+                    var path = Path.Combine(root, PublicApiSuffix);
+                    AddCandidate(candidates, fileSystem, root, path, $"registry:{view}");
+                }
             }
         }
 
-        AddCandidate(candidates, fileSystem, StandardOpennessInstallPath, "default");
+        AddCandidate(
+            candidates,
+            fileSystem,
+            StandardPortalInstallPath,
+            Path.Combine(StandardPortalInstallPath, PublicApiSuffix),
+            "default");
 
-        var selected = candidates.FirstOrDefault(c => c.AssembliesPresent);
+        var selected = candidates.FirstOrDefault(c => c.InstallationPresent);
+        var selectedOpenness = candidates.FirstOrDefault(c => c.AssembliesPresent);
         return new TiaPortalInstallationResult(
             selected is not null,
             selected?.Path,
+            selected?.InstallationPath,
             selected?.Source,
+            selectedOpenness is not null,
+            selectedOpenness?.Path,
+            selectedOpenness?.Source,
             candidates);
     }
 
     private static void AddCandidate(
         List<TiaPortalCandidate> candidates,
         IFileSystemService fileSystem,
-        string path,
+        string installationPath,
+        string apiPath,
         string source)
     {
         var missing = new List<string>();
-        var present = fileSystem.DirectoryExists(path);
-        if (present)
+        var installationPresent = fileSystem.DirectoryExists(installationPath);
+        var directoryPresent = fileSystem.DirectoryExists(apiPath);
+        var assembliesPresent = directoryPresent;
+        if (directoryPresent)
         {
             foreach (var assembly in RequiredAssemblies)
             {
-                if (!fileSystem.FileExists(Path.Combine(path, assembly)))
+                if (!fileSystem.FileExists(Path.Combine(apiPath, assembly)))
                 {
                     missing.Add(assembly);
                 }
             }
-            present = missing.Count == 0;
+            assembliesPresent = missing.Count == 0;
         }
         else
         {
             missing.AddRange(RequiredAssemblies);
         }
 
-        candidates.Add(new TiaPortalCandidate(path, source, present, missing));
+        candidates.Add(new TiaPortalCandidate(
+            apiPath,
+            installationPath,
+            source,
+            installationPresent,
+            directoryPresent,
+            assembliesPresent,
+            missing));
     }
 }

--- a/TiaMcpServer/Worker/TiaPortalInstallationLocator.cs
+++ b/TiaMcpServer/Worker/TiaPortalInstallationLocator.cs
@@ -1,0 +1,119 @@
+using Microsoft.Win32;
+using TiaMcpServer.Diagnostics;
+
+namespace TiaMcpServer.Worker;
+
+
+public sealed record TiaPortalCandidate(
+    string Path,
+    string Source,
+    bool AssembliesPresent,
+    IReadOnlyList<string> MissingAssemblies);
+
+public sealed record TiaPortalInstallationResult(
+    bool Found,
+    string? SelectedPath,
+    string? Source,
+    IReadOnlyList<TiaPortalCandidate> Candidates);
+
+/// <summary>
+/// Locates the TIA Portal V21 Openness API folder from the host (.NET 8) process.
+/// Mirrors the precedence of <c>TiaMcpServer.OpennessWorker.Openness.AssemblyResolver</c>
+/// (which lives in the net48 worker and cannot be referenced here):
+/// 1. <c>TiaPortalV21Dir</c> environment variable (used as-is, points at the net48 API folder).
+/// 2. <c>TiaPortalLocation</c> environment variable (Portal root; <c>PublicAPI\V21\net48</c> appended).
+/// 3. Siemens installation registry key <c>INSTALLPATH</c> (64- then 32-bit view).
+/// 4. Default install path.
+/// A candidate is only accepted when the required Openness assemblies are present.
+/// </summary>
+public static class TiaPortalInstallationLocator
+{
+    public static readonly string[] RequiredAssemblies =
+    {
+        "Siemens.Engineering.Base.dll",
+        "Siemens.Engineering.Step7.dll"
+    };
+
+    private const string TiaPortalV21DirEnvironmentVariable = "TiaPortalV21Dir";
+    private const string TiaPortalLocationEnvironmentVariable = "TiaPortalLocation";
+    private const string TiaPortalV21RegistrySubKey =
+        @"SOFTWARE\Siemens\Automation\InstalledApps\Totally Integrated Automation Portal V21";
+    private const string RegistryInstallValueName = "INSTALLPATH";
+    private const string PublicApiSuffix = @"PublicAPI\V21\net48";
+    private const string StandardOpennessInstallPath =
+        @"C:\Program Files\Siemens\Automation\Portal V21\PublicAPI\V21\net48";
+
+    public static TiaPortalInstallationResult Locate(
+        IEnvironmentVariableService env,
+        IRegistryService registry,
+        IFileSystemService fileSystem)
+    {
+        var candidates = new List<TiaPortalCandidate>();
+
+        var envV21Dir = env.Get(TiaPortalV21DirEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(envV21Dir))
+        {
+            var path = envV21Dir!.Trim().Trim('"');
+            AddCandidate(candidates, fileSystem, path, $"env:{TiaPortalV21DirEnvironmentVariable}");
+        }
+
+        var envLocation = env.Get(TiaPortalLocationEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(envLocation))
+        {
+            var root = envLocation!.Trim().Trim('"');
+            var path = Path.Combine(root, PublicApiSuffix);
+            AddCandidate(candidates, fileSystem, path, $"env:{TiaPortalLocationEnvironmentVariable}");
+        }
+
+        foreach (var view in new[] { RegistryView.Registry64, RegistryView.Registry32 })
+        {
+            var installPath = registry.GetStringValue(
+                RegistryHive.LocalMachine,
+                view,
+                TiaPortalV21RegistrySubKey,
+                RegistryInstallValueName);
+
+            if (!string.IsNullOrWhiteSpace(installPath))
+            {
+                var path = Path.Combine(installPath!, PublicApiSuffix);
+                AddCandidate(candidates, fileSystem, path, $"registry:{view}");
+            }
+        }
+
+        AddCandidate(candidates, fileSystem, StandardOpennessInstallPath, "default");
+
+        var selected = candidates.FirstOrDefault(c => c.AssembliesPresent);
+        return new TiaPortalInstallationResult(
+            selected is not null,
+            selected?.Path,
+            selected?.Source,
+            candidates);
+    }
+
+    private static void AddCandidate(
+        List<TiaPortalCandidate> candidates,
+        IFileSystemService fileSystem,
+        string path,
+        string source)
+    {
+        var missing = new List<string>();
+        var present = fileSystem.DirectoryExists(path);
+        if (present)
+        {
+            foreach (var assembly in RequiredAssemblies)
+            {
+                if (!fileSystem.FileExists(Path.Combine(path, assembly)))
+                {
+                    missing.Add(assembly);
+                }
+            }
+            present = missing.Count == 0;
+        }
+        else
+        {
+            missing.AddRange(RequiredAssemblies);
+        }
+
+        candidates.Add(new TiaPortalCandidate(path, source, present, missing));
+    }
+}

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - tia-portal-mcp  (2026-07-17)
+# Graph Report - tia-portal-mcp  (2026-07-19)
 
 ## Corpus Check
-- 101 files · ~34,420 words
+- 156 files · ~44,964 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 1025 nodes · 1601 edges · 109 communities (11 shown, 98 thin omitted)
+- 1336 nodes · 1975 edges · 153 communities (21 shown, 132 thin omitted)
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS · INFERRED: 2 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `52e114ae`
+- Built from commit: `6a9574bf`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -85,6 +85,7 @@
 - [[_COMMUNITY_Community 67|Community 67]]
 - [[_COMMUNITY_Community 68|Community 68]]
 - [[_COMMUNITY_Community 69|Community 69]]
+- [[_COMMUNITY_Community 70|Community 70]]
 - [[_COMMUNITY_Community 71|Community 71]]
 - [[_COMMUNITY_Community 72|Community 72]]
 - [[_COMMUNITY_Community 73|Community 73]]
@@ -118,24 +119,64 @@
 - [[_COMMUNITY_Community 101|Community 101]]
 - [[_COMMUNITY_Community 102|Community 102]]
 - [[_COMMUNITY_Community 103|Community 103]]
-- [[_COMMUNITY_Community 104|Community 104]]
 - [[_COMMUNITY_Community 105|Community 105]]
+- [[_COMMUNITY_Community 106|Community 106]]
 - [[_COMMUNITY_Community 107|Community 107]]
 - [[_COMMUNITY_Community 108|Community 108]]
+- [[_COMMUNITY_Community 109|Community 109]]
+- [[_COMMUNITY_Community 110|Community 110]]
+- [[_COMMUNITY_Community 111|Community 111]]
+- [[_COMMUNITY_Community 112|Community 112]]
+- [[_COMMUNITY_Community 113|Community 113]]
+- [[_COMMUNITY_Community 114|Community 114]]
+- [[_COMMUNITY_Community 115|Community 115]]
+- [[_COMMUNITY_Community 116|Community 116]]
+- [[_COMMUNITY_Community 117|Community 117]]
+- [[_COMMUNITY_Community 118|Community 118]]
+- [[_COMMUNITY_Community 119|Community 119]]
+- [[_COMMUNITY_Community 120|Community 120]]
+- [[_COMMUNITY_Community 121|Community 121]]
+- [[_COMMUNITY_Community 122|Community 122]]
+- [[_COMMUNITY_Community 123|Community 123]]
+- [[_COMMUNITY_Community 124|Community 124]]
+- [[_COMMUNITY_Community 125|Community 125]]
+- [[_COMMUNITY_Community 126|Community 126]]
+- [[_COMMUNITY_Community 127|Community 127]]
+- [[_COMMUNITY_Community 128|Community 128]]
+- [[_COMMUNITY_Community 129|Community 129]]
+- [[_COMMUNITY_Community 130|Community 130]]
+- [[_COMMUNITY_Community 131|Community 131]]
+- [[_COMMUNITY_Community 132|Community 132]]
+- [[_COMMUNITY_Community 133|Community 133]]
+- [[_COMMUNITY_Community 134|Community 134]]
+- [[_COMMUNITY_Community 135|Community 135]]
+- [[_COMMUNITY_Community 136|Community 136]]
+- [[_COMMUNITY_Community 137|Community 137]]
+- [[_COMMUNITY_Community 138|Community 138]]
+- [[_COMMUNITY_Community 139|Community 139]]
+- [[_COMMUNITY_Community 140|Community 140]]
+- [[_COMMUNITY_Community 141|Community 141]]
+- [[_COMMUNITY_Community 142|Community 142]]
+- [[_COMMUNITY_Community 143|Community 143]]
+- [[_COMMUNITY_Community 144|Community 144]]
+- [[_COMMUNITY_Community 151|Community 151]]
+- [[_COMMUNITY_Community 152|Community 152]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `OpennessWorkerClient` - 56 edges
 2. `Program` - 46 edges
 3. `BatchOperationCatalogTests` - 28 edges
-4. `HardwareConfigReader` - 20 edges
-5. `OpennessWorkerClientIntegrationTests` - 20 edges
-6. `ProjectLifecycleTools` - 18 edges
-7. `PersistentWorkerTransport` - 18 edges
-8. `BatchPayloadBudget` - 16 edges
-9. `WriteSafetyService` - 16 edges
-10. `CompileChecker` - 16 edges
+4. `string` - 26 edges
+5. `HardwareConfigReader` - 20 edges
+6. `OpennessWorkerClientIntegrationTests` - 20 edges
+7. `ProjectLifecycleTools` - 18 edges
+8. `PersistentWorkerTransport` - 18 edges
+9. `BatchPayloadBudget` - 16 edges
+10. `WriteSafetyService` - 16 edges
 
 ## Surprising Connections (you probably didn't know these)
+- `BatchOperationCatalog` --references--> `int`  [EXTRACTED]
+  TiaMcpServer/Batch/BatchOperationCatalog.cs → TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs
 - `BatchPayloadBudget` --references--> `int`  [EXTRACTED]
   TiaMcpServer/Batch/BatchPayloadBudget.cs → TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs
 - `OpennessWorkerClient` --references--> `int`  [EXTRACTED]
@@ -143,67 +184,85 @@
 - `PersistentWorkerTransport` --references--> `int`  [EXTRACTED]
   TiaMcpServer/Worker/PersistentWorkerTransport.cs → TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs
 - `BatchOperationStatus` --references--> `string`  [EXTRACTED]
-  TiaMcpServer/Batch/BatchOperationResult.cs → TiaMcpServer.Tests/BatchSafetyTokenTests.cs
-- `WriteSafetyService` --references--> `string`  [EXTRACTED]
-  TiaMcpServer/Safety/WriteSafetyService.cs → TiaMcpServer.Tests/BatchSafetyTokenTests.cs
+  TiaMcpServer/Batch/BatchOperationResult.cs → TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs
 
-## Communities (109 total, 98 thin omitted)
+## Communities (153 total, 132 thin omitted)
 
 ### Community 0 - "Community 0"
-Cohesion: 0.09
-Nodes (4): object, PersistentWorkerTransport, ProjectSessionBinding, OpennessWorkerClient
+Cohesion: 0.06
+Nodes (13): bool, ConcurrentQueue, IDisposable, ILogger, object, PersistentWorkerTransport, Process, ProjectSessionBinding (+5 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.08
-Nodes (8): BatchOperationStatus, BatchSafetySnapshot, BatchTools, BlockImporter, string, ArchiveModeNames, ProjectSessionBinding, BatchSafetyTokenTests
+Cohesion: 0.05
+Nodes (12): BatchOperationStatus, BatchSafetySnapshot, BatchTools, DoctorCliParser, DoctorCommand, DotNetFrameworkCheckTests, string, ArchiveModeNames (+4 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.04
 Nodes (45): Architecture, Block Paths, Build From Source, code:text (C:\Program Files\Siemens\Automation\Portal V21\PublicAPI\V21), code:powershell (dotnet run --project TiaMcpServer), code:powershell ('{ "method": "browse_project_tree", "projectPath": null }' |), code:json ({"success":true,"payload":"[...]"}), code:json ({"success":false,"error":"No running TIA Portal V21 instance) (+37 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.08
-Nodes (10): BatchResultFormatter, ConcurrentDictionary, Func, JsonSerializerOptions, Invalid(), Valid(), WriteSafetyService, BatchOperationRequestJsonTests (+2 more)
+Cohesion: 0.07
+Nodes (8): BatchResultFormatter, JsonSerializerOptions, Invalid(), Valid(), WriteSafetyTooling, BatchOperationRequestJsonTests, HardwareConfigInfoTests, WorkerResponseJsonTests
 
-### Community 5 - "Community 5"
-Cohesion: 0.12
-Nodes (8): BatchOperationCatalog, Invalid(), Valid(), int, IReadOnlyDictionary, IReadOnlyList, IReadOnlySet, EquipmentCatalogSearcher
+### Community 8 - "Community 8"
+Cohesion: 0.11
+Nodes (6): FakeApplicationInfoService, FakeEnvironmentVariableService, FakeFileSystemService, FakeRegistryService, Dictionary, HashSet
 
-### Community 6 - "Community 6"
-Cohesion: 0.1
-Nodes (11): bool, ConcurrentQueue, IDisposable, ILogger, TiaPortalSession, Process, SemaphoreSlim, Task (+3 more)
-
-### Community 10 - "Community 10"
+### Community 9 - "Community 9"
 Cohesion: 0.1
 Nodes (4): TagOperationsTool, TagTableOperationsTool, TiaMcpServer.Tools, UserConstantOperationsTool
 
-### Community 29 - "Community 29"
-Cohesion: 0.24
-Nodes (3): Invalid(), Valid(), WriteSafetyTooling
+### Community 10 - "Community 10"
+Cohesion: 0.16
+Nodes (7): BatchOperationCatalog, Invalid(), Valid(), DoctorRunner, IReadOnlyDictionary, IReadOnlyList, IReadOnlySet
 
-### Community 45 - "Community 45"
+### Community 19 - "Community 19"
+Cohesion: 0.32
+Nodes (4): ConcurrentDictionary, Invalid(), Valid(), WriteSafetyService
+
+### Community 25 - "Community 25"
+Cohesion: 0.16
+Nodes (6): OpennessAssembliesCheck, ProjectBindingCheck, TiaPortalInstallationCheck, EnvironmentVariableService, IEnvironmentVariableService, IRegistryService
+
+### Community 29 - "Community 29"
+Cohesion: 0.2
+Nodes (4): OpennessGroupCheck, FakeWindowsIdentityService, WindowsIdentityService, IWindowsIdentityService
+
+### Community 34 - "Community 34"
+Cohesion: 0.2
+Nodes (5): DotNetRuntimeCheck, HostWorkerVersionCheck, OpennessWorkerCheck, IApplicationInfoService, IFileSystemService
+
+### Community 48 - "Community 48"
+Cohesion: 0.25
+Nodes (5): OperatingSystemCheck, StubCheck, ThrowingCheck, DiagnosticStatus, IDiagnosticCheck
+
+### Community 50 - "Community 50"
+Cohesion: 0.25
+Nodes (4): TiaPortalProcessCheck, FakeProcessEnumerationService, ProcessEnumerationService, IProcessEnumerationService
+
+### Community 67 - "Community 67"
 Cohesion: 0.29
 Nodes (7): Model Context Protocol, Siemens TIA Openness User Group, Phase 1: Implementation, Phase 2: Universal Block Support, Phase 3: Hardware and Network Discovery, Phase 4: Advanced Diagnostics, tia-portal-mcp
 
 ## Knowledge Gaps
-- **68 isolated node(s):** `IReadOnlyList`, `IReadOnlyDictionary`, `IReadOnlySet`, `BatchOperationRequest`, `ConcurrentDictionary` (+63 more)
+- **68 isolated node(s):** `IReadOnlyDictionary`, `IReadOnlySet`, `BatchOperationRequest`, `IApplicationInfoService`, `ConcurrentDictionary` (+63 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **98 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **132 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `JsonSerializerOptions` connect `Community 4` to `Community 0`, `Community 2`, `Community 29`, `Community 6`?**
-  _High betweenness centrality (0.053) - this node is a cross-community bridge._
-- **Why does `string` connect `Community 1` to `Community 0`, `Community 4`, `Community 5`, `Community 6`, `Community 11`?**
-  _High betweenness centrality (0.039) - this node is a cross-community bridge._
-- **Why does `OpennessWorkerClient` connect `Community 0` to `Community 1`, `Community 4`, `Community 5`, `Community 6`?**
-  _High betweenness centrality (0.039) - this node is a cross-community bridge._
-- **What connects `IReadOnlyList`, `IReadOnlyDictionary`, `IReadOnlySet` to the rest of the system?**
+- **Why does `string` connect `Community 1` to `Community 0`, `Community 34`, `Community 35`, `Community 73`, `Community 11`, `Community 46`, `Community 50`, `Community 19`, `Community 52`, `Community 54`, `Community 23`, `Community 25`, `Community 90`, `Community 29`?**
+  _High betweenness centrality (0.100) - this node is a cross-community bridge._
+- **Why does `JsonSerializerOptions` connect `Community 4` to `Community 0`, `Community 2`, `Community 19`?**
+  _High betweenness centrality (0.048) - this node is a cross-community bridge._
+- **Why does `OpennessWorkerClient` connect `Community 0` to `Community 1`, `Community 90`, `Community 4`?**
+  _High betweenness centrality (0.047) - this node is a cross-community bridge._
+- **What connects `IReadOnlyDictionary`, `IReadOnlySet`, `BatchOperationRequest` to the rest of the system?**
   _68 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.09 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.08 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.05 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
   _Cohesion score 0.04 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -4,48 +4,57 @@
   "graph": {},
   "nodes": [
     {
+      "label": "verify-doctor-package.ps1",
+      "file_type": "code",
+      "source_file": "scripts/verify-doctor-package.ps1",
+      "source_location": "L1",
+      "id": "scripts_verify_doctor_package_ps1",
+      "community": 145,
+      "norm_label": "verify-doctor-package.ps1"
+    },
+    {
       "label": "Program.cs",
       "file_type": "code",
       "source_file": "TiaMcpServer/Program.cs",
       "source_location": "L1",
       "id": "tiamcpserver_program_cs",
-      "community": 38,
+      "community": 57,
       "norm_label": "program.cs"
     },
     {
       "label": "TiaMcpServer",
       "file_type": "code",
       "source_file": "TiaMcpServer/Program.cs",
-      "source_location": "L9",
+      "source_location": "L10",
       "id": "tiamcpserver_program_tiamcpserver",
-      "community": 38,
+      "community": 57,
       "norm_label": "tiamcpserver"
     },
     {
       "label": "Program",
       "file_type": "code",
       "source_file": "TiaMcpServer/Program.cs",
-      "source_location": "L11",
+      "source_location": "L12",
       "id": "tiamcpserver_program_program",
-      "community": 38,
+      "community": 57,
       "norm_label": "program"
     },
     {
       "label": ".Main()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Program.cs",
-      "source_location": "L13",
+      "source_location": "L14",
       "id": "tiamcpserver_program_program_main",
-      "community": 38,
+      "community": 57,
       "norm_label": ".main()"
     },
     {
       "label": ".ResolveStartupProjectPath()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Program.cs",
-      "source_location": "L26",
+      "source_location": "L33",
       "id": "tiamcpserver_program_program_resolvestartupprojectpath",
-      "community": 38,
+      "community": 57,
       "norm_label": ".resolvestartupprojectpath()"
     },
     {
@@ -54,7 +63,7 @@
       "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
       "source_location": "L1",
       "id": "tiamcpserver_batch_batchexecutionengine_cs",
-      "community": 46,
+      "community": 68,
       "norm_label": "batchexecutionengine.cs"
     },
     {
@@ -63,7 +72,7 @@
       "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
       "source_location": "L10",
       "id": "batch_batchexecutionengine_batchexecutionengine",
-      "community": 46,
+      "community": 68,
       "norm_label": "batchexecutionengine"
     },
     {
@@ -72,7 +81,7 @@
       "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
       "source_location": "L13",
       "id": "batch_batchexecutionengine_batchexecutionengine_executereadsasync",
-      "community": 46,
+      "community": 68,
       "norm_label": ".executereadsasync()"
     },
     {
@@ -81,7 +90,7 @@
       "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
       "source_location": "L28",
       "id": "batch_batchexecutionengine_batchexecutionengine_applywritesasync",
-      "community": 46,
+      "community": 68,
       "norm_label": ".applywritesasync()"
     },
     {
@@ -90,7 +99,7 @@
       "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
       "source_location": "L50",
       "id": "batch_batchexecutionengine_batchexecutionengine_tooperationresult",
-      "community": 46,
+      "community": 68,
       "norm_label": ".tooperationresult()"
     },
     {
@@ -99,7 +108,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L1",
       "id": "tiamcpserver_batch_batchoperationcatalog_cs",
-      "community": 5,
+      "community": 10,
       "norm_label": "batchoperationcatalog.cs"
     },
     {
@@ -108,7 +117,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L18",
       "id": "batch_batchoperationcatalog_valid",
-      "community": 5,
+      "community": 10,
       "norm_label": "valid()"
     },
     {
@@ -117,7 +126,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L20",
       "id": "batch_batchoperationcatalog_invalid",
-      "community": 5,
+      "community": 10,
       "norm_label": "invalid()"
     },
     {
@@ -126,7 +135,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L28",
       "id": "batch_batchoperationcatalog_batchoperationcatalog",
-      "community": 5,
+      "community": 10,
       "norm_label": "batchoperationcatalog"
     },
     {
@@ -135,16 +144,16 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L13",
       "id": "int",
-      "community": 5,
+      "community": 90,
       "norm_label": "int"
     },
     {
       "label": "IReadOnlyList",
       "file_type": "code",
-      "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
-      "source_location": "L32",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorRunner.cs",
+      "source_location": "L6",
       "id": "ireadonlylist",
-      "community": 5,
+      "community": 10,
       "norm_label": "ireadonlylist"
     },
     {
@@ -153,7 +162,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L34",
       "id": "ireadonlydictionary",
-      "community": 5,
+      "community": 10,
       "norm_label": "ireadonlydictionary"
     },
     {
@@ -162,7 +171,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L42",
       "id": "ireadonlyset",
-      "community": 5,
+      "community": 10,
       "norm_label": "ireadonlyset"
     },
     {
@@ -171,7 +180,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L52",
       "id": "batch_batchoperationcatalog_batchoperationcatalog_trygetspec",
-      "community": 5,
+      "community": 10,
       "norm_label": ".trygetspec()"
     },
     {
@@ -180,7 +189,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L55",
       "id": "batch_batchoperationcatalog_batchoperationcatalog_validatereadbatch",
-      "community": 5,
+      "community": 10,
       "norm_label": ".validatereadbatch()"
     },
     {
@@ -189,7 +198,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L58",
       "id": "batch_batchoperationcatalog_batchoperationcatalog_validatewritebatch",
-      "community": 5,
+      "community": 10,
       "norm_label": ".validatewritebatch()"
     },
     {
@@ -198,7 +207,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L61",
       "id": "batch_batchoperationcatalog_batchoperationcatalog_validate",
-      "community": 5,
+      "community": 10,
       "norm_label": ".validate()"
     },
     {
@@ -207,7 +216,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L142",
       "id": "batch_batchoperationcatalog_batchoperationcatalog_resolvespec",
-      "community": 5,
+      "community": 10,
       "norm_label": ".resolvespec()"
     },
     {
@@ -216,7 +225,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L173",
       "id": "batch_batchoperationcatalog_batchoperationcatalog_isfieldpresent",
-      "community": 5,
+      "community": 10,
       "norm_label": ".isfieldpresent()"
     },
     {
@@ -225,7 +234,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L188",
       "id": "batch_batchoperationcatalog_batchoperationcatalog_validatebounds",
-      "community": 5,
+      "community": 10,
       "norm_label": ".validatebounds()"
     },
     {
@@ -234,7 +243,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L221",
       "id": "batch_batchoperationcatalog_batchoperationcatalog_namesbycategory",
-      "community": 5,
+      "community": 10,
       "norm_label": ".namesbycategory()"
     },
     {
@@ -243,7 +252,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationCatalog.cs",
       "source_location": "L224",
       "id": "batch_batchoperationcatalog_batchoperationcatalog_buildspecs",
-      "community": 5,
+      "community": 10,
       "norm_label": ".buildspecs()"
     },
     {
@@ -252,7 +261,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationRequest.cs",
       "source_location": "L1",
       "id": "tiamcpserver_batch_batchoperationrequest_cs",
-      "community": 98,
+      "community": 136,
       "norm_label": "batchoperationrequest.cs"
     },
     {
@@ -261,7 +270,7 @@
       "source_file": "TiaMcpServer/Batch/BatchOperationRequest.cs",
       "source_location": "L11",
       "id": "batch_batchoperationrequest_batchoperationrequest",
-      "community": 98,
+      "community": 136,
       "norm_label": "batchoperationrequest"
     },
     {
@@ -285,8 +294,8 @@
     {
       "label": "string",
       "file_type": "code",
-      "source_file": "TiaMcpServer.Tests/BatchSafetyTokenTests.cs",
-      "source_location": "L16",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L10",
       "id": "string",
       "community": 1,
       "norm_label": "string"
@@ -621,7 +630,7 @@
       "source_file": "TiaMcpServer/Batch/BatchWorkerInvoker.cs",
       "source_location": "L1",
       "id": "tiamcpserver_batch_batchworkerinvoker_cs",
-      "community": 56,
+      "community": 79,
       "norm_label": "batchworkerinvoker.cs"
     },
     {
@@ -630,7 +639,7 @@
       "source_file": "TiaMcpServer/Batch/BatchWorkerInvoker.cs",
       "source_location": "L10",
       "id": "batch_batchworkerinvoker_batchworkerinvoker",
-      "community": 56,
+      "community": 79,
       "norm_label": "batchworkerinvoker"
     },
     {
@@ -639,7 +648,7 @@
       "source_file": "TiaMcpServer/Batch/BatchWorkerInvoker.cs",
       "source_location": "L13",
       "id": "batch_batchworkerinvoker_batchworkerinvoker_readcurrentstateasync",
-      "community": 56,
+      "community": 79,
       "norm_label": ".readcurrentstateasync()"
     },
     {
@@ -648,7 +657,7 @@
       "source_file": "TiaMcpServer/Batch/BatchWorkerInvoker.cs",
       "source_location": "L32",
       "id": "batch_batchworkerinvoker_batchworkerinvoker_invokeasync",
-      "community": 56,
+      "community": 79,
       "norm_label": ".invokeasync()"
     },
     {
@@ -657,8 +666,1088 @@
       "source_file": "TiaMcpServer/Batch/BatchWorkerInvoker.cs",
       "source_location": "L66",
       "id": "batch_batchworkerinvoker_batchworkerinvoker_resolvedeviceitemname",
-      "community": 56,
+      "community": 79,
       "norm_label": ".resolvedeviceitemname()"
+    },
+    {
+      "label": "DoctorCliParser.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Cli/DoctorCliParser.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_cli_doctorcliparser_cs",
+      "community": 1,
+      "norm_label": "doctorcliparser.cs"
+    },
+    {
+      "label": "DoctorCliParser",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Cli/DoctorCliParser.cs",
+      "source_location": "L11",
+      "id": "cli_doctorcliparser_doctorcliparser",
+      "community": 1,
+      "norm_label": "doctorcliparser"
+    },
+    {
+      "label": ".Parse()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Cli/DoctorCliParser.cs",
+      "source_location": "L19",
+      "id": "cli_doctorcliparser_doctorcliparser_parse",
+      "community": 1,
+      "norm_label": ".parse()"
+    },
+    {
+      "label": "DoctorCommand.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Cli/DoctorCommand.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_cli_doctorcommand_cs",
+      "community": 1,
+      "norm_label": "doctorcommand.cs"
+    },
+    {
+      "label": "DoctorCommand",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Cli/DoctorCommand.cs",
+      "source_location": "L8",
+      "id": "cli_doctorcommand_doctorcommand",
+      "community": 1,
+      "norm_label": "doctorcommand"
+    },
+    {
+      "label": ".RunAsync()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Cli/DoctorCommand.cs",
+      "source_location": "L25",
+      "id": "cli_doctorcommand_doctorcommand_runasync",
+      "community": 1,
+      "norm_label": ".runasync()"
+    },
+    {
+      "label": ".BuildRunner()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Cli/DoctorCommand.cs",
+      "source_location": "L88",
+      "id": "cli_doctorcommand_doctorcommand_buildrunner",
+      "community": 1,
+      "norm_label": ".buildrunner()"
+    },
+    {
+      "label": "ApplicationInfoService.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_applicationinfoservice_cs",
+      "community": 73,
+      "norm_label": "applicationinfoservice.cs"
+    },
+    {
+      "label": "ApplicationInfoService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L8",
+      "id": "diagnostics_applicationinfoservice_applicationinfoservice",
+      "community": 73,
+      "norm_label": "applicationinfoservice"
+    },
+    {
+      "label": "IApplicationInfoService",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "id": "iapplicationinfoservice",
+      "community": 34,
+      "norm_label": "iapplicationinfoservice"
+    },
+    {
+      "label": "IRegistryService",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "id": "iregistryservice",
+      "community": 25,
+      "norm_label": "iregistryservice"
+    },
+    {
+      "label": "Func",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
+      "source_location": "L21",
+      "id": "func",
+      "community": 73,
+      "norm_label": "func"
+    },
+    {
+      "label": ".GetWindowsProductName()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L87",
+      "id": "diagnostics_applicationinfoservice_applicationinfoservice_getwindowsproductname",
+      "community": 73,
+      "norm_label": ".getwindowsproductname()"
+    },
+    {
+      "label": ".NormalizeWindowsProductName()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L113",
+      "id": "diagnostics_applicationinfoservice_applicationinfoservice_normalizewindowsproductname",
+      "community": 73,
+      "norm_label": ".normalizewindowsproductname()"
+    },
+    {
+      "label": ".IsWindows11OrLater()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L118",
+      "id": "diagnostics_applicationinfoservice_applicationinfoservice_iswindows11orlater",
+      "community": 73,
+      "norm_label": ".iswindows11orlater()"
+    },
+    {
+      "label": "DiagnosticCheckResult.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DiagnosticCheckResult.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_diagnosticcheckresult_cs",
+      "community": 146,
+      "norm_label": "diagnosticcheckresult.cs"
+    },
+    {
+      "label": "DiagnosticStatus.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DiagnosticStatus.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_diagnosticstatus_cs",
+      "community": 147,
+      "norm_label": "diagnosticstatus.cs"
+    },
+    {
+      "label": "DoctorJsonRenderer.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_doctorjsonrenderer_cs",
+      "community": 80,
+      "norm_label": "doctorjsonrenderer.cs"
+    },
+    {
+      "label": "DoctorJsonRenderer",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs",
+      "source_location": "L6",
+      "id": "diagnostics_doctorjsonrenderer_doctorjsonrenderer",
+      "community": 80,
+      "norm_label": "doctorjsonrenderer"
+    },
+    {
+      "label": ".Render()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs",
+      "source_location": "L8",
+      "id": "diagnostics_doctorjsonrenderer_doctorjsonrenderer_render",
+      "community": 80,
+      "norm_label": ".render()"
+    },
+    {
+      "label": ".StatusString()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs",
+      "source_location": "L71",
+      "id": "diagnostics_doctorjsonrenderer_doctorjsonrenderer_statusstring",
+      "community": 80,
+      "norm_label": ".statusstring()"
+    },
+    {
+      "label": ".FormatTimestamp()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs",
+      "source_location": "L79",
+      "id": "diagnostics_doctorjsonrenderer_doctorjsonrenderer_formattimestamp",
+      "community": 80,
+      "norm_label": ".formattimestamp()"
+    },
+    {
+      "label": "DoctorReport.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorReport.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_doctorreport_cs",
+      "community": 148,
+      "norm_label": "doctorreport.cs"
+    },
+    {
+      "label": "DoctorRunner.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorRunner.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_doctorrunner_cs",
+      "community": 10,
+      "norm_label": "doctorrunner.cs"
+    },
+    {
+      "label": "DoctorRunner",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorRunner.cs",
+      "source_location": "L3",
+      "id": "diagnostics_doctorrunner_doctorrunner",
+      "community": 10,
+      "norm_label": "doctorrunner"
+    },
+    {
+      "label": ".Run()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorRunner.cs",
+      "source_location": "L14",
+      "id": "diagnostics_doctorrunner_doctorrunner_run",
+      "community": 10,
+      "norm_label": ".run()"
+    },
+    {
+      "label": "DoctorSummary.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorSummary.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_doctorsummary_cs",
+      "community": 149,
+      "norm_label": "doctorsummary.cs"
+    },
+    {
+      "label": "DoctorTextRenderer.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_doctortextrenderer_cs",
+      "community": 58,
+      "norm_label": "doctortextrenderer.cs"
+    },
+    {
+      "label": "DoctorTextRenderer",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L3",
+      "id": "diagnostics_doctortextrenderer_doctortextrenderer",
+      "community": 58,
+      "norm_label": "doctortextrenderer"
+    },
+    {
+      "label": ".Render()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L5",
+      "id": "diagnostics_doctortextrenderer_doctortextrenderer_render",
+      "community": 58,
+      "norm_label": ".render()"
+    },
+    {
+      "label": ".RenderCheck()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L23",
+      "id": "diagnostics_doctortextrenderer_doctortextrenderer_rendercheck",
+      "community": 58,
+      "norm_label": ".rendercheck()"
+    },
+    {
+      "label": ".FormatValue()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L59",
+      "id": "diagnostics_doctortextrenderer_doctortextrenderer_formatvalue",
+      "community": 58,
+      "norm_label": ".formatvalue()"
+    },
+    {
+      "label": ".SplitLines()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L61",
+      "id": "diagnostics_doctortextrenderer_doctortextrenderer_splitlines",
+      "community": 58,
+      "norm_label": ".splitlines()"
+    },
+    {
+      "label": ".Pluralize()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L69",
+      "id": "diagnostics_doctortextrenderer_doctortextrenderer_pluralize",
+      "community": 58,
+      "norm_label": ".pluralize()"
+    },
+    {
+      "label": "EnvironmentVariableService.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/EnvironmentVariableService.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_environmentvariableservice_cs",
+      "community": 25,
+      "norm_label": "environmentvariableservice.cs"
+    },
+    {
+      "label": "EnvironmentVariableService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/EnvironmentVariableService.cs",
+      "source_location": "L3",
+      "id": "diagnostics_environmentvariableservice_environmentvariableservice",
+      "community": 25,
+      "norm_label": "environmentvariableservice"
+    },
+    {
+      "label": "IEnvironmentVariableService",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "id": "ienvironmentvariableservice",
+      "community": 25,
+      "norm_label": "ienvironmentvariableservice"
+    },
+    {
+      "label": ".Get()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/EnvironmentVariableService.cs",
+      "source_location": "L7",
+      "id": "diagnostics_environmentvariableservice_environmentvariableservice_get",
+      "community": 25,
+      "norm_label": ".get()"
+    },
+    {
+      "label": "FileSystemService.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/FileSystemService.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_filesystemservice_cs",
+      "community": 88,
+      "norm_label": "filesystemservice.cs"
+    },
+    {
+      "label": "FileSystemService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/FileSystemService.cs",
+      "source_location": "L5",
+      "id": "diagnostics_filesystemservice_filesystemservice",
+      "community": 88,
+      "norm_label": "filesystemservice"
+    },
+    {
+      "label": "IFileSystemService",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "id": "ifilesystemservice",
+      "community": 34,
+      "norm_label": "ifilesystemservice"
+    },
+    {
+      "label": ".FileExists()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/FileSystemService.cs",
+      "source_location": "L9",
+      "id": "diagnostics_filesystemservice_filesystemservice_fileexists",
+      "community": 88,
+      "norm_label": ".fileexists()"
+    },
+    {
+      "label": ".DirectoryExists()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/FileSystemService.cs",
+      "source_location": "L11",
+      "id": "diagnostics_filesystemservice_filesystemservice_directoryexists",
+      "community": 88,
+      "norm_label": ".directoryexists()"
+    },
+    {
+      "label": ".GetFileVersion()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/FileSystemService.cs",
+      "source_location": "L13",
+      "id": "diagnostics_filesystemservice_filesystemservice_getfileversion",
+      "community": 88,
+      "norm_label": ".getfileversion()"
+    },
+    {
+      "label": "IApplicationInfoService.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IApplicationInfoService.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_iapplicationinfoservice_cs",
+      "community": 137,
+      "norm_label": "iapplicationinfoservice.cs"
+    },
+    {
+      "label": "IApplicationInfoService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IApplicationInfoService.cs",
+      "source_location": "L5",
+      "id": "diagnostics_iapplicationinfoservice_iapplicationinfoservice",
+      "community": 137,
+      "norm_label": "iapplicationinfoservice"
+    },
+    {
+      "label": "IDiagnosticCheck.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IDiagnosticCheck.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_idiagnosticcheck_cs",
+      "community": 108,
+      "norm_label": "idiagnosticcheck.cs"
+    },
+    {
+      "label": "IDiagnosticCheck",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IDiagnosticCheck.cs",
+      "source_location": "L3",
+      "id": "diagnostics_idiagnosticcheck_idiagnosticcheck",
+      "community": 108,
+      "norm_label": "idiagnosticcheck"
+    },
+    {
+      "label": ".Run()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IDiagnosticCheck.cs",
+      "source_location": "L9",
+      "id": "diagnostics_idiagnosticcheck_idiagnosticcheck_run",
+      "community": 108,
+      "norm_label": ".run()"
+    },
+    {
+      "label": "IEnvironmentVariableService.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IEnvironmentVariableService.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_ienvironmentvariableservice_cs",
+      "community": 109,
+      "norm_label": "ienvironmentvariableservice.cs"
+    },
+    {
+      "label": "IEnvironmentVariableService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IEnvironmentVariableService.cs",
+      "source_location": "L3",
+      "id": "diagnostics_ienvironmentvariableservice_ienvironmentvariableservice",
+      "community": 109,
+      "norm_label": "ienvironmentvariableservice"
+    },
+    {
+      "label": ".Get()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IEnvironmentVariableService.cs",
+      "source_location": "L5",
+      "id": "diagnostics_ienvironmentvariableservice_ienvironmentvariableservice_get",
+      "community": 109,
+      "norm_label": ".get()"
+    },
+    {
+      "label": "IFileSystemService.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IFileSystemService.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_ifilesystemservice_cs",
+      "community": 81,
+      "norm_label": "ifilesystemservice.cs"
+    },
+    {
+      "label": "IFileSystemService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IFileSystemService.cs",
+      "source_location": "L3",
+      "id": "diagnostics_ifilesystemservice_ifilesystemservice",
+      "community": 81,
+      "norm_label": "ifilesystemservice"
+    },
+    {
+      "label": ".FileExists()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IFileSystemService.cs",
+      "source_location": "L5",
+      "id": "diagnostics_ifilesystemservice_ifilesystemservice_fileexists",
+      "community": 81,
+      "norm_label": ".fileexists()"
+    },
+    {
+      "label": ".DirectoryExists()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IFileSystemService.cs",
+      "source_location": "L7",
+      "id": "diagnostics_ifilesystemservice_ifilesystemservice_directoryexists",
+      "community": 81,
+      "norm_label": ".directoryexists()"
+    },
+    {
+      "label": ".GetFileVersion()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IFileSystemService.cs",
+      "source_location": "L9",
+      "id": "diagnostics_ifilesystemservice_ifilesystemservice_getfileversion",
+      "community": 81,
+      "norm_label": ".getfileversion()"
+    },
+    {
+      "label": "IProcessEnumerationService.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IProcessEnumerationService.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_iprocessenumerationservice_cs",
+      "community": 110,
+      "norm_label": "iprocessenumerationservice.cs"
+    },
+    {
+      "label": "IProcessEnumerationService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IProcessEnumerationService.cs",
+      "source_location": "L5",
+      "id": "diagnostics_iprocessenumerationservice_iprocessenumerationservice",
+      "community": 110,
+      "norm_label": "iprocessenumerationservice"
+    },
+    {
+      "label": ".ListProcesses()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IProcessEnumerationService.cs",
+      "source_location": "L7",
+      "id": "diagnostics_iprocessenumerationservice_iprocessenumerationservice_listprocesses",
+      "community": 110,
+      "norm_label": ".listprocesses()"
+    },
+    {
+      "label": "IRegistryService.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IRegistryService.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_iregistryservice_cs",
+      "community": 82,
+      "norm_label": "iregistryservice.cs"
+    },
+    {
+      "label": "IRegistryService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IRegistryService.cs",
+      "source_location": "L5",
+      "id": "diagnostics_iregistryservice_iregistryservice",
+      "community": 82,
+      "norm_label": "iregistryservice"
+    },
+    {
+      "label": ".GetStringValue()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IRegistryService.cs",
+      "source_location": "L7",
+      "id": "diagnostics_iregistryservice_iregistryservice_getstringvalue",
+      "community": 82,
+      "norm_label": ".getstringvalue()"
+    },
+    {
+      "label": ".GetIntValue()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IRegistryService.cs",
+      "source_location": "L9",
+      "id": "diagnostics_iregistryservice_iregistryservice_getintvalue",
+      "community": 82,
+      "norm_label": ".getintvalue()"
+    },
+    {
+      "label": ".KeyExists()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IRegistryService.cs",
+      "source_location": "L11",
+      "id": "diagnostics_iregistryservice_iregistryservice_keyexists",
+      "community": 82,
+      "norm_label": ".keyexists()"
+    },
+    {
+      "label": "IWindowsIdentityService.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IWindowsIdentityService.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_iwindowsidentityservice_cs",
+      "community": 102,
+      "norm_label": "iwindowsidentityservice.cs"
+    },
+    {
+      "label": "IWindowsIdentityService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IWindowsIdentityService.cs",
+      "source_location": "L11",
+      "id": "diagnostics_iwindowsidentityservice_iwindowsidentityservice",
+      "community": 102,
+      "norm_label": "iwindowsidentityservice"
+    },
+    {
+      "label": ".GetCurrentUserInfo()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IWindowsIdentityService.cs",
+      "source_location": "L15",
+      "id": "diagnostics_iwindowsidentityservice_iwindowsidentityservice_getcurrentuserinfo",
+      "community": 102,
+      "norm_label": ".getcurrentuserinfo()"
+    },
+    {
+      "label": ".CheckGroupMembership()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/IWindowsIdentityService.cs",
+      "source_location": "L17",
+      "id": "diagnostics_iwindowsidentityservice_iwindowsidentityservice_checkgroupmembership",
+      "community": 102,
+      "norm_label": ".checkgroupmembership()"
+    },
+    {
+      "label": "ProcessEnumerationService.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/ProcessEnumerationService.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_processenumerationservice_cs",
+      "community": 50,
+      "norm_label": "processenumerationservice.cs"
+    },
+    {
+      "label": "ProcessEnumerationService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/ProcessEnumerationService.cs",
+      "source_location": "L5",
+      "id": "diagnostics_processenumerationservice_processenumerationservice",
+      "community": 50,
+      "norm_label": "processenumerationservice"
+    },
+    {
+      "label": "IProcessEnumerationService",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "id": "iprocessenumerationservice",
+      "community": 50,
+      "norm_label": "iprocessenumerationservice"
+    },
+    {
+      "label": ".ListProcesses()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/ProcessEnumerationService.cs",
+      "source_location": "L9",
+      "id": "diagnostics_processenumerationservice_processenumerationservice_listprocesses",
+      "community": 50,
+      "norm_label": ".listprocesses()"
+    },
+    {
+      "label": "RegistryService.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/RegistryService.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_registryservice_cs",
+      "community": 89,
+      "norm_label": "registryservice.cs"
+    },
+    {
+      "label": "RegistryService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/RegistryService.cs",
+      "source_location": "L5",
+      "id": "diagnostics_registryservice_registryservice",
+      "community": 89,
+      "norm_label": "registryservice"
+    },
+    {
+      "label": ".GetStringValue()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/RegistryService.cs",
+      "source_location": "L9",
+      "id": "diagnostics_registryservice_registryservice_getstringvalue",
+      "community": 89,
+      "norm_label": ".getstringvalue()"
+    },
+    {
+      "label": ".GetIntValue()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/RegistryService.cs",
+      "source_location": "L21",
+      "id": "diagnostics_registryservice_registryservice_getintvalue",
+      "community": 89,
+      "norm_label": ".getintvalue()"
+    },
+    {
+      "label": ".KeyExists()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/RegistryService.cs",
+      "source_location": "L44",
+      "id": "diagnostics_registryservice_registryservice_keyexists",
+      "community": 89,
+      "norm_label": ".keyexists()"
+    },
+    {
+      "label": "WindowsIdentityService.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/WindowsIdentityService.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_windowsidentityservice_cs",
+      "community": 29,
+      "norm_label": "windowsidentityservice.cs"
+    },
+    {
+      "label": "WindowsIdentityService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/WindowsIdentityService.cs",
+      "source_location": "L6",
+      "id": "diagnostics_windowsidentityservice_windowsidentityservice",
+      "community": 29,
+      "norm_label": "windowsidentityservice"
+    },
+    {
+      "label": "IWindowsIdentityService",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "id": "iwindowsidentityservice",
+      "community": 29,
+      "norm_label": "iwindowsidentityservice"
+    },
+    {
+      "label": ".GetCurrentUserInfo()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/WindowsIdentityService.cs",
+      "source_location": "L12",
+      "id": "diagnostics_windowsidentityservice_windowsidentityservice_getcurrentuserinfo",
+      "community": 29,
+      "norm_label": ".getcurrentuserinfo()"
+    },
+    {
+      "label": ".CheckGroupMembership()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/WindowsIdentityService.cs",
+      "source_location": "L36",
+      "id": "diagnostics_windowsidentityservice_windowsidentityservice_checkgroupmembership",
+      "community": 29,
+      "norm_label": ".checkgroupmembership()"
+    },
+    {
+      "label": ".TryResolveGroupSid()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/WindowsIdentityService.cs",
+      "source_location": "L82",
+      "id": "diagnostics_windowsidentityservice_windowsidentityservice_tryresolvegroupsid",
+      "community": 29,
+      "norm_label": ".tryresolvegroupsid()"
+    },
+    {
+      "label": "DotNetFrameworkCheck.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_checks_dotnetframeworkcheck_cs",
+      "community": 90,
+      "norm_label": "dotnetframeworkcheck.cs"
+    },
+    {
+      "label": "DotNetFrameworkCheck",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs",
+      "source_location": "L5",
+      "id": "checks_dotnetframeworkcheck_dotnetframeworkcheck",
+      "community": 90,
+      "norm_label": "dotnetframeworkcheck"
+    },
+    {
+      "label": "IDiagnosticCheck",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "id": "idiagnosticcheck",
+      "community": 48,
+      "norm_label": "idiagnosticcheck"
+    },
+    {
+      "label": ".Run()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs",
+      "source_location": "L23",
+      "id": "checks_dotnetframeworkcheck_dotnetframeworkcheck_run",
+      "community": 90,
+      "norm_label": ".run()"
+    },
+    {
+      "label": ".InterpretRelease()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs",
+      "source_location": "L100",
+      "id": "checks_dotnetframeworkcheck_dotnetframeworkcheck_interpretrelease",
+      "community": 90,
+      "norm_label": ".interpretrelease()"
+    },
+    {
+      "label": "DotNetRuntimeCheck.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetRuntimeCheck.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_checks_dotnetruntimecheck_cs",
+      "community": 34,
+      "norm_label": "dotnetruntimecheck.cs"
+    },
+    {
+      "label": "DotNetRuntimeCheck",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetRuntimeCheck.cs",
+      "source_location": "L3",
+      "id": "checks_dotnetruntimecheck_dotnetruntimecheck",
+      "community": 34,
+      "norm_label": "dotnetruntimecheck"
+    },
+    {
+      "label": ".Run()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetRuntimeCheck.cs",
+      "source_location": "L12",
+      "id": "checks_dotnetruntimecheck_dotnetruntimecheck_run",
+      "community": 34,
+      "norm_label": ".run()"
+    },
+    {
+      "label": "Evidence.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/Evidence.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_checks_evidence_cs",
+      "community": 103,
+      "norm_label": "evidence.cs"
+    },
+    {
+      "label": "Evidence",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/Evidence.cs",
+      "source_location": "L3",
+      "id": "checks_evidence_evidence",
+      "community": 103,
+      "norm_label": "evidence"
+    },
+    {
+      "label": ".Empty()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/Evidence.cs",
+      "source_location": "L5",
+      "id": "checks_evidence_evidence_empty",
+      "community": 103,
+      "norm_label": ".empty()"
+    },
+    {
+      "label": "HostWorkerVersionCheck.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_checks_hostworkerversioncheck_cs",
+      "community": 34,
+      "norm_label": "hostworkerversioncheck.cs"
+    },
+    {
+      "label": "HostWorkerVersionCheck",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs",
+      "source_location": "L5",
+      "id": "checks_hostworkerversioncheck_hostworkerversioncheck",
+      "community": 34,
+      "norm_label": "hostworkerversioncheck"
+    },
+    {
+      "label": ".Run()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs",
+      "source_location": "L19",
+      "id": "checks_hostworkerversioncheck_hostworkerversioncheck_run",
+      "community": 34,
+      "norm_label": ".run()"
+    },
+    {
+      "label": ".TryParseMajor()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs",
+      "source_location": "L95",
+      "id": "checks_hostworkerversioncheck_hostworkerversioncheck_tryparsemajor",
+      "community": 34,
+      "norm_label": ".tryparsemajor()"
+    },
+    {
+      "label": "OpennessAssembliesCheck.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessAssembliesCheck.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_checks_opennessassembliescheck_cs",
+      "community": 25,
+      "norm_label": "opennessassembliescheck.cs"
+    },
+    {
+      "label": "OpennessAssembliesCheck",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessAssembliesCheck.cs",
+      "source_location": "L5",
+      "id": "checks_opennessassembliescheck_opennessassembliescheck",
+      "community": 25,
+      "norm_label": "opennessassembliescheck"
+    },
+    {
+      "label": ".Run()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessAssembliesCheck.cs",
+      "source_location": "L24",
+      "id": "checks_opennessassembliescheck_opennessassembliescheck_run",
+      "community": 25,
+      "norm_label": ".run()"
+    },
+    {
+      "label": "OpennessGroupCheck.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessGroupCheck.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_checks_opennessgroupcheck_cs",
+      "community": 29,
+      "norm_label": "opennessgroupcheck.cs"
+    },
+    {
+      "label": "OpennessGroupCheck",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessGroupCheck.cs",
+      "source_location": "L3",
+      "id": "checks_opennessgroupcheck_opennessgroupcheck",
+      "community": 29,
+      "norm_label": "opennessgroupcheck"
+    },
+    {
+      "label": ".Run()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessGroupCheck.cs",
+      "source_location": "L14",
+      "id": "checks_opennessgroupcheck_opennessgroupcheck_run",
+      "community": 29,
+      "norm_label": ".run()"
+    },
+    {
+      "label": "OpennessWorkerCheck.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_checks_opennessworkercheck_cs",
+      "community": 34,
+      "norm_label": "opennessworkercheck.cs"
+    },
+    {
+      "label": "OpennessWorkerCheck",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs",
+      "source_location": "L5",
+      "id": "checks_opennessworkercheck_opennessworkercheck",
+      "community": 34,
+      "norm_label": "opennessworkercheck"
+    },
+    {
+      "label": ".Run()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs",
+      "source_location": "L34",
+      "id": "checks_opennessworkercheck_opennessworkercheck_run",
+      "community": 34,
+      "norm_label": ".run()"
+    },
+    {
+      "label": "OperatingSystemCheck.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OperatingSystemCheck.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_checks_operatingsystemcheck_cs",
+      "community": 48,
+      "norm_label": "operatingsystemcheck.cs"
+    },
+    {
+      "label": "OperatingSystemCheck",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OperatingSystemCheck.cs",
+      "source_location": "L3",
+      "id": "checks_operatingsystemcheck_operatingsystemcheck",
+      "community": 48,
+      "norm_label": "operatingsystemcheck"
+    },
+    {
+      "label": ".Run()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OperatingSystemCheck.cs",
+      "source_location": "L12",
+      "id": "checks_operatingsystemcheck_operatingsystemcheck_run",
+      "community": 48,
+      "norm_label": ".run()"
+    },
+    {
+      "label": "ProjectBindingCheck.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/ProjectBindingCheck.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_checks_projectbindingcheck_cs",
+      "community": 25,
+      "norm_label": "projectbindingcheck.cs"
+    },
+    {
+      "label": "ProjectBindingCheck",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/ProjectBindingCheck.cs",
+      "source_location": "L3",
+      "id": "checks_projectbindingcheck_projectbindingcheck",
+      "community": 25,
+      "norm_label": "projectbindingcheck"
+    },
+    {
+      "label": ".Run()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/ProjectBindingCheck.cs",
+      "source_location": "L20",
+      "id": "checks_projectbindingcheck_projectbindingcheck_run",
+      "community": 25,
+      "norm_label": ".run()"
+    },
+    {
+      "label": "TiaPortalInstallationCheck.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalInstallationCheck.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_checks_tiaportalinstallationcheck_cs",
+      "community": 25,
+      "norm_label": "tiaportalinstallationcheck.cs"
+    },
+    {
+      "label": "TiaPortalInstallationCheck",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalInstallationCheck.cs",
+      "source_location": "L5",
+      "id": "checks_tiaportalinstallationcheck_tiaportalinstallationcheck",
+      "community": 25,
+      "norm_label": "tiaportalinstallationcheck"
+    },
+    {
+      "label": ".Run()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalInstallationCheck.cs",
+      "source_location": "L24",
+      "id": "checks_tiaportalinstallationcheck_tiaportalinstallationcheck_run",
+      "community": 25,
+      "norm_label": ".run()"
+    },
+    {
+      "label": "TiaPortalProcessCheck.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalProcessCheck.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_diagnostics_checks_tiaportalprocesscheck_cs",
+      "community": 50,
+      "norm_label": "tiaportalprocesscheck.cs"
+    },
+    {
+      "label": "TiaPortalProcessCheck",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalProcessCheck.cs",
+      "source_location": "L3",
+      "id": "checks_tiaportalprocesscheck_tiaportalprocesscheck",
+      "community": 50,
+      "norm_label": "tiaportalprocesscheck"
+    },
+    {
+      "label": ".Run()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalProcessCheck.cs",
+      "source_location": "L25",
+      "id": "checks_tiaportalprocesscheck_tiaportalprocesscheck_run",
+      "community": 50,
+      "norm_label": ".run()"
     },
     {
       "label": "WriteSafetyService.cs",
@@ -666,7 +1755,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L1",
       "id": "tiamcpserver_safety_writesafetyservice_cs",
-      "community": 4,
+      "community": 19,
       "norm_label": "writesafetyservice.cs"
     },
     {
@@ -675,7 +1764,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L8",
       "id": "safety_writesafetyservice_writesafetyservice",
-      "community": 4,
+      "community": 19,
       "norm_label": "writesafetyservice"
     },
     {
@@ -684,7 +1773,7 @@
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L31",
       "id": "timespan",
-      "community": 6,
+      "community": 0,
       "norm_label": "timespan"
     },
     {
@@ -693,17 +1782,8 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L20",
       "id": "concurrentdictionary",
-      "community": 4,
+      "community": 19,
       "norm_label": "concurrentdictionary"
-    },
-    {
-      "label": "Func",
-      "file_type": "code",
-      "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
-      "source_location": "L21",
-      "id": "func",
-      "community": 4,
-      "norm_label": "func"
     },
     {
       "label": ".CreatePreview()",
@@ -711,7 +1791,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L43",
       "id": "safety_writesafetyservice_writesafetyservice_createpreview",
-      "community": 4,
+      "community": 19,
       "norm_label": ".createpreview()"
     },
     {
@@ -720,7 +1800,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L93",
       "id": "safety_writesafetyservice_writesafetyservice_validateenvelope",
-      "community": 4,
+      "community": 19,
       "norm_label": ".validateenvelope()"
     },
     {
@@ -729,7 +1809,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L140",
       "id": "safety_writesafetyservice_writesafetyservice_validateandconsume",
-      "community": 4,
+      "community": 19,
       "norm_label": ".validateandconsume()"
     },
     {
@@ -738,7 +1818,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L201",
       "id": "safety_writesafetyservice_writesafetyservice_evictexpiredtokens",
-      "community": 4,
+      "community": 19,
       "norm_label": ".evictexpiredtokens()"
     },
     {
@@ -747,7 +1827,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L213",
       "id": "safety_writesafetyservice_writesafetyservice_rejected",
-      "community": 4,
+      "community": 19,
       "norm_label": ".rejected()"
     },
     {
@@ -756,7 +1836,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L221",
       "id": "safety_writesafetyservice_writesafetyservice_appendaudit",
-      "community": 4,
+      "community": 19,
       "norm_label": ".appendaudit()"
     },
     {
@@ -765,7 +1845,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L263",
       "id": "safety_writesafetyservice_writesafetyservice_normalizeprojectpath",
-      "community": 4,
+      "community": 19,
       "norm_label": ".normalizeprojectpath()"
     },
     {
@@ -774,7 +1854,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L280",
       "id": "safety_writesafetyservice_writesafetyservice_hashtext",
-      "community": 4,
+      "community": 19,
       "norm_label": ".hashtext()"
     },
     {
@@ -783,7 +1863,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L286",
       "id": "safety_writesafetyservice_writesafetyservice_tostablejson",
-      "community": 4,
+      "community": 19,
       "norm_label": ".tostablejson()"
     },
     {
@@ -792,7 +1872,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L291",
       "id": "safety_writesafetyservice_writesafetyservice_createtoken",
-      "community": 4,
+      "community": 19,
       "norm_label": ".createtoken()"
     },
     {
@@ -801,7 +1881,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L314",
       "id": "safety_writesafetyservice_valid",
-      "community": 4,
+      "community": 19,
       "norm_label": "valid()"
     },
     {
@@ -810,7 +1890,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L319",
       "id": "safety_writesafetyservice_invalid",
-      "community": 4,
+      "community": 19,
       "norm_label": "invalid()"
     },
     {
@@ -819,7 +1899,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
       "source_location": "L1",
       "id": "tiamcpserver_safety_writesafetytooling_cs",
-      "community": 29,
+      "community": 4,
       "norm_label": "writesafetytooling.cs"
     },
     {
@@ -828,7 +1908,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
       "source_location": "L7",
       "id": "safety_writesafetytooling_writesafetytooling",
-      "community": 29,
+      "community": 4,
       "norm_label": "writesafetytooling"
     },
     {
@@ -837,7 +1917,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
       "source_location": "L15",
       "id": "safety_writesafetytooling_writesafetytooling_validateforapplyasync",
-      "community": 29,
+      "community": 4,
       "norm_label": ".validateforapplyasync()"
     },
     {
@@ -846,7 +1926,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
       "source_location": "L51",
       "id": "safety_writesafetytooling_writesafetytooling_createpreview",
-      "community": 29,
+      "community": 4,
       "norm_label": ".createpreview()"
     },
     {
@@ -855,7 +1935,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
       "source_location": "L77",
       "id": "safety_writesafetytooling_writesafetytooling_buildapplyresult",
-      "community": 29,
+      "community": 4,
       "norm_label": ".buildapplyresult()"
     },
     {
@@ -864,7 +1944,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
       "source_location": "L101",
       "id": "safety_writesafetytooling_writesafetytooling_createlinediff",
-      "community": 29,
+      "community": 4,
       "norm_label": ".createlinediff()"
     },
     {
@@ -873,7 +1953,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
       "source_location": "L133",
       "id": "safety_writesafetytooling_writesafetytooling_describepathstate",
-      "community": 29,
+      "community": 4,
       "norm_label": ".describepathstate()"
     },
     {
@@ -882,7 +1962,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
       "source_location": "L167",
       "id": "safety_writesafetytooling_writesafetytooling_describeprojectcreationstate",
-      "community": 29,
+      "community": 4,
       "norm_label": ".describeprojectcreationstate()"
     },
     {
@@ -891,7 +1971,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
       "source_location": "L183",
       "id": "safety_writesafetytooling_valid",
-      "community": 29,
+      "community": 4,
       "norm_label": "valid()"
     },
     {
@@ -900,7 +1980,7 @@
       "source_file": "TiaMcpServer/Safety/WriteSafetyTooling.cs",
       "source_location": "L188",
       "id": "safety_writesafetytooling_invalid",
-      "community": 29,
+      "community": 4,
       "norm_label": "invalid()"
     },
     {
@@ -1033,7 +2113,7 @@
       "label": "OpennessWorkerClient",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L8",
+      "source_location": "L9",
       "id": "worker_opennessworkerclient_opennessworkerclient",
       "community": 0,
       "norm_label": "opennessworkerclient"
@@ -1044,14 +2124,14 @@
       "source_file": "",
       "source_location": "",
       "id": "idisposable",
-      "community": 6,
+      "community": 0,
       "norm_label": "idisposable"
     },
     {
       "label": "ProjectSessionBinding",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L12",
+      "source_location": "L13",
       "id": "projectsessionbinding",
       "community": 0,
       "norm_label": "projectsessionbinding"
@@ -1062,14 +2142,14 @@
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L32",
       "id": "ilogger",
-      "community": 6,
+      "community": 0,
       "norm_label": "ilogger"
     },
     {
       "label": "object",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L16",
+      "source_location": "L17",
       "id": "object",
       "community": 0,
       "norm_label": "object"
@@ -1078,7 +2158,7 @@
       "label": "PersistentWorkerTransport",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L17",
+      "source_location": "L18",
       "id": "persistentworkertransport",
       "community": 0,
       "norm_label": "persistentworkertransport"
@@ -1087,7 +2167,7 @@
       "label": ".BrowseProjectTreeAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L31",
+      "source_location": "L32",
       "id": "worker_opennessworkerclient_opennessworkerclient_browseprojecttreeasync",
       "community": 0,
       "norm_label": ".browseprojecttreeasync()"
@@ -1096,7 +2176,7 @@
       "label": ".ReadHardwareConfigAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L44",
+      "source_location": "L45",
       "id": "worker_opennessworkerclient_opennessworkerclient_readhardwareconfigasync",
       "community": 0,
       "norm_label": ".readhardwareconfigasync()"
@@ -1105,7 +2185,7 @@
       "label": ".SearchEquipmentCatalogAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L49",
+      "source_location": "L50",
       "id": "worker_opennessworkerclient_opennessworkerclient_searchequipmentcatalogasync",
       "community": 0,
       "norm_label": ".searchequipmentcatalogasync()"
@@ -1114,7 +2194,7 @@
       "label": ".AddNetworkDeviceAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L62",
+      "source_location": "L63",
       "id": "worker_opennessworkerclient_opennessworkerclient_addnetworkdeviceasync",
       "community": 0,
       "norm_label": ".addnetworkdeviceasync()"
@@ -1123,7 +2203,7 @@
       "label": ".ConfigureNetworkDeviceAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L82",
+      "source_location": "L83",
       "id": "worker_opennessworkerclient_opennessworkerclient_configurenetworkdeviceasync",
       "community": 0,
       "norm_label": ".configurenetworkdeviceasync()"
@@ -1132,7 +2212,7 @@
       "label": ".ReadCrossReferencesAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L108",
+      "source_location": "L109",
       "id": "worker_opennessworkerclient_opennessworkerclient_readcrossreferencesasync",
       "community": 0,
       "norm_label": ".readcrossreferencesasync()"
@@ -1141,7 +2221,7 @@
       "label": ".GetBlockContentAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L128",
+      "source_location": "L129",
       "id": "worker_opennessworkerclient_opennessworkerclient_getblockcontentasync",
       "community": 0,
       "norm_label": ".getblockcontentasync()"
@@ -1150,7 +2230,7 @@
       "label": ".UpdateBlockLogicAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L137",
+      "source_location": "L138",
       "id": "worker_opennessworkerclient_opennessworkerclient_updateblocklogicasync",
       "community": 0,
       "norm_label": ".updateblocklogicasync()"
@@ -1159,7 +2239,7 @@
       "label": ".ListTagTablesAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L151",
+      "source_location": "L152",
       "id": "worker_opennessworkerclient_opennessworkerclient_listtagtablesasync",
       "community": 0,
       "norm_label": ".listtagtablesasync()"
@@ -1168,7 +2248,7 @@
       "label": ".CompileCheckAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L160",
+      "source_location": "L161",
       "id": "worker_opennessworkerclient_opennessworkerclient_compilecheckasync",
       "community": 0,
       "norm_label": ".compilecheckasync()"
@@ -1177,7 +2257,7 @@
       "label": ".CreateTagTableAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L173",
+      "source_location": "L174",
       "id": "worker_opennessworkerclient_opennessworkerclient_createtagtableasync",
       "community": 0,
       "norm_label": ".createtagtableasync()"
@@ -1186,7 +2266,7 @@
       "label": ".DeleteTagTableAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L193",
+      "source_location": "L194",
       "id": "worker_opennessworkerclient_opennessworkerclient_deletetagtableasync",
       "community": 0,
       "norm_label": ".deletetagtableasync()"
@@ -1195,7 +2275,7 @@
       "label": ".CreateTagAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L213",
+      "source_location": "L214",
       "id": "worker_opennessworkerclient_opennessworkerclient_createtagasync",
       "community": 0,
       "norm_label": ".createtagasync()"
@@ -1204,7 +2284,7 @@
       "label": ".UpdateTagAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L239",
+      "source_location": "L240",
       "id": "worker_opennessworkerclient_opennessworkerclient_updatetagasync",
       "community": 0,
       "norm_label": ".updatetagasync()"
@@ -1213,7 +2293,7 @@
       "label": ".DeleteTagAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L275",
+      "source_location": "L276",
       "id": "worker_opennessworkerclient_opennessworkerclient_deletetagasync",
       "community": 0,
       "norm_label": ".deletetagasync()"
@@ -1222,7 +2302,7 @@
       "label": ".CreateUserConstantAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L297",
+      "source_location": "L298",
       "id": "worker_opennessworkerclient_opennessworkerclient_createuserconstantasync",
       "community": 0,
       "norm_label": ".createuserconstantasync()"
@@ -1231,7 +2311,7 @@
       "label": ".UpdateUserConstantAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L323",
+      "source_location": "L324",
       "id": "worker_opennessworkerclient_opennessworkerclient_updateuserconstantasync",
       "community": 0,
       "norm_label": ".updateuserconstantasync()"
@@ -1240,7 +2320,7 @@
       "label": ".DeleteUserConstantAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L349",
+      "source_location": "L350",
       "id": "worker_opennessworkerclient_opennessworkerclient_deleteuserconstantasync",
       "community": 0,
       "norm_label": ".deleteuserconstantasync()"
@@ -1249,7 +2329,7 @@
       "label": ".CreateBlockAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L371",
+      "source_location": "L372",
       "id": "worker_opennessworkerclient_opennessworkerclient_createblockasync",
       "community": 0,
       "norm_label": ".createblockasync()"
@@ -1258,7 +2338,7 @@
       "label": ".DeleteBlockAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L393",
+      "source_location": "L394",
       "id": "worker_opennessworkerclient_opennessworkerclient_deleteblockasync",
       "community": 0,
       "norm_label": ".deleteblockasync()"
@@ -1267,7 +2347,7 @@
       "label": ".CreateBlockGroupAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L407",
+      "source_location": "L408",
       "id": "worker_opennessworkerclient_opennessworkerclient_createblockgroupasync",
       "community": 0,
       "norm_label": ".createblockgroupasync()"
@@ -1276,7 +2356,7 @@
       "label": ".DeleteBlockGroupAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L421",
+      "source_location": "L422",
       "id": "worker_opennessworkerclient_opennessworkerclient_deleteblockgroupasync",
       "community": 0,
       "norm_label": ".deleteblockgroupasync()"
@@ -1285,7 +2365,7 @@
       "label": ".StartPlcAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L435",
+      "source_location": "L436",
       "id": "worker_opennessworkerclient_opennessworkerclient_startplcasync",
       "community": 0,
       "norm_label": ".startplcasync()"
@@ -1294,7 +2374,7 @@
       "label": ".StopPlcAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L449",
+      "source_location": "L450",
       "id": "worker_opennessworkerclient_opennessworkerclient_stopplcasync",
       "community": 0,
       "norm_label": ".stopplcasync()"
@@ -1303,7 +2383,7 @@
       "label": ".GetProjectStatusAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L463",
+      "source_location": "L464",
       "id": "worker_opennessworkerclient_opennessworkerclient_getprojectstatusasync",
       "community": 0,
       "norm_label": ".getprojectstatusasync()"
@@ -1312,7 +2392,7 @@
       "label": ".OpenProjectAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L472",
+      "source_location": "L473",
       "id": "worker_opennessworkerclient_opennessworkerclient_openprojectasync",
       "community": 0,
       "norm_label": ".openprojectasync()"
@@ -1321,7 +2401,7 @@
       "label": ".CreateProjectAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L502",
+      "source_location": "L503",
       "id": "worker_opennessworkerclient_opennessworkerclient_createprojectasync",
       "community": 0,
       "norm_label": ".createprojectasync()"
@@ -1330,7 +2410,7 @@
       "label": ".SaveProjectAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L534",
+      "source_location": "L535",
       "id": "worker_opennessworkerclient_opennessworkerclient_saveprojectasync",
       "community": 0,
       "norm_label": ".saveprojectasync()"
@@ -1339,7 +2419,7 @@
       "label": ".SaveProjectAsAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L547",
+      "source_location": "L548",
       "id": "worker_opennessworkerclient_opennessworkerclient_saveprojectasasync",
       "community": 0,
       "norm_label": ".saveprojectasasync()"
@@ -1348,7 +2428,7 @@
       "label": ".ArchiveProjectAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L578",
+      "source_location": "L579",
       "id": "worker_opennessworkerclient_opennessworkerclient_archiveprojectasync",
       "community": 0,
       "norm_label": ".archiveprojectasync()"
@@ -1357,7 +2437,7 @@
       "label": ".CloseProjectAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L605",
+      "source_location": "L606",
       "id": "worker_opennessworkerclient_opennessworkerclient_closeprojectasync",
       "community": 0,
       "norm_label": ".closeprojectasync()"
@@ -1366,7 +2446,7 @@
       "label": ".SendBoundProjectRequestAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L626",
+      "source_location": "L627",
       "id": "worker_opennessworkerclient_opennessworkerclient_sendboundprojectrequestasync",
       "community": 0,
       "norm_label": ".sendboundprojectrequestasync()"
@@ -1375,7 +2455,7 @@
       "label": ".InvokeWorkerAsync()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L658",
+      "source_location": "L659",
       "id": "worker_opennessworkerclient_opennessworkerclient_invokeworkerasync",
       "community": 0,
       "norm_label": ".invokeworkerasync()"
@@ -1384,7 +2464,7 @@
       "label": ".GetOrCreateTransport()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L688",
+      "source_location": "L689",
       "id": "worker_opennessworkerclient_opennessworkerclient_getorcreatetransport",
       "community": 0,
       "norm_label": ".getorcreatetransport()"
@@ -1393,7 +2473,7 @@
       "label": ".Dispose()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L700",
+      "source_location": "L701",
       "id": "worker_opennessworkerclient_opennessworkerclient_dispose",
       "community": 0,
       "norm_label": ".dispose()"
@@ -1402,7 +2482,7 @@
       "label": ".CanBind()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L709",
+      "source_location": "L710",
       "id": "worker_opennessworkerclient_opennessworkerclient_canbind",
       "community": 0,
       "norm_label": ".canbind()"
@@ -1411,7 +2491,7 @@
       "label": ".TryReadProjectPath()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L731",
+      "source_location": "L732",
       "id": "worker_opennessworkerclient_opennessworkerclient_tryreadprojectpath",
       "community": 0,
       "norm_label": ".tryreadprojectpath()"
@@ -1420,7 +2500,7 @@
       "label": ".CapWarnings()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L769",
+      "source_location": "L770",
       "id": "worker_opennessworkerclient_opennessworkerclient_capwarnings",
       "community": 0,
       "norm_label": ".capwarnings()"
@@ -1429,7 +2509,7 @@
       "label": ".CapWarningLine()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L791",
+      "source_location": "L792",
       "id": "worker_opennessworkerclient_opennessworkerclient_capwarningline",
       "community": 0,
       "norm_label": ".capwarningline()"
@@ -1438,10 +2518,46 @@
       "label": ".LocateWorkerExecutable()",
       "file_type": "code",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
-      "source_location": "L802",
+      "source_location": "L803",
       "id": "worker_opennessworkerclient_opennessworkerclient_locateworkerexecutable",
       "community": 0,
       "norm_label": ".locateworkerexecutable()"
+    },
+    {
+      "label": "OpennessWorkerLocator.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerLocator.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_worker_opennessworkerlocator_cs",
+      "community": 1,
+      "norm_label": "opennessworkerlocator.cs"
+    },
+    {
+      "label": "OpennessWorkerLocator",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerLocator.cs",
+      "source_location": "L19",
+      "id": "worker_opennessworkerlocator_opennessworkerlocator",
+      "community": 1,
+      "norm_label": "opennessworkerlocator"
+    },
+    {
+      "label": ".Locate()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerLocator.cs",
+      "source_location": "L24",
+      "id": "worker_opennessworkerlocator_opennessworkerlocator_locate",
+      "community": 1,
+      "norm_label": ".locate()"
+    },
+    {
+      "label": ".LocateOrThrow()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerLocator.cs",
+      "source_location": "L61",
+      "id": "worker_opennessworkerlocator_opennessworkerlocator_locateorthrow",
+      "community": 1,
+      "norm_label": ".locateorthrow()"
     },
     {
       "label": "PersistentWorkerTransport.cs",
@@ -1449,7 +2565,7 @@
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L1",
       "id": "tiamcpserver_worker_persistentworkertransport_cs",
-      "community": 6,
+      "community": 0,
       "norm_label": "persistentworkertransport.cs"
     },
     {
@@ -1458,7 +2574,7 @@
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L19",
       "id": "worker_persistentworkertransport_persistentworkertransport",
-      "community": 6,
+      "community": 0,
       "norm_label": "persistentworkertransport"
     },
     {
@@ -1467,7 +2583,7 @@
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L29",
       "id": "semaphoreslim",
-      "community": 6,
+      "community": 0,
       "norm_label": "semaphoreslim"
     },
     {
@@ -1476,7 +2592,7 @@
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L33",
       "id": "concurrentqueue",
-      "community": 6,
+      "community": 0,
       "norm_label": "concurrentqueue"
     },
     {
@@ -1485,7 +2601,7 @@
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L35",
       "id": "process",
-      "community": 6,
+      "community": 0,
       "norm_label": "process"
     },
     {
@@ -1494,7 +2610,7 @@
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L36",
       "id": "task",
-      "community": 6,
+      "community": 0,
       "norm_label": "task"
     },
     {
@@ -1503,7 +2619,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L10",
       "id": "bool",
-      "community": 6,
+      "community": 0,
       "norm_label": "bool"
     },
     {
@@ -1512,7 +2628,7 @@
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L46",
       "id": "worker_persistentworkertransport_persistentworkertransport_sendasync",
-      "community": 6,
+      "community": 0,
       "norm_label": ".sendasync()"
     },
     {
@@ -1521,7 +2637,7 @@
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L115",
       "id": "worker_persistentworkertransport_persistentworkertransport_ensureprocessstarted",
-      "community": 6,
+      "community": 0,
       "norm_label": ".ensureprocessstarted()"
     },
     {
@@ -1530,7 +2646,7 @@
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L147",
       "id": "worker_persistentworkertransport_persistentworkertransport_pumpstderrasync",
-      "community": 6,
+      "community": 0,
       "norm_label": ".pumpstderrasync()"
     },
     {
@@ -1539,7 +2655,7 @@
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L174",
       "id": "worker_persistentworkertransport_persistentworkertransport_capturecrashdetailasync",
-      "community": 6,
+      "community": 0,
       "norm_label": ".capturecrashdetailasync()"
     },
     {
@@ -1548,7 +2664,7 @@
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L188",
       "id": "worker_persistentworkertransport_persistentworkertransport_killprocess",
-      "community": 6,
+      "community": 0,
       "norm_label": ".killprocess()"
     },
     {
@@ -1557,8 +2673,44 @@
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L213",
       "id": "worker_persistentworkertransport_persistentworkertransport_dispose",
-      "community": 6,
+      "community": 0,
       "norm_label": ".dispose()"
+    },
+    {
+      "label": "TiaPortalInstallationLocator.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/TiaPortalInstallationLocator.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_worker_tiaportalinstallationlocator_cs",
+      "community": 1,
+      "norm_label": "tiaportalinstallationlocator.cs"
+    },
+    {
+      "label": "TiaPortalInstallationLocator",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/TiaPortalInstallationLocator.cs",
+      "source_location": "L37",
+      "id": "worker_tiaportalinstallationlocator_tiaportalinstallationlocator",
+      "community": 1,
+      "norm_label": "tiaportalinstallationlocator"
+    },
+    {
+      "label": ".Locate()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/TiaPortalInstallationLocator.cs",
+      "source_location": "L54",
+      "id": "worker_tiaportalinstallationlocator_tiaportalinstallationlocator_locate",
+      "community": 1,
+      "norm_label": ".locate()"
+    },
+    {
+      "label": ".AddCandidate()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Worker/TiaPortalInstallationLocator.cs",
+      "source_location": "L115",
+      "id": "worker_tiaportalinstallationlocator_tiaportalinstallationlocator_addcandidate",
+      "community": 1,
+      "norm_label": ".addcandidate()"
     },
     {
       "label": "WorkerCallResult.cs",
@@ -1566,7 +2718,7 @@
       "source_file": "TiaMcpServer/Worker/WorkerCallResult.cs",
       "source_location": "L1",
       "id": "tiamcpserver_worker_workercallresult_cs",
-      "community": 70,
+      "community": 104,
       "norm_label": "workercallresult.cs"
     },
     {
@@ -1575,7 +2727,7 @@
       "source_file": "TiaMcpServer/Worker/WorkerCallResult.cs",
       "source_location": "L15",
       "id": "worker_workercallresult_ok",
-      "community": 70,
+      "community": 104,
       "norm_label": "ok()"
     },
     {
@@ -1584,7 +2736,7 @@
       "source_file": "TiaMcpServer/Worker/WorkerCallResult.cs",
       "source_location": "L18",
       "id": "worker_workercallresult_fail",
-      "community": 70,
+      "community": 104,
       "norm_label": "fail()"
     },
     {
@@ -1593,7 +2745,7 @@
       "source_file": "TiaMcpServer/Worker/WorkerCallResult.cs",
       "source_location": "L22",
       "id": "worker_workercallresult_totext",
-      "community": 70,
+      "community": 104,
       "norm_label": "totext()"
     },
     {
@@ -1602,7 +2754,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/AddDeviceResultInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_adddeviceresultinfo_cs",
-      "community": 73,
+      "community": 111,
       "norm_label": "adddeviceresultinfo.cs"
     },
     {
@@ -1611,7 +2763,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/AddDeviceResultInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_adddeviceresultinfo_adddeviceresultinfo",
-      "community": 73,
+      "community": 111,
       "norm_label": "adddeviceresultinfo"
     },
     {
@@ -1647,7 +2799,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/BlockAddress.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_blockaddress_cs",
-      "community": 31,
+      "community": 41,
       "norm_label": "blockaddress.cs"
     },
     {
@@ -1656,7 +2808,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/BlockAddress.cs",
       "source_location": "L7",
       "id": "tiamcpserver_contracts_blockaddress_blockaddress",
-      "community": 31,
+      "community": 41,
       "norm_label": "blockaddress"
     },
     {
@@ -1665,7 +2817,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/BlockAddress.cs",
       "source_location": "L38",
       "id": "tiamcpserver_contracts_blockaddress_blockaddress_parse",
-      "community": 31,
+      "community": 41,
       "norm_label": ".parse()"
     },
     {
@@ -1674,7 +2826,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/BlockAddress.cs",
       "source_location": "L85",
       "id": "tiamcpserver_contracts_blockaddress_blockaddress_todisplaypath",
-      "community": 31,
+      "community": 41,
       "norm_label": ".todisplaypath()"
     },
     {
@@ -1683,7 +2835,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/BlockAddress.cs",
       "source_location": "L111",
       "id": "tiamcpserver_contracts_blockaddress_blockaddress_fromblocksegments",
-      "community": 31,
+      "community": 41,
       "norm_label": ".fromblocksegments()"
     },
     {
@@ -1692,7 +2844,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/BlockAddress.cs",
       "source_location": "L136",
       "id": "tiamcpserver_contracts_blockaddress_blockaddress_splitsegments",
-      "community": 31,
+      "community": 41,
       "norm_label": ".splitsegments()"
     },
     {
@@ -1701,7 +2853,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/BlockAddress.cs",
       "source_location": "L153",
       "id": "tiamcpserver_contracts_blockaddress_blockaddress_stripblocksuffix",
-      "community": 31,
+      "community": 41,
       "norm_label": ".stripblocksuffix()"
     },
     {
@@ -1710,7 +2862,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/BlockAddress.cs",
       "source_location": "L164",
       "id": "tiamcpserver_contracts_blockaddress_blockaddress_isreservedsegment",
-      "community": 31,
+      "community": 41,
       "norm_label": ".isreservedsegment()"
     },
     {
@@ -1719,7 +2871,7 @@
       "source_file": "TiaMcpServer.Contracts/BlockMutationResultInfo.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_blockmutationresultinfo_cs",
-      "community": 99,
+      "community": 138,
       "norm_label": "blockmutationresultinfo.cs"
     },
     {
@@ -1728,7 +2880,7 @@
       "source_file": "TiaMcpServer.Contracts/BlockMutationResultInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_blockmutationresultinfo_blockmutationresultinfo",
-      "community": 99,
+      "community": 138,
       "norm_label": "blockmutationresultinfo"
     },
     {
@@ -1737,7 +2889,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CatalogEntryInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_catalogentryinfo_cs",
-      "community": 74,
+      "community": 112,
       "norm_label": "catalogentryinfo.cs"
     },
     {
@@ -1746,7 +2898,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CatalogEntryInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_catalogentryinfo_catalogentryinfo",
-      "community": 74,
+      "community": 112,
       "norm_label": "catalogentryinfo"
     },
     {
@@ -1755,7 +2907,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CatalogTypeIdentifier.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_catalogtypeidentifier_cs",
-      "community": 57,
+      "community": 83,
       "norm_label": "catalogtypeidentifier.cs"
     },
     {
@@ -1764,7 +2916,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CatalogTypeIdentifier.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_catalogtypeidentifier_catalogtypeidentifier",
-      "community": 57,
+      "community": 83,
       "norm_label": "catalogtypeidentifier"
     },
     {
@@ -1773,7 +2925,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CatalogTypeIdentifier.cs",
       "source_location": "L12",
       "id": "tiamcpserver_contracts_catalogtypeidentifier_catalogtypeidentifier_iscreatable",
-      "community": 57,
+      "community": 83,
       "norm_label": ".iscreatable()"
     },
     {
@@ -1782,7 +2934,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CatalogTypeIdentifier.cs",
       "source_location": "L36",
       "id": "tiamcpserver_contracts_catalogtypeidentifier_catalogtypeidentifier_buildvalidationmessage",
-      "community": 57,
+      "community": 83,
       "norm_label": ".buildvalidationmessage()"
     },
     {
@@ -1791,7 +2943,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CompileCheckReport.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_compilecheckreport_cs",
-      "community": 75,
+      "community": 113,
       "norm_label": "compilecheckreport.cs"
     },
     {
@@ -1800,7 +2952,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CompileCheckReport.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_compilecheckreport_compilecheckreport",
-      "community": 75,
+      "community": 113,
       "norm_label": "compilecheckreport"
     },
     {
@@ -1809,7 +2961,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CompileMessageInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_compilemessageinfo_cs",
-      "community": 76,
+      "community": 114,
       "norm_label": "compilemessageinfo.cs"
     },
     {
@@ -1818,7 +2970,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CompileMessageInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_compilemessageinfo_compilemessageinfo",
-      "community": 76,
+      "community": 114,
       "norm_label": "compilemessageinfo"
     },
     {
@@ -1827,7 +2979,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/ConfigureNetworkDeviceResultInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_configurenetworkdeviceresultinfo_cs",
-      "community": 77,
+      "community": 115,
       "norm_label": "configurenetworkdeviceresultinfo.cs"
     },
     {
@@ -1836,7 +2988,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/ConfigureNetworkDeviceResultInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_configurenetworkdeviceresultinfo_configurenetworkdeviceresultinfo",
-      "community": 77,
+      "community": 115,
       "norm_label": "configurenetworkdeviceresultinfo"
     },
     {
@@ -1845,7 +2997,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceFilterNames.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_crossreferencefilternames_cs",
-      "community": 71,
+      "community": 105,
       "norm_label": "crossreferencefilternames.cs"
     },
     {
@@ -1854,7 +3006,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceFilterNames.cs",
       "source_location": "L6",
       "id": "tiamcpserver_contracts_crossreferencefilternames_crossreferencefilternames",
-      "community": 71,
+      "community": 105,
       "norm_label": "crossreferencefilternames"
     },
     {
@@ -1863,7 +3015,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceFilterNames.cs",
       "source_location": "L23",
       "id": "tiamcpserver_contracts_crossreferencefilternames_crossreferencefilternames_trynormalize",
-      "community": 71,
+      "community": 105,
       "norm_label": ".trynormalize()"
     },
     {
@@ -1872,7 +3024,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceLocationInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_crossreferencelocationinfo_cs",
-      "community": 78,
+      "community": 116,
       "norm_label": "crossreferencelocationinfo.cs"
     },
     {
@@ -1881,7 +3033,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceLocationInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_crossreferencelocationinfo_crossreferencelocationinfo",
-      "community": 78,
+      "community": 116,
       "norm_label": "crossreferencelocationinfo"
     },
     {
@@ -1890,7 +3042,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceReport.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_crossreferencereport_cs",
-      "community": 79,
+      "community": 117,
       "norm_label": "crossreferencereport.cs"
     },
     {
@@ -1899,7 +3051,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceReport.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_crossreferencereport_crossreferencereport",
-      "community": 79,
+      "community": 117,
       "norm_label": "crossreferencereport"
     },
     {
@@ -1908,7 +3060,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceSourceInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_crossreferencesourceinfo_cs",
-      "community": 80,
+      "community": 118,
       "norm_label": "crossreferencesourceinfo.cs"
     },
     {
@@ -1917,7 +3069,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceSourceInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_crossreferencesourceinfo_crossreferencesourceinfo",
-      "community": 80,
+      "community": 118,
       "norm_label": "crossreferencesourceinfo"
     },
     {
@@ -1926,7 +3078,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceTargetInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_crossreferencetargetinfo_cs",
-      "community": 81,
+      "community": 119,
       "norm_label": "crossreferencetargetinfo.cs"
     },
     {
@@ -1935,7 +3087,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/CrossReferenceTargetInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_crossreferencetargetinfo_crossreferencetargetinfo",
-      "community": 81,
+      "community": 119,
       "norm_label": "crossreferencetargetinfo"
     },
     {
@@ -1944,7 +3096,7 @@
       "source_file": "TiaMcpServer.Contracts/DeviceInfo.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_deviceinfo_cs",
-      "community": 82,
+      "community": 120,
       "norm_label": "deviceinfo.cs"
     },
     {
@@ -1953,7 +3105,7 @@
       "source_file": "TiaMcpServer.Contracts/DeviceInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_deviceinfo_deviceinfo",
-      "community": 82,
+      "community": 120,
       "norm_label": "deviceinfo"
     },
     {
@@ -1962,7 +3114,7 @@
       "source_file": "TiaMcpServer.Contracts/DeviceItemInfo.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_deviceiteminfo_cs",
-      "community": 83,
+      "community": 121,
       "norm_label": "deviceiteminfo.cs"
     },
     {
@@ -1971,7 +3123,7 @@
       "source_file": "TiaMcpServer.Contracts/DeviceItemInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_deviceiteminfo_deviceiteminfo",
-      "community": 83,
+      "community": 121,
       "norm_label": "deviceiteminfo"
     },
     {
@@ -1980,7 +3132,7 @@
       "source_file": "TiaMcpServer.Contracts/HardwareConfigInfo.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_hardwareconfiginfo_cs",
-      "community": 84,
+      "community": 122,
       "norm_label": "hardwareconfiginfo.cs"
     },
     {
@@ -1989,7 +3141,7 @@
       "source_file": "TiaMcpServer.Contracts/HardwareConfigInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_hardwareconfiginfo_hardwareconfiginfo",
-      "community": 84,
+      "community": 122,
       "norm_label": "hardwareconfiginfo"
     },
     {
@@ -1998,7 +3150,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/IoSystemInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_iosysteminfo_cs",
-      "community": 85,
+      "community": 123,
       "norm_label": "iosysteminfo.cs"
     },
     {
@@ -2007,7 +3159,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/IoSystemInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_iosysteminfo_iosysteminfo",
-      "community": 85,
+      "community": 123,
       "norm_label": "iosysteminfo"
     },
     {
@@ -2016,7 +3168,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/NetworkInterfaceInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_networkinterfaceinfo_cs",
-      "community": 86,
+      "community": 124,
       "norm_label": "networkinterfaceinfo.cs"
     },
     {
@@ -2025,7 +3177,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/NetworkInterfaceInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_networkinterfaceinfo_networkinterfaceinfo",
-      "community": 86,
+      "community": 124,
       "norm_label": "networkinterfaceinfo"
     },
     {
@@ -2034,7 +3186,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/NodeInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_nodeinfo_cs",
-      "community": 87,
+      "community": 125,
       "norm_label": "nodeinfo.cs"
     },
     {
@@ -2043,7 +3195,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/NodeInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_nodeinfo_nodeinfo",
-      "community": 87,
+      "community": 125,
       "norm_label": "nodeinfo"
     },
     {
@@ -2052,7 +3204,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/PlcCompileInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_plccompileinfo_cs",
-      "community": 88,
+      "community": 126,
       "norm_label": "plccompileinfo.cs"
     },
     {
@@ -2061,7 +3213,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/PlcCompileInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_plccompileinfo_plccompileinfo",
-      "community": 88,
+      "community": 126,
       "norm_label": "plccompileinfo"
     },
     {
@@ -2070,7 +3222,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/PlcCrossReferenceInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_plccrossreferenceinfo_cs",
-      "community": 89,
+      "community": 127,
       "norm_label": "plccrossreferenceinfo.cs"
     },
     {
@@ -2079,7 +3231,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/PlcCrossReferenceInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_plccrossreferenceinfo_plccrossreferenceinfo",
-      "community": 89,
+      "community": 127,
       "norm_label": "plccrossreferenceinfo"
     },
     {
@@ -2088,7 +3240,7 @@
       "source_file": "TiaMcpServer.Contracts/PlcOnlineResultInfo.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_plconlineresultinfo_cs",
-      "community": 100,
+      "community": 139,
       "norm_label": "plconlineresultinfo.cs"
     },
     {
@@ -2097,7 +3249,7 @@
       "source_file": "TiaMcpServer.Contracts/PlcOnlineResultInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_plconlineresultinfo_plconlineresultinfo",
-      "community": 100,
+      "community": 139,
       "norm_label": "plconlineresultinfo"
     },
     {
@@ -2106,7 +3258,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectLifecycleResultInfo.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_projectlifecycleresultinfo_cs",
-      "community": 101,
+      "community": 140,
       "norm_label": "projectlifecycleresultinfo.cs"
     },
     {
@@ -2115,7 +3267,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectLifecycleResultInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_projectlifecycleresultinfo_projectlifecycleresultinfo",
-      "community": 101,
+      "community": 140,
       "norm_label": "projectlifecycleresultinfo"
     },
     {
@@ -2178,7 +3330,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectStatusInfo.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_projectstatusinfo_cs",
-      "community": 102,
+      "community": 141,
       "norm_label": "projectstatusinfo.cs"
     },
     {
@@ -2187,7 +3339,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectStatusInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_projectstatusinfo_projectstatusinfo",
-      "community": 102,
+      "community": 141,
       "norm_label": "projectstatusinfo"
     },
     {
@@ -2196,7 +3348,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectTreeFilter.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_projecttreefilter_cs",
-      "community": 36,
+      "community": 53,
       "norm_label": "projecttreefilter.cs"
     },
     {
@@ -2205,7 +3357,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectTreeFilter.cs",
       "source_location": "L13",
       "id": "tiamcpserver_contracts_projecttreefilter_projecttreefilter",
-      "community": 36,
+      "community": 53,
       "norm_label": "projecttreefilter"
     },
     {
@@ -2214,7 +3366,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectTreeFilter.cs",
       "source_location": "L15",
       "id": "tiamcpserver_contracts_projecttreefilter_projecttreefilter_apply",
-      "community": 36,
+      "community": 53,
       "norm_label": ".apply()"
     },
     {
@@ -2223,7 +3375,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectTreeFilter.cs",
       "source_location": "L40",
       "id": "tiamcpserver_contracts_projecttreefilter_projecttreefilter_findbypath",
-      "community": 36,
+      "community": 53,
       "norm_label": ".findbypath()"
     },
     {
@@ -2232,7 +3384,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectTreeFilter.cs",
       "source_location": "L67",
       "id": "tiamcpserver_contracts_projecttreefilter_projecttreefilter_prune",
-      "community": 36,
+      "community": 53,
       "norm_label": ".prune()"
     },
     {
@@ -2241,7 +3393,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectTreeFilter.cs",
       "source_location": "L98",
       "id": "tiamcpserver_contracts_projecttreefilter_projecttreefilter_clone",
-      "community": 36,
+      "community": 53,
       "norm_label": ".clone()"
     },
     {
@@ -2250,7 +3402,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectTreeFilter.cs",
       "source_location": "L111",
       "id": "tiamcpserver_contracts_projecttreefilter_projecttreefilter_copydetails",
-      "community": 36,
+      "community": 53,
       "norm_label": ".copydetails()"
     },
     {
@@ -2259,7 +3411,7 @@
       "source_file": "TiaMcpServer.Contracts/ProjectTreeFilter.cs",
       "source_location": "L118",
       "id": "tiamcpserver_contracts_projecttreefilter_projecttreefilter_copydetailsornull",
-      "community": 36,
+      "community": 53,
       "norm_label": ".copydetailsornull()"
     },
     {
@@ -2268,7 +3420,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/ProjectTreeNode.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_projecttreenode_cs",
-      "community": 90,
+      "community": 128,
       "norm_label": "projecttreenode.cs"
     },
     {
@@ -2277,7 +3429,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/ProjectTreeNode.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_projecttreenode_projecttreenode",
-      "community": 90,
+      "community": 128,
       "norm_label": "projecttreenode"
     },
     {
@@ -2286,7 +3438,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/SubnetInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_subnetinfo_cs",
-      "community": 91,
+      "community": 129,
       "norm_label": "subnetinfo.cs"
     },
     {
@@ -2295,7 +3447,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/SubnetInfo.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_subnetinfo_subnetinfo",
-      "community": 91,
+      "community": 129,
       "norm_label": "subnetinfo"
     },
     {
@@ -2304,7 +3456,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/TagInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_taginfo_cs",
-      "community": 92,
+      "community": 130,
       "norm_label": "taginfo.cs"
     },
     {
@@ -2313,7 +3465,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/TagInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_taginfo_taginfo",
-      "community": 92,
+      "community": 130,
       "norm_label": "taginfo"
     },
     {
@@ -2322,7 +3474,7 @@
       "source_file": "TiaMcpServer.Contracts/TagMutationResultInfo.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_tagmutationresultinfo_cs",
-      "community": 103,
+      "community": 142,
       "norm_label": "tagmutationresultinfo.cs"
     },
     {
@@ -2331,7 +3483,7 @@
       "source_file": "TiaMcpServer.Contracts/TagMutationResultInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_tagmutationresultinfo_tagmutationresultinfo",
-      "community": 103,
+      "community": 142,
       "norm_label": "tagmutationresultinfo"
     },
     {
@@ -2340,7 +3492,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/TagTableInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_tagtableinfo_cs",
-      "community": 93,
+      "community": 131,
       "norm_label": "tagtableinfo.cs"
     },
     {
@@ -2349,7 +3501,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/TagTableInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_tagtableinfo_tagtableinfo",
-      "community": 93,
+      "community": 131,
       "norm_label": "tagtableinfo"
     },
     {
@@ -2358,7 +3510,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/UserConstantInfo.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_userconstantinfo_cs",
-      "community": 94,
+      "community": 132,
       "norm_label": "userconstantinfo.cs"
     },
     {
@@ -2367,7 +3519,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/UserConstantInfo.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_userconstantinfo_userconstantinfo",
-      "community": 94,
+      "community": 132,
       "norm_label": "userconstantinfo"
     },
     {
@@ -2376,7 +3528,7 @@
       "source_file": "TiaMcpServer.Contracts/WorkerRequest.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_workerrequest_cs",
-      "community": 104,
+      "community": 143,
       "norm_label": "workerrequest.cs"
     },
     {
@@ -2385,7 +3537,7 @@
       "source_file": "TiaMcpServer.Contracts/WorkerRequest.cs",
       "source_location": "L3",
       "id": "tiamcpserver_contracts_workerrequest_workerrequest",
-      "community": 104,
+      "community": 143,
       "norm_label": "workerrequest"
     },
     {
@@ -2394,7 +3546,7 @@
       "source_file": "TiaMcpServer.Contracts/WorkerResponse.cs",
       "source_location": "L1",
       "id": "tiamcpserver_contracts_workerresponse_cs",
-      "community": 95,
+      "community": 133,
       "norm_label": "workerresponse.cs"
     },
     {
@@ -2403,7 +3555,7 @@
       "source_file": "TiaMcpServer.Contracts/WorkerResponse.cs",
       "source_location": "L5",
       "id": "tiamcpserver_contracts_workerresponse_workerresponse",
-      "community": 95,
+      "community": 133,
       "norm_label": "workerresponse"
     },
     {
@@ -2412,7 +3564,7 @@
       "source_file": "TiaMcpServer.FakeWorker/Program.cs",
       "source_location": "L1",
       "id": "tiamcpserver_fakeworker_program_cs",
-      "community": 106,
+      "community": 150,
       "norm_label": "program.cs"
     },
     {
@@ -2832,55 +3984,91 @@
     {
       "label": "AssemblyResolver.cs",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
       "source_location": "L1",
-      "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_assemblyresolver_cs",
-      "community": 39,
+      "id": "tiamcpserver_opennessworker_openness_assemblyresolver_cs",
+      "community": 35,
       "norm_label": "assemblyresolver.cs"
     },
     {
       "label": "AssemblyResolver",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
-      "source_location": "L10",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L11",
       "id": "openness_assemblyresolver_assemblyresolver",
-      "community": 39,
+      "community": 35,
       "norm_label": "assemblyresolver"
     },
     {
       "label": ".Register()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
-      "source_location": "L24",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L27",
       "id": "openness_assemblyresolver_assemblyresolver_register",
-      "community": 39,
+      "community": 35,
       "norm_label": ".register()"
+    },
+    {
+      "label": ".ExpandTiaPortalLocation()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L33",
+      "id": "openness_assemblyresolver_assemblyresolver_expandtiaportallocation",
+      "community": 35,
+      "norm_label": ".expandtiaportallocation()"
+    },
+    {
+      "label": ".CreateCandidatePaths()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L38",
+      "id": "openness_assemblyresolver_assemblyresolver_createcandidatepaths",
+      "community": 35,
+      "norm_label": ".createcandidatepaths()"
+    },
+    {
+      "label": ".SelectFirstCompleteCandidate()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L65",
+      "id": "openness_assemblyresolver_assemblyresolver_selectfirstcompletecandidate",
+      "community": 35,
+      "norm_label": ".selectfirstcompletecandidate()"
     },
     {
       "label": ".OnAssemblyResolve()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
-      "source_location": "L30",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L82",
       "id": "openness_assemblyresolver_assemblyresolver_onassemblyresolve",
-      "community": 39,
+      "community": 35,
       "norm_label": ".onassemblyresolve()"
     },
     {
       "label": ".GetOpennessInstallPath()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
-      "source_location": "L58",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L110",
       "id": "openness_assemblyresolver_assemblyresolver_getopennessinstallpath",
-      "community": 39,
+      "community": 35,
       "norm_label": ".getopennessinstallpath()"
+    },
+    {
+      "label": ".GetRegistryInstallPaths()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L139",
+      "id": "openness_assemblyresolver_assemblyresolver_getregistryinstallpaths",
+      "community": 35,
+      "norm_label": ".getregistryinstallpaths()"
     },
     {
       "label": ".ContainsRequiredAssemblies()",
       "file_type": "code",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
-      "source_location": "L115",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L169",
       "id": "openness_assemblyresolver_assemblyresolver_containsrequiredassemblies",
-      "community": 39,
+      "community": 35,
       "norm_label": ".containsrequiredassemblies()"
     },
     {
@@ -2889,7 +4077,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockExporter.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_blockexporter_cs",
-      "community": 58,
+      "community": 84,
       "norm_label": "blockexporter.cs"
     },
     {
@@ -2898,7 +4086,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockExporter.cs",
       "source_location": "L10",
       "id": "openness_blockexporter_blockexporter",
-      "community": 58,
+      "community": 84,
       "norm_label": "blockexporter"
     },
     {
@@ -2907,7 +4095,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockExporter.cs",
       "source_location": "L12",
       "id": "openness_blockexporter_blockexporter_export",
-      "community": 58,
+      "community": 84,
       "norm_label": ".export()"
     },
     {
@@ -2916,7 +4104,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockExporter.cs",
       "source_location": "L69",
       "id": "openness_blockexporter_blockexporter_stripnondeterministic",
-      "community": 58,
+      "community": 84,
       "norm_label": ".stripnondeterministic()"
     },
     {
@@ -2925,7 +4113,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_blockimporter_cs",
-      "community": 1,
+      "community": 54,
       "norm_label": "blockimporter.cs"
     },
     {
@@ -2934,7 +4122,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L8",
       "id": "openness_blockimporter_blockimporter",
-      "community": 1,
+      "community": 54,
       "norm_label": "blockimporter"
     },
     {
@@ -2943,7 +4131,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L12",
       "id": "openness_blockimporter_blockimporter_import",
-      "community": 1,
+      "community": 54,
       "norm_label": ".import()"
     },
     {
@@ -2952,7 +4140,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L77",
       "id": "openness_blockimporter_blockimporter_isxmlcontent",
-      "community": 1,
+      "community": 54,
       "norm_label": ".isxmlcontent()"
     },
     {
@@ -2961,7 +4149,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L85",
       "id": "openness_blockimporter_blockimporter_writecontenttotempdir",
-      "community": 1,
+      "community": 54,
       "norm_label": ".writecontenttotempdir()"
     },
     {
@@ -2970,7 +4158,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L115",
       "id": "openness_blockimporter_blockimporter_extractfilename",
-      "community": 1,
+      "community": 54,
       "norm_label": ".extractfilename()"
     },
     {
@@ -2979,7 +4167,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L127",
       "id": "openness_blockimporter_blockimporter_flushsection",
-      "community": 1,
+      "community": 54,
       "norm_label": ".flushsection()"
     },
     {
@@ -2988,7 +4176,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_blockmutationservice_cs",
-      "community": 22,
+      "community": 27,
       "norm_label": "blockmutationservice.cs"
     },
     {
@@ -2997,7 +4185,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L11",
       "id": "openness_blockmutationservice_blockmutationservice",
-      "community": 22,
+      "community": 27,
       "norm_label": "blockmutationservice"
     },
     {
@@ -3006,7 +4194,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L13",
       "id": "openness_blockmutationservice_blockmutationservice_createblock",
-      "community": 22,
+      "community": 27,
       "norm_label": ".createblock()"
     },
     {
@@ -3015,7 +4203,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L49",
       "id": "openness_blockmutationservice_blockmutationservice_deleteblock",
-      "community": 22,
+      "community": 27,
       "norm_label": ".deleteblock()"
     },
     {
@@ -3024,7 +4212,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L72",
       "id": "openness_blockmutationservice_blockmutationservice_createblockgroup",
-      "community": 22,
+      "community": 27,
       "norm_label": ".createblockgroup()"
     },
     {
@@ -3033,7 +4221,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L89",
       "id": "openness_blockmutationservice_blockmutationservice_deleteblockgroup",
-      "community": 22,
+      "community": 27,
       "norm_label": ".deleteblockgroup()"
     },
     {
@@ -3042,7 +4230,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L112",
       "id": "openness_blockmutationservice_blockmutationservice_resolvegroupfromaddress",
-      "community": 22,
+      "community": 27,
       "norm_label": ".resolvegroupfromaddress()"
     },
     {
@@ -3051,7 +4239,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L124",
       "id": "openness_blockmutationservice_blockmutationservice_findgroupbypath",
-      "community": 22,
+      "community": 27,
       "norm_label": ".findgroupbypath()"
     },
     {
@@ -3060,7 +4248,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L151",
       "id": "openness_blockmutationservice_blockmutationservice_findusergroupbypath",
-      "community": 22,
+      "community": 27,
       "norm_label": ".findusergroupbypath()"
     },
     {
@@ -3069,7 +4257,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L179",
       "id": "openness_blockmutationservice_blockmutationservice_importblockfromxml",
-      "community": 22,
+      "community": 27,
       "norm_label": ".importblockfromxml()"
     },
     {
@@ -3078,7 +4266,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L205",
       "id": "openness_blockmutationservice_blockmutationservice_generateblockxml",
-      "community": 22,
+      "community": 27,
       "norm_label": ".generateblockxml()"
     },
     {
@@ -3087,7 +4275,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L290",
       "id": "openness_blockmutationservice_blockmutationservice_generatefbxml",
-      "community": 22,
+      "community": 27,
       "norm_label": ".generatefbxml()"
     },
     {
@@ -3096,7 +4284,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs",
       "source_location": "L334",
       "id": "openness_blockmutationservice_blockmutationservice_toprogramminglanguagexml",
-      "community": 22,
+      "community": 27,
       "norm_label": ".toprogramminglanguagexml()"
     },
     {
@@ -3105,7 +4293,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_blocktargetresolver_cs",
-      "community": 23,
+      "community": 28,
       "norm_label": "blocktargetresolver.cs"
     },
     {
@@ -3114,7 +4302,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L11",
       "id": "openness_blocktargetresolver_blocktargetresolver",
-      "community": 23,
+      "community": 28,
       "norm_label": "blocktargetresolver"
     },
     {
@@ -3123,7 +4311,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L13",
       "id": "openness_blocktargetresolver_blocktargetresolver_resolveforexport",
-      "community": 23,
+      "community": 28,
       "norm_label": ".resolveforexport()"
     },
     {
@@ -3132,7 +4320,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L41",
       "id": "openness_blocktargetresolver_blocktargetresolver_resolveforimport",
-      "community": 23,
+      "community": 28,
       "norm_label": ".resolveforimport()"
     },
     {
@@ -3141,7 +4329,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L64",
       "id": "openness_blocktargetresolver_blocktargetresolver_resolvedeterministicblockgroup",
-      "community": 23,
+      "community": 28,
       "norm_label": ".resolvedeterministicblockgroup()"
     },
     {
@@ -3150,7 +4338,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L73",
       "id": "openness_blocktargetresolver_blocktargetresolver_findsoftwareunit",
-      "community": 23,
+      "community": 28,
       "norm_label": ".findsoftwareunit()"
     },
     {
@@ -3159,7 +4347,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L92",
       "id": "openness_blocktargetresolver_blocktargetresolver_findblockgroup",
-      "community": 23,
+      "community": 28,
       "norm_label": ".findblockgroup()"
     },
     {
@@ -3168,7 +4356,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L114",
       "id": "openness_blocktargetresolver_blocktargetresolver_findlegacymatches",
-      "community": 23,
+      "community": 28,
       "norm_label": ".findlegacymatches()"
     },
     {
@@ -3177,7 +4365,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L131",
       "id": "openness_blocktargetresolver_blocktargetresolver_collectmatches",
-      "community": 23,
+      "community": 28,
       "norm_label": ".collectmatches()"
     },
     {
@@ -3186,7 +4374,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L146",
       "id": "openness_blocktargetresolver_resolvedblocktarget",
-      "community": 23,
+      "community": 28,
       "norm_label": "resolvedblocktarget"
     },
     {
@@ -3429,7 +4617,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_equipmentcatalogsearcher_cs",
-      "community": 5,
+      "community": 23,
       "norm_label": "equipmentcatalogsearcher.cs"
     },
     {
@@ -3438,7 +4626,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L10",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher",
-      "community": 5,
+      "community": 23,
       "norm_label": "equipmentcatalogsearcher"
     },
     {
@@ -3447,7 +4635,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L30",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_search",
-      "community": 5,
+      "community": 23,
       "norm_label": ".search()"
     },
     {
@@ -3456,7 +4644,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L73",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_addmatchesfromhardwarecatalogfind",
-      "community": 5,
+      "community": 23,
       "norm_label": ".addmatchesfromhardwarecatalogfind()"
     },
     {
@@ -3465,7 +4653,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L99",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_findcatalogroots",
-      "community": 5,
+      "community": 23,
       "norm_label": ".findcatalogroots()"
     },
     {
@@ -3474,7 +4662,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L126",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_traverse",
-      "community": 5,
+      "community": 23,
       "norm_label": ".traverse()"
     },
     {
@@ -3483,7 +4671,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L172",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_addmatch",
-      "community": 5,
+      "community": 23,
       "norm_label": ".addmatch()"
     },
     {
@@ -3492,7 +4680,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L225",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_hasreadableproperty",
-      "community": 5,
+      "community": 23,
       "norm_label": ".hasreadableproperty()"
     },
     {
@@ -3501,7 +4689,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L230",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_appendpath",
-      "community": 5,
+      "community": 23,
       "norm_label": ".appendpath()"
     },
     {
@@ -3510,7 +4698,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L237",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_contains",
-      "community": 5,
+      "community": 23,
       "norm_label": ".contains()"
     },
     {
@@ -3519,7 +4707,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L242",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_readstringproperty",
-      "community": 5,
+      "community": 23,
       "norm_label": ".readstringproperty()"
     },
     {
@@ -3528,7 +4716,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_hardwareconfigreader_cs",
-      "community": 8,
+      "community": 6,
       "norm_label": "hardwareconfigreader.cs"
     },
     {
@@ -3537,7 +4725,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L8",
       "id": "openness_hardwareconfigreader_hardwareconfigreader",
-      "community": 8,
+      "community": 6,
       "norm_label": "hardwareconfigreader"
     },
     {
@@ -3546,7 +4734,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L10",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_read",
-      "community": 8,
+      "community": 6,
       "norm_label": ".read()"
     },
     {
@@ -3555,7 +4743,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L41",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readdevice",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readdevice()"
     },
     {
@@ -3564,7 +4752,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L55",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readdeviceitems",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readdeviceitems()"
     },
     {
@@ -3573,7 +4761,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L74",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readdeviceitem",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readdeviceitem()"
     },
     {
@@ -3582,7 +4770,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L101",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readnetworkinterfaces",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readnetworkinterfaces()"
     },
     {
@@ -3591,7 +4779,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L121",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readnetworkinterface",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readnetworkinterface()"
     },
     {
@@ -3600,7 +4788,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L144",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readnode",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readnode()"
     },
     {
@@ -3609,7 +4797,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L159",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readsubnet",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readsubnet()"
     },
     {
@@ -3618,7 +4806,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L194",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readiosystem",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readiosystem()"
     },
     {
@@ -3627,7 +4815,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L216",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readconnectedsubnetname",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readconnectedsubnetname()"
     },
     {
@@ -3636,7 +4824,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L224",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readiosystemname",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readiosystemname()"
     },
     {
@@ -3645,7 +4833,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L242",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_findparentdevicename",
-      "community": 8,
+      "community": 6,
       "norm_label": ".findparentdevicename()"
     },
     {
@@ -3654,7 +4842,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L264",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readstring",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readstring()"
     },
     {
@@ -3663,7 +4851,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L277",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readint",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readint()"
     },
     {
@@ -3672,7 +4860,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L290",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readattribute",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readattribute()"
     },
     {
@@ -3681,7 +4869,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L303",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readpropertyorattribute",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readpropertyorattribute()"
     },
     {
@@ -3690,7 +4878,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L316",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readproperty",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readproperty()"
     },
     {
@@ -3699,7 +4887,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L321",
       "id": "openness_hardwareconfigreader_hardwareconfigreader_readenumerableproperty",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readenumerableproperty()"
     },
     {
@@ -3843,7 +5031,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/NetworkDeviceCreator.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_networkdevicecreator_cs",
-      "community": 8,
+      "community": 6,
       "norm_label": "networkdevicecreator.cs"
     },
     {
@@ -3852,7 +5040,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/NetworkDeviceCreator.cs",
       "source_location": "L7",
       "id": "openness_networkdevicecreator_networkdevicecreator",
-      "community": 8,
+      "community": 6,
       "norm_label": "networkdevicecreator"
     },
     {
@@ -3861,7 +5049,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/NetworkDeviceCreator.cs",
       "source_location": "L9",
       "id": "openness_networkdevicecreator_networkdevicecreator_create",
-      "community": 8,
+      "community": 6,
       "norm_label": ".create()"
     },
     {
@@ -3870,7 +5058,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/NetworkDeviceCreator.cs",
       "source_location": "L52",
       "id": "openness_networkdevicecreator_networkdevicecreator_getfirstdeviceitem",
-      "community": 8,
+      "community": 6,
       "norm_label": ".getfirstdeviceitem()"
     },
     {
@@ -3879,7 +5067,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/NetworkDeviceCreator.cs",
       "source_location": "L69",
       "id": "openness_networkdevicecreator_networkdevicecreator_readstring",
-      "community": 8,
+      "community": 6,
       "norm_label": ".readstring()"
     },
     {
@@ -3888,7 +5076,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/OpennessReflection.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_opennessreflection_cs",
-      "community": 59,
+      "community": 85,
       "norm_label": "opennessreflection.cs"
     },
     {
@@ -3897,7 +5085,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/OpennessReflection.cs",
       "source_location": "L16",
       "id": "openness_opennessreflection_opennessreflection",
-      "community": 59,
+      "community": 85,
       "norm_label": "opennessreflection"
     },
     {
@@ -3906,7 +5094,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/OpennessReflection.cs",
       "source_location": "L18",
       "id": "openness_opennessreflection_opennessreflection_readproperty",
-      "community": 59,
+      "community": 85,
       "norm_label": ".readproperty()"
     },
     {
@@ -3915,7 +5103,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/OpennessReflection.cs",
       "source_location": "L68",
       "id": "openness_opennessreflection_opennessreflection_readenumerableproperty",
-      "community": 59,
+      "community": 85,
       "norm_label": ".readenumerableproperty()"
     },
     {
@@ -3924,7 +5112,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/OpennessReflection.cs",
       "source_location": "L78",
       "id": "openness_opennessreflection_opennessreflection_enumerate",
-      "community": 59,
+      "community": 85,
       "norm_label": ".enumerate()"
     },
     {
@@ -3933,7 +5121,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_plconlineservice_cs",
-      "community": 47,
+      "community": 69,
       "norm_label": "plconlineservice.cs"
     },
     {
@@ -3942,7 +5130,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L10",
       "id": "openness_plconlineservice_plconlineservice",
-      "community": 47,
+      "community": 69,
       "norm_label": "plconlineservice"
     },
     {
@@ -3951,7 +5139,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L12",
       "id": "openness_plconlineservice_plconlineservice_start",
-      "community": 47,
+      "community": 69,
       "norm_label": ".start()"
     },
     {
@@ -3960,7 +5148,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L15",
       "id": "openness_plconlineservice_plconlineservice_stop",
-      "community": 47,
+      "community": 69,
       "norm_label": ".stop()"
     },
     {
@@ -3969,7 +5157,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L18",
       "id": "openness_plconlineservice_plconlineservice_controlplc",
-      "community": 47,
+      "community": 69,
       "norm_label": ".controlplc()"
     },
     {
@@ -3978,7 +5166,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcOnlineService.cs",
       "source_location": "L55",
       "id": "openness_plconlineservice_plconlineservice_invokecontrolmethod",
-      "community": 47,
+      "community": 69,
       "norm_label": ".invokecontrolmethod()"
     },
     {
@@ -3987,7 +5175,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_plcsoftwarelocator_cs",
-      "community": 40,
+      "community": 59,
       "norm_label": "plcsoftwarelocator.cs"
     },
     {
@@ -3996,7 +5184,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs",
       "source_location": "L8",
       "id": "openness_plcsoftwarelocator_plcsoftwarelocator",
-      "community": 40,
+      "community": 59,
       "norm_label": "plcsoftwarelocator"
     },
     {
@@ -4005,7 +5193,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs",
       "source_location": "L11",
       "id": "openness_plcsoftwarelocator_plcsoftwarelocator_find",
-      "community": 40,
+      "community": 59,
       "norm_label": ".find()"
     },
     {
@@ -4014,7 +5202,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs",
       "source_location": "L26",
       "id": "openness_plcsoftwarelocator_plcsoftwarelocator_findall",
-      "community": 40,
+      "community": 59,
       "norm_label": ".findall()"
     },
     {
@@ -4023,7 +5211,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs",
       "source_location": "L45",
       "id": "openness_plcsoftwarelocator_plcsoftwarelocator_findindevice",
-      "community": 40,
+      "community": 59,
       "norm_label": ".findindevice()"
     },
     {
@@ -4032,7 +5220,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs",
       "source_location": "L50",
       "id": "openness_plcsoftwarelocator_plcsoftwarelocator_findindeviceitems",
-      "community": 40,
+      "community": 59,
       "norm_label": ".findindeviceitems()"
     },
     {
@@ -4041,7 +5229,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/PlcSoftwareLocator.cs",
       "source_location": "L78",
       "id": "openness_plcsoftwarelocator_discoveredplcsoftware",
-      "community": 40,
+      "community": 59,
       "norm_label": "discoveredplcsoftware"
     },
     {
@@ -4203,7 +5391,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectRebindCloseGuard.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_projectrebindcloseguard_cs",
-      "community": 96,
+      "community": 134,
       "norm_label": "projectrebindcloseguard.cs"
     },
     {
@@ -4212,7 +5400,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectRebindCloseGuard.cs",
       "source_location": "L6",
       "id": "openness_projectrebindcloseguard_projectrebindcloseguard",
-      "community": 96,
+      "community": 134,
       "norm_label": "projectrebindcloseguard"
     },
     {
@@ -4221,7 +5409,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectRebindCloseGuard.cs",
       "source_location": "L8",
       "id": "openness_projectrebindcloseguard_projectrebindcloseguard_closebeforerebind",
-      "community": 96,
+      "community": 134,
       "norm_label": ".closebeforerebind()"
     },
     {
@@ -4230,7 +5418,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_projecttreewalker_cs",
-      "community": 24,
+      "community": 30,
       "norm_label": "projecttreewalker.cs"
     },
     {
@@ -4239,7 +5427,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L14",
       "id": "openness_projecttreewalker_projecttreewalker",
-      "community": 24,
+      "community": 30,
       "norm_label": "projecttreewalker"
     },
     {
@@ -4248,7 +5436,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L16",
       "id": "openness_projecttreewalker_projecttreewalker_walk",
-      "community": 24,
+      "community": 30,
       "norm_label": ".walk()"
     },
     {
@@ -4257,7 +5445,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L44",
       "id": "openness_projecttreewalker_projecttreewalker_walkplcsoftware",
-      "community": 24,
+      "community": 30,
       "norm_label": ".walkplcsoftware()"
     },
     {
@@ -4266,7 +5454,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L68",
       "id": "openness_projecttreewalker_projecttreewalker_walksoftwareunits",
-      "community": 24,
+      "community": 30,
       "norm_label": ".walksoftwareunits()"
     },
     {
@@ -4275,7 +5463,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L108",
       "id": "openness_projecttreewalker_projecttreewalker_walkblockgroup",
-      "community": 24,
+      "community": 30,
       "norm_label": ".walkblockgroup()"
     },
     {
@@ -4284,7 +5472,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L174",
       "id": "openness_projecttreewalker_projecttreewalker_walktagtablegroup",
-      "community": 24,
+      "community": 30,
       "norm_label": ".walktagtablegroup()"
     },
     {
@@ -4293,7 +5481,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L222",
       "id": "openness_projecttreewalker_projecttreewalker_walktypegroup",
-      "community": 24,
+      "community": 30,
       "norm_label": ".walktypegroup()"
     },
     {
@@ -4302,7 +5490,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L270",
       "id": "openness_projecttreewalker_projecttreewalker_combinepath",
-      "community": 24,
+      "community": 30,
       "norm_label": ".combinepath()"
     },
     {
@@ -4455,7 +5643,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_tagtablereader_cs",
-      "community": 32,
+      "community": 42,
       "norm_label": "tagtablereader.cs"
     },
     {
@@ -4464,7 +5652,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L7",
       "id": "openness_tagtablereader_tagtablereader",
-      "community": 32,
+      "community": 42,
       "norm_label": "tagtablereader"
     },
     {
@@ -4473,7 +5661,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L9",
       "id": "openness_tagtablereader_tagtablereader_readall",
-      "community": 32,
+      "community": 42,
       "norm_label": ".readall()"
     },
     {
@@ -4482,7 +5670,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L20",
       "id": "openness_tagtablereader_tagtablereader_collecttablesfromgroup",
-      "community": 32,
+      "community": 42,
       "norm_label": ".collecttablesfromgroup()"
     },
     {
@@ -4491,7 +5679,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L56",
       "id": "openness_tagtablereader_tagtablereader_readtagtable",
-      "community": 32,
+      "community": 42,
       "norm_label": ".readtagtable()"
     },
     {
@@ -4500,7 +5688,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L70",
       "id": "openness_tagtablereader_tagtablereader_readtags",
-      "community": 32,
+      "community": 42,
       "norm_label": ".readtags()"
     },
     {
@@ -4509,7 +5697,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L95",
       "id": "openness_tagtablereader_tagtablereader_readuserconstants",
-      "community": 32,
+      "community": 42,
       "norm_label": ".readuserconstants()"
     },
     {
@@ -4518,7 +5706,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L1",
       "id": "tiamcpserver_opennessworker_openness_tiaportalsession_cs",
-      "community": 6,
+      "community": 26,
       "norm_label": "tiaportalsession.cs"
     },
     {
@@ -4527,7 +5715,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L8",
       "id": "openness_tiaportalsession_tiaportalsession",
-      "community": 6,
+      "community": 26,
       "norm_label": "tiaportalsession"
     },
     {
@@ -4536,7 +5724,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L11",
       "id": "tiaportal",
-      "community": 6,
+      "community": 26,
       "norm_label": "tiaportal"
     },
     {
@@ -4545,7 +5733,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L26",
       "id": "openness_tiaportalsession_tiaportalsession_connect",
-      "community": 6,
+      "community": 26,
       "norm_label": ".connect()"
     },
     {
@@ -4554,7 +5742,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L52",
       "id": "openness_tiaportalsession_tiaportalsession_openproject",
-      "community": 6,
+      "community": 26,
       "norm_label": ".openproject()"
     },
     {
@@ -4563,7 +5751,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L113",
       "id": "openness_tiaportalsession_tiaportalsession_tryreadcurrentprojectpath",
-      "community": 6,
+      "community": 26,
       "norm_label": ".tryreadcurrentprojectpath()"
     },
     {
@@ -4572,7 +5760,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L133",
       "id": "openness_tiaportalsession_tiaportalsession_markprojectclosed",
-      "community": 6,
+      "community": 26,
       "norm_label": ".markprojectclosed()"
     },
     {
@@ -4581,7 +5769,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L139",
       "id": "openness_tiaportalsession_tiaportalsession_ensureconnected",
-      "community": 6,
+      "community": 26,
       "norm_label": ".ensureconnected()"
     },
     {
@@ -4590,7 +5778,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L149",
       "id": "openness_tiaportalsession_tiaportalsession_onnotification",
-      "community": 6,
+      "community": 26,
       "norm_label": ".onnotification()"
     },
     {
@@ -4599,7 +5787,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L154",
       "id": "openness_tiaportalsession_tiaportalsession_onconfirmation",
-      "community": 6,
+      "community": 26,
       "norm_label": ".onconfirmation()"
     },
     {
@@ -4608,7 +5796,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L161",
       "id": "openness_tiaportalsession_tiaportalsession_ondisposed",
-      "community": 6,
+      "community": 26,
       "norm_label": ".ondisposed()"
     },
     {
@@ -4617,7 +5805,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L169",
       "id": "openness_tiaportalsession_tiaportalsession_dispose",
-      "community": 6,
+      "community": 26,
       "norm_label": ".dispose()"
     },
     {
@@ -4626,7 +5814,7 @@
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs",
       "source_location": "L197",
       "id": "openness_tiaportalsession_tiaportalsession_throwifdisposed",
-      "community": 6,
+      "community": 26,
       "norm_label": ".throwifdisposed()"
     },
     {
@@ -4635,7 +5823,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddDeviceResultInfoTests.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_adddeviceresultinfotests_cs",
-      "community": 48,
+      "community": 70,
       "norm_label": "adddeviceresultinfotests.cs"
     },
     {
@@ -4644,7 +5832,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddDeviceResultInfoTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_adddeviceresultinfotests_adddeviceresultinfotests",
-      "community": 48,
+      "community": 70,
       "norm_label": "adddeviceresultinfotests"
     },
     {
@@ -4653,7 +5841,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddDeviceResultInfoTests.cs",
       "source_location": "L17",
       "id": "tiamcpserver_tests_adddeviceresultinfotests_adddeviceresultinfotests_serializesemptyresult",
-      "community": 48,
+      "community": 70,
       "norm_label": ".serializesemptyresult()"
     },
     {
@@ -4662,7 +5850,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddDeviceResultInfoTests.cs",
       "source_location": "L31",
       "id": "tiamcpserver_tests_adddeviceresultinfotests_adddeviceresultinfotests_roundtripsresultwithwarnings",
-      "community": 48,
+      "community": 70,
       "norm_label": ".roundtripsresultwithwarnings()"
     },
     {
@@ -4671,7 +5859,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddDeviceResultInfoTests.cs",
       "source_location": "L50",
       "id": "tiamcpserver_tests_adddeviceresultinfotests_adddeviceresultinfotests_roundtrip",
-      "community": 48,
+      "community": 70,
       "norm_label": ".roundtrip()"
     },
     {
@@ -4680,7 +5868,7 @@
       "source_file": "TiaMcpServer.Tests/ArchiveModeNamesTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_archivemodenamestests_cs",
-      "community": 60,
+      "community": 86,
       "norm_label": "archivemodenamestests.cs"
     },
     {
@@ -4689,7 +5877,7 @@
       "source_file": "TiaMcpServer.Tests/ArchiveModeNamesTests.cs",
       "source_location": "L6",
       "id": "tiamcpserver_tests_archivemodenamestests_archivemodenamestests",
-      "community": 60,
+      "community": 86,
       "norm_label": "archivemodenamestests"
     },
     {
@@ -4698,7 +5886,7 @@
       "source_file": "TiaMcpServer.Tests/ArchiveModeNamesTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_archivemodenamestests_archivemodenamestests_emptyarchivemodedefaultstocompressed",
-      "community": 60,
+      "community": 86,
       "norm_label": ".emptyarchivemodedefaultstocompressed()"
     },
     {
@@ -4707,7 +5895,7 @@
       "source_file": "TiaMcpServer.Tests/ArchiveModeNamesTests.cs",
       "source_location": "L17",
       "id": "tiamcpserver_tests_archivemodenamestests_archivemodenamestests_archivemodenormalizesignoringcase",
-      "community": 60,
+      "community": 86,
       "norm_label": ".archivemodenormalizesignoringcase()"
     },
     {
@@ -4716,7 +5904,7 @@
       "source_file": "TiaMcpServer.Tests/ArchiveModeNamesTests.cs",
       "source_location": "L26",
       "id": "tiamcpserver_tests_archivemodenamestests_archivemodenamestests_invalidarchivemodereturnserror",
-      "community": 60,
+      "community": 86,
       "norm_label": ".invalidarchivemodereturnserror()"
     },
     {
@@ -4725,7 +5913,7 @@
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_batchexecutionenginetests_cs",
-      "community": 33,
+      "community": 43,
       "norm_label": "batchexecutionenginetests.cs"
     },
     {
@@ -4734,7 +5922,7 @@
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
       "source_location": "L10",
       "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests",
-      "community": 33,
+      "community": 43,
       "norm_label": "batchexecutionenginetests"
     },
     {
@@ -4743,7 +5931,7 @@
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
       "source_location": "L12",
       "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_op",
-      "community": 33,
+      "community": 43,
       "norm_label": ".op()"
     },
     {
@@ -4752,7 +5940,7 @@
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
       "source_location": "L15",
       "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_executereadsasync_allsucceed_preservesorderandresults",
-      "community": 33,
+      "community": 43,
       "norm_label": ".executereadsasync_allsucceed_preservesorderandresults()"
     },
     {
@@ -4761,7 +5949,7 @@
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
       "source_location": "L29",
       "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_executereadsasync_peritemfailuredoesnotstopothers",
-      "community": 33,
+      "community": 43,
       "norm_label": ".executereadsasync_peritemfailuredoesnotstopothers()"
     },
     {
@@ -4770,7 +5958,7 @@
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
       "source_location": "L49",
       "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_applywritesasync_allsucceed_marksallsucceeded",
-      "community": 33,
+      "community": 43,
       "norm_label": ".applywritesasync_allsucceed_marksallsucceeded()"
     },
     {
@@ -4779,7 +5967,7 @@
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
       "source_location": "L61",
       "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_applywritesasync_stopsonfirstfailureandskipsrest",
-      "community": 33,
+      "community": 43,
       "norm_label": ".applywritesasync_stopsonfirstfailureandskipsrest()"
     },
     {
@@ -4788,7 +5976,7 @@
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
       "source_location": "L89",
       "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_executereadsasync_payloadstartingwitherrorprefix_isnotafailure",
-      "community": 33,
+      "community": 43,
       "norm_label": ".executereadsasync_payloadstartingwitherrorprefix_isnotafailure()"
     },
     {
@@ -4797,7 +5985,7 @@
       "source_file": "TiaMcpServer.Tests/BatchExecutionEngineTests.cs",
       "source_location": "L101",
       "id": "tiamcpserver_tests_batchexecutionenginetests_batchexecutionenginetests_executereadsasync_copieswarningsontoresult",
-      "community": 33,
+      "community": 43,
       "norm_label": ".executereadsasync_copieswarningsontoresult()"
     },
     {
@@ -4806,7 +5994,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_cs",
-      "community": 7,
+      "community": 5,
       "norm_label": "batchoperationcatalogtests.cs"
     },
     {
@@ -4815,7 +6003,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L7",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests",
-      "community": 7,
+      "community": 5,
       "norm_label": "batchoperationcatalogtests"
     },
     {
@@ -4824,7 +6012,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L9",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_op",
-      "community": 7,
+      "community": 5,
       "norm_label": ".op()"
     },
     {
@@ -4833,7 +6021,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L16",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_acceptsknownreadswithrequiredfields",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatereadbatch_acceptsknownreadswithrequiredfields()"
     },
     {
@@ -4842,7 +6030,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L31",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectsemptybatch",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatereadbatch_rejectsemptybatch()"
     },
     {
@@ -4851,7 +6039,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L40",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectsnullbatch",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatereadbatch_rejectsnullbatch()"
     },
     {
@@ -4860,7 +6048,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L48",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectsbatchoverfiftyitems",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatereadbatch_rejectsbatchoverfiftyitems()"
     },
     {
@@ -4869,7 +6057,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L63",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectsunknownoperation",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatereadbatch_rejectsunknownoperation()"
     },
     {
@@ -4878,7 +6066,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L72",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectswriteoperation",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatereadbatch_rejectswriteoperation()"
     },
     {
@@ -4887,7 +6075,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L83",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectsduplicateoperationid",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatereadbatch_rejectsduplicateoperationid()"
     },
     {
@@ -4896,7 +6084,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L93",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectsmissingoperationid",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatereadbatch_rejectsmissingoperationid()"
     },
     {
@@ -4905,7 +6093,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L102",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_rejectsmissingrequiredfield",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatereadbatch_rejectsmissingrequiredfield()"
     },
     {
@@ -4914,7 +6102,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L111",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_acceptsknowndatawrites",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatewritebatch_acceptsknowndatawrites()"
     },
     {
@@ -4923,7 +6111,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L126",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_rejectsreadoperation",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatewritebatch_rejectsreadoperation()"
     },
     {
@@ -4932,7 +6120,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L137",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_rejectsprojectlifecycleoperation",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatewritebatch_rejectsprojectlifecycleoperation()"
     },
     {
@@ -4941,7 +6129,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L147",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_rejectsmissingrequiredfield",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatewritebatch_rejectsmissingrequiredfield()"
     },
     {
@@ -4950,7 +6138,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L157",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_rejectsunknownoperation",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatewritebatch_rejectsunknownoperation()"
     },
     {
@@ -4959,7 +6147,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L166",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_rejectsmixedprojectpaths",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatewritebatch_rejectsmixedprojectpaths()"
     },
     {
@@ -4968,7 +6156,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L181",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_allowssameprojectpathoneveryitem",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatewritebatch_allowssameprojectpathoneveryitem()"
     },
     {
@@ -4977,7 +6165,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L195",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_allwriteoperations_acceptafullypopulatedrequest",
-      "community": 7,
+      "community": 5,
       "norm_label": ".allwriteoperations_acceptafullypopulatedrequest()"
     },
     {
@@ -4986,7 +6174,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L205",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_allreadoperations_acceptafullypopulatedrequest",
-      "community": 7,
+      "community": 5,
       "norm_label": ".allreadoperations_acceptafullypopulatedrequest()"
     },
     {
@@ -4995,7 +6183,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L215",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatereadbatch_unknownoperationerrorlistsvalidreadoperations",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatereadbatch_unknownoperationerrorlistsvalidreadoperations()"
     },
     {
@@ -5004,7 +6192,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L226",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_unknownoperationerrorlistsvalidwriteoperations",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatewritebatch_unknownoperationerrorlistsvalidwriteoperations()"
     },
     {
@@ -5013,7 +6201,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L237",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validatewritebatch_reportsallinvaliditemsatonce",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validatewritebatch_reportsallinvaliditemsatonce()"
     },
     {
@@ -5022,7 +6210,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L255",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validate_rejectsdepthandstartpathonnontreeoperations",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validate_rejectsdepthandstartpathonnontreeoperations()"
     },
     {
@@ -5031,7 +6219,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L273",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validate_rejectsmaxresultsonunsupportedoperations",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validate_rejectsmaxresultsonunsupportedoperations()"
     },
     {
@@ -5040,7 +6228,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L287",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validate_rejectsoutofrangebounds",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validate_rejectsoutofrangebounds()"
     },
     {
@@ -5049,7 +6237,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L303",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_validate_acceptsboundsontheiroperations",
-      "community": 7,
+      "community": 5,
       "norm_label": ".validate_acceptsboundsontheiroperations()"
     },
     {
@@ -5058,7 +6246,7 @@
       "source_file": "TiaMcpServer.Tests/BatchOperationCatalogTests.cs",
       "source_location": "L318",
       "id": "tiamcpserver_tests_batchoperationcatalogtests_batchoperationcatalogtests_fullypopulated",
-      "community": 7,
+      "community": 5,
       "norm_label": ".fullypopulated()"
     },
     {
@@ -5256,7 +6444,7 @@
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_batchresultformattertests_cs",
-      "community": 34,
+      "community": 44,
       "norm_label": "batchresultformattertests.cs"
     },
     {
@@ -5265,7 +6453,7 @@
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
       "source_location": "L7",
       "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests",
-      "community": 34,
+      "community": 44,
       "norm_label": "batchresultformattertests"
     },
     {
@@ -5274,7 +6462,7 @@
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
       "source_location": "L9",
       "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_parse",
-      "community": 34,
+      "community": 44,
       "norm_label": ".parse()"
     },
     {
@@ -5283,7 +6471,7 @@
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
       "source_location": "L11",
       "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_error_producesunsuccessfulenvelopewithmessage",
-      "community": 34,
+      "community": 44,
       "norm_label": ".error_producesunsuccessfulenvelopewithmessage()"
     },
     {
@@ -5292,7 +6480,7 @@
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
       "source_location": "L21",
       "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_readbatch_allsucceeded_issuccesswithcounts",
-      "community": 34,
+      "community": 44,
       "norm_label": ".readbatch_allsucceeded_issuccesswithcounts()"
     },
     {
@@ -5301,7 +6489,7 @@
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
       "source_location": "L39",
       "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_readbatch_anyfailure_isnotsuccess",
-      "community": 34,
+      "community": 44,
       "norm_label": ".readbatch_anyfailure_isnotsuccess()"
     },
     {
@@ -5310,7 +6498,7 @@
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
       "source_location": "L54",
       "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_applybatch_countssucceededfailedandskipped",
-      "community": 34,
+      "community": 44,
       "norm_label": ".applybatch_countssucceededfailedandskipped()"
     },
     {
@@ -5319,7 +6507,7 @@
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
       "source_location": "L73",
       "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_readbatch_includeswarningswhenpresent",
-      "community": 34,
+      "community": 44,
       "norm_label": ".readbatch_includeswarningswhenpresent()"
     },
     {
@@ -5328,7 +6516,7 @@
       "source_file": "TiaMcpServer.Tests/BatchResultFormatterTests.cs",
       "source_location": "L90",
       "id": "tiamcpserver_tests_batchresultformattertests_batchresultformattertests_readbatch_countsomitteditemsandclearssuccess",
-      "community": 34,
+      "community": 44,
       "norm_label": ".readbatch_countsomitteditemsandclearssuccess()"
     },
     {
@@ -5337,7 +6525,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetySnapshotTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_batchsafetysnapshottests_cs",
-      "community": 30,
+      "community": 38,
       "norm_label": "batchsafetysnapshottests.cs"
     },
     {
@@ -5346,7 +6534,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetySnapshotTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_batchsafetysnapshottests_batchsafetysnapshottests",
-      "community": 30,
+      "community": 38,
       "norm_label": "batchsafetysnapshottests"
     },
     {
@@ -5355,7 +6543,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetySnapshotTests.cs",
       "source_location": "L10",
       "id": "tiamcpserver_tests_batchsafetysnapshottests_batchsafetysnapshottests_op",
-      "community": 30,
+      "community": 38,
       "norm_label": ".op()"
     },
     {
@@ -5364,7 +6552,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetySnapshotTests.cs",
       "source_location": "L17",
       "id": "tiamcpserver_tests_batchsafetysnapshottests_batchsafetysnapshottests_describeoperation_describesblockupdatewithpath",
-      "community": 30,
+      "community": 38,
       "norm_label": ".describeoperation_describesblockupdatewithpath()"
     },
     {
@@ -5373,7 +6561,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetySnapshotTests.cs",
       "source_location": "L26",
       "id": "tiamcpserver_tests_batchsafetysnapshottests_batchsafetysnapshottests_describeoperation_describestagcreatewithnameandtable",
-      "community": 30,
+      "community": 38,
       "norm_label": ".describeoperation_describestagcreatewithnameandtable()"
     },
     {
@@ -5382,7 +6570,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetySnapshotTests.cs",
       "source_location": "L36",
       "id": "tiamcpserver_tests_batchsafetysnapshottests_batchsafetysnapshottests_buildtargets_preservesorderandoperationidentity",
-      "community": 30,
+      "community": 38,
       "norm_label": ".buildtargets_preservesorderandoperationidentity()"
     },
     {
@@ -5391,7 +6579,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetySnapshotTests.cs",
       "source_location": "L52",
       "id": "tiamcpserver_tests_batchsafetysnapshottests_batchsafetysnapshottests_buildtargets_isordersensitive",
-      "community": 30,
+      "community": 38,
       "norm_label": ".buildtargets_isordersensitive()"
     },
     {
@@ -5400,7 +6588,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetySnapshotTests.cs",
       "source_location": "L64",
       "id": "tiamcpserver_tests_batchsafetysnapshottests_batchsafetysnapshottests_combinecurrentstate_includeseachstateandisordersensitive",
-      "community": 30,
+      "community": 38,
       "norm_label": ".combinecurrentstate_includeseachstateandisordersensitive()"
     },
     {
@@ -5409,7 +6597,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetySnapshotTests.cs",
       "source_location": "L81",
       "id": "tiamcpserver_tests_batchsafetysnapshottests_batchsafetysnapshottests_resolveprojectpath_returnsfirstnonemptypath",
-      "community": 30,
+      "community": 38,
       "norm_label": ".resolveprojectpath_returnsfirstnonemptypath()"
     },
     {
@@ -5418,7 +6606,7 @@
       "source_file": "TiaMcpServer.Tests/BatchSafetySnapshotTests.cs",
       "source_location": "L93",
       "id": "tiamcpserver_tests_batchsafetysnapshottests_batchsafetysnapshottests_resolveprojectpath_returnsnullwhennopathprovided",
-      "community": 30,
+      "community": 38,
       "norm_label": ".resolveprojectpath_returnsnullwhennopathprovided()"
     },
     {
@@ -5553,7 +6741,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_cs",
-      "community": 21,
+      "community": 24,
       "norm_label": "batchtoolmetadatatests.cs"
     },
     {
@@ -5562,7 +6750,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L11",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests",
-      "community": 21,
+      "community": 24,
       "norm_label": "batchtoolmetadatatests"
     },
     {
@@ -5571,7 +6759,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L13",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_methoddescription",
-      "community": 21,
+      "community": 24,
       "norm_label": ".methoddescription()"
     },
     {
@@ -5580,7 +6768,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L22",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_executereadbatchdescription_listseveryreadoperation",
-      "community": 21,
+      "community": 24,
       "norm_label": ".executereadbatchdescription_listseveryreadoperation()"
     },
     {
@@ -5589,7 +6777,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L32",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_previewwritebatchdescription_listseverywriteoperation",
-      "community": 21,
+      "community": 24,
       "norm_label": ".previewwritebatchdescription_listseverywriteoperation()"
     },
     {
@@ -5598,7 +6786,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L42",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_applywritebatchdescription_listseverywriteoperation",
-      "community": 21,
+      "community": 24,
       "norm_label": ".applywritebatchdescription_listseverywriteoperation()"
     },
     {
@@ -5607,7 +6795,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L52",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_operationpropertydescription_listseverybatchableoperation",
-      "community": 21,
+      "community": 24,
       "norm_label": ".operationpropertydescription_listseverybatchableoperation()"
     },
     {
@@ -5616,7 +6804,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L68",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_previewwritebatchdescription_statestheactualtokenlifetime",
-      "community": 21,
+      "community": 24,
       "norm_label": ".previewwritebatchdescription_statestheactualtokenlifetime()"
     },
     {
@@ -5625,7 +6813,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L75",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_propertydescription",
-      "community": 21,
+      "community": 24,
       "norm_label": ".propertydescription()"
     },
     {
@@ -5634,7 +6822,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L84",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_filterdescription_namesitsoperationandlistsallvalues",
-      "community": 21,
+      "community": 24,
       "norm_label": ".filterdescription_namesitsoperationandlistsallvalues()"
     },
     {
@@ -5643,7 +6831,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L95",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_blockpathdescription_coversallblockoperationsandcompilecheck",
-      "community": 21,
+      "community": 24,
       "norm_label": ".blockpathdescription_coversallblockoperationsandcompilecheck()"
     },
     {
@@ -5652,7 +6840,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L104",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_newnamedescription_doesnotclaimuserconstantrename",
-      "community": 21,
+      "community": 24,
       "norm_label": ".newnamedescription_doesnotclaimuserconstantrename()"
     },
     {
@@ -5661,7 +6849,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L115",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_plcnamedescription_namestheoperationsthathonorit",
-      "community": 21,
+      "community": 24,
       "norm_label": ".plcnamedescription_namestheoperationsthathonorit()"
     },
     {
@@ -5670,7 +6858,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolMetadataTests.cs",
       "source_location": "L123",
       "id": "tiamcpserver_tests_batchtoolmetadatatests_batchtoolmetadatatests_keyrequestfieldshavedescriptions",
-      "community": 21,
+      "community": 24,
       "norm_label": ".keyrequestfieldshavedescriptions()"
     },
     {
@@ -5679,7 +6867,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_batchtoolstests_cs",
-      "community": 25,
+      "community": 31,
       "norm_label": "batchtoolstests.cs"
     },
     {
@@ -5688,7 +6876,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L9",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests",
-      "community": 25,
+      "community": 31,
       "norm_label": "batchtoolstests"
     },
     {
@@ -5697,7 +6885,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L11",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_op",
-      "community": 25,
+      "community": 31,
       "norm_label": ".op()"
     },
     {
@@ -5706,7 +6894,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L18",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_batchtoolshavemcpmetadata",
-      "community": 25,
+      "community": 31,
       "norm_label": ".batchtoolshavemcpmetadata()"
     },
     {
@@ -5715,7 +6903,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L34",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_executereadbatch_rejectswriteoperation",
-      "community": 25,
+      "community": 31,
       "norm_label": ".executereadbatch_rejectswriteoperation()"
     },
     {
@@ -5724,7 +6912,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L46",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_executereadbatch_rejectsemptybatch",
-      "community": 25,
+      "community": 31,
       "norm_label": ".executereadbatch_rejectsemptybatch()"
     },
     {
@@ -5733,7 +6921,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L56",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_previewwritebatch_rejectsreadoperation",
-      "community": 25,
+      "community": 31,
       "norm_label": ".previewwritebatch_rejectsreadoperation()"
     },
     {
@@ -5742,7 +6930,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L68",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_previewwritebatch_rejectsprojectlifecycleoperation",
-      "community": 25,
+      "community": 31,
       "norm_label": ".previewwritebatch_rejectsprojectlifecycleoperation()"
     },
     {
@@ -5751,7 +6939,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L80",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_applywritebatch_rejectsunconfirmedrequests",
-      "community": 25,
+      "community": 31,
       "norm_label": ".applywritebatch_rejectsunconfirmedrequests()"
     },
     {
@@ -5760,7 +6948,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L93",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_applywritebatch_rejectsinvalidbatchbeforeworker",
-      "community": 25,
+      "community": 31,
       "norm_label": ".applywritebatch_rejectsinvalidbatchbeforeworker()"
     },
     {
@@ -5769,7 +6957,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L107",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_applywritebatch_rejectsmissingsafetytoken",
-      "community": 25,
+      "community": 31,
       "norm_label": ".applywritebatch_rejectsmissingsafetytoken()"
     },
     {
@@ -5778,7 +6966,7 @@
       "source_file": "TiaMcpServer.Tests/BatchToolsTests.cs",
       "source_location": "L119",
       "id": "tiamcpserver_tests_batchtoolstests_batchtoolstests_applywritebatch_rejectsbadtokenbeforereadingcurrentstate",
-      "community": 25,
+      "community": 31,
       "norm_label": ".applywritebatch_rejectsbadtokenbeforereadingcurrentstate()"
     },
     {
@@ -5787,7 +6975,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_blockaddresstests_cs",
-      "community": 35,
+      "community": 45,
       "norm_label": "blockaddresstests.cs"
     },
     {
@@ -5796,7 +6984,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L6",
       "id": "tiamcpserver_tests_blockaddresstests_blockaddresstests",
-      "community": 35,
+      "community": 45,
       "norm_label": "blockaddresstests"
     },
     {
@@ -5805,7 +6993,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_blockaddresstests_blockaddresstests_parsesupportslegacyblockonly",
-      "community": 35,
+      "community": 45,
       "norm_label": ".parsesupportslegacyblockonly()"
     },
     {
@@ -5814,7 +7002,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L21",
       "id": "tiamcpserver_tests_blockaddresstests_blockaddresstests_parsesupportslegacyplcqualifiedblock",
-      "community": 35,
+      "community": 45,
       "norm_label": ".parsesupportslegacyplcqualifiedblock()"
     },
     {
@@ -5823,7 +7011,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L33",
       "id": "tiamcpserver_tests_blockaddresstests_blockaddresstests_parsesupportsnestedblockfolderpath",
-      "community": 35,
+      "community": 45,
       "norm_label": ".parsesupportsnestedblockfolderpath()"
     },
     {
@@ -5832,7 +7020,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L46",
       "id": "tiamcpserver_tests_blockaddresstests_blockaddresstests_parsesupportssoftwareunitblockpath",
-      "community": 35,
+      "community": 45,
       "norm_label": ".parsesupportssoftwareunitblockpath()"
     },
     {
@@ -5841,7 +7029,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L59",
       "id": "tiamcpserver_tests_blockaddresstests_blockaddresstests_parsestripsblocksuffixfromfinalsegment",
-      "community": 35,
+      "community": 45,
       "norm_label": ".parsestripsblocksuffixfromfinalsegment()"
     },
     {
@@ -5850,7 +7038,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L67",
       "id": "tiamcpserver_tests_blockaddresstests_blockaddresstests_parserejectsinvalidpaths",
-      "community": 35,
+      "community": 45,
       "norm_label": ".parserejectsinvalidpaths()"
     },
     {
@@ -5859,7 +7047,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogEntryInfoTests.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_catalogentryinfotests_cs",
-      "community": 41,
+      "community": 60,
       "norm_label": "catalogentryinfotests.cs"
     },
     {
@@ -5868,7 +7056,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogEntryInfoTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_catalogentryinfotests_catalogentryinfotests",
-      "community": 41,
+      "community": 60,
       "norm_label": "catalogentryinfotests"
     },
     {
@@ -5877,7 +7065,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogEntryInfoTests.cs",
       "source_location": "L17",
       "id": "tiamcpserver_tests_catalogentryinfotests_catalogentryinfotests_serializesdefaultcatalogentry",
-      "community": 41,
+      "community": 60,
       "norm_label": ".serializesdefaultcatalogentry()"
     },
     {
@@ -5886,7 +7074,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogEntryInfoTests.cs",
       "source_location": "L33",
       "id": "tiamcpserver_tests_catalogentryinfotests_catalogentryinfotests_roundtripsfullcatalogentry",
-      "community": 41,
+      "community": 60,
       "norm_label": ".roundtripsfullcatalogentry()"
     },
     {
@@ -5895,7 +7083,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogEntryInfoTests.cs",
       "source_location": "L58",
       "id": "tiamcpserver_tests_catalogentryinfotests_catalogentryinfotests_nullablefieldsomittedwhennull",
-      "community": 41,
+      "community": 60,
       "norm_label": ".nullablefieldsomittedwhennull()"
     },
     {
@@ -5904,7 +7092,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogEntryInfoTests.cs",
       "source_location": "L88",
       "id": "tiamcpserver_tests_catalogentryinfotests_catalogentryinfotests_roundtrip",
-      "community": 41,
+      "community": 60,
       "norm_label": ".roundtrip()"
     },
     {
@@ -5913,7 +7101,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogTypeIdentifierTests.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_catalogtypeidentifiertests_cs",
-      "community": 49,
+      "community": 71,
       "norm_label": "catalogtypeidentifiertests.cs"
     },
     {
@@ -5922,7 +7110,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogTypeIdentifierTests.cs",
       "source_location": "L6",
       "id": "tiamcpserver_tests_catalogtypeidentifiertests_catalogtypeidentifiertests",
-      "community": 49,
+      "community": 71,
       "norm_label": "catalogtypeidentifiertests"
     },
     {
@@ -5931,7 +7119,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogTypeIdentifierTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_catalogtypeidentifiertests_catalogtypeidentifiertests_creatableidentifiersusesupportedprefixes",
-      "community": 49,
+      "community": 71,
       "norm_label": ".creatableidentifiersusesupportedprefixes()"
     },
     {
@@ -5940,7 +7128,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogTypeIdentifierTests.cs",
       "source_location": "L17",
       "id": "tiamcpserver_tests_catalogtypeidentifiertests_catalogtypeidentifiertests_noncreatableidentifiersarerejected",
-      "community": 49,
+      "community": 71,
       "norm_label": ".noncreatableidentifiersarerejected()"
     },
     {
@@ -5949,7 +7137,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CatalogTypeIdentifierTests.cs",
       "source_location": "L27",
       "id": "tiamcpserver_tests_catalogtypeidentifiertests_catalogtypeidentifiertests_validationmessagepointsuserbacktocatalogtypeidentifierfield",
-      "community": 49,
+      "community": 71,
       "norm_label": ".validationmessagepointsuserbacktocatalogtypeidentifierfield()"
     },
     {
@@ -5958,7 +7146,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CompileCheckInfoTests.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_compilecheckinfotests_cs",
-      "community": 42,
+      "community": 61,
       "norm_label": "compilecheckinfotests.cs"
     },
     {
@@ -5967,7 +7155,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CompileCheckInfoTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_compilecheckinfotests_compilecheckinfotests",
-      "community": 42,
+      "community": 61,
       "norm_label": "compilecheckinfotests"
     },
     {
@@ -5976,7 +7164,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CompileCheckInfoTests.cs",
       "source_location": "L17",
       "id": "tiamcpserver_tests_compilecheckinfotests_compilecheckinfotests_emptyreportserializeswithdefaultvalues",
-      "community": 42,
+      "community": 61,
       "norm_label": ".emptyreportserializeswithdefaultvalues()"
     },
     {
@@ -5985,7 +7173,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CompileCheckInfoTests.cs",
       "source_location": "L33",
       "id": "tiamcpserver_tests_compilecheckinfotests_compilecheckinfotests_fullreportroundtripsplcinfoandmessages",
-      "community": 42,
+      "community": 61,
       "norm_label": ".fullreportroundtripsplcinfoandmessages()"
     },
     {
@@ -5994,7 +7182,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CompileCheckInfoTests.cs",
       "source_location": "L92",
       "id": "tiamcpserver_tests_compilecheckinfotests_compilecheckinfotests_blockscopereporthascorrectscopeandblockpath",
-      "community": 42,
+      "community": 61,
       "norm_label": ".blockscopereporthascorrectscopeandblockpath()"
     },
     {
@@ -6003,7 +7191,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CompileCheckInfoTests.cs",
       "source_location": "L109",
       "id": "tiamcpserver_tests_compilecheckinfotests_compilecheckinfotests_roundtrip",
-      "community": 42,
+      "community": 61,
       "norm_label": ".roundtrip()"
     },
     {
@@ -6012,7 +7200,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceResultInfoTests.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_configurenetworkdeviceresultinfotests_cs",
-      "community": 50,
+      "community": 72,
       "norm_label": "configurenetworkdeviceresultinfotests.cs"
     },
     {
@@ -6021,7 +7209,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceResultInfoTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_configurenetworkdeviceresultinfotests_configurenetworkdeviceresultinfotests",
-      "community": 50,
+      "community": 72,
       "norm_label": "configurenetworkdeviceresultinfotests"
     },
     {
@@ -6030,7 +7218,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceResultInfoTests.cs",
       "source_location": "L17",
       "id": "tiamcpserver_tests_configurenetworkdeviceresultinfotests_configurenetworkdeviceresultinfotests_serializesemptyresult",
-      "community": 50,
+      "community": 72,
       "norm_label": ".serializesemptyresult()"
     },
     {
@@ -6039,7 +7227,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceResultInfoTests.cs",
       "source_location": "L33",
       "id": "tiamcpserver_tests_configurenetworkdeviceresultinfotests_configurenetworkdeviceresultinfotests_roundtripsresultwithsettingsandmessages",
-      "community": 50,
+      "community": 72,
       "norm_label": ".roundtripsresultwithsettingsandmessages()"
     },
     {
@@ -6048,7 +7236,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceResultInfoTests.cs",
       "source_location": "L60",
       "id": "tiamcpserver_tests_configurenetworkdeviceresultinfotests_configurenetworkdeviceresultinfotests_roundtrip",
-      "community": 50,
+      "community": 72,
       "norm_label": ".roundtrip()"
     },
     {
@@ -6057,7 +7245,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L1",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_crossreferenceinfotests_cs",
-      "community": 28,
+      "community": 36,
       "norm_label": "crossreferenceinfotests.cs"
     },
     {
@@ -6066,7 +7254,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests",
-      "community": 28,
+      "community": 36,
       "norm_label": "crossreferenceinfotests"
     },
     {
@@ -6075,7 +7263,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L17",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_emptyreportserializeswithemptyplclist",
-      "community": 28,
+      "community": 36,
       "norm_label": ".emptyreportserializeswithemptyplclist()"
     },
     {
@@ -6084,7 +7272,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L32",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_fullreportroundtripssourcereferenceandlocation",
-      "community": 28,
+      "community": 36,
       "norm_label": ".fullreportroundtripssourcereferenceandlocation()"
     },
     {
@@ -6093,7 +7281,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L123",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_unusedobjectreportroundtripssourceswithemptyreferences",
-      "community": 28,
+      "community": 36,
       "norm_label": ".unusedobjectreportroundtripssourceswithemptyreferences()"
     },
     {
@@ -6102,7 +7290,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L156",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_plcmessagesroundtrip",
-      "community": 28,
+      "community": 36,
       "norm_label": ".plcmessagesroundtrip()"
     },
     {
@@ -6111,7 +7299,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L177",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_nulloremptyfilterdefaultstoobjectswithreferences",
-      "community": 28,
+      "community": 36,
       "norm_label": ".nulloremptyfilterdefaultstoobjectswithreferences()"
     },
     {
@@ -6120,7 +7308,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L189",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_validfilternamesparsecaseinsensitively",
-      "community": 28,
+      "community": 36,
       "norm_label": ".validfilternamesparsecaseinsensitively()"
     },
     {
@@ -6129,7 +7317,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L198",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_invalidfilterreturnsallowedvalues",
-      "community": 28,
+      "community": 36,
       "norm_label": ".invalidfilterreturnsallowedvalues()"
     },
     {
@@ -6138,7 +7326,7 @@
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L212",
       "id": "tiamcpserver_tests_crossreferenceinfotests_crossreferenceinfotests_roundtrip",
-      "community": 28,
+      "community": 36,
       "norm_label": ".roundtrip()"
     },
     {
@@ -6228,7 +7416,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_cs",
-      "community": 9,
+      "community": 7,
       "norm_label": "opennessworkerclientintegrationtests.cs"
     },
     {
@@ -6237,7 +7425,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L13",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests",
-      "community": 9,
+      "community": 7,
       "norm_label": "opennessworkerclientintegrationtests"
     },
     {
@@ -6246,7 +7434,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L15",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_locatefakeworker",
-      "community": 9,
+      "community": 7,
       "norm_label": ".locatefakeworker()"
     },
     {
@@ -6255,7 +7443,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L38",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_createclient",
-      "community": 9,
+      "community": 7,
       "norm_label": ".createclient()"
     },
     {
@@ -6264,7 +7452,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L45",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_collapsedopenproject_previewthenapply_roundtrips",
-      "community": 9,
+      "community": 7,
       "norm_label": ".collapsedopenproject_previewthenapply_roundtrips()"
     },
     {
@@ -6273,7 +7461,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L65",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_success_returnsstructuredpayload",
-      "community": 9,
+      "community": 7,
       "norm_label": ".success_returnsstructuredpayload()"
     },
     {
@@ -6282,7 +7470,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L77",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_persistentworker_reusesoneprocessacrossrequests",
-      "community": 9,
+      "community": 7,
       "norm_label": ".persistentworker_reusesoneprocessacrossrequests()"
     },
     {
@@ -6291,7 +7479,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L90",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_crashedworker_failstherequestandrestartsforthenext",
-      "community": 9,
+      "community": 7,
       "norm_label": ".crashedworker_failstherequestandrestartsforthenext()"
     },
     {
@@ -6300,7 +7488,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L105",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_hangingworker_timesoutandrestartsforthenext",
-      "community": 9,
+      "community": 7,
       "norm_label": ".hangingworker_timesoutandrestartsforthenext()"
     },
     {
@@ -6309,7 +7497,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L119",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_responsewarnings_surfaceontheresult",
-      "community": 9,
+      "community": 7,
       "norm_label": ".responsewarnings_surfaceontheresult()"
     },
     {
@@ -6318,7 +7506,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L130",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_orphanstderr_doesnotbecomewarnings",
-      "community": 9,
+      "community": 7,
       "norm_label": ".orphanstderr_doesnotbecomewarnings()"
     },
     {
@@ -6327,7 +7515,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L140",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_payloadstartingwitherrorprefix_isnotmisclassified",
-      "community": 9,
+      "community": 7,
       "norm_label": ".payloadstartingwitherrorprefix_isnotmisclassified()"
     },
     {
@@ -6336,7 +7524,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L150",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_workerreportederror_isstructuredfailure",
-      "community": 9,
+      "community": 7,
       "norm_label": ".workerreportederror_isstructuredfailure()"
     },
     {
@@ -6345,7 +7533,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L161",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_failedfirstworkerresponse_doesnotbindthesession",
-      "community": 9,
+      "community": 7,
       "norm_label": ".failedfirstworkerresponse_doesnotbindthesession()"
     },
     {
@@ -6354,7 +7542,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L174",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_successfulfirstrequest_keepsthesessionbinding",
-      "community": 9,
+      "community": 7,
       "norm_label": ".successfulfirstrequest_keepsthesessionbinding()"
     },
     {
@@ -6363,7 +7551,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L187",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_malformedresponse_failsandrestartsforthenext",
-      "community": 9,
+      "community": 7,
       "norm_label": ".malformedresponse_failsandrestartsforthenext()"
     },
     {
@@ -6372,7 +7560,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L202",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_nullresponse_failsandrestartsforthenext",
-      "community": 9,
+      "community": 7,
       "norm_label": ".nullresponse_failsandrestartsforthenext()"
     },
     {
@@ -6381,7 +7569,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L217",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_nonexecutableworkerpath_producesactionablewin32message",
-      "community": 9,
+      "community": 7,
       "norm_label": ".nonexecutableworkerpath_producesactionablewin32message()"
     },
     {
@@ -6390,7 +7578,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientWarningTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_opennessworkerclientwarningtests_cs",
-      "community": 97,
+      "community": 135,
       "norm_label": "opennessworkerclientwarningtests.cs"
     },
     {
@@ -6399,7 +7587,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientWarningTests.cs",
       "source_location": "L7",
       "id": "tiamcpserver_tests_opennessworkerclientwarningtests_opennessworkerclientwarningtests",
-      "community": 97,
+      "community": 135,
       "norm_label": "opennessworkerclientwarningtests"
     },
     {
@@ -6408,7 +7596,7 @@
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientWarningTests.cs",
       "source_location": "L9",
       "id": "tiamcpserver_tests_opennessworkerclientwarningtests_opennessworkerclientwarningtests_capwarnings_truncateseachwarningline",
-      "community": 97,
+      "community": 135,
       "norm_label": ".capwarnings_truncateseachwarningline()"
     },
     {
@@ -6417,7 +7605,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectLifecycleToolTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_projectlifecycletooltests_cs",
-      "community": 43,
+      "community": 62,
       "norm_label": "projectlifecycletooltests.cs"
     },
     {
@@ -6426,7 +7614,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectLifecycleToolTests.cs",
       "source_location": "L10",
       "id": "tiamcpserver_tests_projectlifecycletooltests_projectlifecycletooltests",
-      "community": 43,
+      "community": 62,
       "norm_label": "projectlifecycletooltests"
     },
     {
@@ -6435,7 +7623,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectLifecycleToolTests.cs",
       "source_location": "L12",
       "id": "tiamcpserver_tests_projectlifecycletooltests_projectlifecycletooltests_projectlifecycletoolshavemcpmetadata",
-      "community": 43,
+      "community": 62,
       "norm_label": ".projectlifecycletoolshavemcpmetadata()"
     },
     {
@@ -6444,7 +7632,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectLifecycleToolTests.cs",
       "source_location": "L40",
       "id": "tiamcpserver_tests_projectlifecycletooltests_projectlifecycletooltests_opennessworkerclientexposesprojectlifecyclemethods",
-      "community": 43,
+      "community": 62,
       "norm_label": ".opennessworkerclientexposesprojectlifecyclemethods()"
     },
     {
@@ -6453,7 +7641,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectLifecycleToolTests.cs",
       "source_location": "L56",
       "id": "tiamcpserver_tests_projectlifecycletooltests_projectlifecycletooltests_saveprojectaswithtokenbutnoconfirm_rejects",
-      "community": 43,
+      "community": 62,
       "norm_label": ".saveprojectaswithtokenbutnoconfirm_rejects()"
     },
     {
@@ -6462,7 +7650,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectRebindCloseGuardTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_projectrebindcloseguardtests_cs",
-      "community": 72,
+      "community": 106,
       "norm_label": "projectrebindcloseguardtests.cs"
     },
     {
@@ -6471,7 +7659,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectRebindCloseGuardTests.cs",
       "source_location": "L6",
       "id": "tiamcpserver_tests_projectrebindcloseguardtests_projectrebindcloseguardtests",
-      "community": 72,
+      "community": 106,
       "norm_label": "projectrebindcloseguardtests"
     },
     {
@@ -6480,7 +7668,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectRebindCloseGuardTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_projectrebindcloseguardtests_projectrebindcloseguardtests_closefailure_preservesthefailureandpreventsopeningthereplacementproject",
-      "community": 72,
+      "community": 106,
       "norm_label": ".closefailure_preservesthefailureandpreventsopeningthereplacementproject()"
     },
     {
@@ -6489,7 +7677,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectRebindCloseGuardTests.cs",
       "source_location": "L22",
       "id": "tiamcpserver_tests_projectrebindcloseguardtests_projectrebindcloseguardtests_successfulclose_opensthereplacementproject",
-      "community": 72,
+      "community": 106,
       "norm_label": ".successfulclose_opensthereplacementproject()"
     },
     {
@@ -6498,7 +7686,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_projectsessionbindingtests_cs",
-      "community": 26,
+      "community": 32,
       "norm_label": "projectsessionbindingtests.cs"
     },
     {
@@ -6507,7 +7695,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L6",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests",
-      "community": 26,
+      "community": 32,
       "norm_label": "projectsessionbindingtests"
     },
     {
@@ -6516,7 +7704,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_firstexplicitprojectpathbindssession",
-      "community": 26,
+      "community": 32,
       "norm_label": ".firstexplicitprojectpathbindssession()"
     },
     {
@@ -6525,7 +7713,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L20",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_repeatedsameprojectpathisaccepted",
-      "community": 26,
+      "community": 32,
       "norm_label": ".repeatedsameprojectpathisaccepted()"
     },
     {
@@ -6534,7 +7722,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L32",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_differentprojectpathisrejectedafterbinding",
-      "community": 26,
+      "community": 32,
       "norm_label": ".differentprojectpathisrejectedafterbinding()"
     },
     {
@@ -6543,7 +7731,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L44",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_omittedprojectpathusesstartupprojectpath",
-      "community": 26,
+      "community": 32,
       "norm_label": ".omittedprojectpathusesstartupprojectpath()"
     },
     {
@@ -6552,7 +7740,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L55",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_bindsetsunboundprojectpath",
-      "community": 26,
+      "community": 32,
       "norm_label": ".bindsetsunboundprojectpath()"
     },
     {
@@ -6561,7 +7749,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L66",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_bindrejectsdifferentprojectpathwithoutforce",
-      "community": 26,
+      "community": 32,
       "norm_label": ".bindrejectsdifferentprojectpathwithoutforce()"
     },
     {
@@ -6570,7 +7758,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L77",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_bindforcerebindsdifferentprojectpath",
-      "community": 26,
+      "community": 32,
       "norm_label": ".bindforcerebindsdifferentprojectpath()"
     },
     {
@@ -6579,7 +7767,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L88",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_clearremovesmatchingprojectbinding",
-      "community": 26,
+      "community": 32,
       "norm_label": ".clearremovesmatchingprojectbinding()"
     },
     {
@@ -6588,7 +7776,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L99",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_clearrejectsdifferentprojectpath",
-      "community": 26,
+      "community": 32,
       "norm_label": ".clearrejectsdifferentprojectpath()"
     },
     {
@@ -6597,7 +7785,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectSessionBindingTests.cs",
       "source_location": "L110",
       "id": "tiamcpserver_tests_projectsessionbindingtests_projectsessionbindingtests_tryresolve_rejectionmentionsforcerebindescapehatch",
-      "community": 26,
+      "community": 32,
       "norm_label": ".tryresolve_rejectionmentionsforcerebindescapehatch()"
     },
     {
@@ -6606,7 +7794,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_projecttreefiltertests_cs",
-      "community": 19,
+      "community": 20,
       "norm_label": "projecttreefiltertests.cs"
     },
     {
@@ -6615,7 +7803,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L6",
       "id": "tiamcpserver_tests_projecttreefiltertests_projecttreefiltertests",
-      "community": 19,
+      "community": 20,
       "norm_label": "projecttreefiltertests"
     },
     {
@@ -6624,7 +7812,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_projecttreefiltertests_projecttreefiltertests_node",
-      "community": 19,
+      "community": 20,
       "norm_label": ".node()"
     },
     {
@@ -6633,7 +7821,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L17",
       "id": "tiamcpserver_tests_projecttreefiltertests_projecttreefiltertests_sampletree",
-      "community": 19,
+      "community": 20,
       "norm_label": ".sampletree()"
     },
     {
@@ -6642,7 +7830,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L29",
       "id": "tiamcpserver_tests_projecttreefiltertests_projecttreefiltertests_nofilters_returnstreeunchanged",
-      "community": 19,
+      "community": 20,
       "norm_label": ".nofilters_returnstreeunchanged()"
     },
     {
@@ -6651,7 +7839,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L39",
       "id": "tiamcpserver_tests_projecttreefiltertests_projecttreefiltertests_startpath_selectsthematchingsubtree",
-      "community": 19,
+      "community": 20,
       "norm_label": ".startpath_selectsthematchingsubtree()"
     },
     {
@@ -6660,7 +7848,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L49",
       "id": "tiamcpserver_tests_projecttreefiltertests_projecttreefiltertests_startpath_iscaseinsensitive",
-      "community": 19,
+      "community": 20,
       "norm_label": ".startpath_iscaseinsensitive()"
     },
     {
@@ -6669,7 +7857,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L57",
       "id": "tiamcpserver_tests_projecttreefiltertests_projecttreefiltertests_unknownstartpath_throwswithrecoveryhint",
-      "community": 19,
+      "community": 20,
       "norm_label": ".unknownstartpath_throwswithrecoveryhint()"
     },
     {
@@ -6678,7 +7866,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L67",
       "id": "tiamcpserver_tests_projecttreefiltertests_projecttreefiltertests_depth1_returnsrootswithchildrenomittedmarker",
-      "community": 19,
+      "community": 20,
       "norm_label": ".depth1_returnsrootswithchildrenomittedmarker()"
     },
     {
@@ -6687,7 +7875,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L77",
       "id": "tiamcpserver_tests_projecttreefiltertests_projecttreefiltertests_depth2_keepsonelevelofchildren",
-      "community": 19,
+      "community": 20,
       "norm_label": ".depth2_keepsonelevelofchildren()"
     },
     {
@@ -6696,7 +7884,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L89",
       "id": "tiamcpserver_tests_projecttreefiltertests_projecttreefiltertests_depth_doesnotmutatetheinputtree",
-      "community": 19,
+      "community": 20,
       "norm_label": ".depth_doesnotmutatetheinputtree()"
     },
     {
@@ -6705,7 +7893,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L100",
       "id": "tiamcpserver_tests_projecttreefiltertests_projecttreefiltertests_startpathanddepth_compose",
-      "community": 19,
+      "community": 20,
       "norm_label": ".startpathanddepth_compose()"
     },
     {
@@ -6714,7 +7902,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L111",
       "id": "tiamcpserver_tests_projecttreefiltertests_projecttreefiltertests_leafnodes_getnoomittedmarker",
-      "community": 19,
+      "community": 20,
       "norm_label": ".leafnodes_getnoomittedmarker()"
     },
     {
@@ -6723,7 +7911,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L120",
       "id": "tiamcpserver_tests_projecttreefiltertests_projecttreefiltertests_depthbelowone_throwswithrecoveryhint",
-      "community": 19,
+      "community": 20,
       "norm_label": ".depthbelowone_throwswithrecoveryhint()"
     },
     {
@@ -6732,7 +7920,7 @@
       "source_file": "TiaMcpServer.Tests/ProjectTreeFilterTests.cs",
       "source_location": "L129",
       "id": "tiamcpserver_tests_projecttreefiltertests_projecttreefiltertests_filteredoutput_containsfreshnodeanddetailscopies",
-      "community": 19,
+      "community": 20,
       "norm_label": ".filteredoutput_containsfreshnodeanddetailscopies()"
     },
     {
@@ -6741,7 +7929,7 @@
       "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_workercallresulttests_cs",
-      "community": 37,
+      "community": 55,
       "norm_label": "workercallresulttests.cs"
     },
     {
@@ -6750,7 +7938,7 @@
       "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
       "source_location": "L6",
       "id": "tiamcpserver_tests_workercallresulttests_workercallresulttests",
-      "community": 37,
+      "community": 55,
       "norm_label": "workercallresulttests"
     },
     {
@@ -6759,7 +7947,7 @@
       "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
       "source_location": "L8",
       "id": "tiamcpserver_tests_workercallresulttests_workercallresulttests_ok_carriespayloadwithouterror",
-      "community": 37,
+      "community": 55,
       "norm_label": ".ok_carriespayloadwithouterror()"
     },
     {
@@ -6768,7 +7956,7 @@
       "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
       "source_location": "L19",
       "id": "tiamcpserver_tests_workercallresulttests_workercallresulttests_fail_carrieserrorandemptypayload",
-      "community": 37,
+      "community": 55,
       "norm_label": ".fail_carrieserrorandemptypayload()"
     },
     {
@@ -6777,7 +7965,7 @@
       "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
       "source_location": "L29",
       "id": "tiamcpserver_tests_workercallresulttests_workercallresulttests_totext_renderspayloadonsuccess",
-      "community": 37,
+      "community": 55,
       "norm_label": ".totext_renderspayloadonsuccess()"
     },
     {
@@ -6786,7 +7974,7 @@
       "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
       "source_location": "L35",
       "id": "tiamcpserver_tests_workercallresulttests_workercallresulttests_totext_renderserrorprefixonfailure",
-      "community": 37,
+      "community": 55,
       "norm_label": ".totext_renderserrorprefixonfailure()"
     },
     {
@@ -6795,7 +7983,7 @@
       "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
       "source_location": "L41",
       "id": "tiamcpserver_tests_workercallresulttests_workercallresulttests_ok_payloadstartingwitherrorprefixstayssuccessful",
-      "community": 37,
+      "community": 55,
       "norm_label": ".ok_payloadstartingwitherrorprefixstayssuccessful()"
     },
     {
@@ -6804,7 +7992,7 @@
       "source_file": "TiaMcpServer.Tests/WorkerCallResultTests.cs",
       "source_location": "L50",
       "id": "tiamcpserver_tests_workercallresulttests_workercallresulttests_warnings_areattachedtobothshapes",
-      "community": 37,
+      "community": 55,
       "norm_label": ".warnings_areattachedtobothshapes()"
     },
     {
@@ -6849,7 +8037,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_writesafetyservicetests_cs",
-      "community": 20,
+      "community": 21,
       "norm_label": "writesafetyservicetests.cs"
     },
     {
@@ -6858,7 +8046,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L7",
       "id": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests",
-      "community": 20,
+      "community": 21,
       "norm_label": "writesafetyservicetests"
     },
     {
@@ -6867,7 +8055,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L9",
       "id": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_previewbindstokentotoolinputandcurrentstate",
-      "community": 20,
+      "community": 21,
       "norm_label": ".previewbindstokentotoolinputandcurrentstate()"
     },
     {
@@ -6876,7 +8064,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L37",
       "id": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_tokencannotbereused",
-      "community": 20,
+      "community": 21,
       "norm_label": ".tokencannotbereused()"
     },
     {
@@ -6885,7 +8073,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L70",
       "id": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_tokenrejectschangedinputandchangedcurrentstate",
-      "community": 20,
+      "community": 21,
       "norm_label": ".tokenrejectschangedinputandchangedcurrentstate()"
     },
     {
@@ -6894,7 +8082,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L111",
       "id": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_tokenexpiresafterconfiguredlifetime",
-      "community": 20,
+      "community": 21,
       "norm_label": ".tokenexpiresafterconfiguredlifetime()"
     },
     {
@@ -6903,7 +8091,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L137",
       "id": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_rejectionincludesrecoveryguidancewithpreviewtoolname",
-      "community": 20,
+      "community": 21,
       "norm_label": ".rejectionincludesrecoveryguidancewithpreviewtoolname()"
     },
     {
@@ -6912,7 +8100,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L157",
       "id": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_recoveryguidanceusesconfiguredlifetime",
-      "community": 20,
+      "community": 21,
       "norm_label": ".recoveryguidanceusesconfiguredlifetime()"
     },
     {
@@ -6921,7 +8109,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L170",
       "id": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_appendaudit_writesjsonlrecordtoconfigureddirectory",
-      "community": 20,
+      "community": 21,
       "norm_label": ".appendaudit_writesjsonlrecordtoconfigureddirectory()"
     },
     {
@@ -6930,7 +8118,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L194",
       "id": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_appendaudit_logsfailuretostderrinsteadofthrowing",
-      "community": 20,
+      "community": 21,
       "norm_label": ".appendaudit_logsfailuretostderrinsteadofthrowing()"
     },
     {
@@ -6939,7 +8127,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L216",
       "id": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_createpreview_evictsexpiredtokens",
-      "community": 20,
+      "community": 21,
       "norm_label": ".createpreview_evictsexpiredtokens()"
     },
     {
@@ -6948,7 +8136,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L233",
       "id": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_createpreview_keepsunexpiredtokens",
-      "community": 20,
+      "community": 21,
       "norm_label": ".createpreview_keepsunexpiredtokens()"
     },
     {
@@ -6957,7 +8145,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L246",
       "id": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_validateenvelope_acceptsmatchingtokenwithoutconsumingit",
-      "community": 20,
+      "community": 21,
       "norm_label": ".validateenvelope_acceptsmatchingtokenwithoutconsumingit()"
     },
     {
@@ -6966,7 +8154,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L267",
       "id": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_validateenvelope_rejectsunknownexpiredandmismatchedtokens",
-      "community": 20,
+      "community": 21,
       "norm_label": ".validateenvelope_rejectsunknownexpiredandmismatchedtokens()"
     },
     {
@@ -6975,7 +8163,7 @@
       "source_file": "TiaMcpServer.Tests/WriteSafetyServiceTests.cs",
       "source_location": "L285",
       "id": "tiamcpserver_tests_writesafetyservicetests_writesafetyservicetests_readtoken",
-      "community": 20,
+      "community": 21,
       "norm_label": ".readtoken()"
     },
     {
@@ -6984,7 +8172,7 @@
       "source_file": "TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs",
       "source_location": "L1",
       "id": "tiamcpserver_tests_writetoolsafetytokentests_cs",
-      "community": 27,
+      "community": 33,
       "norm_label": "writetoolsafetytokentests.cs"
     },
     {
@@ -6993,7 +8181,7 @@
       "source_file": "TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs",
       "source_location": "L9",
       "id": "tiamcpserver_tests_writetoolsafetytokentests_writetoolsafetytokentests",
-      "community": 27,
+      "community": 33,
       "norm_label": "writetoolsafetytokentests"
     },
     {
@@ -7002,7 +8190,7 @@
       "source_file": "TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs",
       "source_location": "L11",
       "id": "tiamcpserver_tests_writetoolsafetytokentests_writetoolsafetytokentests_separatepreviewtoolsaregone",
-      "community": 27,
+      "community": 33,
       "norm_label": ".separatepreviewtoolsaregone()"
     },
     {
@@ -7011,7 +8199,7 @@
       "source_file": "TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs",
       "source_location": "L23",
       "id": "tiamcpserver_tests_writetoolsafetytokentests_writetoolsafetytokentests_lifecyclesurfaceisexactlyseventools",
-      "community": 27,
+      "community": 33,
       "norm_label": ".lifecyclesurfaceisexactlyseventools()"
     },
     {
@@ -7020,7 +8208,7 @@
       "source_file": "TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs",
       "source_location": "L42",
       "id": "tiamcpserver_tests_writetoolsafetytokentests_writetoolsafetytokentests_writetoolwithouttoken_returnspreviewwithtokenandinstructions",
-      "community": 27,
+      "community": 33,
       "norm_label": ".writetoolwithouttoken_returnspreviewwithtokenandinstructions()"
     },
     {
@@ -7029,7 +8217,7 @@
       "source_file": "TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs",
       "source_location": "L55",
       "id": "tiamcpserver_tests_writetoolsafetytokentests_writetoolsafetytokentests_writetoolwithtokenbutnoconfirm_rejectsbeforeanywork",
-      "community": 27,
+      "community": 33,
       "norm_label": ".writetoolwithtokenbutnoconfirm_rejectsbeforeanywork()"
     },
     {
@@ -7038,8 +8226,1628 @@
       "source_file": "TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs",
       "source_location": "L67",
       "id": "tiamcpserver_tests_writetoolsafetytokentests_writetoolsafetytokentests_writetoolwithbadtoken_pointsbackatthetokenlesscall",
-      "community": 27,
+      "community": 33,
       "norm_label": ".writetoolwithbadtoken_pointsbackatthetokenlesscall()"
+    },
+    {
+      "label": "ApplicationInfoServiceTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_applicationinfoservicetests_cs",
+      "community": 46,
+      "norm_label": "applicationinfoservicetests.cs"
+    },
+    {
+      "label": "ApplicationInfoServiceTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L10",
+      "id": "diagnostics_applicationinfoservicetests_applicationinfoservicetests",
+      "community": 46,
+      "norm_label": "applicationinfoservicetests"
+    },
+    {
+      "label": ".HostVersion_PreservesInformationalSemVerPrerelease()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L15",
+      "id": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_hostversion_preservesinformationalsemverprerelease",
+      "community": 46,
+      "norm_label": ".hostversion_preservesinformationalsemverprerelease()"
+    },
+    {
+      "label": ".HostVersion_WithoutInformationalVersion_FallsBackToAssemblyVersion()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L31",
+      "id": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_hostversion_withoutinformationalversion_fallsbacktoassemblyversion",
+      "community": 46,
+      "norm_label": ".hostversion_withoutinformationalversion_fallsbacktoassemblyversion()"
+    },
+    {
+      "label": ".OsName_Windows10ProductNameAtBuild22000_ReportsWindows11()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L44",
+      "id": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_osname_windows10productnameatbuild22000_reportswindows11",
+      "community": 46,
+      "norm_label": ".osname_windows10productnameatbuild22000_reportswindows11()"
+    },
+    {
+      "label": ".OsName_Windows10ProductNameBelowBuild22000_RemainsWindows10()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L53",
+      "id": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_osname_windows10productnamebelowbuild22000_remainswindows10",
+      "community": 46,
+      "norm_label": ".osname_windows10productnamebelowbuild22000_remainswindows10()"
+    },
+    {
+      "label": ".OsName_ServerProductNameAtBuild22000_IsPreserved()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L62",
+      "id": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_osname_serverproductnameatbuild22000_ispreserved",
+      "community": 46,
+      "norm_label": ".osname_serverproductnameatbuild22000_ispreserved()"
+    },
+    {
+      "label": ".CreateRegistryWithProductName()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L71",
+      "id": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_createregistrywithproductname",
+      "community": 46,
+      "norm_label": ".createregistrywithproductname()"
+    },
+    {
+      "label": ".CreateAssembly()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L83",
+      "id": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_createassembly",
+      "community": 46,
+      "norm_label": ".createassembly()"
+    },
+    {
+      "label": "AssemblyResolverTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/AssemblyResolverTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_assemblyresolvertests_cs",
+      "community": 87,
+      "norm_label": "assemblyresolvertests.cs"
+    },
+    {
+      "label": "AssemblyResolverTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/AssemblyResolverTests.cs",
+      "source_location": "L6",
+      "id": "diagnostics_assemblyresolvertests_assemblyresolvertests",
+      "community": 87,
+      "norm_label": "assemblyresolvertests"
+    },
+    {
+      "label": ".TiaPortalLocationRoot_AppendsV21Net48PublicApiSuffix()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/AssemblyResolverTests.cs",
+      "source_location": "L8",
+      "id": "diagnostics_assemblyresolvertests_assemblyresolvertests_tiaportallocationroot_appendsv21net48publicapisuffix",
+      "community": 87,
+      "norm_label": ".tiaportallocationroot_appendsv21net48publicapisuffix()"
+    },
+    {
+      "label": ".CandidatePaths_PreserveEnvironmentRegistryDefaultPrecedence()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/AssemblyResolverTests.cs",
+      "source_location": "L19",
+      "id": "diagnostics_assemblyresolvertests_assemblyresolvertests_candidatepaths_preserveenvironmentregistrydefaultprecedence",
+      "community": 87,
+      "norm_label": ".candidatepaths_preserveenvironmentregistrydefaultprecedence()"
+    },
+    {
+      "label": ".FirstIncompleteCandidate_FallsThroughToNextCompleteCandidate()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/AssemblyResolverTests.cs",
+      "source_location": "L40",
+      "id": "diagnostics_assemblyresolvertests_assemblyresolvertests_firstincompletecandidate_fallsthroughtonextcompletecandidate",
+      "community": 87,
+      "norm_label": ".firstincompletecandidate_fallsthroughtonextcompletecandidate()"
+    },
+    {
+      "label": "DoctorCliParserTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_doctorcliparsertests_cs",
+      "community": 22,
+      "norm_label": "doctorcliparsertests.cs"
+    },
+    {
+      "label": "DoctorCliParserTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L6",
+      "id": "diagnostics_doctorcliparsertests_doctorcliparsertests",
+      "community": 22,
+      "norm_label": "doctorcliparsertests"
+    },
+    {
+      "label": ".Parse_EmptyArgs_ReturnsValidDefaults()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L8",
+      "id": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_emptyargs_returnsvaliddefaults",
+      "community": 22,
+      "norm_label": ".parse_emptyargs_returnsvaliddefaults()"
+    },
+    {
+      "label": ".Parse_JsonFlag_SetsJson()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L20",
+      "id": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_jsonflag_setsjson",
+      "community": 22,
+      "norm_label": ".parse_jsonflag_setsjson()"
+    },
+    {
+      "label": ".Parse_VerboseFlag_SetsVerbose()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L29",
+      "id": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_verboseflag_setsverbose",
+      "community": 22,
+      "norm_label": ".parse_verboseflag_setsverbose()"
+    },
+    {
+      "label": ".Parse_ProjectFlag_SetsProjectPath()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L38",
+      "id": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_projectflag_setsprojectpath",
+      "community": 22,
+      "norm_label": ".parse_projectflag_setsprojectpath()"
+    },
+    {
+      "label": ".Parse_ProjectEquals_SetsProjectPath()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L47",
+      "id": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_projectequals_setsprojectpath",
+      "community": 22,
+      "norm_label": ".parse_projectequals_setsprojectpath()"
+    },
+    {
+      "label": ".Parse_CombinedFlags_AllSet()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L56",
+      "id": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_combinedflags_allset",
+      "community": 22,
+      "norm_label": ".parse_combinedflags_allset()"
+    },
+    {
+      "label": ".Parse_UnknownArg_ReturnsInvalid()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L67",
+      "id": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_unknownarg_returnsinvalid",
+      "community": 22,
+      "norm_label": ".parse_unknownarg_returnsinvalid()"
+    },
+    {
+      "label": ".Parse_ProjectFlagWithoutValue_ReturnsInvalid()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L76",
+      "id": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_projectflagwithoutvalue_returnsinvalid",
+      "community": 22,
+      "norm_label": ".parse_projectflagwithoutvalue_returnsinvalid()"
+    },
+    {
+      "label": ".Parse_ProjectFlagFollowedByAnotherFlag_ReturnsInvalid()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L85",
+      "id": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_projectflagfollowedbyanotherflag_returnsinvalid",
+      "community": 22,
+      "norm_label": ".parse_projectflagfollowedbyanotherflag_returnsinvalid()"
+    },
+    {
+      "label": ".Parse_ProjectEqualsWithoutValue_ReturnsInvalid()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L95",
+      "id": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_projectequalswithoutvalue_returnsinvalid",
+      "community": 22,
+      "norm_label": ".parse_projectequalswithoutvalue_returnsinvalid()"
+    },
+    {
+      "label": ".Parse_ProjectFlagWithBlankSeparateValue_ReturnsInvalid()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L104",
+      "id": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_projectflagwithblankseparatevalue_returnsinvalid",
+      "community": 22,
+      "norm_label": ".parse_projectflagwithblankseparatevalue_returnsinvalid()"
+    },
+    {
+      "label": ".Parse_HelpFlag_ReturnsValidHelpRequest()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L117",
+      "id": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_helpflag_returnsvalidhelprequest",
+      "community": 22,
+      "norm_label": ".parse_helpflag_returnsvalidhelprequest()"
+    },
+    {
+      "label": ".Parse_CaseInsensitive_FlagsWork()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L126",
+      "id": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_caseinsensitive_flagswork",
+      "community": 22,
+      "norm_label": ".parse_caseinsensitive_flagswork()"
+    },
+    {
+      "label": "DoctorCommandTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_doctorcommandtests_cs",
+      "community": 47,
+      "norm_label": "doctorcommandtests.cs"
+    },
+    {
+      "label": "DoctorCommandTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L8",
+      "id": "diagnostics_doctorcommandtests_doctorcommandtests",
+      "community": 47,
+      "norm_label": "doctorcommandtests"
+    },
+    {
+      "label": ".RunAsync_Help_WritesUsageToStandardOutputAndReturnsZero()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L10",
+      "id": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_help_writesusagetostandardoutputandreturnszero",
+      "community": 47,
+      "norm_label": ".runasync_help_writesusagetostandardoutputandreturnszero()"
+    },
+    {
+      "label": ".RunAsync_JsonHelp_WritesOneParseableUsageDocumentToStandardOutput()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L27",
+      "id": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_jsonhelp_writesoneparseableusagedocumenttostandardoutput",
+      "community": 47,
+      "norm_label": ".runasync_jsonhelp_writesoneparseableusagedocumenttostandardoutput()"
+    },
+    {
+      "label": ".RunAsync_JsonParseError_WritesParseableErrorToStandardOutput()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L47",
+      "id": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_jsonparseerror_writesparseableerrortostandardoutput",
+      "community": 47,
+      "norm_label": ".runasync_jsonparseerror_writesparseableerrortostandardoutput()"
+    },
+    {
+      "label": ".RunAsync_JsonProjectWithSeparateEmptyValue_WritesOneErrorDocumentAndReturnsTwo()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L67",
+      "id": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_jsonprojectwithseparateemptyvalue_writesoneerrordocumentandreturnstwo",
+      "community": 47,
+      "norm_label": ".runasync_jsonprojectwithseparateemptyvalue_writesoneerrordocumentandreturnstwo()"
+    },
+    {
+      "label": ".RunAsync_ProjectThenJson_WritesParseableErrorToStandardOutput()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L86",
+      "id": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_projectthenjson_writesparseableerrortostandardoutput",
+      "community": 47,
+      "norm_label": ".runasync_projectthenjson_writesparseableerrortostandardoutput()"
+    },
+    {
+      "label": ".RunAsync_MapsReportStateToExpectedExitCode()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L105",
+      "id": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_mapsreportstatetoexpectedexitcode",
+      "community": 47,
+      "norm_label": ".runasync_mapsreportstatetoexpectedexitcode()"
+    },
+    {
+      "label": ".PassedReport()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L137",
+      "id": "diagnostics_doctorcommandtests_doctorcommandtests_passedreport",
+      "community": 47,
+      "norm_label": ".passedreport()"
+    },
+    {
+      "label": "DoctorJsonRendererTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_doctorjsonrenderertests_cs",
+      "community": 39,
+      "norm_label": "doctorjsonrenderertests.cs"
+    },
+    {
+      "label": "DoctorJsonRendererTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L7",
+      "id": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests",
+      "community": 39,
+      "norm_label": "doctorjsonrenderertests"
+    },
+    {
+      "label": ".Render_ProducesValidJsonWithCorrectStructure()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L9",
+      "id": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_producesvalidjsonwithcorrectstructure",
+      "community": 39,
+      "norm_label": ".render_producesvalidjsonwithcorrectstructure()"
+    },
+    {
+      "label": ".Render_FailedStatus_SerializesCorrectly()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L36",
+      "id": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_failedstatus_serializescorrectly",
+      "community": 39,
+      "norm_label": ".render_failedstatus_serializescorrectly()"
+    },
+    {
+      "label": ".Render_Verbose_IncludesEvidence()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L50",
+      "id": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_verbose_includesevidence",
+      "community": 39,
+      "norm_label": ".render_verbose_includesevidence()"
+    },
+    {
+      "label": ".Render_NonVerbose_OmitsEvidence()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L67",
+      "id": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_nonverbose_omitsevidence",
+      "community": 39,
+      "norm_label": ".render_nonverbose_omitsevidence()"
+    },
+    {
+      "label": ".Render_NullRemediation_SerializesAsNull()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L83",
+      "id": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_nullremediation_serializesasnull",
+      "community": 39,
+      "norm_label": ".render_nullremediation_serializesasnull()"
+    },
+    {
+      "label": ".Render_NonNullRemediation_SerializesAsString()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L98",
+      "id": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_nonnullremediation_serializesasstring",
+      "community": 39,
+      "norm_label": ".render_nonnullremediation_serializesasstring()"
+    },
+    {
+      "label": ".Render_EvidenceNullValue_SerializesAsNull()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L113",
+      "id": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_evidencenullvalue_serializesasnull",
+      "community": 39,
+      "norm_label": ".render_evidencenullvalue_serializesasnull()"
+    },
+    {
+      "label": ".CreateReport()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L129",
+      "id": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_createreport",
+      "community": 39,
+      "norm_label": ".createreport()"
+    },
+    {
+      "label": "DoctorRunnerTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_doctorrunnertests_cs",
+      "community": 48,
+      "norm_label": "doctorrunnertests.cs"
+    },
+    {
+      "label": "DoctorRunnerTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L6",
+      "id": "diagnostics_doctorrunnertests_doctorrunnertests",
+      "community": 49,
+      "norm_label": "doctorrunnertests"
+    },
+    {
+      "label": ".Run_AllChecksPass_ReturnsPassedStatus()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L8",
+      "id": "diagnostics_doctorrunnertests_doctorrunnertests_run_allcheckspass_returnspassedstatus",
+      "community": 49,
+      "norm_label": ".run_allcheckspass_returnspassedstatus()"
+    },
+    {
+      "label": ".Run_MixedResults_ReturnsFailedIfAnyFailed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L28",
+      "id": "diagnostics_doctorrunnertests_doctorrunnertests_run_mixedresults_returnsfailedifanyfailed",
+      "community": 49,
+      "norm_label": ".run_mixedresults_returnsfailedifanyfailed()"
+    },
+    {
+      "label": ".Run_OnlyWarnings_ReturnsWarning()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L48",
+      "id": "diagnostics_doctorrunnertests_doctorrunnertests_run_onlywarnings_returnswarning",
+      "community": 49,
+      "norm_label": ".run_onlywarnings_returnswarning()"
+    },
+    {
+      "label": ".Run_ThrowingCheck_CapturedAsFailed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L65",
+      "id": "diagnostics_doctorrunnertests_doctorrunnertests_run_throwingcheck_capturedasfailed",
+      "community": 49,
+      "norm_label": ".run_throwingcheck_capturedasfailed()"
+    },
+    {
+      "label": ".Run_EmptyCheckList_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L86",
+      "id": "diagnostics_doctorrunnertests_doctorrunnertests_run_emptychecklist_returnspassed",
+      "community": 49,
+      "norm_label": ".run_emptychecklist_returnspassed()"
+    },
+    {
+      "label": ".Run_IncludesHostVersionFromAppInfo()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L98",
+      "id": "diagnostics_doctorrunnertests_doctorrunnertests_run_includeshostversionfromappinfo",
+      "community": 49,
+      "norm_label": ".run_includeshostversionfromappinfo()"
+    },
+    {
+      "label": ".Run_SetsTimestamp()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L108",
+      "id": "diagnostics_doctorrunnertests_doctorrunnertests_run_setstimestamp",
+      "community": 49,
+      "norm_label": ".run_setstimestamp()"
+    },
+    {
+      "label": "StubCheck",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L120",
+      "id": "diagnostics_doctorrunnertests_stubcheck",
+      "community": 48,
+      "norm_label": "stubcheck"
+    },
+    {
+      "label": "DiagnosticStatus",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L122",
+      "id": "diagnosticstatus",
+      "community": 48,
+      "norm_label": "diagnosticstatus"
+    },
+    {
+      "label": ".Run()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L126",
+      "id": "diagnostics_doctorrunnertests_stubcheck_run",
+      "community": 48,
+      "norm_label": ".run()"
+    },
+    {
+      "label": "ThrowingCheck",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L129",
+      "id": "diagnostics_doctorrunnertests_throwingcheck",
+      "community": 48,
+      "norm_label": "throwingcheck"
+    },
+    {
+      "label": ".Run()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L133",
+      "id": "diagnostics_doctorrunnertests_throwingcheck_run",
+      "community": 49,
+      "norm_label": ".run()"
+    },
+    {
+      "label": "DoctorTextRendererTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_doctortextrenderertests_cs",
+      "community": 40,
+      "norm_label": "doctortextrenderertests.cs"
+    },
+    {
+      "label": "DoctorTextRendererTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L6",
+      "id": "diagnostics_doctortextrenderertests_doctortextrenderertests",
+      "community": 40,
+      "norm_label": "doctortextrenderertests"
+    },
+    {
+      "label": ".Render_AllPassed_ShowsPassTagsAndReady()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L8",
+      "id": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_allpassed_showspasstagsandready",
+      "community": 40,
+      "norm_label": ".render_allpassed_showspasstagsandready()"
+    },
+    {
+      "label": ".Render_WithFailure_ShowsFailTagsAndNotReady()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L27",
+      "id": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_withfailure_showsfailtagsandnotready",
+      "community": 40,
+      "norm_label": ".render_withfailure_showsfailtagsandnotready()"
+    },
+    {
+      "label": ".Render_WithWarning_ShowsWarnTag()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L46",
+      "id": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_withwarning_showswarntag",
+      "community": 40,
+      "norm_label": ".render_withwarning_showswarntag()"
+    },
+    {
+      "label": ".Render_Verbose_ShowsEvidence()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L62",
+      "id": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_verbose_showsevidence",
+      "community": 40,
+      "norm_label": ".render_verbose_showsevidence()"
+    },
+    {
+      "label": ".Render_NonVerbose_HidesEvidence()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L80",
+      "id": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_nonverbose_hidesevidence",
+      "community": 40,
+      "norm_label": ".render_nonverbose_hidesevidence()"
+    },
+    {
+      "label": ".Render_WithRemediation_ShowsFix()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L97",
+      "id": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_withremediation_showsfix",
+      "community": 40,
+      "norm_label": ".render_withremediation_showsfix()"
+    },
+    {
+      "label": ".Render_MultiLineRemediation_IndentsEachLine()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L113",
+      "id": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_multilineremediation_indentseachline",
+      "community": 40,
+      "norm_label": ".render_multilineremediation_indentseachline()"
+    },
+    {
+      "label": ".CreateReport()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L129",
+      "id": "diagnostics_doctortextrenderertests_doctortextrenderertests_createreport",
+      "community": 40,
+      "norm_label": ".createreport()"
+    },
+    {
+      "label": "DotNetFrameworkCheckTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_dotnetframeworkchecktests_cs",
+      "community": 1,
+      "norm_label": "dotnetframeworkchecktests.cs"
+    },
+    {
+      "label": "DotNetFrameworkCheckTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L9",
+      "id": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests",
+      "community": 1,
+      "norm_label": "dotnetframeworkchecktests"
+    },
+    {
+      "label": ".NotWindows_ReturnsFailed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L14",
+      "id": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests_notwindows_returnsfailed",
+      "community": 1,
+      "norm_label": ".notwindows_returnsfailed()"
+    },
+    {
+      "label": ".NoRegistryValue_ReturnsFailed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L27",
+      "id": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests_noregistryvalue_returnsfailed",
+      "community": 1,
+      "norm_label": ".noregistryvalue_returnsfailed()"
+    },
+    {
+      "label": ".OldRelease_ReturnsFailed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L40",
+      "id": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests_oldrelease_returnsfailed",
+      "community": 1,
+      "norm_label": ".oldrelease_returnsfailed()"
+    },
+    {
+      "label": ".Release48_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L55",
+      "id": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests_release48_returnspassed",
+      "community": 1,
+      "norm_label": ".release48_returnspassed()"
+    },
+    {
+      "label": ".Release481_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L69",
+      "id": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests_release481_returnspassed",
+      "community": 1,
+      "norm_label": ".release481_returnspassed()"
+    },
+    {
+      "label": ".FallsBackToRegistry32()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L83",
+      "id": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests_fallsbacktoregistry32",
+      "community": 1,
+      "norm_label": ".fallsbacktoregistry32()"
+    },
+    {
+      "label": "DotNetRuntimeCheckTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetRuntimeCheckTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_dotnetruntimechecktests_cs",
+      "community": 107,
+      "norm_label": "dotnetruntimechecktests.cs"
+    },
+    {
+      "label": "DotNetRuntimeCheckTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetRuntimeCheckTests.cs",
+      "source_location": "L7",
+      "id": "diagnostics_dotnetruntimechecktests_dotnetruntimechecktests",
+      "community": 107,
+      "norm_label": "dotnetruntimechecktests"
+    },
+    {
+      "label": ".AlwaysPasses_WithRuntimeDescription()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetRuntimeCheckTests.cs",
+      "source_location": "L9",
+      "id": "diagnostics_dotnetruntimechecktests_dotnetruntimechecktests_alwayspasses_withruntimedescription",
+      "community": 107,
+      "norm_label": ".alwayspasses_withruntimedescription()"
+    },
+    {
+      "label": ".IncludesEvidence()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetRuntimeCheckTests.cs",
+      "source_location": "L27",
+      "id": "diagnostics_dotnetruntimechecktests_dotnetruntimechecktests_includesevidence",
+      "community": 107,
+      "norm_label": ".includesevidence()"
+    },
+    {
+      "label": "Fakes.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_fakes_cs",
+      "community": 8,
+      "norm_label": "fakes.cs"
+    },
+    {
+      "label": "FakeApplicationInfoService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L7",
+      "id": "diagnostics_fakes_fakeapplicationinfoservice",
+      "community": 8,
+      "norm_label": "fakeapplicationinfoservice"
+    },
+    {
+      "label": "FakeEnvironmentVariableService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L19",
+      "id": "diagnostics_fakes_fakeenvironmentvariableservice",
+      "community": 8,
+      "norm_label": "fakeenvironmentvariableservice"
+    },
+    {
+      "label": "Dictionary",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L21",
+      "id": "dictionary",
+      "community": 8,
+      "norm_label": "dictionary"
+    },
+    {
+      "label": ".Set()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L23",
+      "id": "diagnostics_fakes_fakeenvironmentvariableservice_set",
+      "community": 8,
+      "norm_label": ".set()"
+    },
+    {
+      "label": ".Get()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L25",
+      "id": "diagnostics_fakes_fakeenvironmentvariableservice_get",
+      "community": 8,
+      "norm_label": ".get()"
+    },
+    {
+      "label": "FakeRegistryService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L28",
+      "id": "diagnostics_fakes_fakeregistryservice",
+      "community": 8,
+      "norm_label": "fakeregistryservice"
+    },
+    {
+      "label": "HashSet",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L33",
+      "id": "hashset",
+      "community": 8,
+      "norm_label": "hashset"
+    },
+    {
+      "label": ".SetStringValue()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L35",
+      "id": "diagnostics_fakes_fakeregistryservice_setstringvalue",
+      "community": 8,
+      "norm_label": ".setstringvalue()"
+    },
+    {
+      "label": ".SetIntValue()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L38",
+      "id": "diagnostics_fakes_fakeregistryservice_setintvalue",
+      "community": 8,
+      "norm_label": ".setintvalue()"
+    },
+    {
+      "label": ".SetKeyExists()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L41",
+      "id": "diagnostics_fakes_fakeregistryservice_setkeyexists",
+      "community": 8,
+      "norm_label": ".setkeyexists()"
+    },
+    {
+      "label": ".GetStringValue()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L44",
+      "id": "diagnostics_fakes_fakeregistryservice_getstringvalue",
+      "community": 8,
+      "norm_label": ".getstringvalue()"
+    },
+    {
+      "label": ".GetIntValue()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L47",
+      "id": "diagnostics_fakes_fakeregistryservice_getintvalue",
+      "community": 8,
+      "norm_label": ".getintvalue()"
+    },
+    {
+      "label": ".KeyExists()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L50",
+      "id": "diagnostics_fakes_fakeregistryservice_keyexists",
+      "community": 8,
+      "norm_label": ".keyexists()"
+    },
+    {
+      "label": "FakeFileSystemService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L54",
+      "id": "diagnostics_fakes_fakefilesystemservice",
+      "community": 8,
+      "norm_label": "fakefilesystemservice"
+    },
+    {
+      "label": ".AddFile()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L60",
+      "id": "diagnostics_fakes_fakefilesystemservice_addfile",
+      "community": 8,
+      "norm_label": ".addfile()"
+    },
+    {
+      "label": ".AddDirectory()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L61",
+      "id": "diagnostics_fakes_fakefilesystemservice_adddirectory",
+      "community": 8,
+      "norm_label": ".adddirectory()"
+    },
+    {
+      "label": ".SetFileVersion()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L62",
+      "id": "diagnostics_fakes_fakefilesystemservice_setfileversion",
+      "community": 8,
+      "norm_label": ".setfileversion()"
+    },
+    {
+      "label": ".FileExists()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L64",
+      "id": "diagnostics_fakes_fakefilesystemservice_fileexists",
+      "community": 8,
+      "norm_label": ".fileexists()"
+    },
+    {
+      "label": ".DirectoryExists()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L65",
+      "id": "diagnostics_fakes_fakefilesystemservice_directoryexists",
+      "community": 8,
+      "norm_label": ".directoryexists()"
+    },
+    {
+      "label": ".GetFileVersion()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L66",
+      "id": "diagnostics_fakes_fakefilesystemservice_getfileversion",
+      "community": 8,
+      "norm_label": ".getfileversion()"
+    },
+    {
+      "label": "FakeWindowsIdentityService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L69",
+      "id": "diagnostics_fakes_fakewindowsidentityservice",
+      "community": 29,
+      "norm_label": "fakewindowsidentityservice"
+    },
+    {
+      "label": ".GetCurrentUserInfo()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L75",
+      "id": "diagnostics_fakes_fakewindowsidentityservice_getcurrentuserinfo",
+      "community": 29,
+      "norm_label": ".getcurrentuserinfo()"
+    },
+    {
+      "label": ".CheckGroupMembership()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L76",
+      "id": "diagnostics_fakes_fakewindowsidentityservice_checkgroupmembership",
+      "community": 29,
+      "norm_label": ".checkgroupmembership()"
+    },
+    {
+      "label": "FakeProcessEnumerationService",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L79",
+      "id": "diagnostics_fakes_fakeprocessenumerationservice",
+      "community": 50,
+      "norm_label": "fakeprocessenumerationservice"
+    },
+    {
+      "label": ".ListProcesses()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L83",
+      "id": "diagnostics_fakes_fakeprocessenumerationservice_listprocesses",
+      "community": 50,
+      "norm_label": ".listprocesses()"
+    },
+    {
+      "label": "HostWorkerVersionCheckTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_hostworkerversionchecktests_cs",
+      "community": 56,
+      "norm_label": "hostworkerversionchecktests.cs"
+    },
+    {
+      "label": "HostWorkerVersionCheckTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L7",
+      "id": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests",
+      "community": 56,
+      "norm_label": "hostworkerversionchecktests"
+    },
+    {
+      "label": ".WorkerNotFound_ReturnsWarning()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L9",
+      "id": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests_workernotfound_returnswarning",
+      "community": 56,
+      "norm_label": ".workernotfound_returnswarning()"
+    },
+    {
+      "label": ".MatchingMajorVersions_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L23",
+      "id": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests_matchingmajorversions_returnspassed",
+      "community": 56,
+      "norm_label": ".matchingmajorversions_returnspassed()"
+    },
+    {
+      "label": ".DifferentMajorVersions_ReturnsFailed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L40",
+      "id": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests_differentmajorversions_returnsfailed",
+      "community": 56,
+      "norm_label": ".differentmajorversions_returnsfailed()"
+    },
+    {
+      "label": ".WorkerVersionNull_ReturnsWarning()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L57",
+      "id": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests_workerversionnull_returnswarning",
+      "community": 56,
+      "norm_label": ".workerversionnull_returnswarning()"
+    },
+    {
+      "label": ".MalformedHostVersion_ReturnsWarningWithEvidence()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L73",
+      "id": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests_malformedhostversion_returnswarningwithevidence",
+      "community": 56,
+      "norm_label": ".malformedhostversion_returnswarningwithevidence()"
+    },
+    {
+      "label": ".MalformedWorkerVersion_ReturnsWarningWithEvidence()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L91",
+      "id": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests_malformedworkerversion_returnswarningwithevidence",
+      "community": 56,
+      "norm_label": ".malformedworkerversion_returnswarningwithevidence()"
+    },
+    {
+      "label": "OpennessAssembliesCheckTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_opennessassemblieschecktests_cs",
+      "community": 51,
+      "norm_label": "opennessassemblieschecktests.cs"
+    },
+    {
+      "label": "OpennessAssembliesCheckTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L9",
+      "id": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests",
+      "community": 51,
+      "norm_label": "opennessassemblieschecktests"
+    },
+    {
+      "label": ".AllAssembliesPresent_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L12",
+      "id": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests_allassembliespresent_returnspassed",
+      "community": 51,
+      "norm_label": ".allassembliespresent_returnspassed()"
+    },
+    {
+      "label": ".ExistingApiDirectoryWithoutAllAssemblies_ReportsMissingAssemblies()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L30",
+      "id": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests_existingapidirectorywithoutallassemblies_reportsmissingassemblies",
+      "community": 51,
+      "norm_label": ".existingapidirectorywithoutallassemblies_reportsmissingassemblies()"
+    },
+    {
+      "label": ".TiaPortalLocationRootWithoutApiDirectory_ReportsMissingApiDirectory()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L51",
+      "id": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests_tiaportallocationrootwithoutapidirectory_reportsmissingapidirectory",
+      "community": 51,
+      "norm_label": ".tiaportallocationrootwithoutapidirectory_reportsmissingapidirectory()"
+    },
+    {
+      "label": ".RegistryRootWithoutApiDirectory_ReportsMissingApiDirectory()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L70",
+      "id": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests_registryrootwithoutapidirectory_reportsmissingapidirectory",
+      "community": 51,
+      "norm_label": ".registryrootwithoutapidirectory_reportsmissingapidirectory()"
+    },
+    {
+      "label": ".EarlyLocationRootAndLaterCompleteRegistry_UsesCompleteRegistryApi()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L93",
+      "id": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests_earlylocationrootandlatercompleteregistry_usescompleteregistryapi",
+      "community": 51,
+      "norm_label": ".earlylocationrootandlatercompleteregistry_usescompleteregistryapi()"
+    },
+    {
+      "label": ".EarlyRegistryRootAndLaterCompleteRegistry_UsesCompleteRegistryApi()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L122",
+      "id": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests_earlyregistryrootandlatercompleteregistry_usescompleteregistryapi",
+      "community": 51,
+      "norm_label": ".earlyregistryrootandlatercompleteregistry_usescompleteregistryapi()"
+    },
+    {
+      "label": ".NoInstallationFound_ReturnsFailed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L147",
+      "id": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests_noinstallationfound_returnsfailed",
+      "community": 51,
+      "norm_label": ".noinstallationfound_returnsfailed()"
+    },
+    {
+      "label": "OpennessGroupCheckTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_opennessgroupchecktests_cs",
+      "community": 63,
+      "norm_label": "opennessgroupchecktests.cs"
+    },
+    {
+      "label": "OpennessGroupCheckTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs",
+      "source_location": "L7",
+      "id": "diagnostics_opennessgroupchecktests_opennessgroupchecktests",
+      "community": 63,
+      "norm_label": "opennessgroupchecktests"
+    },
+    {
+      "label": ".NotWindows_ReturnsFailed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs",
+      "source_location": "L9",
+      "id": "diagnostics_opennessgroupchecktests_opennessgroupchecktests_notwindows_returnsfailed",
+      "community": 63,
+      "norm_label": ".notwindows_returnsfailed()"
+    },
+    {
+      "label": ".GroupDoesNotExist_ReturnsFailed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs",
+      "source_location": "L21",
+      "id": "diagnostics_opennessgroupchecktests_opennessgroupchecktests_groupdoesnotexist_returnsfailed",
+      "community": 63,
+      "norm_label": ".groupdoesnotexist_returnsfailed()"
+    },
+    {
+      "label": ".UserNotMember_ReturnsFailed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs",
+      "source_location": "L37",
+      "id": "diagnostics_opennessgroupchecktests_opennessgroupchecktests_usernotmember_returnsfailed",
+      "community": 63,
+      "norm_label": ".usernotmember_returnsfailed()"
+    },
+    {
+      "label": ".UserIsMember_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs",
+      "source_location": "L53",
+      "id": "diagnostics_opennessgroupchecktests_opennessgroupchecktests_userismember_returnspassed",
+      "community": 63,
+      "norm_label": ".userismember_returnspassed()"
+    },
+    {
+      "label": ".IncludesUserEvidence()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs",
+      "source_location": "L70",
+      "id": "diagnostics_opennessgroupchecktests_opennessgroupchecktests_includesuserevidence",
+      "community": 63,
+      "norm_label": ".includesuserevidence()"
+    },
+    {
+      "label": "OpennessWorkerCheckTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_opennessworkerchecktests_cs",
+      "community": 52,
+      "norm_label": "opennessworkerchecktests.cs"
+    },
+    {
+      "label": "OpennessWorkerCheckTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L8",
+      "id": "diagnostics_opennessworkerchecktests_opennessworkerchecktests",
+      "community": 52,
+      "norm_label": "opennessworkerchecktests"
+    },
+    {
+      "label": ".WorkerFoundWithRequiredCompanionFiles_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L25",
+      "id": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_workerfoundwithrequiredcompanionfiles_returnspassed",
+      "community": 52,
+      "norm_label": ".workerfoundwithrequiredcompanionfiles_returnspassed()"
+    },
+    {
+      "label": ".WorkerNotFound_ReturnsFailed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L45",
+      "id": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_workernotfound_returnsfailed",
+      "community": 52,
+      "norm_label": ".workernotfound_returnsfailed()"
+    },
+    {
+      "label": ".WorkerFoundButContractsAssemblyMissing_ReturnsFailed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L59",
+      "id": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_workerfoundbutcontractsassemblymissing_returnsfailed",
+      "community": 52,
+      "norm_label": ".workerfoundbutcontractsassemblymissing_returnsfailed()"
+    },
+    {
+      "label": ".WorkerFoundWithoutVersion_PassesWithVersionlessMessage()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L78",
+      "id": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_workerfoundwithoutversion_passeswithversionlessmessage",
+      "community": 52,
+      "norm_label": ".workerfoundwithoutversion_passeswithversionlessmessage()"
+    },
+    {
+      "label": ".AddRequiredCompanionFiles()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L97",
+      "id": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_addrequiredcompanionfiles",
+      "community": 52,
+      "norm_label": ".addrequiredcompanionfiles()"
+    },
+    {
+      "label": ".RequiredCompanionFiles_CoverWorkerRuntimeAssets()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L111",
+      "id": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_requiredcompanionfiles_coverworkerruntimeassets",
+      "community": 52,
+      "norm_label": ".requiredcompanionfiles_coverworkerruntimeassets()"
+    },
+    {
+      "label": ".PackageLayout_ExcludesWorkerRuntimeConfigAtCopyAndPackBoundaries()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L159",
+      "id": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_packagelayout_excludesworkerruntimeconfigatcopyandpackboundaries",
+      "community": 52,
+      "norm_label": ".packagelayout_excludesworkerruntimeconfigatcopyandpackboundaries()"
+    },
+    {
+      "label": "OperatingSystemCheckTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OperatingSystemCheckTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_operatingsystemchecktests_cs",
+      "community": 91,
+      "norm_label": "operatingsystemchecktests.cs"
+    },
+    {
+      "label": "OperatingSystemCheckTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OperatingSystemCheckTests.cs",
+      "source_location": "L7",
+      "id": "diagnostics_operatingsystemchecktests_operatingsystemchecktests",
+      "community": 91,
+      "norm_label": "operatingsystemchecktests"
+    },
+    {
+      "label": ".Windows_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OperatingSystemCheckTests.cs",
+      "source_location": "L9",
+      "id": "diagnostics_operatingsystemchecktests_operatingsystemchecktests_windows_returnspassed",
+      "community": 91,
+      "norm_label": ".windows_returnspassed()"
+    },
+    {
+      "label": ".NonWindows_ReturnsFailed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OperatingSystemCheckTests.cs",
+      "source_location": "L21",
+      "id": "diagnostics_operatingsystemchecktests_operatingsystemchecktests_nonwindows_returnsfailed",
+      "community": 91,
+      "norm_label": ".nonwindows_returnsfailed()"
+    },
+    {
+      "label": ".IncludesEvidence()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OperatingSystemCheckTests.cs",
+      "source_location": "L34",
+      "id": "diagnostics_operatingsystemchecktests_operatingsystemchecktests_includesevidence",
+      "community": 91,
+      "norm_label": ".includesevidence()"
+    },
+    {
+      "label": "ProjectBindingCheckTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_projectbindingchecktests_cs",
+      "community": 64,
+      "norm_label": "projectbindingchecktests.cs"
+    },
+    {
+      "label": "ProjectBindingCheckTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs",
+      "source_location": "L7",
+      "id": "diagnostics_projectbindingchecktests_projectbindingchecktests",
+      "community": 64,
+      "norm_label": "projectbindingchecktests"
+    },
+    {
+      "label": ".CliPathProvided_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs",
+      "source_location": "L9",
+      "id": "diagnostics_projectbindingchecktests_projectbindingchecktests_clipathprovided_returnspassed",
+      "community": 64,
+      "norm_label": ".clipathprovided_returnspassed()"
+    },
+    {
+      "label": ".EnvVarProvided_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs",
+      "source_location": "L22",
+      "id": "diagnostics_projectbindingchecktests_projectbindingchecktests_envvarprovided_returnspassed",
+      "community": 64,
+      "norm_label": ".envvarprovided_returnspassed()"
+    },
+    {
+      "label": ".NeitherProvided_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs",
+      "source_location": "L35",
+      "id": "diagnostics_projectbindingchecktests_projectbindingchecktests_neitherprovided_returnspassed",
+      "community": 64,
+      "norm_label": ".neitherprovided_returnspassed()"
+    },
+    {
+      "label": ".CliPathTakesPrecedence()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs",
+      "source_location": "L47",
+      "id": "diagnostics_projectbindingchecktests_projectbindingchecktests_clipathtakesprecedence",
+      "community": 64,
+      "norm_label": ".clipathtakesprecedence()"
+    },
+    {
+      "label": ".WhitespaceCliPath_TreatedAsNotProvided()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs",
+      "source_location": "L61",
+      "id": "diagnostics_projectbindingchecktests_projectbindingchecktests_whitespaceclipath_treatedasnotprovided",
+      "community": 64,
+      "norm_label": ".whitespaceclipath_treatedasnotprovided()"
+    },
+    {
+      "label": "ReleaseWorkflowTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ReleaseWorkflowTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_releaseworkflowtests_cs",
+      "community": 92,
+      "norm_label": "releaseworkflowtests.cs"
+    },
+    {
+      "label": "ReleaseWorkflowTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ReleaseWorkflowTests.cs",
+      "source_location": "L5",
+      "id": "diagnostics_releaseworkflowtests_releaseworkflowtests",
+      "community": 92,
+      "norm_label": "releaseworkflowtests"
+    },
+    {
+      "label": ".StandalonePublish_UsesResolvedPackageVersion()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ReleaseWorkflowTests.cs",
+      "source_location": "L7",
+      "id": "diagnostics_releaseworkflowtests_releaseworkflowtests_standalonepublish_usesresolvedpackageversion",
+      "community": 92,
+      "norm_label": ".standalonepublish_usesresolvedpackageversion()"
+    },
+    {
+      "label": ".NuGetPack_UsesExactResolvedInformationalVersion()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ReleaseWorkflowTests.cs",
+      "source_location": "L18",
+      "id": "diagnostics_releaseworkflowtests_releaseworkflowtests_nugetpack_usesexactresolvedinformationalversion",
+      "community": 92,
+      "norm_label": ".nugetpack_usesexactresolvedinformationalversion()"
+    },
+    {
+      "label": ".ReadWorkflowStep()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ReleaseWorkflowTests.cs",
+      "source_location": "L29",
+      "id": "diagnostics_releaseworkflowtests_releaseworkflowtests_readworkflowstep",
+      "community": 92,
+      "norm_label": ".readworkflowstep()"
+    },
+    {
+      "label": "TiaPortalInstallationCheckTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_tiaportalinstallationchecktests_cs",
+      "community": 37,
+      "norm_label": "tiaportalinstallationchecktests.cs"
+    },
+    {
+      "label": "TiaPortalInstallationCheckTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L9",
+      "id": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests",
+      "community": 37,
+      "norm_label": "tiaportalinstallationchecktests"
+    },
+    {
+      "label": ".FoundViaEnvVar_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L12",
+      "id": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_foundviaenvvar_returnspassed",
+      "community": 37,
+      "norm_label": ".foundviaenvvar_returnspassed()"
+    },
+    {
+      "label": ".ExistingApiDirectoryWithoutAssemblies_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L30",
+      "id": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_existingapidirectorywithoutassemblies_returnspassed",
+      "community": 37,
+      "norm_label": ".existingapidirectorywithoutassemblies_returnspassed()"
+    },
+    {
+      "label": ".TiaPortalLocationRootWithoutApiDirectory_ReturnsPassedWithRootEvidence()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L46",
+      "id": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_tiaportallocationrootwithoutapidirectory_returnspassedwithrootevidence",
+      "community": 37,
+      "norm_label": ".tiaportallocationrootwithoutapidirectory_returnspassedwithrootevidence()"
+    },
+    {
+      "label": ".NotFound_ReturnsFailed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L66",
+      "id": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_notfound_returnsfailed",
+      "community": 37,
+      "norm_label": ".notfound_returnsfailed()"
+    },
+    {
+      "label": ".FoundViaRegistry_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L82",
+      "id": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_foundviaregistry_returnspassed",
+      "community": 37,
+      "norm_label": ".foundviaregistry_returnspassed()"
+    },
+    {
+      "label": ".RegistryRootWithoutApiDirectory_ReturnsPassedWithRootEvidence()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L106",
+      "id": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_registryrootwithoutapidirectory_returnspassedwithrootevidence",
+      "community": 37,
+      "norm_label": ".registryrootwithoutapidirectory_returnspassedwithrootevidence()"
+    },
+    {
+      "label": ".EarlyLocationRootAndLaterCompleteRegistry_SelectsEarlyInstallation()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L128",
+      "id": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_earlylocationrootandlatercompleteregistry_selectsearlyinstallation",
+      "community": 37,
+      "norm_label": ".earlylocationrootandlatercompleteregistry_selectsearlyinstallation()"
+    },
+    {
+      "label": ".EarlyRegistryRootAndLaterCompleteRegistry_SelectsEarlyInstallation()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L157",
+      "id": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_earlyregistryrootandlatercompleteregistry_selectsearlyinstallation",
+      "community": 37,
+      "norm_label": ".earlyregistryrootandlatercompleteregistry_selectsearlyinstallation()"
+    },
+    {
+      "label": ".IncludesCandidateEvidence()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L182",
+      "id": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_includescandidateevidence",
+      "community": 37,
+      "norm_label": ".includescandidateevidence()"
+    },
+    {
+      "label": "TiaPortalProcessCheckTests.cs",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs",
+      "source_location": "L1",
+      "id": "tiamcpserver_tests_diagnostics_tiaportalprocesschecktests_cs",
+      "community": 65,
+      "norm_label": "tiaportalprocesschecktests.cs"
+    },
+    {
+      "label": "TiaPortalProcessCheckTests",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs",
+      "source_location": "L7",
+      "id": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests",
+      "community": 65,
+      "norm_label": "tiaportalprocesschecktests"
+    },
+    {
+      "label": ".NotWindows_ReturnsWarning()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs",
+      "source_location": "L9",
+      "id": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests_notwindows_returnswarning",
+      "community": 65,
+      "norm_label": ".notwindows_returnswarning()"
+    },
+    {
+      "label": ".TiaProcessesFound_ReturnsPassed()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs",
+      "source_location": "L22",
+      "id": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests_tiaprocessesfound_returnspassed",
+      "community": 65,
+      "norm_label": ".tiaprocessesfound_returnspassed()"
+    },
+    {
+      "label": ".MultipleTiaProcesses_CountsAll()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs",
+      "source_location": "L42",
+      "id": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests_multipletiaprocesses_countsall",
+      "community": 65,
+      "norm_label": ".multipletiaprocesses_countsall()"
+    },
+    {
+      "label": ".NoTiaProcesses_ReturnsWarning()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs",
+      "source_location": "L63",
+      "id": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests_notiaprocesses_returnswarning",
+      "community": 65,
+      "norm_label": ".notiaprocesses_returnswarning()"
+    },
+    {
+      "label": ".CaseInsensitiveMatch()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs",
+      "source_location": "L79",
+      "id": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests_caseinsensitivematch",
+      "community": 65,
+      "norm_label": ".caseinsensitivematch()"
+    },
+    {
+      "label": ".With()",
+      "file_type": "code",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/Evidence.cs",
+      "source_location": "L7",
+      "community": 103,
+      "norm_label": ".with()",
+      "id": "checks_evidence_evidence_with"
+    },
+    {
+      "label": "AssemblyResolver.cs",
+      "file_type": "code",
+      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L1",
+      "community": 35,
+      "norm_label": "assemblyresolver.cs",
+      "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_assemblyresolver_cs"
     },
     {
       "label": ".PreviewOpenProject()",
@@ -7100,7 +9908,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/ProjectLifecycleToolTests.cs",
       "source_location": "L56",
-      "community": 43,
+      "community": 62,
       "norm_label": ".openprojectrejectsunconfirmedrequests()",
       "id": "tiamcpserver_tests_projectlifecycletooltests_projectlifecycletooltests_openprojectrejectsunconfirmedrequests"
     },
@@ -7109,7 +9917,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/ProjectLifecycleToolTests.cs",
       "source_location": "L67",
-      "community": 43,
+      "community": 62,
       "norm_label": ".saveprojectasrejectsunconfirmedrequests()",
       "id": "tiamcpserver_tests_projectlifecycletooltests_projectlifecycletooltests_saveprojectasrejectsunconfirmedrequests"
     },
@@ -7118,7 +9926,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs",
       "source_location": "L10",
-      "community": 27,
+      "community": 33,
       "norm_label": ".previewtoolshavemcpmetadata()",
       "id": "tiamcpserver_tests_writetoolsafetytokentests_writetoolsafetytokentests_previewtoolshavemcpmetadata"
     },
@@ -7127,7 +9935,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs",
       "source_location": "L27",
-      "community": 27,
+      "community": 33,
       "norm_label": ".confirmedprojectcloserejectsmissingsafetytoken()",
       "id": "tiamcpserver_tests_writetoolsafetytokentests_writetoolsafetytokentests_confirmedprojectcloserejectsmissingsafetytoken"
     },
@@ -7172,7 +9980,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L50",
-      "community": 9,
+      "community": 7,
       "norm_label": ".stderrlines_surfaceaswarnings()",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_stderrlines_surfaceaswarnings"
     },
@@ -7181,7 +9989,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L80",
-      "community": 9,
+      "community": 7,
       "norm_label": ".malformedresponse_isfailurenotcrash()",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_malformedresponse_isfailurenotcrash"
     },
@@ -7190,7 +9998,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs",
       "source_location": "L89",
-      "community": 9,
+      "community": 7,
       "norm_label": ".silentexit_surfacesstderrdetailinerror()",
       "id": "tiamcpserver_tests_opennessworkerclientintegrationtests_opennessworkerclientintegrationtests_silentexit_surfacesstderrdetailinerror"
     },
@@ -7199,7 +10007,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/WorkerResponse.cs",
       "source_location": "L1",
-      "community": 95,
+      "community": 133,
       "norm_label": "workerresponse.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_workerresponse_cs"
     },
@@ -7208,7 +10016,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Batch/BatchExecutionEngine.cs",
       "source_location": "L10",
-      "community": 46,
+      "community": 68,
       "norm_label": ".isfailure()",
       "id": "batch_batchexecutionengine_batchexecutionengine_isfailure"
     },
@@ -7226,7 +10034,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/DeviceInfo.cs",
       "source_location": "L1",
-      "community": 82,
+      "community": 120,
       "norm_label": "deviceinfo.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_deviceinfo_cs"
     },
@@ -7235,7 +10043,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/DeviceItemInfo.cs",
       "source_location": "L1",
-      "community": 83,
+      "community": 121,
       "norm_label": "deviceiteminfo.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_deviceiteminfo_cs"
     },
@@ -7244,7 +10052,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Contracts/HardwareConfigInfo.cs",
       "source_location": "L1",
-      "community": 84,
+      "community": 122,
       "norm_label": "hardwareconfiginfo.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_contracts_hardwareconfiginfo_cs"
     },
@@ -7253,7 +10061,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L1",
-      "community": 5,
+      "community": 23,
       "norm_label": "equipmentcatalogsearcher.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_equipmentcatalogsearcher_cs"
     },
@@ -7262,7 +10070,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L223",
-      "community": 5,
+      "community": 23,
       "norm_label": ".readproperty()",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_readproperty"
     },
@@ -7271,7 +10079,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/EquipmentCatalogSearcher.cs",
       "source_location": "L258",
-      "community": 5,
+      "community": 23,
       "norm_label": ".enumerate()",
       "id": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher_enumerate"
     },
@@ -7289,7 +10097,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/BlockExporter.cs",
       "source_location": "L1",
-      "community": 58,
+      "community": 84,
       "norm_label": "blockexporter.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_blockexporter_cs"
     },
@@ -7298,7 +10106,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/BlockImporter.cs",
       "source_location": "L1",
-      "community": 1,
+      "community": 54,
       "norm_label": "blockimporter.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_blockimporter_cs"
     },
@@ -7307,7 +10115,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/NetworkDeviceCreator.cs",
       "source_location": "L1",
-      "community": 8,
+      "community": 6,
       "norm_label": "networkdevicecreator.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_networkdevicecreator_cs"
     },
@@ -7316,7 +10124,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/AddNetworkDeviceTool.cs",
       "source_location": "L1",
-      "community": 51,
+      "community": 74,
       "norm_label": "addnetworkdevicetool.cs",
       "id": "tiamcpserver_tools_addnetworkdevicetool_cs"
     },
@@ -7325,7 +10133,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/AddNetworkDeviceTool.cs",
       "source_location": "L6",
-      "community": 51,
+      "community": 74,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_addnetworkdevicetool_tiamcpserver_tools"
     },
@@ -7334,7 +10142,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/AddNetworkDeviceTool.cs",
       "source_location": "L8",
-      "community": 51,
+      "community": 74,
       "norm_label": "addnetworkdevicetool",
       "id": "tools_addnetworkdevicetool_addnetworkdevicetool"
     },
@@ -7343,7 +10151,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/AddNetworkDeviceTool.cs",
       "source_location": "L11",
-      "community": 51,
+      "community": 74,
       "norm_label": ".previewaddnetworkdevice()",
       "id": "tools_addnetworkdevicetool_addnetworkdevicetool_previewaddnetworkdevice"
     },
@@ -7352,7 +10160,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/AddNetworkDeviceTool.cs",
       "source_location": "L36",
-      "community": 51,
+      "community": 74,
       "norm_label": ".addnetworkdevice()",
       "id": "tools_addnetworkdevicetool_addnetworkdevicetool_addnetworkdevice"
     },
@@ -7361,7 +10169,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/BrowseProjectTreeTool.cs",
       "source_location": "L1",
-      "community": 61,
+      "community": 93,
       "norm_label": "browseprojecttreetool.cs",
       "id": "tiamcpserver_tools_browseprojecttreetool_cs"
     },
@@ -7370,7 +10178,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/BrowseProjectTreeTool.cs",
       "source_location": "L5",
-      "community": 61,
+      "community": 93,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_browseprojecttreetool_tiamcpserver_tools"
     },
@@ -7379,7 +10187,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/BrowseProjectTreeTool.cs",
       "source_location": "L7",
-      "community": 61,
+      "community": 93,
       "norm_label": "browseprojecttreetool",
       "id": "tools_browseprojecttreetool_browseprojecttreetool"
     },
@@ -7388,7 +10196,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/BrowseProjectTreeTool.cs",
       "source_location": "L10",
-      "community": 61,
+      "community": 93,
       "norm_label": ".browseprojecttree()",
       "id": "tools_browseprojecttreetool_browseprojecttreetool_browseprojecttree"
     },
@@ -7397,7 +10205,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/CompileCheckTool.cs",
       "source_location": "L1",
-      "community": 62,
+      "community": 94,
       "norm_label": "compilechecktool.cs",
       "id": "tiamcpserver_tools_compilechecktool_cs"
     },
@@ -7406,7 +10214,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/CompileCheckTool.cs",
       "source_location": "L5",
-      "community": 62,
+      "community": 94,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_compilechecktool_tiamcpserver_tools"
     },
@@ -7415,7 +10223,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/CompileCheckTool.cs",
       "source_location": "L7",
-      "community": 62,
+      "community": 94,
       "norm_label": "compilechecktool",
       "id": "tools_compilechecktool_compilechecktool"
     },
@@ -7424,7 +10232,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/CompileCheckTool.cs",
       "source_location": "L10",
-      "community": 62,
+      "community": 94,
       "norm_label": ".compilecheck()",
       "id": "tools_compilechecktool_compilechecktool_compilecheck"
     },
@@ -7433,7 +10241,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ConfigureNetworkDeviceTool.cs",
       "source_location": "L1",
-      "community": 52,
+      "community": 75,
       "norm_label": "configurenetworkdevicetool.cs",
       "id": "tiamcpserver_tools_configurenetworkdevicetool_cs"
     },
@@ -7442,7 +10250,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ConfigureNetworkDeviceTool.cs",
       "source_location": "L6",
-      "community": 52,
+      "community": 75,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_configurenetworkdevicetool_tiamcpserver_tools"
     },
@@ -7451,7 +10259,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ConfigureNetworkDeviceTool.cs",
       "source_location": "L8",
-      "community": 52,
+      "community": 75,
       "norm_label": "configurenetworkdevicetool",
       "id": "tools_configurenetworkdevicetool_configurenetworkdevicetool"
     },
@@ -7460,7 +10268,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ConfigureNetworkDeviceTool.cs",
       "source_location": "L11",
-      "community": 52,
+      "community": 75,
       "norm_label": ".previewconfigurenetworkdevice()",
       "id": "tools_configurenetworkdevicetool_configurenetworkdevicetool_previewconfigurenetworkdevice"
     },
@@ -7469,7 +10277,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ConfigureNetworkDeviceTool.cs",
       "source_location": "L36",
-      "community": 52,
+      "community": 75,
       "norm_label": ".configurenetworkdevice()",
       "id": "tools_configurenetworkdevicetool_configurenetworkdevicetool_configurenetworkdevice"
     },
@@ -7478,7 +10286,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/GetBlockContentTool.cs",
       "source_location": "L1",
-      "community": 63,
+      "community": 95,
       "norm_label": "getblockcontenttool.cs",
       "id": "tiamcpserver_tools_getblockcontenttool_cs"
     },
@@ -7487,7 +10295,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/GetBlockContentTool.cs",
       "source_location": "L5",
-      "community": 63,
+      "community": 95,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_getblockcontenttool_tiamcpserver_tools"
     },
@@ -7496,7 +10304,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/GetBlockContentTool.cs",
       "source_location": "L7",
-      "community": 63,
+      "community": 95,
       "norm_label": "getblockcontenttool",
       "id": "tools_getblockcontenttool_getblockcontenttool"
     },
@@ -7505,7 +10313,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/GetBlockContentTool.cs",
       "source_location": "L10",
-      "community": 63,
+      "community": 95,
       "norm_label": ".getblockcontent()",
       "id": "tools_getblockcontenttool_getblockcontenttool_getblockcontent"
     },
@@ -7514,7 +10322,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ListTagTablesTool.cs",
       "source_location": "L1",
-      "community": 64,
+      "community": 96,
       "norm_label": "listtagtablestool.cs",
       "id": "tiamcpserver_tools_listtagtablestool_cs"
     },
@@ -7523,7 +10331,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ListTagTablesTool.cs",
       "source_location": "L5",
-      "community": 64,
+      "community": 96,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_listtagtablestool_tiamcpserver_tools"
     },
@@ -7532,7 +10340,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ListTagTablesTool.cs",
       "source_location": "L7",
-      "community": 64,
+      "community": 96,
       "norm_label": "listtagtablestool",
       "id": "tools_listtagtablestool_listtagtablestool"
     },
@@ -7541,7 +10349,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ListTagTablesTool.cs",
       "source_location": "L10",
-      "community": 64,
+      "community": 96,
       "norm_label": ".listtagtables()",
       "id": "tools_listtagtablestool_listtagtablestool_listtagtables"
     },
@@ -7550,7 +10358,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ReadCrossReferencesTool.cs",
       "source_location": "L1",
-      "community": 65,
+      "community": 97,
       "norm_label": "readcrossreferencestool.cs",
       "id": "tiamcpserver_tools_readcrossreferencestool_cs"
     },
@@ -7559,7 +10367,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ReadCrossReferencesTool.cs",
       "source_location": "L5",
-      "community": 65,
+      "community": 97,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_readcrossreferencestool_tiamcpserver_tools"
     },
@@ -7568,7 +10376,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ReadCrossReferencesTool.cs",
       "source_location": "L7",
-      "community": 65,
+      "community": 97,
       "norm_label": "readcrossreferencestool",
       "id": "tools_readcrossreferencestool_readcrossreferencestool"
     },
@@ -7577,7 +10385,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ReadCrossReferencesTool.cs",
       "source_location": "L10",
-      "community": 65,
+      "community": 97,
       "norm_label": ".readcrossreferences()",
       "id": "tools_readcrossreferencestool_readcrossreferencestool_readcrossreferences"
     },
@@ -7586,7 +10394,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ReadHardwareConfigTool.cs",
       "source_location": "L1",
-      "community": 66,
+      "community": 98,
       "norm_label": "readhardwareconfigtool.cs",
       "id": "tiamcpserver_tools_readhardwareconfigtool_cs"
     },
@@ -7595,7 +10403,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ReadHardwareConfigTool.cs",
       "source_location": "L5",
-      "community": 66,
+      "community": 98,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_readhardwareconfigtool_tiamcpserver_tools"
     },
@@ -7604,7 +10412,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ReadHardwareConfigTool.cs",
       "source_location": "L7",
-      "community": 66,
+      "community": 98,
       "norm_label": "readhardwareconfigtool",
       "id": "tools_readhardwareconfigtool_readhardwareconfigtool"
     },
@@ -7613,7 +10421,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/ReadHardwareConfigTool.cs",
       "source_location": "L10",
-      "community": 66,
+      "community": 98,
       "norm_label": ".readhardwareconfig()",
       "id": "tools_readhardwareconfigtool_readhardwareconfigtool_readhardwareconfig"
     },
@@ -7622,7 +10430,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/SearchEquipmentCatalogTool.cs",
       "source_location": "L1",
-      "community": 67,
+      "community": 99,
       "norm_label": "searchequipmentcatalogtool.cs",
       "id": "tiamcpserver_tools_searchequipmentcatalogtool_cs"
     },
@@ -7631,7 +10439,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/SearchEquipmentCatalogTool.cs",
       "source_location": "L5",
-      "community": 67,
+      "community": 99,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_searchequipmentcatalogtool_tiamcpserver_tools"
     },
@@ -7640,7 +10448,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/SearchEquipmentCatalogTool.cs",
       "source_location": "L7",
-      "community": 67,
+      "community": 99,
       "norm_label": "searchequipmentcatalogtool",
       "id": "tools_searchequipmentcatalogtool_searchequipmentcatalogtool"
     },
@@ -7649,7 +10457,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/SearchEquipmentCatalogTool.cs",
       "source_location": "L10",
-      "community": 67,
+      "community": 99,
       "norm_label": ".searchequipmentcatalog()",
       "id": "tools_searchequipmentcatalogtool_searchequipmentcatalogtool_searchequipmentcatalog"
     },
@@ -7658,7 +10466,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L1",
-      "community": 10,
+      "community": 9,
       "norm_label": "tagoperationstools.cs",
       "id": "tiamcpserver_tools_tagoperationstools_cs"
     },
@@ -7667,7 +10475,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L6",
-      "community": 10,
+      "community": 9,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_tagoperationstools_tiamcpserver_tools"
     },
@@ -7676,7 +10484,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L8",
-      "community": 10,
+      "community": 9,
       "norm_label": "tagtableoperationstool",
       "id": "tools_tagoperationstools_tagtableoperationstool"
     },
@@ -7685,7 +10493,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L11",
-      "community": 10,
+      "community": 9,
       "norm_label": ".previewcreatetagtable()",
       "id": "tools_tagoperationstools_tagtableoperationstool_previewcreatetagtable"
     },
@@ -7694,7 +10502,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L32",
-      "community": 10,
+      "community": 9,
       "norm_label": ".createtagtable()",
       "id": "tools_tagoperationstools_tagtableoperationstool_createtagtable"
     },
@@ -7703,7 +10511,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L76",
-      "community": 10,
+      "community": 9,
       "norm_label": ".previewdeletetagtable()",
       "id": "tools_tagoperationstools_tagtableoperationstool_previewdeletetagtable"
     },
@@ -7712,7 +10520,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L97",
-      "community": 10,
+      "community": 9,
       "norm_label": ".deletetagtable()",
       "id": "tools_tagoperationstools_tagtableoperationstool_deletetagtable"
     },
@@ -7721,7 +10529,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L142",
-      "community": 10,
+      "community": 9,
       "norm_label": "tagoperationstool",
       "id": "tools_tagoperationstools_tagoperationstool"
     },
@@ -7730,7 +10538,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L145",
-      "community": 10,
+      "community": 9,
       "norm_label": ".previewcreatetag()",
       "id": "tools_tagoperationstools_tagoperationstool_previewcreatetag"
     },
@@ -7739,7 +10547,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L169",
-      "community": 10,
+      "community": 9,
       "norm_label": ".createtag()",
       "id": "tools_tagoperationstools_tagoperationstool_createtag"
     },
@@ -7748,7 +10556,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L219",
-      "community": 10,
+      "community": 9,
       "norm_label": ".previewupdatetag()",
       "id": "tools_tagoperationstools_tagoperationstool_previewupdatetag"
     },
@@ -7757,7 +10565,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L248",
-      "community": 10,
+      "community": 9,
       "norm_label": ".updatetag()",
       "id": "tools_tagoperationstools_tagoperationstool_updatetag"
     },
@@ -7766,7 +10574,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L308",
-      "community": 10,
+      "community": 9,
       "norm_label": ".previewdeletetag()",
       "id": "tools_tagoperationstools_tagoperationstool_previewdeletetag"
     },
@@ -7775,7 +10583,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L330",
-      "community": 10,
+      "community": 9,
       "norm_label": ".deletetag()",
       "id": "tools_tagoperationstools_tagoperationstool_deletetag"
     },
@@ -7784,7 +10592,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L377",
-      "community": 10,
+      "community": 9,
       "norm_label": "userconstantoperationstool",
       "id": "tools_tagoperationstools_userconstantoperationstool"
     },
@@ -7793,7 +10601,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L380",
-      "community": 10,
+      "community": 9,
       "norm_label": ".previewcreateuserconstant()",
       "id": "tools_tagoperationstools_userconstantoperationstool_previewcreateuserconstant"
     },
@@ -7802,7 +10610,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L404",
-      "community": 10,
+      "community": 9,
       "norm_label": ".createuserconstant()",
       "id": "tools_tagoperationstools_userconstantoperationstool_createuserconstant"
     },
@@ -7811,7 +10619,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L454",
-      "community": 10,
+      "community": 9,
       "norm_label": ".previewupdateuserconstant()",
       "id": "tools_tagoperationstools_userconstantoperationstool_previewupdateuserconstant"
     },
@@ -7820,7 +10628,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L478",
-      "community": 10,
+      "community": 9,
       "norm_label": ".updateuserconstant()",
       "id": "tools_tagoperationstools_userconstantoperationstool_updateuserconstant"
     },
@@ -7829,7 +10637,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L528",
-      "community": 10,
+      "community": 9,
       "norm_label": ".previewdeleteuserconstant()",
       "id": "tools_tagoperationstools_userconstantoperationstool_previewdeleteuserconstant"
     },
@@ -7838,7 +10646,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/TagOperationsTools.cs",
       "source_location": "L550",
-      "community": 10,
+      "community": 9,
       "norm_label": ".deleteuserconstant()",
       "id": "tools_tagoperationstools_userconstantoperationstool_deleteuserconstant"
     },
@@ -7847,7 +10655,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/UpdateBlockLogicTool.cs",
       "source_location": "L1",
-      "community": 53,
+      "community": 76,
       "norm_label": "updateblocklogictool.cs",
       "id": "tiamcpserver_tools_updateblocklogictool_cs"
     },
@@ -7856,7 +10664,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/UpdateBlockLogicTool.cs",
       "source_location": "L6",
-      "community": 53,
+      "community": 76,
       "norm_label": "tiamcpserver.tools",
       "id": "tools_updateblocklogictool_tiamcpserver_tools"
     },
@@ -7865,7 +10673,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/UpdateBlockLogicTool.cs",
       "source_location": "L8",
-      "community": 53,
+      "community": 76,
       "norm_label": "updateblocklogictool",
       "id": "tools_updateblocklogictool_updateblocklogictool"
     },
@@ -7874,7 +10682,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/UpdateBlockLogicTool.cs",
       "source_location": "L11",
-      "community": 53,
+      "community": 76,
       "norm_label": ".previewupdateblocklogic()",
       "id": "tools_updateblocklogictool_updateblocklogictool_previewupdateblocklogic"
     },
@@ -7883,7 +10691,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer/Tools/UpdateBlockLogicTool.cs",
       "source_location": "L33",
-      "community": 53,
+      "community": 76,
       "norm_label": ".updateblocklogic()",
       "id": "tools_updateblocklogictool_updateblocklogictool_updateblocklogic"
     },
@@ -7892,7 +10700,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddNetworkDeviceToolTests.cs",
       "source_location": "L1",
-      "community": 54,
+      "community": 77,
       "norm_label": "addnetworkdevicetooltests.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_addnetworkdevicetooltests_cs"
     },
@@ -7901,7 +10709,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddNetworkDeviceToolTests.cs",
       "source_location": "L10",
-      "community": 54,
+      "community": 77,
       "norm_label": "addnetworkdevicetooltests",
       "id": "tiamcpserver_tests_addnetworkdevicetooltests_addnetworkdevicetooltests"
     },
@@ -7910,7 +10718,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddNetworkDeviceToolTests.cs",
       "source_location": "L12",
-      "community": 54,
+      "community": 77,
       "norm_label": ".addnetworkdevicetoolhasmcpmetadata()",
       "id": "tiamcpserver_tests_addnetworkdevicetooltests_addnetworkdevicetooltests_addnetworkdevicetoolhasmcpmetadata"
     },
@@ -7919,7 +10727,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddNetworkDeviceToolTests.cs",
       "source_location": "L34",
-      "community": 54,
+      "community": 77,
       "norm_label": ".addnetworkdevicerejectsunconfirmedrequests()",
       "id": "tiamcpserver_tests_addnetworkdevicetooltests_addnetworkdevicetooltests_addnetworkdevicerejectsunconfirmedrequests"
     },
@@ -7928,7 +10736,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/AddNetworkDeviceToolTests.cs",
       "source_location": "L46",
-      "community": 54,
+      "community": 77,
       "norm_label": ".opennessworkerclientexposesaddnetworkdeviceasync()",
       "id": "tiamcpserver_tests_addnetworkdevicetooltests_addnetworkdevicetooltests_opennessworkerclientexposesaddnetworkdeviceasync"
     },
@@ -7937,7 +10745,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CompileCheckToolTests.cs",
       "source_location": "L1",
-      "community": 68,
+      "community": 100,
       "norm_label": "compilechecktooltests.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_compilechecktooltests_cs"
     },
@@ -7946,7 +10754,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CompileCheckToolTests.cs",
       "source_location": "L10",
-      "community": 68,
+      "community": 100,
       "norm_label": "compilechecktooltests",
       "id": "tiamcpserver_tests_compilechecktooltests_compilechecktooltests"
     },
@@ -7955,7 +10763,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CompileCheckToolTests.cs",
       "source_location": "L12",
-      "community": 68,
+      "community": 100,
       "norm_label": ".compilechecktoolhasmcpmetadata()",
       "id": "tiamcpserver_tests_compilechecktooltests_compilechecktooltests_compilechecktoolhasmcpmetadata"
     },
@@ -7964,7 +10772,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/CompileCheckToolTests.cs",
       "source_location": "L35",
-      "community": 68,
+      "community": 100,
       "norm_label": ".opennessworkerclientexposescompilecheckasync()",
       "id": "tiamcpserver_tests_compilechecktooltests_compilechecktooltests_opennessworkerclientexposescompilecheckasync"
     },
@@ -7973,7 +10781,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceToolTests.cs",
       "source_location": "L1",
-      "community": 55,
+      "community": 78,
       "norm_label": "configurenetworkdevicetooltests.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_configurenetworkdevicetooltests_cs"
     },
@@ -7982,7 +10790,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceToolTests.cs",
       "source_location": "L10",
-      "community": 55,
+      "community": 78,
       "norm_label": "configurenetworkdevicetooltests",
       "id": "tiamcpserver_tests_configurenetworkdevicetooltests_configurenetworkdevicetooltests"
     },
@@ -7991,7 +10799,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceToolTests.cs",
       "source_location": "L12",
-      "community": 55,
+      "community": 78,
       "norm_label": ".configurenetworkdevicetoolhasmcpmetadata()",
       "id": "tiamcpserver_tests_configurenetworkdevicetooltests_configurenetworkdevicetooltests_configurenetworkdevicetoolhasmcpmetadata"
     },
@@ -8000,7 +10808,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceToolTests.cs",
       "source_location": "L34",
-      "community": 55,
+      "community": 78,
       "norm_label": ".configurenetworkdevicerejectsunconfirmedrequests()",
       "id": "tiamcpserver_tests_configurenetworkdevicetooltests_configurenetworkdevicetooltests_configurenetworkdevicerejectsunconfirmedrequests"
     },
@@ -8009,7 +10817,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/ConfigureNetworkDeviceToolTests.cs",
       "source_location": "L46",
-      "community": 55,
+      "community": 78,
       "norm_label": ".opennessworkerclientexposesconfigurenetworkdeviceasync()",
       "id": "tiamcpserver_tests_configurenetworkdevicetooltests_configurenetworkdevicetooltests_opennessworkerclientexposesconfigurenetworkdeviceasync"
     },
@@ -8018,7 +10826,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/SearchEquipmentCatalogToolTests.cs",
       "source_location": "L1",
-      "community": 69,
+      "community": 101,
       "norm_label": "searchequipmentcatalogtooltests.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tests_searchequipmentcatalogtooltests_cs"
     },
@@ -8027,7 +10835,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/SearchEquipmentCatalogToolTests.cs",
       "source_location": "L10",
-      "community": 69,
+      "community": 101,
       "norm_label": "searchequipmentcatalogtooltests",
       "id": "tiamcpserver_tests_searchequipmentcatalogtooltests_searchequipmentcatalogtooltests"
     },
@@ -8036,7 +10844,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/SearchEquipmentCatalogToolTests.cs",
       "source_location": "L12",
-      "community": 69,
+      "community": 101,
       "norm_label": ".searchequipmentcatalogtoolhasmcpmetadata()",
       "id": "tiamcpserver_tests_searchequipmentcatalogtooltests_searchequipmentcatalogtooltests_searchequipmentcatalogtoolhasmcpmetadata"
     },
@@ -8045,7 +10853,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.Tests/SearchEquipmentCatalogToolTests.cs",
       "source_location": "L33",
-      "community": 69,
+      "community": 101,
       "norm_label": ".opennessworkerclientexposessearchequipmentcatalogasync()",
       "id": "tiamcpserver_tests_searchequipmentcatalogtooltests_searchequipmentcatalogtooltests_opennessworkerclientexposessearchequipmentcatalogasync"
     },
@@ -8054,7 +10862,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/TagOperationsToolTests.cs",
       "source_location": "L1",
-      "community": 44,
+      "community": 66,
       "norm_label": "tagoperationstooltests.cs",
       "id": "tiamcpserver_tests_tagoperationstooltests_cs"
     },
@@ -8063,7 +10871,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/TagOperationsToolTests.cs",
       "source_location": "L10",
-      "community": 44,
+      "community": 66,
       "norm_label": "tagoperationstooltests",
       "id": "tiamcpserver_tests_tagoperationstooltests_tagoperationstooltests"
     },
@@ -8072,7 +10880,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/TagOperationsToolTests.cs",
       "source_location": "L12",
-      "community": 44,
+      "community": 66,
       "norm_label": ".tagoperationtoolshavemcpmetadata()",
       "id": "tiamcpserver_tests_tagoperationstooltests_tagoperationstooltests_tagoperationtoolshavemcpmetadata"
     },
@@ -8081,7 +10889,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/TagOperationsToolTests.cs",
       "source_location": "L34",
-      "community": 44,
+      "community": 66,
       "norm_label": ".opennessworkerclientexposestagoperationmethods()",
       "id": "tiamcpserver_tests_tagoperationstooltests_tagoperationstooltests_opennessworkerclientexposestagoperationmethods"
     },
@@ -8090,7 +10898,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/TagOperationsToolTests.cs",
       "source_location": "L51",
-      "community": 44,
+      "community": 66,
       "norm_label": ".createtagtablerejectsunconfirmedrequests()",
       "id": "tiamcpserver_tests_tagoperationstooltests_tagoperationstooltests_createtagtablerejectsunconfirmedrequests"
     },
@@ -8099,7 +10907,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/TagOperationsToolTests.cs",
       "source_location": "L62",
-      "community": 44,
+      "community": 66,
       "norm_label": ".updatetagrejectsunconfirmedrequests()",
       "id": "tiamcpserver_tests_tagoperationstooltests_tagoperationstooltests_updatetagrejectsunconfirmedrequests"
     },
@@ -8108,7 +10916,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/TagOperationsToolTests.cs",
       "source_location": "L74",
-      "community": 44,
+      "community": 66,
       "norm_label": ".deleteuserconstantrejectsunconfirmedrequests()",
       "id": "tiamcpserver_tests_tagoperationstooltests_tagoperationstooltests_deleteuserconstantrejectsunconfirmedrequests"
     },
@@ -8117,7 +10925,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs",
       "source_location": "L38",
-      "community": 27,
+      "community": 33,
       "norm_label": ".confirmedblockupdaterejectsmissingsafetytoken()",
       "id": "tiamcpserver_tests_writetoolsafetytokentests_writetoolsafetytokentests_confirmedblockupdaterejectsmissingsafetytoken"
     },
@@ -8126,7 +10934,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs",
       "source_location": "L51",
-      "community": 27,
+      "community": 33,
       "norm_label": ".confirmeddeviceaddrejectsmissingsafetytoken()",
       "id": "tiamcpserver_tests_writetoolsafetytokentests_writetoolsafetytokentests_confirmeddeviceaddrejectsmissingsafetytoken"
     },
@@ -8135,7 +10943,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs",
       "source_location": "L64",
-      "community": 27,
+      "community": 33,
       "norm_label": ".confirmedtagupdaterejectsmissingsafetytoken()",
       "id": "tiamcpserver_tests_writetoolsafetytokentests_writetoolsafetytokentests_confirmedtagupdaterejectsmissingsafetytoken"
     },
@@ -8144,7 +10952,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Tools/BrowseProjectTreeTool.cs",
       "source_location": "L1",
-      "community": 61,
+      "community": 93,
       "norm_label": "browseprojecttreetool.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tools_browseprojecttreetool_cs"
     },
@@ -8153,7 +10961,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Tools/CompileCheckTool.cs",
       "source_location": "L1",
-      "community": 62,
+      "community": 94,
       "norm_label": "compilechecktool.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tools_compilechecktool_cs"
     },
@@ -8162,7 +10970,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Tools/GetBlockContentTool.cs",
       "source_location": "L1",
-      "community": 63,
+      "community": 95,
       "norm_label": "getblockcontenttool.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tools_getblockcontenttool_cs"
     },
@@ -8171,7 +10979,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Tools/ListTagTablesTool.cs",
       "source_location": "L1",
-      "community": 64,
+      "community": 96,
       "norm_label": "listtagtablestool.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tools_listtagtablestool_cs"
     },
@@ -8180,7 +10988,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Tools/ReadCrossReferencesTool.cs",
       "source_location": "L1",
-      "community": 65,
+      "community": 97,
       "norm_label": "readcrossreferencestool.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tools_readcrossreferencestool_cs"
     },
@@ -8189,7 +10997,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Tools/ReadHardwareConfigTool.cs",
       "source_location": "L1",
-      "community": 66,
+      "community": 98,
       "norm_label": "readhardwareconfigtool.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tools_readhardwareconfigtool_cs"
     },
@@ -8198,7 +11006,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Tools/SearchEquipmentCatalogTool.cs",
       "source_location": "L1",
-      "community": 67,
+      "community": 99,
       "norm_label": "searchequipmentcatalogtool.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tools_searchequipmentcatalogtool_cs"
     },
@@ -8207,7 +11015,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Program.cs",
       "source_location": "L1",
-      "community": 38,
+      "community": 57,
       "norm_label": "program.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_program_cs"
     },
@@ -8216,7 +11024,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Program.cs",
       "source_location": "L17",
-      "community": 38,
+      "community": 57,
       "norm_label": ".currentdomain_assemblyresolve()",
       "id": "tiamcpserver_program_program_currentdomain_assemblyresolve"
     },
@@ -8225,7 +11033,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Tools/AddNetworkDeviceTool.cs",
       "source_location": "L1",
-      "community": 51,
+      "community": 74,
       "norm_label": "addnetworkdevicetool.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tools_addnetworkdevicetool_cs"
     },
@@ -8234,7 +11042,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Tools/ConfigureNetworkDeviceTool.cs",
       "source_location": "L1",
-      "community": 52,
+      "community": 75,
       "norm_label": "configurenetworkdevicetool.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tools_configurenetworkdevicetool_cs"
     },
@@ -8243,7 +11051,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer/Tools/UpdateBlockLogicTool.cs",
       "source_location": "L1",
-      "community": 53,
+      "community": 76,
       "norm_label": "updateblocklogictool.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_tools_updateblocklogictool_cs"
     },
@@ -8252,7 +11060,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L1",
-      "community": 23,
+      "community": 28,
       "norm_label": "blocktargetresolver.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_blocktargetresolver_cs"
     },
@@ -8261,7 +11069,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L75",
-      "community": 23,
+      "community": 28,
       "norm_label": ".findplcsoftware()",
       "id": "openness_blocktargetresolver_blocktargetresolver_findplcsoftware"
     },
@@ -8270,7 +11078,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs",
       "source_location": "L95",
-      "community": 23,
+      "community": 28,
       "norm_label": ".findplcsoftwareindeviceitems()",
       "id": "openness_blocktargetresolver_blocktargetresolver_findplcsoftwareindeviceitems"
     },
@@ -8351,7 +11159,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs",
       "source_location": "L1",
-      "community": 8,
+      "community": 6,
       "norm_label": "hardwareconfigreader.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_hardwareconfigreader_cs"
     },
@@ -8369,7 +11177,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L1",
-      "community": 24,
+      "community": 30,
       "norm_label": "projecttreewalker.cs",
       "id": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_projecttreewalker_cs"
     },
@@ -8378,7 +11186,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L45",
-      "community": 24,
+      "community": 30,
       "norm_label": ".findplcsoftwareindevice()",
       "id": "openness_projecttreewalker_projecttreewalker_findplcsoftwareindevice"
     },
@@ -8387,7 +11195,7 @@
       "file_type": "code",
       "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs",
       "source_location": "L50",
-      "community": 24,
+      "community": 30,
       "norm_label": ".findplcsoftwareindeviceitems()",
       "id": "openness_projecttreewalker_projecttreewalker_findplcsoftwareindeviceitems"
     },
@@ -8810,7 +11618,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/AddDeviceResultInfo.cs",
       "source_location": "L1",
-      "community": 73,
+      "community": 111,
       "norm_label": "adddeviceresultinfo.cs",
       "id": "tiamcpserver_contracts_adddeviceresultinfo_cs"
     },
@@ -8819,7 +11627,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/BlockAddress.cs",
       "source_location": "L1",
-      "community": 31,
+      "community": 41,
       "norm_label": "blockaddress.cs",
       "id": "tiamcpserver_contracts_blockaddress_cs"
     },
@@ -8828,7 +11636,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CatalogEntryInfo.cs",
       "source_location": "L1",
-      "community": 74,
+      "community": 112,
       "norm_label": "catalogentryinfo.cs",
       "id": "tiamcpserver_contracts_catalogentryinfo_cs"
     },
@@ -8837,7 +11645,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CatalogTypeIdentifier.cs",
       "source_location": "L1",
-      "community": 57,
+      "community": 83,
       "norm_label": "catalogtypeidentifier.cs",
       "id": "tiamcpserver_contracts_catalogtypeidentifier_cs"
     },
@@ -8846,7 +11654,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CompileCheckReport.cs",
       "source_location": "L1",
-      "community": 75,
+      "community": 113,
       "norm_label": "compilecheckreport.cs",
       "id": "tiamcpserver_contracts_compilecheckreport_cs"
     },
@@ -8855,7 +11663,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CompileMessageInfo.cs",
       "source_location": "L1",
-      "community": 76,
+      "community": 114,
       "norm_label": "compilemessageinfo.cs",
       "id": "tiamcpserver_contracts_compilemessageinfo_cs"
     },
@@ -8864,7 +11672,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/ConfigureNetworkDeviceResultInfo.cs",
       "source_location": "L1",
-      "community": 77,
+      "community": 115,
       "norm_label": "configurenetworkdeviceresultinfo.cs",
       "id": "tiamcpserver_contracts_configurenetworkdeviceresultinfo_cs"
     },
@@ -8873,7 +11681,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CrossReferenceFilterNames.cs",
       "source_location": "L1",
-      "community": 71,
+      "community": 105,
       "norm_label": "crossreferencefilternames.cs",
       "id": "tiamcpserver_contracts_crossreferencefilternames_cs"
     },
@@ -8882,7 +11690,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CrossReferenceLocationInfo.cs",
       "source_location": "L1",
-      "community": 78,
+      "community": 116,
       "norm_label": "crossreferencelocationinfo.cs",
       "id": "tiamcpserver_contracts_crossreferencelocationinfo_cs"
     },
@@ -8891,7 +11699,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CrossReferenceReport.cs",
       "source_location": "L1",
-      "community": 79,
+      "community": 117,
       "norm_label": "crossreferencereport.cs",
       "id": "tiamcpserver_contracts_crossreferencereport_cs"
     },
@@ -8900,7 +11708,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CrossReferenceSourceInfo.cs",
       "source_location": "L1",
-      "community": 80,
+      "community": 118,
       "norm_label": "crossreferencesourceinfo.cs",
       "id": "tiamcpserver_contracts_crossreferencesourceinfo_cs"
     },
@@ -8909,7 +11717,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/CrossReferenceTargetInfo.cs",
       "source_location": "L1",
-      "community": 81,
+      "community": 119,
       "norm_label": "crossreferencetargetinfo.cs",
       "id": "tiamcpserver_contracts_crossreferencetargetinfo_cs"
     },
@@ -8918,7 +11726,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/IoSystemInfo.cs",
       "source_location": "L1",
-      "community": 85,
+      "community": 123,
       "norm_label": "iosysteminfo.cs",
       "id": "tiamcpserver_contracts_iosysteminfo_cs"
     },
@@ -8927,7 +11735,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/NetworkInterfaceInfo.cs",
       "source_location": "L1",
-      "community": 86,
+      "community": 124,
       "norm_label": "networkinterfaceinfo.cs",
       "id": "tiamcpserver_contracts_networkinterfaceinfo_cs"
     },
@@ -8936,7 +11744,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/NodeInfo.cs",
       "source_location": "L1",
-      "community": 87,
+      "community": 125,
       "norm_label": "nodeinfo.cs",
       "id": "tiamcpserver_contracts_nodeinfo_cs"
     },
@@ -8945,7 +11753,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/PlcCompileInfo.cs",
       "source_location": "L1",
-      "community": 88,
+      "community": 126,
       "norm_label": "plccompileinfo.cs",
       "id": "tiamcpserver_contracts_plccompileinfo_cs"
     },
@@ -8954,7 +11762,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/PlcCrossReferenceInfo.cs",
       "source_location": "L1",
-      "community": 89,
+      "community": 127,
       "norm_label": "plccrossreferenceinfo.cs",
       "id": "tiamcpserver_contracts_plccrossreferenceinfo_cs"
     },
@@ -8963,7 +11771,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/ProjectTreeNode.cs",
       "source_location": "L1",
-      "community": 90,
+      "community": 128,
       "norm_label": "projecttreenode.cs",
       "id": "tiamcpserver_contracts_projecttreenode_cs"
     },
@@ -8972,7 +11780,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/SubnetInfo.cs",
       "source_location": "L1",
-      "community": 91,
+      "community": 129,
       "norm_label": "subnetinfo.cs",
       "id": "tiamcpserver_contracts_subnetinfo_cs"
     },
@@ -8981,7 +11789,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/TagInfo.cs",
       "source_location": "L1",
-      "community": 92,
+      "community": 130,
       "norm_label": "taginfo.cs",
       "id": "tiamcpserver_contracts_taginfo_cs"
     },
@@ -8990,7 +11798,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/TagTableInfo.cs",
       "source_location": "L1",
-      "community": 93,
+      "community": 131,
       "norm_label": "tagtableinfo.cs",
       "id": "tiamcpserver_contracts_tagtableinfo_cs"
     },
@@ -8999,25 +11807,16 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Contracts/UserConstantInfo.cs",
       "source_location": "L1",
-      "community": 94,
+      "community": 132,
       "norm_label": "userconstantinfo.cs",
       "id": "tiamcpserver_contracts_userconstantinfo_cs"
-    },
-    {
-      "label": "AssemblyResolver.cs",
-      "file_type": "code",
-      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
-      "source_location": "L1",
-      "community": 39,
-      "norm_label": "assemblyresolver.cs",
-      "id": "tiamcpserver_opennessworker_openness_assemblyresolver_cs"
     },
     {
       "label": ".FindPlcSoftware()",
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L23",
-      "community": 32,
+      "community": 42,
       "norm_label": ".findplcsoftware()",
       "id": "openness_tagtablereader_tagtablereader_findplcsoftware"
     },
@@ -9026,7 +11825,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/TagTableReader.cs",
       "source_location": "L45",
-      "community": 32,
+      "community": 42,
       "norm_label": ".findplcsoftwareindeviceitems()",
       "id": "openness_tagtablereader_tagtablereader_findplcsoftwareindeviceitems"
     },
@@ -9035,7 +11834,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/AddDeviceResultInfoTests.cs",
       "source_location": "L1",
-      "community": 48,
+      "community": 70,
       "norm_label": "adddeviceresultinfotests.cs",
       "id": "tiamcpserver_tests_adddeviceresultinfotests_cs"
     },
@@ -9044,7 +11843,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/AddNetworkDeviceToolTests.cs",
       "source_location": "L1",
-      "community": 54,
+      "community": 77,
       "norm_label": "addnetworkdevicetooltests.cs",
       "id": "tiamcpserver_tests_addnetworkdevicetooltests_cs"
     },
@@ -9053,7 +11852,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/BlockAddressTests.cs",
       "source_location": "L1",
-      "community": 35,
+      "community": 45,
       "norm_label": "blockaddresstests.cs",
       "id": "tiamcpserver_tests_blockaddresstests_cs"
     },
@@ -9062,7 +11861,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/CatalogEntryInfoTests.cs",
       "source_location": "L1",
-      "community": 41,
+      "community": 60,
       "norm_label": "catalogentryinfotests.cs",
       "id": "tiamcpserver_tests_catalogentryinfotests_cs"
     },
@@ -9071,7 +11870,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/CatalogTypeIdentifierTests.cs",
       "source_location": "L1",
-      "community": 49,
+      "community": 71,
       "norm_label": "catalogtypeidentifiertests.cs",
       "id": "tiamcpserver_tests_catalogtypeidentifiertests_cs"
     },
@@ -9080,7 +11879,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/CompileCheckInfoTests.cs",
       "source_location": "L1",
-      "community": 42,
+      "community": 61,
       "norm_label": "compilecheckinfotests.cs",
       "id": "tiamcpserver_tests_compilecheckinfotests_cs"
     },
@@ -9089,7 +11888,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/CompileCheckToolTests.cs",
       "source_location": "L1",
-      "community": 68,
+      "community": 100,
       "norm_label": "compilechecktooltests.cs",
       "id": "tiamcpserver_tests_compilechecktooltests_cs"
     },
@@ -9098,7 +11897,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/ConfigureNetworkDeviceResultInfoTests.cs",
       "source_location": "L1",
-      "community": 50,
+      "community": 72,
       "norm_label": "configurenetworkdeviceresultinfotests.cs",
       "id": "tiamcpserver_tests_configurenetworkdeviceresultinfotests_cs"
     },
@@ -9107,7 +11906,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/ConfigureNetworkDeviceToolTests.cs",
       "source_location": "L1",
-      "community": 55,
+      "community": 78,
       "norm_label": "configurenetworkdevicetooltests.cs",
       "id": "tiamcpserver_tests_configurenetworkdevicetooltests_cs"
     },
@@ -9116,7 +11915,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/CrossReferenceInfoTests.cs",
       "source_location": "L1",
-      "community": 28,
+      "community": 36,
       "norm_label": "crossreferenceinfotests.cs",
       "id": "tiamcpserver_tests_crossreferenceinfotests_cs"
     },
@@ -9125,7 +11924,7 @@
       "file_type": "code",
       "source_file": "TiaMcpServer.Tests/SearchEquipmentCatalogToolTests.cs",
       "source_location": "L1",
-      "community": 69,
+      "community": 101,
       "norm_label": "searchequipmentcatalogtooltests.cs",
       "id": "tiamcpserver_tests_searchequipmentcatalogtooltests_cs"
     },
@@ -9138,7 +11937,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 45,
+      "community": 67,
       "norm_label": "tia-portal-mcp",
       "id": "readme_tia_portal_mcp"
     },
@@ -9151,7 +11950,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 45,
+      "community": 67,
       "norm_label": "model context protocol",
       "id": "readme_mcp"
     },
@@ -9164,7 +11963,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 105,
+      "community": 144,
       "norm_label": "multi-process architecture rationale",
       "id": "readme_arch_rationale"
     },
@@ -9177,7 +11976,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 105,
+      "community": 144,
       "norm_label": ".net remoting incompatibility in .net 8",
       "id": "readme_remoting_limitation"
     },
@@ -9190,7 +11989,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 45,
+      "community": 67,
       "norm_label": "phase 1: implementation",
       "id": "readme_phase1"
     },
@@ -9203,7 +12002,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 45,
+      "community": 67,
       "norm_label": "phase 2: universal block support",
       "id": "readme_phase2"
     },
@@ -9216,7 +12015,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 45,
+      "community": 67,
       "norm_label": "phase 3: hardware and network discovery",
       "id": "readme_phase3"
     },
@@ -9229,7 +12028,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 45,
+      "community": 67,
       "norm_label": "phase 4: advanced diagnostics",
       "id": "readme_phase4"
     },
@@ -9242,7 +12041,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 45,
+      "community": 67,
       "norm_label": "siemens tia openness user group",
       "id": "readme_openness_group"
     },
@@ -9255,7 +12054,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 107,
+      "community": 151,
       "norm_label": ".net 8",
       "id": "readme_dotnet8"
     },
@@ -9268,7 +12067,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 108,
+      "community": 152,
       "norm_label": ".net framework 4.8",
       "id": "readme_dotnet48"
     }
@@ -9671,6 +12470,17 @@
     {
       "relation": "references",
       "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_dotnetframeworkcheck_dotnetframeworkcheck",
+      "target": "int"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer/Worker/OpennessWorkerClient.cs",
       "source_location": "L791",
       "weight": 1.0,
@@ -9700,6 +12510,17 @@
       "confidence_score": 1.0,
       "source": "openness_equipmentcatalogsearcher_equipmentcatalogsearcher",
       "target": "int"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorRunner.cs",
+      "source_location": "L6",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunner_doctorrunner",
+      "target": "ireadonlylist"
     },
     {
       "relation": "calls",
@@ -9812,6 +12633,94 @@
     {
       "relation": "references",
       "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Cli/DoctorCliParser.cs",
+      "source_location": "L17",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "cli_doctorcliparser_doctorcliparser",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Cli/DoctorCommand.cs",
+      "source_location": "L10",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "cli_doctorcommand_doctorcommand",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L12",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservice_applicationinfoservice",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_dotnetframeworkcheck_dotnetframeworkcheck",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessGroupCheck.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_opennessgroupcheck_opennessgroupcheck",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_opennessworkercheck_opennessworkercheck",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/ProjectBindingCheck.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_projectbindingcheck_projectbindingcheck",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalProcessCheck.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_tiaportalprocesscheck_tiaportalprocesscheck",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L22",
       "weight": 1.0,
@@ -9845,12 +12754,34 @@
     {
       "relation": "references",
       "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerLocator.cs",
+      "source_location": "L22",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "worker_opennessworkerlocator_opennessworkerlocator",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L30",
       "weight": 1.0,
       "context": "field",
       "confidence_score": 1.0,
       "source": "worker_persistentworkertransport_persistentworkertransport",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/TiaPortalInstallationLocator.cs",
+      "source_location": "L45",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "worker_tiaportalinstallationlocator_tiaportalinstallationlocator",
       "target": "string"
     },
     {
@@ -9873,6 +12804,17 @@
       "context": "field",
       "confidence_score": 1.0,
       "source": "tiamcpserver_contracts_projectsessionbinding_projectsessionbinding",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L21",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "openness_assemblyresolver_assemblyresolver",
       "target": "string"
     },
     {
@@ -9906,6 +12848,39 @@
       "context": "field",
       "confidence_score": 1.0,
       "source": "tiamcpserver_tests_batchsafetytokentests_batchsafetytokentests",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L11",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservicetests_applicationinfoservicetests",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L10",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests",
+      "target": "string"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L10",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessworkerchecktests_opennessworkerchecktests",
       "target": "string"
     },
     {
@@ -10734,6 +13709,1497 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Cli/DoctorCliParser.cs",
+      "source_location": "L11",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_cli_doctorcliparser_cs",
+      "target": "cli_doctorcliparser_doctorcliparser"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Cli/DoctorCliParser.cs",
+      "source_location": "L19",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "cli_doctorcliparser_doctorcliparser",
+      "target": "cli_doctorcliparser_doctorcliparser_parse"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Cli/DoctorCommand.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_cli_doctorcommand_cs",
+      "target": "cli_doctorcommand_doctorcommand"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Cli/DoctorCommand.cs",
+      "source_location": "L28",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "cli_doctorcommand_doctorcommand",
+      "target": "cli_doctorcommand_doctorcommand_runasync"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Cli/DoctorCommand.cs",
+      "source_location": "L88",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "cli_doctorcommand_doctorcommand",
+      "target": "cli_doctorcommand_doctorcommand_buildrunner"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Cli/DoctorCommand.cs",
+      "source_location": "L26",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "cli_doctorcommand_doctorcommand_runasync",
+      "target": "cli_doctorcommand_doctorcommand_buildrunner"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_applicationinfoservice_cs",
+      "target": "diagnostics_applicationinfoservice_applicationinfoservice"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservice_applicationinfoservice",
+      "target": "iapplicationinfoservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L10",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservice_applicationinfoservice",
+      "target": "diagnostics_applicationinfoservice_applicationinfoservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L13",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservice_applicationinfoservice",
+      "target": "iregistryservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L15",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservice_applicationinfoservice",
+      "target": "func"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L64",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservice_applicationinfoservice",
+      "target": "diagnostics_applicationinfoservice_applicationinfoservice_getwindowsproductname"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L90",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservice_applicationinfoservice",
+      "target": "diagnostics_applicationinfoservice_applicationinfoservice_normalizewindowsproductname"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L95",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservice_applicationinfoservice",
+      "target": "diagnostics_applicationinfoservice_applicationinfoservice_iswindows11orlater"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorRunner.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunner_doctorrunner",
+      "target": "iapplicationinfoservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs",
+      "source_location": "L12",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_dotnetframeworkcheck_dotnetframeworkcheck",
+      "target": "iapplicationinfoservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetRuntimeCheck.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_dotnetruntimecheck_dotnetruntimecheck",
+      "target": "iapplicationinfoservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_hostworkerversioncheck_hostworkerversioncheck",
+      "target": "iapplicationinfoservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs",
+      "source_location": "L22",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_opennessworkercheck_opennessworkercheck",
+      "target": "iapplicationinfoservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OperatingSystemCheck.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_operatingsystemcheck_operatingsystemcheck",
+      "target": "iapplicationinfoservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalProcessCheck.cs",
+      "source_location": "L14",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_tiaportalprocesscheck_tiaportalprocesscheck",
+      "target": "iapplicationinfoservice"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L6",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeapplicationinfoservice",
+      "target": "iapplicationinfoservice"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/RegistryService.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_registryservice_registryservice",
+      "target": "iregistryservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs",
+      "source_location": "L11",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_dotnetframeworkcheck_dotnetframeworkcheck",
+      "target": "iregistryservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessAssembliesCheck.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_opennessassembliescheck_opennessassembliescheck",
+      "target": "iregistryservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalInstallationCheck.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_tiaportalinstallationcheck_tiaportalinstallationcheck",
+      "target": "iregistryservice"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L26",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeregistryservice",
+      "target": "iregistryservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
+      "source_location": "L19",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "safety_writesafetyservice_writesafetyservice",
+      "target": "func"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L78",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservice_applicationinfoservice_getwindowsproductname",
+      "target": "diagnostics_applicationinfoservice_applicationinfoservice_normalizewindowsproductname"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L87",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservice_applicationinfoservice_getwindowsproductname",
+      "target": "diagnostics_applicationinfoservice_applicationinfoservice_iswindows11orlater"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ApplicationInfoService.cs",
+      "source_location": "L91",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservice_applicationinfoservice_normalizewindowsproductname",
+      "target": "diagnostics_applicationinfoservice_applicationinfoservice_iswindows11orlater"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs",
+      "source_location": "L6",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_doctorjsonrenderer_cs",
+      "target": "diagnostics_doctorjsonrenderer_doctorjsonrenderer"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderer_doctorjsonrenderer",
+      "target": "diagnostics_doctorjsonrenderer_doctorjsonrenderer_render"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs",
+      "source_location": "L71",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderer_doctorjsonrenderer",
+      "target": "diagnostics_doctorjsonrenderer_doctorjsonrenderer_statusstring"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs",
+      "source_location": "L79",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderer_doctorjsonrenderer",
+      "target": "diagnostics_doctorjsonrenderer_doctorjsonrenderer_formattimestamp"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs",
+      "source_location": "L14",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderer_doctorjsonrenderer_render",
+      "target": "diagnostics_doctorjsonrenderer_doctorjsonrenderer_statusstring"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs",
+      "source_location": "L15",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderer_doctorjsonrenderer_render",
+      "target": "diagnostics_doctorjsonrenderer_doctorjsonrenderer_formattimestamp"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorRunner.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_doctorrunner_cs",
+      "target": "diagnostics_doctorrunner_doctorrunner"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorRunner.cs",
+      "source_location": "L14",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunner_doctorrunner",
+      "target": "diagnostics_doctorrunner_doctorrunner_run"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_doctortextrenderer_cs",
+      "target": "diagnostics_doctortextrenderer_doctortextrenderer"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderer_doctortextrenderer",
+      "target": "diagnostics_doctortextrenderer_doctortextrenderer_render"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L25",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderer_doctortextrenderer",
+      "target": "diagnostics_doctortextrenderer_doctortextrenderer_rendercheck"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L61",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderer_doctortextrenderer",
+      "target": "diagnostics_doctortextrenderer_doctortextrenderer_formatvalue"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L63",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderer_doctortextrenderer",
+      "target": "diagnostics_doctortextrenderer_doctortextrenderer_splitlines"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L71",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderer_doctortextrenderer",
+      "target": "diagnostics_doctortextrenderer_doctortextrenderer_pluralize"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L14",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderer_doctortextrenderer_render",
+      "target": "diagnostics_doctortextrenderer_doctortextrenderer_rendercheck"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L17",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderer_doctortextrenderer_render",
+      "target": "diagnostics_doctortextrenderer_doctortextrenderer_pluralize"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L42",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderer_doctortextrenderer_rendercheck",
+      "target": "diagnostics_doctortextrenderer_doctortextrenderer_splitlines"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/DoctorTextRenderer.cs",
+      "source_location": "L54",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderer_doctortextrenderer_rendercheck",
+      "target": "diagnostics_doctortextrenderer_doctortextrenderer_formatvalue"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/EnvironmentVariableService.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_environmentvariableservice_cs",
+      "target": "diagnostics_environmentvariableservice_environmentvariableservice"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/EnvironmentVariableService.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_environmentvariableservice_environmentvariableservice",
+      "target": "ienvironmentvariableservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/EnvironmentVariableService.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_environmentvariableservice_environmentvariableservice",
+      "target": "diagnostics_environmentvariableservice_environmentvariableservice"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/EnvironmentVariableService.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_environmentvariableservice_environmentvariableservice",
+      "target": "diagnostics_environmentvariableservice_environmentvariableservice_get"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessAssembliesCheck.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_opennessassembliescheck_opennessassembliescheck",
+      "target": "ienvironmentvariableservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/ProjectBindingCheck.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_projectbindingcheck_projectbindingcheck",
+      "target": "ienvironmentvariableservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalInstallationCheck.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_tiaportalinstallationcheck_tiaportalinstallationcheck",
+      "target": "ienvironmentvariableservice"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L17",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeenvironmentvariableservice",
+      "target": "ienvironmentvariableservice"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/FileSystemService.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_filesystemservice_cs",
+      "target": "diagnostics_filesystemservice_filesystemservice"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/FileSystemService.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_filesystemservice_filesystemservice",
+      "target": "ifilesystemservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/FileSystemService.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_filesystemservice_filesystemservice",
+      "target": "diagnostics_filesystemservice_filesystemservice"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/FileSystemService.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_filesystemservice_filesystemservice",
+      "target": "diagnostics_filesystemservice_filesystemservice_fileexists"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/FileSystemService.cs",
+      "source_location": "L11",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_filesystemservice_filesystemservice",
+      "target": "diagnostics_filesystemservice_filesystemservice_directoryexists"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/FileSystemService.cs",
+      "source_location": "L13",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_filesystemservice_filesystemservice",
+      "target": "diagnostics_filesystemservice_filesystemservice_getfileversion"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_hostworkerversioncheck_hostworkerversioncheck",
+      "target": "ifilesystemservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessAssembliesCheck.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_opennessassembliescheck_opennessassembliescheck",
+      "target": "ifilesystemservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs",
+      "source_location": "L23",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_opennessworkercheck_opennessworkercheck",
+      "target": "ifilesystemservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalInstallationCheck.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_tiaportalinstallationcheck_tiaportalinstallationcheck",
+      "target": "ifilesystemservice"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L51",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakefilesystemservice",
+      "target": "ifilesystemservice"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IApplicationInfoService.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_iapplicationinfoservice_cs",
+      "target": "diagnostics_iapplicationinfoservice_iapplicationinfoservice"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IDiagnosticCheck.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_idiagnosticcheck_cs",
+      "target": "diagnostics_idiagnosticcheck_idiagnosticcheck"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IDiagnosticCheck.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_idiagnosticcheck_idiagnosticcheck",
+      "target": "diagnostics_idiagnosticcheck_idiagnosticcheck_run"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IEnvironmentVariableService.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_ienvironmentvariableservice_cs",
+      "target": "diagnostics_ienvironmentvariableservice_ienvironmentvariableservice"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IEnvironmentVariableService.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_ienvironmentvariableservice_ienvironmentvariableservice",
+      "target": "diagnostics_ienvironmentvariableservice_ienvironmentvariableservice_get"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IFileSystemService.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_ifilesystemservice_cs",
+      "target": "diagnostics_ifilesystemservice_ifilesystemservice"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IFileSystemService.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_ifilesystemservice_ifilesystemservice",
+      "target": "diagnostics_ifilesystemservice_ifilesystemservice_fileexists"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IFileSystemService.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_ifilesystemservice_ifilesystemservice",
+      "target": "diagnostics_ifilesystemservice_ifilesystemservice_directoryexists"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IFileSystemService.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_ifilesystemservice_ifilesystemservice",
+      "target": "diagnostics_ifilesystemservice_ifilesystemservice_getfileversion"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IProcessEnumerationService.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_iprocessenumerationservice_cs",
+      "target": "diagnostics_iprocessenumerationservice_iprocessenumerationservice"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IProcessEnumerationService.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_iprocessenumerationservice_iprocessenumerationservice",
+      "target": "diagnostics_iprocessenumerationservice_iprocessenumerationservice_listprocesses"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IRegistryService.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_iregistryservice_cs",
+      "target": "diagnostics_iregistryservice_iregistryservice"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IRegistryService.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_iregistryservice_iregistryservice",
+      "target": "diagnostics_iregistryservice_iregistryservice_getstringvalue"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IRegistryService.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_iregistryservice_iregistryservice",
+      "target": "diagnostics_iregistryservice_iregistryservice_getintvalue"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IRegistryService.cs",
+      "source_location": "L11",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_iregistryservice_iregistryservice",
+      "target": "diagnostics_iregistryservice_iregistryservice_keyexists"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IWindowsIdentityService.cs",
+      "source_location": "L11",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_iwindowsidentityservice_cs",
+      "target": "diagnostics_iwindowsidentityservice_iwindowsidentityservice"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IWindowsIdentityService.cs",
+      "source_location": "L15",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_iwindowsidentityservice_iwindowsidentityservice",
+      "target": "diagnostics_iwindowsidentityservice_iwindowsidentityservice_getcurrentuserinfo"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/IWindowsIdentityService.cs",
+      "source_location": "L17",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_iwindowsidentityservice_iwindowsidentityservice",
+      "target": "diagnostics_iwindowsidentityservice_iwindowsidentityservice_checkgroupmembership"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ProcessEnumerationService.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_processenumerationservice_cs",
+      "target": "diagnostics_processenumerationservice_processenumerationservice"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ProcessEnumerationService.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_processenumerationservice_processenumerationservice",
+      "target": "iprocessenumerationservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ProcessEnumerationService.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_processenumerationservice_processenumerationservice",
+      "target": "diagnostics_processenumerationservice_processenumerationservice"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/ProcessEnumerationService.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_processenumerationservice_processenumerationservice",
+      "target": "diagnostics_processenumerationservice_processenumerationservice_listprocesses"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalProcessCheck.cs",
+      "source_location": "L13",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_tiaportalprocesscheck_tiaportalprocesscheck",
+      "target": "iprocessenumerationservice"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L76",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeprocessenumerationservice",
+      "target": "iprocessenumerationservice"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/RegistryService.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_registryservice_cs",
+      "target": "diagnostics_registryservice_registryservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/RegistryService.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_registryservice_registryservice",
+      "target": "diagnostics_registryservice_registryservice"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/RegistryService.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_registryservice_registryservice",
+      "target": "diagnostics_registryservice_registryservice_getstringvalue"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/RegistryService.cs",
+      "source_location": "L21",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_registryservice_registryservice",
+      "target": "diagnostics_registryservice_registryservice_getintvalue"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/RegistryService.cs",
+      "source_location": "L44",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_registryservice_registryservice",
+      "target": "diagnostics_registryservice_registryservice_keyexists"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/WindowsIdentityService.cs",
+      "source_location": "L6",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_windowsidentityservice_cs",
+      "target": "diagnostics_windowsidentityservice_windowsidentityservice"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/WindowsIdentityService.cs",
+      "source_location": "L6",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_windowsidentityservice_windowsidentityservice",
+      "target": "iwindowsidentityservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/WindowsIdentityService.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_windowsidentityservice_windowsidentityservice",
+      "target": "diagnostics_windowsidentityservice_windowsidentityservice"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/WindowsIdentityService.cs",
+      "source_location": "L12",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_windowsidentityservice_windowsidentityservice",
+      "target": "diagnostics_windowsidentityservice_windowsidentityservice_getcurrentuserinfo"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/WindowsIdentityService.cs",
+      "source_location": "L36",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_windowsidentityservice_windowsidentityservice",
+      "target": "diagnostics_windowsidentityservice_windowsidentityservice_checkgroupmembership"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/WindowsIdentityService.cs",
+      "source_location": "L82",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_windowsidentityservice_windowsidentityservice",
+      "target": "diagnostics_windowsidentityservice_windowsidentityservice_tryresolvegroupsid"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessGroupCheck.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "checks_opennessgroupcheck_opennessgroupcheck",
+      "target": "iwindowsidentityservice"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L66",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakewindowsidentityservice",
+      "target": "iwindowsidentityservice"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/WindowsIdentityService.cs",
+      "source_location": "L53",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_windowsidentityservice_windowsidentityservice_checkgroupmembership",
+      "target": "diagnostics_windowsidentityservice_windowsidentityservice_tryresolvegroupsid"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_checks_dotnetframeworkcheck_cs",
+      "target": "checks_dotnetframeworkcheck_dotnetframeworkcheck"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_dotnetframeworkcheck_dotnetframeworkcheck",
+      "target": "idiagnosticcheck"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs",
+      "source_location": "L23",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_dotnetframeworkcheck_dotnetframeworkcheck",
+      "target": "checks_dotnetframeworkcheck_dotnetframeworkcheck_run"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs",
+      "source_location": "L100",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_dotnetframeworkcheck_dotnetframeworkcheck",
+      "target": "checks_dotnetframeworkcheck_dotnetframeworkcheck_interpretrelease"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetRuntimeCheck.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_dotnetruntimecheck_dotnetruntimecheck",
+      "target": "idiagnosticcheck"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_hostworkerversioncheck_hostworkerversioncheck",
+      "target": "idiagnosticcheck"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessAssembliesCheck.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_opennessassembliescheck_opennessassembliescheck",
+      "target": "idiagnosticcheck"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessGroupCheck.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_opennessgroupcheck_opennessgroupcheck",
+      "target": "idiagnosticcheck"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_opennessworkercheck_opennessworkercheck",
+      "target": "idiagnosticcheck"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OperatingSystemCheck.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_operatingsystemcheck_operatingsystemcheck",
+      "target": "idiagnosticcheck"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/ProjectBindingCheck.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_projectbindingcheck_projectbindingcheck",
+      "target": "idiagnosticcheck"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalInstallationCheck.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_tiaportalinstallationcheck_tiaportalinstallationcheck",
+      "target": "idiagnosticcheck"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalProcessCheck.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_tiaportalprocesscheck_tiaportalprocesscheck",
+      "target": "idiagnosticcheck"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L120",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_stubcheck",
+      "target": "idiagnosticcheck"
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L129",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_throwingcheck",
+      "target": "idiagnosticcheck"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetFrameworkCheck.cs",
+      "source_location": "L77",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_dotnetframeworkcheck_dotnetframeworkcheck_run",
+      "target": "checks_dotnetframeworkcheck_dotnetframeworkcheck_interpretrelease"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetRuntimeCheck.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_checks_dotnetruntimecheck_cs",
+      "target": "checks_dotnetruntimecheck_dotnetruntimecheck"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/DotNetRuntimeCheck.cs",
+      "source_location": "L12",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_dotnetruntimecheck_dotnetruntimecheck",
+      "target": "checks_dotnetruntimecheck_dotnetruntimecheck_run"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/Evidence.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_checks_evidence_cs",
+      "target": "checks_evidence_evidence"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/Evidence.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_evidence_evidence",
+      "target": "checks_evidence_evidence_empty"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/Evidence.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_evidence_evidence",
+      "target": "checks_evidence_evidence_with"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_checks_hostworkerversioncheck_cs",
+      "target": "checks_hostworkerversioncheck_hostworkerversioncheck"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs",
+      "source_location": "L19",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_hostworkerversioncheck_hostworkerversioncheck",
+      "target": "checks_hostworkerversioncheck_hostworkerversioncheck_run"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs",
+      "source_location": "L95",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_hostworkerversioncheck_hostworkerversioncheck",
+      "target": "checks_hostworkerversioncheck_hostworkerversioncheck_tryparsemajor"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/HostWorkerVersionCheck.cs",
+      "source_location": "L52",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_hostworkerversioncheck_hostworkerversioncheck_run",
+      "target": "checks_hostworkerversioncheck_hostworkerversioncheck_tryparsemajor"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessAssembliesCheck.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_checks_opennessassembliescheck_cs",
+      "target": "checks_opennessassembliescheck_opennessassembliescheck"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessAssembliesCheck.cs",
+      "source_location": "L24",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_opennessassembliescheck_opennessassembliescheck",
+      "target": "checks_opennessassembliescheck_opennessassembliescheck_run"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessGroupCheck.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_checks_opennessgroupcheck_cs",
+      "target": "checks_opennessgroupcheck_opennessgroupcheck"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessGroupCheck.cs",
+      "source_location": "L14",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_opennessgroupcheck_opennessgroupcheck",
+      "target": "checks_opennessgroupcheck_opennessgroupcheck_run"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_checks_opennessworkercheck_cs",
+      "target": "checks_opennessworkercheck_opennessworkercheck"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs",
+      "source_location": "L34",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_opennessworkercheck_opennessworkercheck",
+      "target": "checks_opennessworkercheck_opennessworkercheck_run"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OperatingSystemCheck.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_checks_operatingsystemcheck_cs",
+      "target": "checks_operatingsystemcheck_operatingsystemcheck"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/OperatingSystemCheck.cs",
+      "source_location": "L12",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_operatingsystemcheck_operatingsystemcheck",
+      "target": "checks_operatingsystemcheck_operatingsystemcheck_run"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/ProjectBindingCheck.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_checks_projectbindingcheck_cs",
+      "target": "checks_projectbindingcheck_projectbindingcheck"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/ProjectBindingCheck.cs",
+      "source_location": "L20",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_projectbindingcheck_projectbindingcheck",
+      "target": "checks_projectbindingcheck_projectbindingcheck_run"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalInstallationCheck.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_checks_tiaportalinstallationcheck_cs",
+      "target": "checks_tiaportalinstallationcheck_tiaportalinstallationcheck"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalInstallationCheck.cs",
+      "source_location": "L24",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_tiaportalinstallationcheck_tiaportalinstallationcheck",
+      "target": "checks_tiaportalinstallationcheck_tiaportalinstallationcheck_run"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalProcessCheck.cs",
+      "source_location": "L3",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_diagnostics_checks_tiaportalprocesscheck_cs",
+      "target": "checks_tiaportalprocesscheck_tiaportalprocesscheck"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Diagnostics/Checks/TiaPortalProcessCheck.cs",
+      "source_location": "L25",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "checks_tiaportalprocesscheck_tiaportalprocesscheck",
+      "target": "checks_tiaportalprocesscheck_tiaportalprocesscheck_run"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
       "source_location": "L8",
       "weight": 1.0,
@@ -10782,17 +15248,6 @@
       "confidence_score": 1.0,
       "source": "safety_writesafetyservice_writesafetyservice",
       "target": "concurrentdictionary"
-    },
-    {
-      "relation": "references",
-      "confidence": "EXTRACTED",
-      "source_file": "TiaMcpServer/Safety/WriteSafetyService.cs",
-      "source_location": "L19",
-      "weight": 1.0,
-      "context": "field",
-      "confidence_score": 1.0,
-      "source": "safety_writesafetyservice_writesafetyservice",
-      "target": "func"
     },
     {
       "relation": "method",
@@ -12834,6 +17289,47 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerLocator.cs",
+      "source_location": "L19",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_worker_opennessworkerlocator_cs",
+      "target": "worker_opennessworkerlocator_opennessworkerlocator"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerLocator.cs",
+      "source_location": "L24",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "worker_opennessworkerlocator_opennessworkerlocator",
+      "target": "worker_opennessworkerlocator_opennessworkerlocator_locate"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerLocator.cs",
+      "source_location": "L61",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "worker_opennessworkerlocator_opennessworkerlocator",
+      "target": "worker_opennessworkerlocator_opennessworkerlocator_locateorthrow"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/OpennessWorkerLocator.cs",
+      "source_location": "L63",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "worker_opennessworkerlocator_opennessworkerlocator_locateorthrow",
+      "target": "worker_opennessworkerlocator_opennessworkerlocator_locate"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer/Worker/PersistentWorkerTransport.cs",
       "source_location": "L19",
       "weight": 1.0,
@@ -13043,6 +17539,47 @@
       "confidence_score": 1.0,
       "source": "worker_persistentworkertransport_persistentworkertransport_killprocess",
       "target": "worker_persistentworkertransport_persistentworkertransport_dispose"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/TiaPortalInstallationLocator.cs",
+      "source_location": "L31",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_worker_tiaportalinstallationlocator_cs",
+      "target": "worker_tiaportalinstallationlocator_tiaportalinstallationlocator"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/TiaPortalInstallationLocator.cs",
+      "source_location": "L48",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "worker_tiaportalinstallationlocator_tiaportalinstallationlocator",
+      "target": "worker_tiaportalinstallationlocator_tiaportalinstallationlocator_locate"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/TiaPortalInstallationLocator.cs",
+      "source_location": "L98",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "worker_tiaportalinstallationlocator_tiaportalinstallationlocator",
+      "target": "worker_tiaportalinstallationlocator_tiaportalinstallationlocator_addcandidate"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer/Worker/TiaPortalInstallationLocator.cs",
+      "source_location": "L59",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "worker_tiaportalinstallationlocator_tiaportalinstallationlocator_locate",
+      "target": "worker_tiaportalinstallationlocator_tiaportalinstallationlocator_addcandidate"
     },
     {
       "relation": "contains",
@@ -15840,11 +20377,11 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
       "source_location": "L10",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_assemblyresolver_cs",
+      "source": "tiamcpserver_opennessworker_openness_assemblyresolver_cs",
       "target": "openness_assemblyresolver_assemblyresolver"
     },
     {
@@ -15856,6 +20393,36 @@
       "confidence_score": 1.0,
       "source": "openness_assemblyresolver_assemblyresolver",
       "target": "openness_assemblyresolver_assemblyresolver_register"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L33",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "openness_assemblyresolver_assemblyresolver",
+      "target": "openness_assemblyresolver_assemblyresolver_expandtiaportallocation"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L38",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "openness_assemblyresolver_assemblyresolver",
+      "target": "openness_assemblyresolver_assemblyresolver_createcandidatepaths"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L65",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "openness_assemblyresolver_assemblyresolver",
+      "target": "openness_assemblyresolver_assemblyresolver_selectfirstcompletecandidate"
     },
     {
       "relation": "method",
@@ -15881,6 +20448,16 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L139",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "openness_assemblyresolver_assemblyresolver",
+      "target": "openness_assemblyresolver_assemblyresolver_getregistryinstallpaths"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
       "source_location": "L115",
       "weight": 1.0,
       "confidence_score": 1.0,
@@ -15890,15 +20467,49 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_file": "C:/Users/LCZ/Desktop/RnD/tia-portal-mcp/TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
       "source_location": "L10",
       "weight": 1.0,
       "confidence_score": 1.0,
-      "source": "tiamcpserver_opennessworker_openness_assemblyresolver_cs",
+      "source": "c_users_lcz_desktop_rnd_tia_portal_mcp_tiamcpserver_opennessworker_openness_assemblyresolver_cs",
       "target": "openness_assemblyresolver_assemblyresolver"
     },
     {
       "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L51",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "openness_assemblyresolver_assemblyresolver_createcandidatepaths",
+      "target": "openness_assemblyresolver_assemblyresolver_expandtiaportallocation"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L118",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "openness_assemblyresolver_assemblyresolver_getopennessinstallpath",
+      "target": "openness_assemblyresolver_assemblyresolver_createcandidatepaths"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L123",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "openness_assemblyresolver_assemblyresolver_getopennessinstallpath",
+      "target": "openness_assemblyresolver_assemblyresolver_selectfirstcompletecandidate"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
       "source_location": "L40",
@@ -15906,6 +20517,17 @@
       "confidence_score": 1.0,
       "source": "openness_assemblyresolver_assemblyresolver_onassemblyresolve",
       "target": "openness_assemblyresolver_assemblyresolver_getopennessinstallpath"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.OpennessWorker/Openness/AssemblyResolver.cs",
+      "source_location": "L116",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "openness_assemblyresolver_assemblyresolver_getopennessinstallpath",
+      "target": "openness_assemblyresolver_assemblyresolver_getregistryinstallpaths"
     },
     {
       "relation": "calls",
@@ -24343,6 +28965,2028 @@
       "target": "tiamcpserver_tests_writetoolsafetytokentests_writetoolsafetytokentests_confirmedtagupdaterejectsmissingsafetytoken"
     },
     {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_applicationinfoservicetests_cs",
+      "target": "diagnostics_applicationinfoservicetests_applicationinfoservicetests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L15",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservicetests_applicationinfoservicetests",
+      "target": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_hostversion_preservesinformationalsemverprerelease"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L31",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservicetests_applicationinfoservicetests",
+      "target": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_hostversion_withoutinformationalversion_fallsbacktoassemblyversion"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L13",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservicetests_applicationinfoservicetests",
+      "target": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_osname_windows10productnameatbuild22000_reportswindows11"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L22",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservicetests_applicationinfoservicetests",
+      "target": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_osname_windows10productnamebelowbuild22000_remainswindows10"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L31",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservicetests_applicationinfoservicetests",
+      "target": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_osname_serverproductnameatbuild22000_ispreserved"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L40",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservicetests_applicationinfoservicetests",
+      "target": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_createregistrywithproductname"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L83",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservicetests_applicationinfoservicetests",
+      "target": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_createassembly"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L18",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_hostversion_preservesinformationalsemverprerelease",
+      "target": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_createassembly"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L34",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_hostversion_withoutinformationalversion_fallsbacktoassemblyversion",
+      "target": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_createassembly"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L16",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_osname_windows10productnameatbuild22000_reportswindows11",
+      "target": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_createregistrywithproductname"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L25",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_osname_windows10productnamebelowbuild22000_remainswindows10",
+      "target": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_createregistrywithproductname"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ApplicationInfoServiceTests.cs",
+      "source_location": "L34",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_osname_serverproductnameatbuild22000_ispreserved",
+      "target": "diagnostics_applicationinfoservicetests_applicationinfoservicetests_createregistrywithproductname"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/AssemblyResolverTests.cs",
+      "source_location": "L6",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_assemblyresolvertests_cs",
+      "target": "diagnostics_assemblyresolvertests_assemblyresolvertests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/AssemblyResolverTests.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_assemblyresolvertests_assemblyresolvertests",
+      "target": "diagnostics_assemblyresolvertests_assemblyresolvertests_tiaportallocationroot_appendsv21net48publicapisuffix"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/AssemblyResolverTests.cs",
+      "source_location": "L19",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_assemblyresolvertests_assemblyresolvertests",
+      "target": "diagnostics_assemblyresolvertests_assemblyresolvertests_candidatepaths_preserveenvironmentregistrydefaultprecedence"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/AssemblyResolverTests.cs",
+      "source_location": "L40",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_assemblyresolvertests_assemblyresolvertests",
+      "target": "diagnostics_assemblyresolvertests_assemblyresolvertests_firstincompletecandidate_fallsthroughtonextcompletecandidate"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L6",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_doctorcliparsertests_cs",
+      "target": "diagnostics_doctorcliparsertests_doctorcliparsertests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcliparsertests_doctorcliparsertests",
+      "target": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_emptyargs_returnsvaliddefaults"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L20",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcliparsertests_doctorcliparsertests",
+      "target": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_jsonflag_setsjson"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L29",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcliparsertests_doctorcliparsertests",
+      "target": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_verboseflag_setsverbose"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L38",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcliparsertests_doctorcliparsertests",
+      "target": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_projectflag_setsprojectpath"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L47",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcliparsertests_doctorcliparsertests",
+      "target": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_projectequals_setsprojectpath"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L56",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcliparsertests_doctorcliparsertests",
+      "target": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_combinedflags_allset"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L67",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcliparsertests_doctorcliparsertests",
+      "target": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_unknownarg_returnsinvalid"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L76",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcliparsertests_doctorcliparsertests",
+      "target": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_projectflagwithoutvalue_returnsinvalid"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L85",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcliparsertests_doctorcliparsertests",
+      "target": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_projectflagfollowedbyanotherflag_returnsinvalid"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L95",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcliparsertests_doctorcliparsertests",
+      "target": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_projectequalswithoutvalue_returnsinvalid"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L104",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcliparsertests_doctorcliparsertests",
+      "target": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_projectflagwithblankseparatevalue_returnsinvalid"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L104",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcliparsertests_doctorcliparsertests",
+      "target": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_helpflag_returnsvalidhelprequest"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCliParserTests.cs",
+      "source_location": "L113",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcliparsertests_doctorcliparsertests",
+      "target": "diagnostics_doctorcliparsertests_doctorcliparsertests_parse_caseinsensitive_flagswork"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_doctorcommandtests_cs",
+      "target": "diagnostics_doctorcommandtests_doctorcommandtests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L10",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcommandtests_doctorcommandtests",
+      "target": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_help_writesusagetostandardoutputandreturnszero"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L27",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcommandtests_doctorcommandtests",
+      "target": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_jsonhelp_writesoneparseableusagedocumenttostandardoutput"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L47",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcommandtests_doctorcommandtests",
+      "target": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_jsonparseerror_writesparseableerrortostandardoutput"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L67",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcommandtests_doctorcommandtests",
+      "target": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_jsonprojectwithseparateemptyvalue_writesoneerrordocumentandreturnstwo"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L67",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcommandtests_doctorcommandtests",
+      "target": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_projectthenjson_writesparseableerrortostandardoutput"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L86",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcommandtests_doctorcommandtests",
+      "target": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_mapsreportstatetoexpectedexitcode"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L118",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcommandtests_doctorcommandtests",
+      "target": "diagnostics_doctorcommandtests_doctorcommandtests_passedreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L18",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_help_writesusagetostandardoutputandreturnszero",
+      "target": "diagnostics_doctorcommandtests_doctorcommandtests_passedreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L35",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_jsonhelp_writesoneparseableusagedocumenttostandardoutput",
+      "target": "diagnostics_doctorcommandtests_doctorcommandtests_passedreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L55",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_jsonparseerror_writesparseableerrortostandardoutput",
+      "target": "diagnostics_doctorcommandtests_doctorcommandtests_passedreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L75",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_jsonprojectwithseparateemptyvalue_writesoneerrordocumentandreturnstwo",
+      "target": "diagnostics_doctorcommandtests_doctorcommandtests_passedreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorCommandTests.cs",
+      "source_location": "L75",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorcommandtests_doctorcommandtests_runasync_projectthenjson_writesparseableerrortostandardoutput",
+      "target": "diagnostics_doctorcommandtests_doctorcommandtests_passedreport"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_doctorjsonrenderertests_cs",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_producesvalidjsonwithcorrectstructure"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L36",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_failedstatus_serializescorrectly"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L50",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_verbose_includesevidence"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L67",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_nonverbose_omitsevidence"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L83",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_nullremediation_serializesasnull"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L98",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_nonnullremediation_serializesasstring"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L113",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_evidencenullvalue_serializesasnull"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L129",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_createreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L12",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_producesvalidjsonwithcorrectstructure",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_createreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L39",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_failedstatus_serializescorrectly",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_createreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L54",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_verbose_includesevidence",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_createreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L71",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_nonverbose_omitsevidence",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_createreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L86",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_nullremediation_serializesasnull",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_createreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L101",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_nonnullremediation_serializesasstring",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_createreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorJsonRendererTests.cs",
+      "source_location": "L117",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_render_evidencenullvalue_serializesasnull",
+      "target": "diagnostics_doctorjsonrenderertests_doctorjsonrenderertests_createreport"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L6",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_doctorrunnertests_cs",
+      "target": "diagnostics_doctorrunnertests_doctorrunnertests"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L120",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_doctorrunnertests_cs",
+      "target": "diagnostics_doctorrunnertests_stubcheck"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L129",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_doctorrunnertests_cs",
+      "target": "diagnostics_doctorrunnertests_throwingcheck"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_doctorrunnertests",
+      "target": "diagnostics_doctorrunnertests_doctorrunnertests_run_allcheckspass_returnspassedstatus"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L28",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_doctorrunnertests",
+      "target": "diagnostics_doctorrunnertests_doctorrunnertests_run_mixedresults_returnsfailedifanyfailed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L48",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_doctorrunnertests",
+      "target": "diagnostics_doctorrunnertests_doctorrunnertests_run_onlywarnings_returnswarning"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L65",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_doctorrunnertests",
+      "target": "diagnostics_doctorrunnertests_doctorrunnertests_run_throwingcheck_capturedasfailed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L86",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_doctorrunnertests",
+      "target": "diagnostics_doctorrunnertests_doctorrunnertests_run_emptychecklist_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L98",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_doctorrunnertests",
+      "target": "diagnostics_doctorrunnertests_doctorrunnertests_run_includeshostversionfromappinfo"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L108",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_doctorrunnertests",
+      "target": "diagnostics_doctorrunnertests_doctorrunnertests_run_setstimestamp"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L19",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_doctorrunnertests_run_allcheckspass_returnspassedstatus",
+      "target": "diagnostics_doctorrunnertests_throwingcheck_run"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L40",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_doctorrunnertests_run_mixedresults_returnsfailedifanyfailed",
+      "target": "diagnostics_doctorrunnertests_throwingcheck_run"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L59",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_doctorrunnertests_run_onlywarnings_returnswarning",
+      "target": "diagnostics_doctorrunnertests_throwingcheck_run"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L77",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_doctorrunnertests_run_throwingcheck_capturedasfailed",
+      "target": "diagnostics_doctorrunnertests_throwingcheck_run"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L91",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_doctorrunnertests_run_emptychecklist_returnspassed",
+      "target": "diagnostics_doctorrunnertests_throwingcheck_run"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L103",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_doctorrunnertests_run_includeshostversionfromappinfo",
+      "target": "diagnostics_doctorrunnertests_throwingcheck_run"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L114",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_doctorrunnertests_run_setstimestamp",
+      "target": "diagnostics_doctorrunnertests_throwingcheck_run"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L122",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_stubcheck",
+      "target": "diagnosticstatus"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L126",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_stubcheck",
+      "target": "diagnostics_doctorrunnertests_stubcheck_run"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorRunnerTests.cs",
+      "source_location": "L133",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctorrunnertests_throwingcheck",
+      "target": "diagnostics_doctorrunnertests_throwingcheck_run"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L6",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_doctortextrenderertests_cs",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_allpassed_showspasstagsandready"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L27",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_withfailure_showsfailtagsandnotready"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L46",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_withwarning_showswarntag"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L62",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_verbose_showsevidence"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L80",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_nonverbose_hidesevidence"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L97",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_withremediation_showsfix"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L113",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_multilineremediation_indentseachline"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L129",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_createreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L11",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_allpassed_showspasstagsandready",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_createreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L30",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_withfailure_showsfailtagsandnotready",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_createreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L49",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_withwarning_showswarntag",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_createreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L66",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_verbose_showsevidence",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_createreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L84",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_nonverbose_hidesevidence",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_createreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L100",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_withremediation_showsfix",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_createreport"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DoctorTextRendererTests.cs",
+      "source_location": "L116",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_doctortextrenderertests_doctortextrenderertests_render_multilineremediation_indentseachline",
+      "target": "diagnostics_doctortextrenderertests_doctortextrenderertests_createreport"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_dotnetframeworkchecktests_cs",
+      "target": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L12",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests",
+      "target": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests_notwindows_returnsfailed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L25",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests",
+      "target": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests_noregistryvalue_returnsfailed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L38",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests",
+      "target": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests_oldrelease_returnsfailed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L53",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests",
+      "target": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests_release48_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L67",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests",
+      "target": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests_release481_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetFrameworkCheckTests.cs",
+      "source_location": "L81",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests",
+      "target": "diagnostics_dotnetframeworkchecktests_dotnetframeworkchecktests_fallsbacktoregistry32"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetRuntimeCheckTests.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_dotnetruntimechecktests_cs",
+      "target": "diagnostics_dotnetruntimechecktests_dotnetruntimechecktests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetRuntimeCheckTests.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_dotnetruntimechecktests_dotnetruntimechecktests",
+      "target": "diagnostics_dotnetruntimechecktests_dotnetruntimechecktests_alwayspasses_withruntimedescription"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/DotNetRuntimeCheckTests.cs",
+      "source_location": "L27",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_dotnetruntimechecktests_dotnetruntimechecktests",
+      "target": "diagnostics_dotnetruntimechecktests_dotnetruntimechecktests_includesevidence"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L6",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_fakes_cs",
+      "target": "diagnostics_fakes_fakeapplicationinfoservice"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L17",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_fakes_cs",
+      "target": "diagnostics_fakes_fakeenvironmentvariableservice"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L26",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_fakes_cs",
+      "target": "diagnostics_fakes_fakeregistryservice"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L51",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_fakes_cs",
+      "target": "diagnostics_fakes_fakefilesystemservice"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L66",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_fakes_cs",
+      "target": "diagnostics_fakes_fakewindowsidentityservice"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L76",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_fakes_cs",
+      "target": "diagnostics_fakes_fakeprocessenumerationservice"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L19",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeenvironmentvariableservice",
+      "target": "dictionary"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L21",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeenvironmentvariableservice",
+      "target": "diagnostics_fakes_fakeenvironmentvariableservice_set"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L23",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeenvironmentvariableservice",
+      "target": "diagnostics_fakes_fakeenvironmentvariableservice_get"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L29",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeregistryservice",
+      "target": "dictionary"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L55",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakefilesystemservice",
+      "target": "dictionary"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L30",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeregistryservice",
+      "target": "hashset"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L32",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeregistryservice",
+      "target": "diagnostics_fakes_fakeregistryservice_setstringvalue"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L35",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeregistryservice",
+      "target": "diagnostics_fakes_fakeregistryservice_setintvalue"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L38",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeregistryservice",
+      "target": "diagnostics_fakes_fakeregistryservice_setkeyexists"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L41",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeregistryservice",
+      "target": "diagnostics_fakes_fakeregistryservice_getstringvalue"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L44",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeregistryservice",
+      "target": "diagnostics_fakes_fakeregistryservice_getintvalue"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L47",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeregistryservice",
+      "target": "diagnostics_fakes_fakeregistryservice_keyexists"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L54",
+      "weight": 1.0,
+      "context": "field",
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakefilesystemservice",
+      "target": "hashset"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L57",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakefilesystemservice",
+      "target": "diagnostics_fakes_fakefilesystemservice_addfile"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L58",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakefilesystemservice",
+      "target": "diagnostics_fakes_fakefilesystemservice_adddirectory"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L59",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakefilesystemservice",
+      "target": "diagnostics_fakes_fakefilesystemservice_setfileversion"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L61",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakefilesystemservice",
+      "target": "diagnostics_fakes_fakefilesystemservice_fileexists"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L62",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakefilesystemservice",
+      "target": "diagnostics_fakes_fakefilesystemservice_directoryexists"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L63",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakefilesystemservice",
+      "target": "diagnostics_fakes_fakefilesystemservice_getfileversion"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L72",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakewindowsidentityservice",
+      "target": "diagnostics_fakes_fakewindowsidentityservice_getcurrentuserinfo"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L73",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakewindowsidentityservice",
+      "target": "diagnostics_fakes_fakewindowsidentityservice_checkgroupmembership"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/Fakes.cs",
+      "source_location": "L80",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_fakes_fakeprocessenumerationservice",
+      "target": "diagnostics_fakes_fakeprocessenumerationservice_listprocesses"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_hostworkerversionchecktests_cs",
+      "target": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests",
+      "target": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests_workernotfound_returnswarning"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L23",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests",
+      "target": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests_matchingmajorversions_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L40",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests",
+      "target": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests_differentmajorversions_returnsfailed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L57",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests",
+      "target": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests_workerversionnull_returnswarning"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L73",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests",
+      "target": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests_malformedhostversion_returnswarningwithevidence"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/HostWorkerVersionCheckTests.cs",
+      "source_location": "L91",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests",
+      "target": "diagnostics_hostworkerversionchecktests_hostworkerversionchecktests_malformedworkerversion_returnswarningwithevidence"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_opennessassemblieschecktests_cs",
+      "target": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L10",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests",
+      "target": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests_allassembliespresent_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L28",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests",
+      "target": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests_existingapidirectorywithoutallassemblies_reportsmissingassemblies"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L51",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests",
+      "target": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests_tiaportallocationrootwithoutapidirectory_reportsmissingapidirectory"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L70",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests",
+      "target": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests_registryrootwithoutapidirectory_reportsmissingapidirectory"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L93",
+      "weight": 1.0,
+      "source": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests",
+      "target": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests_earlylocationrootandlatercompleteregistry_usescompleteregistryapi",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L122",
+      "weight": 1.0,
+      "source": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests",
+      "target": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests_earlyregistryrootandlatercompleteregistry_usescompleteregistryapi",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessAssembliesCheckTests.cs",
+      "source_location": "L49",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests",
+      "target": "diagnostics_opennessassemblieschecktests_opennessassemblieschecktests_noinstallationfound_returnsfailed"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_opennessgroupchecktests_cs",
+      "target": "diagnostics_opennessgroupchecktests_opennessgroupchecktests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessgroupchecktests_opennessgroupchecktests",
+      "target": "diagnostics_opennessgroupchecktests_opennessgroupchecktests_notwindows_returnsfailed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs",
+      "source_location": "L21",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessgroupchecktests_opennessgroupchecktests",
+      "target": "diagnostics_opennessgroupchecktests_opennessgroupchecktests_groupdoesnotexist_returnsfailed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs",
+      "source_location": "L37",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessgroupchecktests_opennessgroupchecktests",
+      "target": "diagnostics_opennessgroupchecktests_opennessgroupchecktests_usernotmember_returnsfailed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs",
+      "source_location": "L53",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessgroupchecktests_opennessgroupchecktests",
+      "target": "diagnostics_opennessgroupchecktests_opennessgroupchecktests_userismember_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessGroupCheckTests.cs",
+      "source_location": "L70",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessgroupchecktests_opennessgroupchecktests",
+      "target": "diagnostics_opennessgroupchecktests_opennessgroupchecktests_includesuserevidence"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L8",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_opennessworkerchecktests_cs",
+      "target": "diagnostics_opennessworkerchecktests_opennessworkerchecktests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L25",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessworkerchecktests_opennessworkerchecktests",
+      "target": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_workerfoundwithrequiredcompanionfiles_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L45",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessworkerchecktests_opennessworkerchecktests",
+      "target": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_workernotfound_returnsfailed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L59",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessworkerchecktests_opennessworkerchecktests",
+      "target": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_workerfoundbutcontractsassemblymissing_returnsfailed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L78",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessworkerchecktests_opennessworkerchecktests",
+      "target": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_workerfoundwithoutversion_passeswithversionlessmessage"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L97",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessworkerchecktests_opennessworkerchecktests",
+      "target": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_addrequiredcompanionfiles"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L111",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessworkerchecktests_opennessworkerchecktests",
+      "target": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_requiredcompanionfiles_coverworkerruntimeassets"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L159",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessworkerchecktests_opennessworkerchecktests",
+      "target": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_packagelayout_excludesworkerruntimeconfigatcopyandpackboundaries"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L35",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_workerfoundwithrequiredcompanionfiles_returnspassed",
+      "target": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_addrequiredcompanionfiles"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L69",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_workerfoundbutcontractsassemblymissing_returnsfailed",
+      "target": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_addrequiredcompanionfiles"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs",
+      "source_location": "L88",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_workerfoundwithoutversion_passeswithversionlessmessage",
+      "target": "diagnostics_opennessworkerchecktests_opennessworkerchecktests_addrequiredcompanionfiles"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OperatingSystemCheckTests.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_operatingsystemchecktests_cs",
+      "target": "diagnostics_operatingsystemchecktests_operatingsystemchecktests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OperatingSystemCheckTests.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_operatingsystemchecktests_operatingsystemchecktests",
+      "target": "diagnostics_operatingsystemchecktests_operatingsystemchecktests_windows_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OperatingSystemCheckTests.cs",
+      "source_location": "L21",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_operatingsystemchecktests_operatingsystemchecktests",
+      "target": "diagnostics_operatingsystemchecktests_operatingsystemchecktests_nonwindows_returnsfailed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/OperatingSystemCheckTests.cs",
+      "source_location": "L34",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_operatingsystemchecktests_operatingsystemchecktests",
+      "target": "diagnostics_operatingsystemchecktests_operatingsystemchecktests_includesevidence"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_projectbindingchecktests_cs",
+      "target": "diagnostics_projectbindingchecktests_projectbindingchecktests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_projectbindingchecktests_projectbindingchecktests",
+      "target": "diagnostics_projectbindingchecktests_projectbindingchecktests_clipathprovided_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs",
+      "source_location": "L22",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_projectbindingchecktests_projectbindingchecktests",
+      "target": "diagnostics_projectbindingchecktests_projectbindingchecktests_envvarprovided_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs",
+      "source_location": "L35",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_projectbindingchecktests_projectbindingchecktests",
+      "target": "diagnostics_projectbindingchecktests_projectbindingchecktests_neitherprovided_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs",
+      "source_location": "L47",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_projectbindingchecktests_projectbindingchecktests",
+      "target": "diagnostics_projectbindingchecktests_projectbindingchecktests_clipathtakesprecedence"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ProjectBindingCheckTests.cs",
+      "source_location": "L61",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_projectbindingchecktests_projectbindingchecktests",
+      "target": "diagnostics_projectbindingchecktests_projectbindingchecktests_whitespaceclipath_treatedasnotprovided"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ReleaseWorkflowTests.cs",
+      "source_location": "L5",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_releaseworkflowtests_cs",
+      "target": "diagnostics_releaseworkflowtests_releaseworkflowtests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ReleaseWorkflowTests.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_releaseworkflowtests_releaseworkflowtests",
+      "target": "diagnostics_releaseworkflowtests_releaseworkflowtests_standalonepublish_usesresolvedpackageversion"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ReleaseWorkflowTests.cs",
+      "source_location": "L18",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_releaseworkflowtests_releaseworkflowtests",
+      "target": "diagnostics_releaseworkflowtests_releaseworkflowtests_nugetpack_usesexactresolvedinformationalversion"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ReleaseWorkflowTests.cs",
+      "source_location": "L29",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_releaseworkflowtests_releaseworkflowtests",
+      "target": "diagnostics_releaseworkflowtests_releaseworkflowtests_readworkflowstep"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ReleaseWorkflowTests.cs",
+      "source_location": "L10",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_releaseworkflowtests_releaseworkflowtests_standalonepublish_usesresolvedpackageversion",
+      "target": "diagnostics_releaseworkflowtests_releaseworkflowtests_readworkflowstep"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/ReleaseWorkflowTests.cs",
+      "source_location": "L21",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_releaseworkflowtests_releaseworkflowtests_nugetpack_usesexactresolvedinformationalversion",
+      "target": "diagnostics_releaseworkflowtests_releaseworkflowtests_readworkflowstep"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_tiaportalinstallationchecktests_cs",
+      "target": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L11",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests",
+      "target": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_foundviaenvvar_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L29",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests",
+      "target": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_existingapidirectorywithoutassemblies_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L46",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests",
+      "target": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_tiaportallocationrootwithoutapidirectory_returnspassedwithrootevidence"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L45",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests",
+      "target": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_notfound_returnsfailed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L61",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests",
+      "target": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_foundviaregistry_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L106",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests",
+      "target": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_registryrootwithoutapidirectory_returnspassedwithrootevidence"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L128",
+      "weight": 1.0,
+      "source": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests",
+      "target": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_earlylocationrootandlatercompleteregistry_selectsearlyinstallation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L157",
+      "weight": 1.0,
+      "source": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests",
+      "target": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_earlyregistryrootandlatercompleteregistry_selectsearlyinstallation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalInstallationCheckTests.cs",
+      "source_location": "L84",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests",
+      "target": "diagnostics_tiaportalinstallationchecktests_tiaportalinstallationchecktests_includescandidateevidence"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs",
+      "source_location": "L7",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "tiamcpserver_tests_diagnostics_tiaportalprocesschecktests_cs",
+      "target": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs",
+      "source_location": "L9",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests",
+      "target": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests_notwindows_returnswarning"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs",
+      "source_location": "L22",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests",
+      "target": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests_tiaprocessesfound_returnspassed"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs",
+      "source_location": "L42",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests",
+      "target": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests_multipletiaprocesses_countsall"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs",
+      "source_location": "L63",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests",
+      "target": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests_notiaprocesses_returnswarning"
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "TiaMcpServer.Tests/Diagnostics/TiaPortalProcessCheckTests.cs",
+      "source_location": "L79",
+      "weight": 1.0,
+      "confidence_score": 1.0,
+      "source": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests",
+      "target": "diagnostics_tiaportalprocesschecktests_tiaportalprocesschecktests_caseinsensitivematch"
+    },
+    {
       "relation": "calls",
       "context": "call",
       "confidence": "EXTRACTED",
@@ -25948,5 +32592,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "52e114aef6daf6144bcbfe27a44c198d0648149b"
+  "built_at_commit": "6a9574bffed5eda5af179fc6a6d7d8cf628e77e8"
 }

--- a/scripts/verify-doctor-package.ps1
+++ b/scripts/verify-doctor-package.ps1
@@ -1,0 +1,86 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string] $PackagePath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$resolvedPackage = (Resolve-Path -LiteralPath $PackagePath -ErrorAction Stop).Path
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$archive = [System.IO.Compression.ZipFile]::OpenRead($resolvedPackage)
+try {
+    $entries = @($archive.Entries | ForEach-Object { $_.FullName.Replace('\', '/') })
+}
+finally {
+    $archive.Dispose()
+}
+
+$canonicalPrefix = 'tools/net8.0/any/openness-worker/'
+$workerEntries = @($entries | Where-Object { $_ -match '(^|/)openness-worker/' })
+$canonicalEntries = @($workerEntries | Where-Object {
+    $_.StartsWith($canonicalPrefix, [System.StringComparison]::Ordinal)
+})
+$nonCanonicalEntries = @($workerEntries | Where-Object {
+    -not $_.StartsWith($canonicalPrefix, [System.StringComparison]::Ordinal)
+})
+
+if ($canonicalEntries.Count -eq 0) {
+    throw "NuGet package has no canonical '$canonicalPrefix' worker subtree."
+}
+
+if ($nonCanonicalEntries.Count -gt 0) {
+    throw "NuGet package contains non-canonical worker subtree entries: $($nonCanonicalEntries -join ', ')."
+}
+
+$duplicateEntries = @($canonicalEntries |
+    Group-Object |
+    Where-Object { $_.Count -ne 1 } |
+    Select-Object -ExpandProperty Name)
+if ($duplicateEntries.Count -gt 0) {
+    throw "NuGet package contains duplicate canonical worker entries: $($duplicateEntries -join ', ')."
+}
+
+$requiredFiles = @(
+    'TiaMcpServer.OpennessWorker.exe',
+    'TiaMcpServer.OpennessWorker.exe.config',
+    'TiaMcpServer.Contracts.dll',
+    'Microsoft.Bcl.AsyncInterfaces.dll',
+    'System.Buffers.dll',
+    'System.IO.Pipelines.dll',
+    'System.Memory.dll',
+    'System.Numerics.Vectors.dll',
+    'System.Runtime.CompilerServices.Unsafe.dll',
+    'System.Text.Encodings.Web.dll',
+    'System.Text.Json.dll',
+    'System.Threading.Tasks.Extensions.dll'
+)
+
+foreach ($requiredFile in $requiredFiles) {
+    $expectedEntry = $canonicalPrefix + $requiredFile
+    $matches = @($canonicalEntries | Where-Object {
+        [string]::Equals($_, $expectedEntry, [System.StringComparison]::OrdinalIgnoreCase)
+    })
+    if ($matches.Count -ne 1) {
+        throw "NuGet package must contain exactly one '$expectedEntry'; found $($matches.Count)."
+    }
+}
+
+$workerRuntimeConfigs = @($workerEntries | Where-Object {
+    $_.EndsWith('runtimeconfig.json', [System.StringComparison]::OrdinalIgnoreCase)
+})
+if ($workerRuntimeConfigs.Count -gt 0) {
+    throw "NuGet package must not include worker runtimeconfig files: $($workerRuntimeConfigs -join ', ')."
+}
+
+$siemensAssemblies = @($entries | Where-Object {
+    [System.IO.Path]::GetFileName($_) -match '^Siemens\.Engineering.*\.dll$'
+})
+if ($siemensAssemblies.Count -gt 0) {
+    throw "NuGet package must not include Siemens Openness assemblies: $($siemensAssemblies -join ', ')."
+}
+
+Write-Host "Verified ${resolvedPackage}: one canonical worker subtree, $($requiredFiles.Count) required files, no worker runtimeconfig, no Siemens DLLs."


### PR DESCRIPTION
## Summary
- Add `tia-mcp doctor` CLI command that validates the runtime environment before using the MCP server
- 10 diagnostic checks: OS, .NET runtime, .NET Framework 4.8, TIA Portal installation, Openness assemblies, user group membership, worker executable, host/worker version compatibility, TIA Portal processes, project binding
- Text and JSON output with `--verbose` evidence and `--project` flag
- 71 unit tests with fakes for all 6 service interfaces (299 total tests pass)

## Key changes
- **Diagnostics system**: Interface-based service abstractions (`IApplicationInfoService`, `IEnvironmentVariableService`, `IRegistryService`, `IFileSystemService`, `IWindowsIdentityService`, `IProcessEnumerationService`) with concrete implementations
- **Locator extraction**: `OpennessWorkerLocator` and `TiaPortalInstallationLocator` extracted for shared resolution between doctor command and runtime
- **Bug fixes from code review**:
  - Fixed `Process` handle leak in `ProcessEnumerationService` (was leaking handles for all running processes per call)
  - Fixed lossy `long`-to-`int` cast in `RegistryService` (added bounds check)
  - Fixed Windows Server OS name detection via registry `ProductName` lookup
  - Narrowed bare `catch` blocks in `WindowsIdentityService` to specific exception types
  - Removed unnecessary `async` from `DoctorCommand.RunAsync`
  - Added `runtimeconfig.json` generation for net48 worker builds
- **README**: Added doctor command documentation

## Files
56 files changed, 3062 insertions(+), 34 deletions(-)

## Test plan
- [x] `dotnet build TiaMcpServer.sln -m:1` succeeds with 0 errors
- [x] `dotnet test` - all 299 tests pass
- [x] `tia-mcp doctor` runs and produces correct output
