### PR TITLE
fix: resolve ICompilable via GetService instead of reflection

### DIFF
--- a/TiaMcpServer.OpennessWorker/Openness/CompileChecker.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/CompileChecker.cs
@@ -126,6 +126,19 @@ public static class CompileChecker
 
     private static CompilerResult CompileObject(object compilable)
     {
+        // Most compilable Openness objects (e.g. PlcSoftware) do not implement
+        // ICompilable directly - the capability is exposed as a service via
+        // IEngineeringServiceProvider.GetService<T>(), not as a type-level
+        // interface, so reflecting over GetInterfaces() never finds it.
+        if (compilable is IEngineeringServiceProvider serviceProvider)
+        {
+            var compilableService = serviceProvider.GetService<ICompilable>();
+            if (compilableService != null)
+            {
+                return compilableService.Compile();
+            }
+        }
+
         var compileMethod = FindCompileMethod(compilable.GetType());
         if (compileMethod == null)
         {


### PR DESCRIPTION
## Summary
- `compile_check` (both PLC-level and block-level) currently fails against a real project with `Object 'PlcSoftware' does not expose a Compile method.`
- `CompileObject` looks for a `Compile` method via reflection over `GetType().GetInterfaces()`, but `PlcSoftware` doesn't implement `ICompilable` directly - the capability is only reachable via `IEngineeringServiceProvider.GetService<ICompilable>()`, which the interface-reflection approach never finds.
- Fix: try `GetService<ICompilable>()` first; keep the existing reflection-based lookup as a fallback for any object that does expose `Compile` directly.

## Test plan
- [x] `dotnet test TiaMcpServer.sln` — all 336 tests pass
- [x] Tested against a **real TIA Portal V21 installation**: ran `compile_check` (PLC scope) against a real project before and after the fix. Before: `Object 'PlcSoftware' does not expose a Compile method.` on every call. After: `{"errorCount":0,"warningCount":0,"overallState":"Success"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)