### PR TITLE
Round 4: session binding and contract integrity

### DIFF
--- a/.superpowers/sdd/task-6-report.md
+++ b/.superpowers/sdd/task-6-report.md
@@ -55,8 +55,16 @@ Outcome: passed — 385 passed, 0 failed, 0 skipped.
 
 ## Commit
 
-`b2f6a7d0077a1f8cca9088e52e74fbe776ac6e13` — `feat: declare each batch operation's optional field surface in the catalog`
+`0aab1868d8efe00b6f22c837559be29f44519cd4` — `feat: declare each batch operation's optional field surface in the catalog`
 
 ## Concerns
 
 None.
+
+## Review correction — exact catalog contract coverage
+
+- Added `All_MatchesTheAuthoritativeOperationFieldContract`, which specifies every operation name, category, required-field list, and optional-field list for all 25 catalog entries.
+- The test was added as coverage for the existing green implementation, so no red state was fabricated. It passed against current production code.
+- Focused verification: `dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~BatchOperationCatalogTests` — 33 passed, 0 failed, 0 skipped.
+- Full verification: `dotnet test TiaMcpServer.Tests` — 386 passed, 0 failed, 0 skipped.
+- Self-review: the expected dictionary verifies exact names before comparing every category and field list, preventing count-preserving substitutions, table swaps, and field renames from passing.

--- a/.superpowers/sdd/task-6-report.md
+++ b/.superpowers/sdd/task-6-report.md
@@ -1,0 +1,62 @@
+# Task 6 Report — Optional Batch Operation Fields
+
+## Scope
+
+- Added `OptionalFields` to `BatchOperationSpec`.
+- Exposed the immutable catalog snapshot through `BatchOperationCatalog.All`.
+- Declared the 8 read and 17 write operation optional-field surfaces exactly as specified.
+- Added catalog metadata invariant tests only. No inapplicable-field validation was introduced; that belongs to Task 7.
+
+## TDD evidence
+
+### RED
+
+Command:
+
+```powershell
+dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~BatchOperationCatalogTests
+```
+
+Outcome: failed to compile as expected. The added tests reported `CS0117` because `BatchOperationCatalog.All` did not exist and `CS1061` because `BatchOperationSpec.OptionalFields` did not exist.
+
+### GREEN
+
+Command:
+
+```powershell
+dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~BatchOperationCatalogTests
+```
+
+Outcome: passed — 32 passed, 0 failed, 0 skipped.
+
+## Full-suite verification
+
+Command:
+
+```powershell
+dotnet test TiaMcpServer.Tests
+```
+
+Outcome: passed — 385 passed, 0 failed, 0 skipped.
+
+## Modified files
+
+- `TiaMcpServer/Batch/BatchOperationCatalog.cs`
+- `TiaMcpServer.Tests/BatchOperationCatalogTests.cs`
+- `.superpowers/sdd/task-6-report.md`
+
+## Self-review
+
+- The table has exactly 25 specs: 8 reads and 17 writes.
+- Optional fields match the brief's authoritative forwarding map.
+- Universal fields are excluded; required and optional fields do not overlap, covered by tests.
+- No validation behavior changed, preserving Task 7 ownership.
+- `git diff --check` produced no whitespace errors.
+
+## Commit
+
+`b2f6a7d0077a1f8cca9088e52e74fbe776ac6e13` — `feat: declare each batch operation's optional field surface in the catalog`
+
+## Concerns
+
+None.

--- a/README.md
+++ b/README.md
@@ -445,6 +445,14 @@ With an explicit project binding:
 - Access denied or attach failure: confirm the Windows user belongs to the `Siemens TIA Openness` user group, then sign out and back in.
 - `dotnet` selects the wrong SDK: install .NET SDK 8.0.4xx or update `global.json` to a locally installed .NET 8 SDK feature band.
 
+## Known Issues
+
+Found via manual end-to-end testing of every tool against a live TIA Portal project. Not yet fixed.
+
+- **`create_block` fails for `language: "SCL"`.** Creating a block with `language: "SCL"` fails with `Language of 'SCL' have to have at least one compile unit.` from `Siemens.Engineering.SW.Blocks.PlcBlockComposition.Import`. The identical call with `language: "LAD"` succeeds, so the empty-block XML template used before `Import` appears to omit a compile unit for the SCL case. Workaround: none currently; avoid creating SCL blocks via `create_block`.
+- **`update_block_logic` fails unconditionally.** Every call fails with `The file '<BlockName>' does not exist` from `ImportFromDocuments`, including a byte-for-byte round-trip of content just read back via `get_block_content` with no edits at all. The target block is left unmodified by the failed call (verified via `get_block_content` and `compile_check` afterward), so the failure is non-destructive but the operation is currently unusable for its documented purpose (modifying existing blocks).
+- **`save_project_as` with `rebind: false` can strand the MCP session.** Siemens' underlying `SaveAs` API switches the actually-open TIA Portal project to the new copy regardless of the `rebind` flag; `rebind: false` only affects the MCP session's own path bookkeeping, not the live engineering session. Once that mismatch happens, no MCP call can recover it: `open_project`/`get_project_status` against the original path fail with `Another project is already open`, and any call against the new, actually-open path is rejected upfront because the session is still bound to the original path. Recovery currently requires closing the project by hand in the TIA Portal UI and reopening it via `open_project`. Treat `rebind: false` as unsafe until this is fixed.
+
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow and how to set up your environment. For architecture and build reference, see [AGENTS.md](AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -115,7 +115,12 @@ $env:TIA_MCP_PROJECT_PATH = 'C:\Projects\Line.ap21'
 tia-mcp
 ```
 
-Once a server process is bound to a project path, later tool calls with a different `projectPath` are rejected. Call `open_project` with `forceRebind=true` to rebind the session, or start a new MCP session for a different customer project.
+After the first successful call, the session binds to the worker-reported active project. A later call
+that names a different `projectPath` is rejected; call `open_project` with `forceRebind=true` to
+rebind the session, or start a new MCP session for a different customer project. Read operations also
+refuse to switch projects: `TIA Portal currently has project 'A' open, but this request targets 'B'.
+Read operations never switch projects. Omit projectPath to use the open project, or call
+open_project to switch.`
 
 ### Doctor command
 
@@ -363,7 +368,12 @@ $env:TIA_MCP_PROJECT_PATH = 'C:\Projects\Line.ap21'
 tia-mcp
 ```
 
-Once a server process is bound to a project path, later tool calls with a different `projectPath` are rejected. Call `open_project` with `forceRebind=true` to rebind the session, or start a new MCP session for a different customer project.
+After the first successful call, the session binds to the worker-reported active project. A later call
+that names a different `projectPath` is rejected; call `open_project` with `forceRebind=true` to
+rebind the session, or start a new MCP session for a different customer project. Read operations also
+refuse to switch projects: `TIA Portal currently has project 'A' open, but this request targets 'B'.
+Read operations never switch projects. Omit projectPath to use the open project, or call
+open_project to switch.`
 
 ## Block Paths
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ project-scoped call that names a different `projectPath` is rejected; call `open
 rebind the session, or start a new MCP session for a different customer project. Project-scoped read
 operations also refuse to switch projects: `TIA Portal currently has project 'A' open, but this
 request targets 'B'. Read operations never switch projects. Omit projectPath to use the open project,
-or call open_project to switch.` `get_project_status(projectPath)` is currently excluded from that
-policy because it shares a lifecycle RPC with guarded write-state probes; do not use it to switch
+or call open_project to switch.` `get_project_status(projectPath)` is the human-approved Round 5
+deferral from that policy because it shares a lifecycle RPC with guarded write-state probes; do not use it to switch
 projects. Use `open_project` for deliberate session switching.
 
 ### Doctor command
@@ -375,8 +375,8 @@ project-scoped call that names a different `projectPath` is rejected; call `open
 rebind the session, or start a new MCP session for a different customer project. Project-scoped read
 operations also refuse to switch projects: `TIA Portal currently has project 'A' open, but this
 request targets 'B'. Read operations never switch projects. Omit projectPath to use the open project,
-or call open_project to switch.` `get_project_status(projectPath)` is currently excluded from that
-policy because it shares a lifecycle RPC with guarded write-state probes; do not use it to switch
+or call open_project to switch.` `get_project_status(projectPath)` is the human-approved Round 5
+deferral from that policy because it shares a lifecycle RPC with guarded write-state probes; do not use it to switch
 projects. Use `open_project` for deliberate session switching.
 
 ## Block Paths

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ or call open_project to switch.` `get_project_status(projectPath)` is the human-
 deferral from that policy because it shares a lifecycle RPC with guarded write-state probes; do not use it to switch
 projects. Use `open_project` for deliberate session switching.
 
+### Version flag
+
+Run `tia-mcp --version` (or `tia-mcp -v`) to print the host version and exit without starting the MCP server.
+
 ### Doctor command
 
 Run `tia-mcp doctor` to validate the runtime environment before using the MCP server. It checks the operating system, .NET runtimes, TIA Portal installation, Openness assemblies, user group membership, worker executable, host/worker version compatibility, running TIA Portal processes, and project binding.

--- a/README.md
+++ b/README.md
@@ -115,12 +115,14 @@ $env:TIA_MCP_PROJECT_PATH = 'C:\Projects\Line.ap21'
 tia-mcp
 ```
 
-After the first successful call, the session binds to the worker-reported active project. A later call
-that names a different `projectPath` is rejected; call `open_project` with `forceRebind=true` to
-rebind the session, or start a new MCP session for a different customer project. Read operations also
-refuse to switch projects: `TIA Portal currently has project 'A' open, but this request targets 'B'.
-Read operations never switch projects. Omit projectPath to use the open project, or call
-open_project to switch.`
+After the first successful call, the session binds to the worker-reported active project. A later
+project-scoped call that names a different `projectPath` is rejected; call `open_project` with `forceRebind=true` to
+rebind the session, or start a new MCP session for a different customer project. Project-scoped read
+operations also refuse to switch projects: `TIA Portal currently has project 'A' open, but this
+request targets 'B'. Read operations never switch projects. Omit projectPath to use the open project,
+or call open_project to switch.` `get_project_status(projectPath)` is currently excluded from that
+policy because it shares a lifecycle RPC with guarded write-state probes; do not use it to switch
+projects. Use `open_project` for deliberate session switching.
 
 ### Doctor command
 
@@ -368,12 +370,14 @@ $env:TIA_MCP_PROJECT_PATH = 'C:\Projects\Line.ap21'
 tia-mcp
 ```
 
-After the first successful call, the session binds to the worker-reported active project. A later call
-that names a different `projectPath` is rejected; call `open_project` with `forceRebind=true` to
-rebind the session, or start a new MCP session for a different customer project. Read operations also
-refuse to switch projects: `TIA Portal currently has project 'A' open, but this request targets 'B'.
-Read operations never switch projects. Omit projectPath to use the open project, or call
-open_project to switch.`
+After the first successful call, the session binds to the worker-reported active project. A later
+project-scoped call that names a different `projectPath` is rejected; call `open_project` with `forceRebind=true` to
+rebind the session, or start a new MCP session for a different customer project. Project-scoped read
+operations also refuse to switch projects: `TIA Portal currently has project 'A' open, but this
+request targets 'B'. Read operations never switch projects. Omit projectPath to use the open project,
+or call open_project to switch.` `get_project_status(projectPath)` is currently excluded from that
+policy because it shares a lifecycle RPC with guarded write-state probes; do not use it to switch
+projects. Use `open_project` for deliberate session switching.
 
 ## Block Paths
 

--- a/TiaMcpServer.Contracts/ProjectOpenPolicy.cs
+++ b/TiaMcpServer.Contracts/ProjectOpenPolicy.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO;
+
+namespace TiaMcpServer.Contracts;
+
+public enum ProjectOpenDecision
+{
+    /// <summary>Operate on whatever is already attached.</summary>
+    UseAttached,
+
+    /// <summary>Nothing is attached; opening the requested project cannot clobber anything.</summary>
+    OpenRequested,
+
+    /// <summary>A different project is attached; refuse rather than open one alongside it.</summary>
+    Refuse
+}
+
+/// <summary>
+/// Decides whether a non-lifecycle operation may cause TIA Portal to open a project. Read
+/// operations must never open a second project alongside one the user already has open — live
+/// testing against V21 showed a read tool doing exactly that, stopped only by TIA Portal's own
+/// refusal. Pure so the net8.0 test project can cover it; the worker is net48 and references
+/// Siemens assemblies the tests cannot load.
+/// </summary>
+public static class ProjectOpenPolicy
+{
+    public static ProjectOpenDecision Decide(string? currentPath, string? requestedPath)
+    {
+        var requested = Normalize(requestedPath);
+        if (requested is null)
+        {
+            return ProjectOpenDecision.UseAttached;
+        }
+
+        var current = Normalize(currentPath);
+        if (current is null)
+        {
+            return ProjectOpenDecision.OpenRequested;
+        }
+
+        return string.Equals(current, requested, StringComparison.OrdinalIgnoreCase)
+            ? ProjectOpenDecision.UseAttached
+            : ProjectOpenDecision.Refuse;
+    }
+
+    public static string RefusalMessage(string currentPath, string requestedPath)
+        => $"TIA Portal currently has project '{currentPath}' open, but this request targets "
+            + $"'{requestedPath}'. Read operations never switch projects. Omit projectPath to use "
+            + "the open project, or call open_project to switch.";
+
+    private static string? Normalize(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        var trimmed = path!.Trim();
+        try
+        {
+            return Path.GetFullPath(trimmed);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            // Not a resolvable path (a FakeWorker scenario keyword, for instance). Compare literally.
+            return trimmed;
+        }
+    }
+}

--- a/TiaMcpServer.Contracts/ProjectOpenPolicy.cs
+++ b/TiaMcpServer.Contracts/ProjectOpenPolicy.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 
 namespace TiaMcpServer.Contracts;
 
@@ -26,13 +25,13 @@ public static class ProjectOpenPolicy
 {
     public static ProjectOpenDecision Decide(string? currentPath, string? requestedPath)
     {
-        var requested = Normalize(requestedPath);
+        var requested = ProjectPathNormalization.Canonicalize(requestedPath);
         if (requested is null)
         {
             return ProjectOpenDecision.UseAttached;
         }
 
-        var current = Normalize(currentPath);
+        var current = ProjectPathNormalization.Canonicalize(currentPath);
         if (current is null)
         {
             return ProjectOpenDecision.OpenRequested;
@@ -47,23 +46,4 @@ public static class ProjectOpenPolicy
         => $"TIA Portal currently has project '{currentPath}' open, but this request targets "
             + $"'{requestedPath}'. Read operations never switch projects. Omit projectPath to use "
             + "the open project, or call open_project to switch.";
-
-    private static string? Normalize(string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return null;
-        }
-
-        var trimmed = path!.Trim();
-        try
-        {
-            return Path.GetFullPath(trimmed);
-        }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
-        {
-            // Not a resolvable path (a FakeWorker scenario keyword, for instance). Compare literally.
-            return trimmed;
-        }
-    }
 }

--- a/TiaMcpServer.Contracts/ProjectPathNormalization.cs
+++ b/TiaMcpServer.Contracts/ProjectPathNormalization.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+
+namespace TiaMcpServer.Contracts;
+
+/// <summary>
+/// Shared "is this the same project?" comparability primitive. <see cref="ProjectOpenPolicy"/>
+/// (worker-side: is the requested path the same as what TIA already has attached) and
+/// <see cref="ProjectSessionBinding"/> (host-side: is the requested path the same as what this
+/// MCP session is bound to) both need path comparisons to survive relative segments ("..",
+/// trailing separators, forward vs back slashes) - not just casing - so they share this helper
+/// rather than each rolling their own.
+///
+/// <see cref="Path.GetFullPath(string)"/> can throw for more than obviously-invalid paths: on
+/// .NET Framework (where the worker runs) it also throws <see cref="System.Security.SecurityException"/>
+/// when the caller lacks the required filesystem permission, on top of the usual
+/// <see cref="ArgumentException"/> / <see cref="NotSupportedException"/> / <see cref="PathTooLongException"/> /
+/// <see cref="IOException"/> family. This helper only ever wants a comparable string, never a
+/// crash, so any failure to canonicalize falls back to the trimmed literal instead of
+/// propagating - a bare catch is the correct scope here, not an enumerated exception list.
+/// </summary>
+internal static class ProjectPathNormalization
+{
+    public static string? Canonicalize(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        var trimmed = path!.Trim();
+        try
+        {
+            return Path.GetFullPath(trimmed);
+        }
+        catch (Exception)
+        {
+            // Not a resolvable path (a FakeWorker scenario keyword, a permission failure, an
+            // exotic path shape, etc). Compare literally rather than letting a pure
+            // comparability helper crash its caller.
+            return trimmed;
+        }
+    }
+}

--- a/TiaMcpServer.Contracts/ProjectSessionBinding.cs
+++ b/TiaMcpServer.Contracts/ProjectSessionBinding.cs
@@ -87,6 +87,24 @@ public sealed class ProjectSessionBinding
         return true;
     }
 
+    /// <summary>
+    /// True when <paramref name="projectPath"/>, once canonicalized, identifies the same project
+    /// this session is currently bound to. Lets callers outside this assembly (notably
+    /// <c>OpennessWorkerClient</c>) compare against the binding using the same canonicalization
+    /// as <see cref="TryResolve"/>/<see cref="Bind"/> without <see cref="ProjectPathNormalization"/>
+    /// itself needing to be public. Returns false when unbound or given a null path - there is no
+    /// "same project" to affirm in either case.
+    /// </summary>
+    public bool IsBoundTo(string? projectPath)
+    {
+        if (_boundProjectPath is null || projectPath is null)
+        {
+            return false;
+        }
+
+        return IsSameProject(_boundProjectPath, projectPath);
+    }
+
     public bool Clear(string? projectPath, out string? error)
     {
         error = null;

--- a/TiaMcpServer.Contracts/ProjectSessionBinding.cs
+++ b/TiaMcpServer.Contracts/ProjectSessionBinding.cs
@@ -8,7 +8,7 @@ public sealed class ProjectSessionBinding
 
     public ProjectSessionBinding(string? startupProjectPath)
     {
-        _boundProjectPath = Normalize(startupProjectPath);
+        _boundProjectPath = ProjectPathNormalization.Canonicalize(startupProjectPath);
     }
 
     public string? BoundProjectPath => _boundProjectPath;
@@ -36,7 +36,7 @@ public sealed class ProjectSessionBinding
         }
 
         if (_boundProjectPath is null ||
-            string.Equals(_boundProjectPath, requested, StringComparison.OrdinalIgnoreCase) ||
+            IsSameProject(_boundProjectPath, requested) ||
             forceRebind)
         {
             return true;
@@ -66,7 +66,7 @@ public sealed class ProjectSessionBinding
             return true;
         }
 
-        if (string.Equals(_boundProjectPath, requested, StringComparison.OrdinalIgnoreCase))
+        if (IsSameProject(_boundProjectPath, requested))
         {
             effectiveProjectPath = _boundProjectPath;
             return true;
@@ -83,7 +83,7 @@ public sealed class ProjectSessionBinding
             return false;
         }
 
-        _boundProjectPath = Normalize(projectPath);
+        _boundProjectPath = ProjectPathNormalization.Canonicalize(projectPath);
         return true;
     }
 
@@ -94,7 +94,7 @@ public sealed class ProjectSessionBinding
         var requested = Normalize(projectPath);
         if (requested is not null &&
             _boundProjectPath is not null &&
-            !string.Equals(_boundProjectPath, requested, StringComparison.OrdinalIgnoreCase))
+            !IsSameProject(_boundProjectPath, requested))
         {
             error = $"This MCP session is already bound to project '{_boundProjectPath}' and cannot clear '{requested}'.";
             return false;
@@ -104,6 +104,26 @@ public sealed class ProjectSessionBinding
         return true;
     }
 
+    /// <summary>
+    /// True when both paths identify the same project once canonicalized (relative segments
+    /// resolved, separators normalized), compared case-insensitively. <paramref name="requestedProjectPath"/>
+    /// arrives here only trimmed (see <see cref="Normalize"/>), so this is where the actual
+    /// "same project?" comparison happens - not a second normalization pass on the bound value's
+    /// storage, which is already canonical (see <see cref="Bind"/> and the constructor).
+    /// </summary>
+    private static bool IsSameProject(string boundProjectPath, string requestedProjectPath)
+        => string.Equals(
+            ProjectPathNormalization.Canonicalize(boundProjectPath),
+            ProjectPathNormalization.Canonicalize(requestedProjectPath),
+            StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Trims only - deliberately not canonicalized. This is the value forwarded to the worker
+    /// when the session is unbound (<see cref="TryResolve"/>) and the value used for null-checks
+    /// throughout; canonicalizing it would change what gets sent over the wire for every unbound
+    /// call, not just what gets compared. <see cref="IsSameProject"/> is where canonical
+    /// comparison actually happens.
+    /// </summary>
     private static string? Normalize(string? projectPath)
     {
         if (string.IsNullOrWhiteSpace(projectPath))

--- a/TiaMcpServer.Contracts/ProjectSessionBinding.cs
+++ b/TiaMcpServer.Contracts/ProjectSessionBinding.cs
@@ -60,7 +60,8 @@ public sealed class ProjectSessionBinding
 
         if (_boundProjectPath is null)
         {
-            _boundProjectPath = requested;
+            // Deliberately does NOT adopt: a mistyped-but-real path must not retarget the session.
+            // OpennessWorkerClient binds after the call succeeds, using the worker-reported path.
             effectiveProjectPath = requested;
             return true;
         }

--- a/TiaMcpServer.Contracts/WorkerResponse.cs
+++ b/TiaMcpServer.Contracts/WorkerResponse.cs
@@ -15,4 +15,11 @@ public class WorkerResponse
     /// request was being handled (e.g. "Skipping device X: access denied"). Null when none.
     /// </summary>
     public List<string>? Warnings { get; set; }
+
+    /// <summary>
+    /// Absolute path of the project the worker actually operated on, or null when no project was
+    /// attached. This is ground truth for session binding: the host binds to THIS, never to the
+    /// path the caller requested, so a mistyped-but-real path cannot silently retarget a session.
+    /// </summary>
+    public string? ResolvedProjectPath { get; set; }
 }

--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -43,6 +43,13 @@ while ((line = Console.In.ReadLine()) is not null)
             // own scenario key back as resolvedProjectPath - no divergence, no warning expected.
             Respond("""{"success":true,"payload":"{}","resolvedProjectPath":"C:\\stable\\Project.ap21"}""");
             break;
+        case "C:\\equivalent\\Project.ap21":
+            // Used by the "equivalent but differently-spelled path" divergence test (Finding 2):
+            // reports the identical project via forward slashes instead of back slashes. A raw
+            // string.Equals would misclassify this as divergence; the canonicalized comparison
+            // (ProjectSessionBinding.IsBoundTo) must not.
+            Respond("""{"success":true,"payload":"{}","resolvedProjectPath":"C:/equivalent/Project.ap21"}""");
+            break;
         case "ok-with-warnings":
             Respond("""{"success":true,"payload":"{\"hello\":true}","warnings":["Skipping device 'X' while reading hardware configuration: access denied.","Skipping subnet 'Y' while reading hardware configuration: not supported."]}""");
             break;

--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -31,6 +31,18 @@ while ((line = Console.In.ReadLine()) is not null)
         case "ok-with-resolved-path":
             Respond("""{"success":true,"payload":"{}","resolvedProjectPath":"C:\\resolved\\Ground.ap21"}""");
             break;
+        case "C:\\bound\\Session.ap21":
+            // Used by the "already bound but worker reports a different project" test: the
+            // session is pre-bound to this literal path (see IsSameProject/TryResolve), so a
+            // request without an explicit projectPath forwards this exact string as the
+            // scenario key. Reports a DIFFERENT resolvedProjectPath to simulate divergence.
+            Respond("""{"success":true,"payload":"{}","resolvedProjectPath":"C:\\actual\\Other.ap21"}""");
+            break;
+        case "C:\\stable\\Project.ap21":
+            // Used by the "already bound, worker reports the SAME project" test: reports its
+            // own scenario key back as resolvedProjectPath - no divergence, no warning expected.
+            Respond("""{"success":true,"payload":"{}","resolvedProjectPath":"C:\\stable\\Project.ap21"}""");
+            break;
         case "ok-with-warnings":
             Respond("""{"success":true,"payload":"{\"hello\":true}","warnings":["Skipping device 'X' while reading hardware configuration: access denied.","Skipping subnet 'Y' while reading hardware configuration: not supported."]}""");
             break;

--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -80,6 +80,11 @@ while ((line = Console.In.ReadLine()) is not null)
         case "hang":
             Thread.Sleep(Timeout.Infinite);
             break;
+        case "echo":
+            // Returns the received request verbatim so tests can assert which fields survived
+            // the BatchOperationRequest -> WorkerRequest hop.
+            Respond(JsonSerializer.Serialize(new { success = true, payload = line }));
+            break;
         default:
             Respond($$"""{"success":false,"error":"unknown scenario '{{scenario}}'"}""");
             break;

--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -28,6 +28,9 @@ while ((line = Console.In.ReadLine()) is not null)
             // seq proves whether two requests hit the same process (2.1 reuse/restart tests).
             Respond($$"""{"success":true,"payload":"{\"seq\":{{seq}}}"}""");
             break;
+        case "ok-with-resolved-path":
+            Respond("""{"success":true,"payload":"{}","resolvedProjectPath":"C:\\resolved\\Ground.ap21"}""");
+            break;
         case "ok-with-warnings":
             Respond("""{"success":true,"payload":"{\"hello\":true}","warnings":["Skipping device 'X' while reading hardware configuration: access denied.","Skipping subnet 'Y' while reading hardware configuration: not supported."]}""");
             break;

--- a/TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs
@@ -110,6 +110,9 @@ public class TiaPortalSession : IDisposable
         _projectOpenedByWorker = true;
     }
 
+    /// <summary>Absolute path of the attached project, or null when nothing is attached.</summary>
+    public string? CurrentProjectPath => TryReadCurrentProjectPath();
+
     private string? TryReadCurrentProjectPath()
     {
         if (Project is null)

--- a/TiaMcpServer.OpennessWorker/Program.cs
+++ b/TiaMcpServer.OpennessWorker/Program.cs
@@ -167,9 +167,10 @@ internal static class Program
         {
             session.EnsureConnected();
 
-            if (!string.IsNullOrEmpty(request.ProjectPath))
+            var failure = EnsureRequestedProjectOpen(session, request.ProjectPath);
+            if (failure is not null)
             {
-                session.OpenProject(request.ProjectPath!);
+                return failure;
             }
 
             if (session.TiaPortal is null)
@@ -576,9 +577,10 @@ internal static class Program
         {
             session.EnsureConnected();
 
-            if (!string.IsNullOrEmpty(request.ProjectPath))
+            var failure = EnsureRequestedProjectOpen(session, request.ProjectPath);
+            if (failure is not null)
             {
-                session.OpenProject(request.ProjectPath!);
+                return failure;
             }
 
             if (session.Project is null)
@@ -588,6 +590,25 @@ internal static class Program
 
             return body(session.Project);
         });
+    }
+
+    /// <summary>
+    /// Applies <see cref="ProjectOpenPolicy"/> before any non-lifecycle operation may open a
+    /// project. Returns null to continue, or the failure response to return to the host.
+    /// </summary>
+    private static WorkerResponse? EnsureRequestedProjectOpen(WorkerTiaPortalSession session, string? requestedProjectPath)
+    {
+        var currentPath = session.CurrentProjectPath;
+        switch (ProjectOpenPolicy.Decide(currentPath, requestedProjectPath))
+        {
+            case ProjectOpenDecision.OpenRequested:
+                session.OpenProject(requestedProjectPath!);
+                return null;
+            case ProjectOpenDecision.Refuse:
+                return Failure(ProjectOpenPolicy.RefusalMessage(currentPath!, requestedProjectPath!));
+            default:
+                return null;
+        }
     }
 
     /// <summary>Runs <paramref name="body"/> with the shared long-lived session.</summary>

--- a/TiaMcpServer.OpennessWorker/Program.cs
+++ b/TiaMcpServer.OpennessWorker/Program.cs
@@ -596,7 +596,7 @@ internal static class Program
         return Execute(() => body(_sharedSession));
     }
 
-    /// <summary>Single place that maps Openness exceptions to a <see cref="WorkerResponse"/> failure.</summary>
+    /// <summary>Single place that maps Openness exceptions to a <see cref="WorkerResponse"/> failure and stamps completed operations with their resolved project path.</summary>
     private static WorkerResponse Execute(Func<WorkerResponse> body)
     {
         try
@@ -627,9 +627,20 @@ internal static class Program
     /// </summary>
     private static WorkerResponse Stamp(WorkerResponse response)
     {
-        if (response.Success)
+        if (!response.Success)
+        {
+            return response;
+        }
+
+        try
         {
             response.ResolvedProjectPath = _sharedSession.CurrentProjectPath;
+        }
+        catch (Exception)
+        {
+            // A diagnostic stamp must never demote a completed operation to a failure:
+            // the operation already succeeded, so a failed path read leaves the path null
+            // rather than propagating out of Execute and being reported as an error.
         }
 
         return response;

--- a/TiaMcpServer.OpennessWorker/Program.cs
+++ b/TiaMcpServer.OpennessWorker/Program.cs
@@ -636,11 +636,14 @@ internal static class Program
         {
             response.ResolvedProjectPath = _sharedSession.CurrentProjectPath;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             // A diagnostic stamp must never demote a completed operation to a failure:
             // the operation already succeeded, so a failed path read leaves the path null
             // rather than propagating out of Execute and being reported as an error.
+            // However, a systematically failing path read must not vanish: stderr is captured
+            // into the response's Warnings, and stdout is the wire protocol so it cannot be used.
+            Console.Error.WriteLine($"Could not resolve project path for response stamp: {ex.GetType().Name}: {ex.Message}");
         }
 
         return response;

--- a/TiaMcpServer.OpennessWorker/Program.cs
+++ b/TiaMcpServer.OpennessWorker/Program.cs
@@ -466,16 +466,32 @@ internal static class Program
 
     private static WorkerResponse GetProjectStatus(WorkerRequest request)
     {
-        return ProjectLifecycle(request, session =>
+        // get_project_status is a read tool with no confirm gate (unlike SaveProject,
+        // SaveProjectAs, ArchiveProject, and CloseProject, which are safety-token gated at the
+        // host layer and are allowed to switch projects as part of their write). It must never
+        // open a project alongside one the user already has open, so route it through the same
+        // ProjectOpenPolicy check as WithProject/SearchEquipmentCatalog. Once the policy has
+        // settled which project is attached, call GetStatus with projectPath: null so it only
+        // reads the already-attached project instead of re-running its own unconditional
+        // EnsureProject open.
+        return WithSession(request, session =>
         {
-            var status = ProjectLifecycleService.GetStatus(session, request.ProjectPath);
-            return new ProjectLifecycleResultInfo
+            session.EnsureConnected();
+
+            var failure = EnsureRequestedProjectOpen(session, request.ProjectPath);
+            if (failure is not null)
+            {
+                return failure;
+            }
+
+            var status = ProjectLifecycleService.GetStatus(session, projectPath: null);
+            return Success(new ProjectLifecycleResultInfo
             {
                 Operation = "get_project_status",
                 ProjectPath = status.Path,
                 Project = status
-            };
-        }, requiresConfirm: false);
+            });
+        });
     }
 
     private static WorkerResponse OpenProject(WorkerRequest request)

--- a/TiaMcpServer.OpennessWorker/Program.cs
+++ b/TiaMcpServer.OpennessWorker/Program.cs
@@ -601,7 +601,7 @@ internal static class Program
     {
         try
         {
-            return body();
+            return Stamp(body());
         }
         catch (EngineeringException ex)
         {
@@ -619,6 +619,20 @@ internal static class Program
         {
             return Failure(ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Records which project the worker actually operated on. Stamped in one place so all
+    /// operations report it without each remembering to.
+    /// </summary>
+    private static WorkerResponse Stamp(WorkerResponse response)
+    {
+        if (response.Success)
+        {
+            response.ResolvedProjectPath = _sharedSession.CurrentProjectPath;
+        }
+
+        return response;
     }
 
     private static WorkerResponse Success<T>(T payload)

--- a/TiaMcpServer.OpennessWorker/Program.cs
+++ b/TiaMcpServer.OpennessWorker/Program.cs
@@ -466,32 +466,16 @@ internal static class Program
 
     private static WorkerResponse GetProjectStatus(WorkerRequest request)
     {
-        // get_project_status is a read tool with no confirm gate (unlike SaveProject,
-        // SaveProjectAs, ArchiveProject, and CloseProject, which are safety-token gated at the
-        // host layer and are allowed to switch projects as part of their write). It must never
-        // open a project alongside one the user already has open, so route it through the same
-        // ProjectOpenPolicy check as WithProject/SearchEquipmentCatalog. Once the policy has
-        // settled which project is attached, call GetStatus with projectPath: null so it only
-        // reads the already-attached project instead of re-running its own unconditional
-        // EnsureProject open.
-        return WithSession(request, session =>
+        return ProjectLifecycle(request, session =>
         {
-            session.EnsureConnected();
-
-            var failure = EnsureRequestedProjectOpen(session, request.ProjectPath);
-            if (failure is not null)
-            {
-                return failure;
-            }
-
-            var status = ProjectLifecycleService.GetStatus(session, projectPath: null);
-            return Success(new ProjectLifecycleResultInfo
+            var status = ProjectLifecycleService.GetStatus(session, request.ProjectPath);
+            return new ProjectLifecycleResultInfo
             {
                 Operation = "get_project_status",
                 ProjectPath = status.Path,
                 Project = status
-            });
-        });
+            };
+        }, requiresConfirm: false);
     }
 
     private static WorkerResponse OpenProject(WorkerRequest request)

--- a/TiaMcpServer.Tests/AuditIsolationTests.cs
+++ b/TiaMcpServer.Tests/AuditIsolationTests.cs
@@ -7,84 +7,54 @@ using Xunit;
 namespace TiaMcpServer.Tests;
 
 /// <summary>
-/// The tool layer must never reach a process-wide audit directory. Before DI this was impossible
-/// to assert: ProjectLifecycleTools resolved WriteSafetyService.Shared, so 39 of 42 records in a
-/// real machine's audit trail came from `dotnet test`.
+/// The tool layer must never reach a process-wide audit directory. Before dependency injection
+/// was introduced, ProjectLifecycleTools resolved a single process-wide WriteSafetyService
+/// instance, so 39 of 42 records in a real machine's audit trail came from `dotnet test`.
 /// </summary>
 public class AuditIsolationTests
 {
-    private static string LocateFakeWorker()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null)
-        {
-            foreach (var configuration in new[] { "Debug", "Release" })
-            {
-                var candidate = Path.Combine(
-                    directory.FullName,
-                    "TiaMcpServer.FakeWorker", "bin", configuration, "net8.0",
-                    "TiaMcpServer.FakeWorker.exe");
-                if (File.Exists(candidate))
-                {
-                    return candidate;
-                }
-            }
-
-            directory = directory.Parent!;
-        }
-
-        throw new FileNotFoundException("TiaMcpServer.FakeWorker.exe not found; build the solution first.");
-    }
+    /// <summary>
+    /// Records are appended as lines to an existing per-day *.jsonl file, so a stray write can
+    /// leave the file count in a directory unchanged. Summing line counts across all files is
+    /// the only way this assertion can actually detect an unwanted write.
+    /// </summary>
+    private static int CountAuditLines(string directory)
+        => Directory.Exists(directory)
+            ? Directory.GetFiles(directory).Sum(file => File.ReadAllLines(file).Length)
+            : 0;
 
     [Fact]
     public async Task LifecycleTool_WritesAuditOnlyToTheInjectedDirectory()
     {
-        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-audit-" + Guid.NewGuid().ToString("N"));
         var defaultDirectory = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "TiaMcpServer",
             "audit");
-        var before = Directory.Exists(defaultDirectory)
-            ? Directory.GetFiles(defaultDirectory).Length
-            : 0;
+        var before = CountAuditLines(defaultDirectory);
 
-        try
-        {
-            var safety = new WriteSafetyService(
-                () => DateTimeOffset.UtcNow,
-                TimeSpan.FromMinutes(10),
-                auditDirectory);
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
 
-            using var client = new OpennessWorkerClient(
-                new ProjectSessionBinding(null),
-                logger: null,
-                workerExecutablePath: LocateFakeWorker());
+        using var client = new OpennessWorkerClient(
+            new ProjectSessionBinding(null),
+            logger: null,
+            workerExecutablePath: FakeWorkerLocator.Locate());
 
-            var preview = await ProjectLifecycleTools.OpenProject(client, safety, projectPath: "ok");
-            using var previewDoc = System.Text.Json.JsonDocument.Parse(preview);
-            var token = previewDoc.RootElement.GetProperty("safetyToken").GetString();
+        var preview = await ProjectLifecycleTools.OpenProject(client, safety, projectPath: "ok");
+        using var previewDoc = System.Text.Json.JsonDocument.Parse(preview);
+        var token = previewDoc.RootElement.GetProperty("safetyToken").GetString();
 
-            await ProjectLifecycleTools.OpenProject(
-                client,
-                safety,
-                projectPath: "ok",
-                confirm: true,
-                safetyToken: token);
+        await ProjectLifecycleTools.OpenProject(
+            client,
+            safety,
+            projectPath: "ok",
+            confirm: true,
+            safetyToken: token);
 
-            Assert.True(Directory.Exists(auditDirectory));
-            Assert.NotEmpty(Directory.GetFiles(auditDirectory));
+        Assert.True(Directory.Exists(audit.Path));
+        Assert.NotEmpty(Directory.GetFiles(audit.Path));
 
-            var after = Directory.Exists(defaultDirectory)
-                ? Directory.GetFiles(defaultDirectory).Length
-                : 0;
-            Assert.Equal(before, after);
-        }
-        finally
-        {
-            if (Directory.Exists(auditDirectory))
-            {
-                Directory.Delete(auditDirectory, recursive: true);
-            }
-        }
+        var after = CountAuditLines(defaultDirectory);
+        Assert.Equal(before, after);
     }
 }

--- a/TiaMcpServer.Tests/AuditIsolationTests.cs
+++ b/TiaMcpServer.Tests/AuditIsolationTests.cs
@@ -1,0 +1,90 @@
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tools;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+/// <summary>
+/// The tool layer must never reach a process-wide audit directory. Before DI this was impossible
+/// to assert: ProjectLifecycleTools resolved WriteSafetyService.Shared, so 39 of 42 records in a
+/// real machine's audit trail came from `dotnet test`.
+/// </summary>
+public class AuditIsolationTests
+{
+    private static string LocateFakeWorker()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (var configuration in new[] { "Debug", "Release" })
+            {
+                var candidate = Path.Combine(
+                    directory.FullName,
+                    "TiaMcpServer.FakeWorker", "bin", configuration, "net8.0",
+                    "TiaMcpServer.FakeWorker.exe");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent!;
+        }
+
+        throw new FileNotFoundException("TiaMcpServer.FakeWorker.exe not found; build the solution first.");
+    }
+
+    [Fact]
+    public async Task LifecycleTool_WritesAuditOnlyToTheInjectedDirectory()
+    {
+        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-audit-" + Guid.NewGuid().ToString("N"));
+        var defaultDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "TiaMcpServer",
+            "audit");
+        var before = Directory.Exists(defaultDirectory)
+            ? Directory.GetFiles(defaultDirectory).Length
+            : 0;
+
+        try
+        {
+            var safety = new WriteSafetyService(
+                () => DateTimeOffset.UtcNow,
+                TimeSpan.FromMinutes(10),
+                auditDirectory);
+
+            using var client = new OpennessWorkerClient(
+                new ProjectSessionBinding(null),
+                logger: null,
+                workerExecutablePath: LocateFakeWorker());
+
+            var preview = await ProjectLifecycleTools.OpenProject(client, safety, projectPath: "ok");
+            using var previewDoc = System.Text.Json.JsonDocument.Parse(preview);
+            var token = previewDoc.RootElement.GetProperty("safetyToken").GetString();
+
+            await ProjectLifecycleTools.OpenProject(
+                client,
+                safety,
+                projectPath: "ok",
+                confirm: true,
+                safetyToken: token);
+
+            Assert.True(Directory.Exists(auditDirectory));
+            Assert.NotEmpty(Directory.GetFiles(auditDirectory));
+
+            var after = Directory.Exists(defaultDirectory)
+                ? Directory.GetFiles(defaultDirectory).Length
+                : 0;
+            Assert.Equal(before, after);
+        }
+        finally
+        {
+            if (Directory.Exists(auditDirectory))
+            {
+                Directory.Delete(auditDirectory, recursive: true);
+            }
+        }
+    }
+}

--- a/TiaMcpServer.Tests/BatchFieldForwardingTests.cs
+++ b/TiaMcpServer.Tests/BatchFieldForwardingTests.cs
@@ -1,0 +1,153 @@
+using System.Reflection;
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+/// <summary>
+/// Every field an operation declares must actually reach the worker. Two live instances of the
+/// opposite — deviceItemName on configure_network_device, and the external* attributes on
+/// create_tag — were silently discarded for months because nothing checked. Asserts by VALUE, not
+/// by property name, so renaming either side of the boundary cannot make this pass vacuously.
+/// </summary>
+public class BatchFieldForwardingTests
+{
+    private static string LocateFakeWorker()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (var configuration in new[] { "Debug", "Release" })
+            {
+                var candidate = Path.Combine(
+                    directory.FullName,
+                    "TiaMcpServer.FakeWorker", "bin", configuration, "net8.0",
+                    "TiaMcpServer.FakeWorker.exe");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent!;
+        }
+
+        throw new FileNotFoundException("TiaMcpServer.FakeWorker.exe not found; build the solution first.");
+    }
+
+    private static readonly Dictionary<string, object> ValidatedFieldValues = new(StringComparer.Ordinal)
+    {
+        ["filter"] = "UnusedObjects",
+        ["blockType"] = "FB",
+        ["language"] = "SCL",
+        ["obEventClass"] = "CyclicInterrupt",
+        ["dataType"] = "Bool",
+        ["depth"] = 7,
+        ["maxResults"] = 4242,
+    };
+
+    private static object SentinelFor(PropertyInfo property, string fieldName)
+    {
+        if (ValidatedFieldValues.TryGetValue(fieldName, out var known))
+        {
+            return known;
+        }
+
+        var type = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+        if (type == typeof(bool))
+        {
+            return true;
+        }
+
+        if (type == typeof(int))
+        {
+            return 4243;
+        }
+
+        return $"__sentinel_{fieldName}__";
+    }
+
+    private static (BatchOperationRequest Request, List<object> Expected) Build(BatchOperationSpec spec)
+    {
+        var request = new BatchOperationRequest
+        {
+            OperationId = "item-1",
+            Operation = spec.Name,
+            ProjectPath = "echo"
+        };
+
+        var expected = new List<object>();
+        foreach (var fieldName in spec.RequiredFields.Concat(spec.OptionalFields))
+        {
+            var propertyName = char.ToUpperInvariant(fieldName[0]) + fieldName.Substring(1);
+            var property = typeof(BatchOperationRequest).GetProperty(propertyName)
+                ?? throw new InvalidOperationException(
+                    $"Spec '{spec.Name}' declares field '{fieldName}' with no matching BatchOperationRequest property.");
+
+            var value = SentinelFor(property, fieldName);
+            property.SetValue(request, value);
+            expected.Add(value);
+        }
+
+        return (request, expected);
+    }
+
+    public static TheoryData<string> AllOperations()
+    {
+        var data = new TheoryData<string>();
+        foreach (var spec in BatchOperationCatalog.All)
+        {
+            data.Add(spec.Name);
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(AllOperations))]
+    public async Task EveryDeclaredField_ReachesTheWorker(string operationName)
+    {
+        Assert.True(BatchOperationCatalog.TryGetSpec(operationName, out var spec));
+        var (request, expected) = Build(spec!);
+
+        using var client = new OpennessWorkerClient(
+            new ProjectSessionBinding(null),
+            logger: null,
+            workerExecutablePath: LocateFakeWorker());
+
+        var result = await BatchWorkerInvoker.InvokeAsync(client, request);
+
+        Assert.True(result.Success, result.Error);
+
+        foreach (var value in expected)
+        {
+            var rendered = value switch
+            {
+                bool b => b ? "true" : "false",
+                int i => i.ToString(),
+                _ => JsonSerializer.Serialize(value).Trim('"')
+            };
+
+            Assert.True(
+                result.Payload.Contains(rendered, StringComparison.Ordinal),
+                $"Operation '{operationName}' declares a field whose value '{rendered}' never reached "
+                + $"the worker. Echoed request: {result.Payload}");
+        }
+    }
+
+    [Fact]
+    public void EveryDeclaredField_HasAMatchingRequestProperty()
+    {
+        foreach (var spec in BatchOperationCatalog.All)
+        {
+            foreach (var fieldName in spec.RequiredFields.Concat(spec.OptionalFields))
+            {
+                var propertyName = char.ToUpperInvariant(fieldName[0]) + fieldName.Substring(1);
+                Assert.NotNull(typeof(BatchOperationRequest).GetProperty(propertyName));
+            }
+        }
+    }
+}

--- a/TiaMcpServer.Tests/BatchFieldForwardingTests.cs
+++ b/TiaMcpServer.Tests/BatchFieldForwardingTests.cs
@@ -95,6 +95,33 @@ public class BatchFieldForwardingTests
         return (request, expected);
     }
 
+    private static string RenderValue(object value) => value switch
+    {
+        bool b => b ? "true" : "false",
+        int i => i.ToString(),
+        _ => JsonSerializer.Serialize(value).Trim('"')
+    };
+
+    private static int CountOccurrences(string value, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = value.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+
+    private static BatchOperationRequest BuildBaseline(BatchOperationSpec spec) => new()
+    {
+        OperationId = "baseline",
+        Operation = spec.Name,
+        ProjectPath = "echo"
+    };
+
     public static TheoryData<string> AllOperations()
     {
         var data = new TheoryData<string>();
@@ -122,19 +149,23 @@ public class BatchFieldForwardingTests
 
         Assert.True(result.Success, result.Error);
 
-        foreach (var value in expected)
+        var groups = expected.Select(RenderValue).GroupBy(value => value, StringComparer.Ordinal).ToList();
+        var baselinePayload = string.Empty;
+        if (groups.Any(group => group.Count() > 1))
         {
-            var rendered = value switch
-            {
-                bool b => b ? "true" : "false",
-                int i => i.ToString(),
-                _ => JsonSerializer.Serialize(value).Trim('"')
-            };
+            var baselineResult = await BatchWorkerInvoker.InvokeAsync(client, BuildBaseline(spec!));
+            Assert.True(baselineResult.Success, baselineResult.Error);
+            baselinePayload = baselineResult.Payload;
+        }
 
+        foreach (var group in groups)
+        {
+            var actualCount = CountOccurrences(result.Payload, group.Key)
+                - CountOccurrences(baselinePayload, group.Key);
             Assert.True(
-                result.Payload.Contains(rendered, StringComparison.Ordinal),
-                $"Operation '{operationName}' declares a field whose value '{rendered}' never reached "
-                + $"the worker. Echoed request: {result.Payload}");
+                actualCount == group.Count(),
+                $"Operation '{operationName}' expected {group.Count()} occurrences of value "
+                + $"'{group.Key}' but received {actualCount}. Echoed request: {result.Payload}");
         }
     }
 

--- a/TiaMcpServer.Tests/BatchOperationCatalogTests.cs
+++ b/TiaMcpServer.Tests/BatchOperationCatalogTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using TiaMcpServer.Batch;
 using Xunit;
 
@@ -313,6 +314,77 @@ public class BatchOperationCatalogTests
         var result = BatchOperationCatalog.ValidateReadBatch(operations);
 
         Assert.True(result.IsValid, result.Error);
+    }
+
+    [Fact]
+    public void All_ExposesEverySpec()
+    {
+        // 8 reads + 17 writes.
+        Assert.Equal(25, BatchOperationCatalog.All.Count);
+    }
+
+    [Fact]
+    public void ConfigureNetworkDevice_DoesNotDeclareDeviceItemName()
+    {
+        Assert.True(BatchOperationCatalog.TryGetSpec("configure_network_device", out var spec));
+
+        Assert.DoesNotContain("deviceItemName", spec!.OptionalFields);
+        Assert.Contains("ipAddress", spec.OptionalFields);
+        Assert.Contains("subnetMask", spec.OptionalFields);
+        Assert.Contains("pnDeviceName", spec.OptionalFields);
+        Assert.Contains("subnetName", spec.OptionalFields);
+        Assert.Contains("ioSystemName", spec.OptionalFields);
+    }
+
+    [Fact]
+    public void AddNetworkDevice_DeclaresDeviceItemName()
+    {
+        Assert.True(BatchOperationCatalog.TryGetSpec("add_network_device", out var spec));
+
+        Assert.Contains("deviceItemName", spec!.OptionalFields);
+    }
+
+    [Fact]
+    public void CreateTag_DoesNotDeclareTheExternalAttributes()
+    {
+        Assert.True(BatchOperationCatalog.TryGetSpec("create_tag", out var spec));
+
+        Assert.DoesNotContain("externalAccessible", spec!.OptionalFields);
+        Assert.DoesNotContain("externalVisible", spec.OptionalFields);
+        Assert.DoesNotContain("externalWritable", spec.OptionalFields);
+        Assert.DoesNotContain("isSafety", spec.OptionalFields);
+    }
+
+    [Fact]
+    public void UpdateTag_DeclaresTheExternalAttributes()
+    {
+        Assert.True(BatchOperationCatalog.TryGetSpec("update_tag", out var spec));
+
+        Assert.Contains("externalAccessible", spec!.OptionalFields);
+        Assert.Contains("externalVisible", spec.OptionalFields);
+        Assert.Contains("externalWritable", spec.OptionalFields);
+        Assert.Contains("isSafety", spec.OptionalFields);
+        Assert.Contains("newName", spec.OptionalFields);
+    }
+
+    [Fact]
+    public void NoSpecDeclaresAUniversalFieldAsOptional()
+    {
+        foreach (var spec in BatchOperationCatalog.All)
+        {
+            Assert.DoesNotContain("operationId", spec.OptionalFields);
+            Assert.DoesNotContain("operation", spec.OptionalFields);
+            Assert.DoesNotContain("projectPath", spec.OptionalFields);
+        }
+    }
+
+    [Fact]
+    public void RequiredAndOptionalFieldsNeverOverlap()
+    {
+        foreach (var spec in BatchOperationCatalog.All)
+        {
+            Assert.Empty(spec.RequiredFields.Intersect(spec.OptionalFields));
+        }
     }
 
     private static BatchOperationRequest FullyPopulated(string id, string operation) => new()

--- a/TiaMcpServer.Tests/BatchOperationCatalogTests.cs
+++ b/TiaMcpServer.Tests/BatchOperationCatalogTests.cs
@@ -551,6 +551,24 @@ public class BatchOperationCatalogTests
         Assert.Contains("1 or greater", result.Error);
     }
 
+    [Fact]
+    public void ObEventClassOnCreateBlock_IsAccepted()
+    {
+        var result = BatchOperationCatalog.ValidateWriteBatch(new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "a",
+                Operation = "create_block",
+                BlockPath = "PLC_1/Blocks/Main",
+                BlockType = "OB",
+                ObEventClass = "ProgramCycle"
+            }
+        });
+
+        Assert.True(result.IsValid, result.Error);
+    }
+
     private static BatchOperationRequest FullyPopulated(string id, string operation)
     {
         Assert.True(BatchOperationCatalog.TryGetSpec(operation, out var spec));

--- a/TiaMcpServer.Tests/BatchOperationCatalogTests.cs
+++ b/TiaMcpServer.Tests/BatchOperationCatalogTests.cs
@@ -324,6 +324,50 @@ public class BatchOperationCatalogTests
     }
 
     [Fact]
+    public void All_MatchesTheAuthoritativeOperationFieldContract()
+    {
+        var none = Array.Empty<string>();
+        var expected = new Dictionary<string, (BatchOperationCategory Category, IReadOnlyList<string> Required, IReadOnlyList<string> Optional)>
+        {
+            ["browse_project_tree"] = (BatchOperationCategory.Read, none, new[] { "depth", "startPath" }),
+            ["read_hardware_config"] = (BatchOperationCategory.Read, none, none),
+            ["search_equipment_catalog"] = (BatchOperationCategory.Read, new[] { "query" }, new[] { "maxResults" }),
+            ["read_cross_references"] = (BatchOperationCategory.Read, none, new[] { "plcName", "filter", "maxResults" }),
+            ["get_block_content"] = (BatchOperationCategory.Read, new[] { "blockPath" }, none),
+            ["list_tag_tables"] = (BatchOperationCategory.Read, none, new[] { "plcName" }),
+            ["compile_check"] = (BatchOperationCategory.Read, none, new[] { "blockPath", "plcName" }),
+            ["get_project_status"] = (BatchOperationCategory.Read, none, none),
+            ["update_block_logic"] = (BatchOperationCategory.Write, new[] { "blockPath", "yamlContent" }, none),
+            ["create_tag_table"] = (BatchOperationCategory.Write, new[] { "tableName" }, new[] { "plcName", "folderPath" }),
+            ["delete_tag_table"] = (BatchOperationCategory.Write, new[] { "tableName" }, new[] { "plcName", "folderPath" }),
+            ["create_tag"] = (BatchOperationCategory.Write, new[] { "tableName", "name", "dataType" }, new[] { "plcName", "folderPath", "logicalAddress" }),
+            ["update_tag"] = (BatchOperationCategory.Write, new[] { "tableName", "name" }, new[] { "plcName", "folderPath", "newName", "dataType", "logicalAddress", "externalAccessible", "externalVisible", "externalWritable", "isSafety" }),
+            ["delete_tag"] = (BatchOperationCategory.Write, new[] { "tableName", "name" }, new[] { "plcName", "folderPath" }),
+            ["create_user_constant"] = (BatchOperationCategory.Write, new[] { "tableName", "name", "dataType", "value" }, new[] { "plcName", "folderPath" }),
+            ["update_user_constant"] = (BatchOperationCategory.Write, new[] { "tableName", "name" }, new[] { "plcName", "folderPath", "dataType", "value" }),
+            ["delete_user_constant"] = (BatchOperationCategory.Write, new[] { "tableName", "name" }, new[] { "plcName", "folderPath" }),
+            ["add_network_device"] = (BatchOperationCategory.Write, new[] { "typeIdentifier", "deviceName" }, new[] { "deviceItemName" }),
+            ["configure_network_device"] = (BatchOperationCategory.Write, new[] { "deviceName" }, new[] { "ipAddress", "subnetMask", "pnDeviceName", "subnetName", "ioSystemName" }),
+            ["create_block"] = (BatchOperationCategory.Write, new[] { "blockPath", "blockType" }, new[] { "language", "obEventClass" }),
+            ["delete_block"] = (BatchOperationCategory.Write, new[] { "blockPath" }, none),
+            ["create_block_group"] = (BatchOperationCategory.Write, new[] { "blockPath" }, none),
+            ["delete_block_group"] = (BatchOperationCategory.Write, new[] { "blockPath" }, none),
+            ["start_plc"] = (BatchOperationCategory.Write, none, new[] { "plcName" }),
+            ["stop_plc"] = (BatchOperationCategory.Write, none, new[] { "plcName" }),
+        };
+        var actual = BatchOperationCatalog.All.ToDictionary(spec => spec.Name, StringComparer.Ordinal);
+
+        Assert.Equal(expected.Keys.OrderBy(name => name), actual.Keys.OrderBy(name => name));
+        foreach (var (name, expectedSpec) in expected)
+        {
+            var actualSpec = actual[name];
+            Assert.Equal(expectedSpec.Category, actualSpec.Category);
+            Assert.Equal(expectedSpec.Required, actualSpec.RequiredFields);
+            Assert.Equal(expectedSpec.Optional, actualSpec.OptionalFields);
+        }
+    }
+
+    [Fact]
     public void ConfigureNetworkDevice_DoesNotDeclareDeviceItemName()
     {
         Assert.True(BatchOperationCatalog.TryGetSpec("configure_network_device", out var spec));

--- a/TiaMcpServer.Tests/BatchOperationCatalogTests.cs
+++ b/TiaMcpServer.Tests/BatchOperationCatalogTests.cs
@@ -194,7 +194,7 @@ public class BatchOperationCatalogTests
     }
 
     [Fact]
-    public void AllWriteOperations_AcceptAFullyPopulatedRequest()
+    public void AllWriteOperations_AcceptARequestWithTheirRequiredFields()
     {
         foreach (var operation in BatchOperationCatalog.WriteOperationNames)
         {
@@ -204,7 +204,7 @@ public class BatchOperationCatalogTests
     }
 
     [Fact]
-    public void AllReadOperations_AcceptAFullyPopulatedRequest()
+    public void AllReadOperations_AcceptARequestWithTheirRequiredFields()
     {
         foreach (var operation in BatchOperationCatalog.ReadOperationNames)
         {
@@ -265,8 +265,8 @@ public class BatchOperationCatalogTests
         var result = BatchOperationCatalog.ValidateReadBatch(operations);
 
         Assert.False(result.IsValid);
-        Assert.Contains("'depth' is only valid for browse_project_tree", result.Error);
-        Assert.Contains("'startPath' is only valid for browse_project_tree", result.Error);
+        Assert.Contains("'depth' is not valid for list_tag_tables", result.Error);
+        Assert.Contains("'startPath' is not valid for get_project_status", result.Error);
         Assert.Contains("operationId 'a'", result.Error);
         Assert.Contains("operationId 'b'", result.Error);
     }
@@ -282,7 +282,7 @@ public class BatchOperationCatalogTests
         var result = BatchOperationCatalog.ValidateReadBatch(operations);
 
         Assert.False(result.IsValid);
-        Assert.Contains("'maxResults' is only valid for search_equipment_catalog and read_cross_references", result.Error);
+        Assert.Contains("'maxResults' is not valid for browse_project_tree", result.Error);
     }
 
     [Fact]
@@ -431,19 +431,149 @@ public class BatchOperationCatalogTests
         }
     }
 
-    private static BatchOperationRequest FullyPopulated(string id, string operation) => new()
+    [Fact]
+    public void DeviceItemNameOnConfigureNetworkDevice_IsRejected()
     {
-        OperationId = id,
-        Operation = operation,
-        BlockPath = "PLC_1/Main",
-        YamlContent = "name: Main",
-        BlockType = "FB",
-        Query = "CPU",
-        TableName = "Inputs",
-        Name = "Item",
-        DataType = "Bool",
-        Value = "1",
-        TypeIdentifier = "OrderNumber:X/V1.0",
-        DeviceName = "PLC_1",
-    };
+        var result = BatchOperationCatalog.ValidateWriteBatch(new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "a",
+                Operation = "configure_network_device",
+                DeviceName = "PLC_1",
+                DeviceItemName = "PROFINET interface_1"
+            }
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("deviceItemName", result.Error);
+        Assert.Contains("configure_network_device", result.Error);
+        Assert.Contains("ipAddress", result.Error);
+    }
+
+    [Fact]
+    public void ExternalAttributesOnCreateTag_AreRejected()
+    {
+        var result = BatchOperationCatalog.ValidateWriteBatch(new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "a",
+                Operation = "create_tag",
+                TableName = "Default tag table",
+                Name = "Motor",
+                DataType = "Bool",
+                ExternalAccessible = true,
+                IsSafety = false
+            }
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("externalAccessible", result.Error);
+        Assert.Contains("isSafety", result.Error);
+    }
+
+    [Fact]
+    public void ExternalAttributesOnUpdateTag_AreAccepted()
+    {
+        var result = BatchOperationCatalog.ValidateWriteBatch(new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "a",
+                Operation = "update_tag",
+                TableName = "Default tag table",
+                Name = "Motor",
+                ExternalAccessible = true,
+                IsSafety = false
+            }
+        });
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void InapplicableFieldErrors_AggregateWithOtherErrors()
+    {
+        var result = BatchOperationCatalog.ValidateWriteBatch(new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "a",
+                Operation = "create_tag",
+                TableName = "Default tag table",
+                ExternalAccessible = true
+            }
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("missing required field(s)", result.Error);
+        Assert.Contains("externalAccessible", result.Error);
+    }
+
+    [Fact]
+    public void UniversalFields_AreNeverRejected()
+    {
+        var result = BatchOperationCatalog.ValidateReadBatch(new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "a",
+                Operation = "get_project_status",
+                ProjectPath = "C:\\p.ap21"
+            }
+        });
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void DepthOnANonTreeOperation_IsStillRejected()
+    {
+        var result = BatchOperationCatalog.ValidateReadBatch(new[]
+        {
+            new BatchOperationRequest { OperationId = "a", Operation = "read_hardware_config", Depth = 2 }
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("depth", result.Error);
+    }
+
+    [Fact]
+    public void DepthBelowOne_IsStillRejected()
+    {
+        var result = BatchOperationCatalog.ValidateReadBatch(new[]
+        {
+            new BatchOperationRequest { OperationId = "a", Operation = "browse_project_tree", Depth = 0 }
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("1 or greater", result.Error);
+    }
+
+    private static BatchOperationRequest FullyPopulated(string id, string operation)
+    {
+        Assert.True(BatchOperationCatalog.TryGetSpec(operation, out var spec));
+        var request = new BatchOperationRequest { OperationId = id, Operation = operation };
+
+        foreach (var field in spec!.RequiredFields)
+        {
+            switch (field)
+            {
+                case "blockPath": request.BlockPath = "PLC_1/Main"; break;
+                case "yamlContent": request.YamlContent = "name: Main"; break;
+                case "blockType": request.BlockType = "FB"; break;
+                case "query": request.Query = "CPU"; break;
+                case "tableName": request.TableName = "Inputs"; break;
+                case "name": request.Name = "Item"; break;
+                case "dataType": request.DataType = "Bool"; break;
+                case "value": request.Value = "1"; break;
+                case "typeIdentifier": request.TypeIdentifier = "OrderNumber:X/V1.0"; break;
+                case "deviceName": request.DeviceName = "PLC_1"; break;
+                default: throw new InvalidOperationException($"No test value configured for required field '{field}'.");
+            }
+        }
+
+        return request;
+    }
 }

--- a/TiaMcpServer.Tests/BatchSafetyTokenTests.cs
+++ b/TiaMcpServer.Tests/BatchSafetyTokenTests.cs
@@ -59,7 +59,8 @@ public class BatchSafetyTokenTests
     [Fact]
     public void UnchangedBatchValidates()
     {
-        var service = new WriteSafetyService();
+        using var audit = new TempAuditDirectory();
+        var service = audit.CreateSafety();
         var (ops, states) = TwoItemBatch();
         var token = CreatePreview(service, ops, states);
 
@@ -71,7 +72,8 @@ public class BatchSafetyTokenTests
     [Fact]
     public void ReorderedOperationsAreRejected()
     {
-        var service = new WriteSafetyService();
+        using var audit = new TempAuditDirectory();
+        var service = audit.CreateSafety();
         var (ops, states) = TwoItemBatch();
         var token = CreatePreview(service, ops, states);
 
@@ -85,7 +87,8 @@ public class BatchSafetyTokenTests
     [Fact]
     public void ChangedInputIsRejected()
     {
-        var service = new WriteSafetyService();
+        using var audit = new TempAuditDirectory();
+        var service = audit.CreateSafety();
         var (ops, states) = TwoItemBatch();
         var token = CreatePreview(service, ops, states);
 
@@ -102,7 +105,8 @@ public class BatchSafetyTokenTests
     [Fact]
     public void ChangedCurrentStateIsRejected()
     {
-        var service = new WriteSafetyService();
+        using var audit = new TempAuditDirectory();
+        var service = audit.CreateSafety();
         var (ops, states) = TwoItemBatch();
         var token = CreatePreview(service, ops, states);
 
@@ -114,7 +118,8 @@ public class BatchSafetyTokenTests
     [Fact]
     public void DifferentProjectPathIsRejected()
     {
-        var service = new WriteSafetyService();
+        using var audit = new TempAuditDirectory();
+        var service = audit.CreateSafety();
         var (ops, states) = TwoItemBatch();
         var token = CreatePreview(service, ops, states);
 
@@ -131,7 +136,8 @@ public class BatchSafetyTokenTests
     [Fact]
     public void WrongToolNameIsRejected()
     {
-        var service = new WriteSafetyService();
+        using var audit = new TempAuditDirectory();
+        var service = audit.CreateSafety();
         var (ops, states) = TwoItemBatch();
         var token = CreatePreview(service, ops, states);
 
@@ -143,7 +149,8 @@ public class BatchSafetyTokenTests
     [Fact]
     public void TokenIsSingleUse()
     {
-        var service = new WriteSafetyService();
+        using var audit = new TempAuditDirectory();
+        var service = audit.CreateSafety();
         var (ops, states) = TwoItemBatch();
         var token = CreatePreview(service, ops, states);
 
@@ -154,7 +161,8 @@ public class BatchSafetyTokenTests
     [Fact]
     public void UnknownTokenIsRejected()
     {
-        var service = new WriteSafetyService();
+        using var audit = new TempAuditDirectory();
+        var service = audit.CreateSafety();
         var (ops, states) = TwoItemBatch();
 
         var result = Consume(service, "never-issued", ops, states);

--- a/TiaMcpServer.Tests/BatchToolsTests.cs
+++ b/TiaMcpServer.Tests/BatchToolsTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Text.Json;
 using ModelContextProtocol.Server;
 using TiaMcpServer.Batch;
+using TiaMcpServer.Safety;
 using Xunit;
 
 namespace TiaMcpServer.Tests;
@@ -14,6 +15,9 @@ public class BatchToolsTests
         configure?.Invoke(request);
         return request;
     }
+
+    private static WriteSafetyService CreateSafety(string auditDirectory)
+        => new(() => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, auditDirectory);
 
     [Theory]
     [InlineData("ExecuteReadBatch", "execute_read_batch")]
@@ -56,83 +60,161 @@ public class BatchToolsTests
     [Fact]
     public async Task PreviewWriteBatch_RejectsReadOperation()
     {
-        var result = await BatchTools.PreviewWriteBatch(
-            workerClient: null!,
-            new[] { Op("a", "get_block_content", r => r.BlockPath = "Main") });
+        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
+        var safety = CreateSafety(auditDirectory);
+        try
+        {
+            var result = await BatchTools.PreviewWriteBatch(
+                workerClient: null!,
+                safety,
+                new[] { Op("a", "get_block_content", r => r.BlockPath = "Main") });
 
-        var root = JsonDocument.Parse(result).RootElement;
-        Assert.False(root.GetProperty("success").GetBoolean());
-        Assert.Contains("get_block_content", root.GetProperty("error").GetString());
+            var root = JsonDocument.Parse(result).RootElement;
+            Assert.False(root.GetProperty("success").GetBoolean());
+            Assert.Contains("get_block_content", root.GetProperty("error").GetString());
+        }
+        finally
+        {
+            if (Directory.Exists(auditDirectory))
+            {
+                Directory.Delete(auditDirectory, recursive: true);
+            }
+        }
     }
 
     [Fact]
     public async Task PreviewWriteBatch_RejectsProjectLifecycleOperation()
     {
-        var result = await BatchTools.PreviewWriteBatch(
-            workerClient: null!,
-            new[] { Op("a", "close_project") });
+        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
+        var safety = CreateSafety(auditDirectory);
+        try
+        {
+            var result = await BatchTools.PreviewWriteBatch(
+                workerClient: null!,
+                safety,
+                new[] { Op("a", "close_project") });
 
-        var root = JsonDocument.Parse(result).RootElement;
-        Assert.False(root.GetProperty("success").GetBoolean());
-        Assert.Contains("close_project", root.GetProperty("error").GetString());
+            var root = JsonDocument.Parse(result).RootElement;
+            Assert.False(root.GetProperty("success").GetBoolean());
+            Assert.Contains("close_project", root.GetProperty("error").GetString());
+        }
+        finally
+        {
+            if (Directory.Exists(auditDirectory))
+            {
+                Directory.Delete(auditDirectory, recursive: true);
+            }
+        }
     }
 
     [Fact]
     public async Task ApplyWriteBatch_RejectsUnconfirmedRequests()
     {
-        var result = await BatchTools.ApplyWriteBatch(
-            workerClient: null!,
-            new[] { Op("a", "create_tag", r => { r.TableName = "Inputs"; r.Name = "Start"; r.DataType = "Bool"; }) },
-            confirm: false);
+        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
+        var safety = CreateSafety(auditDirectory);
+        try
+        {
+            var result = await BatchTools.ApplyWriteBatch(
+                workerClient: null!,
+                safety,
+                new[] { Op("a", "create_tag", r => { r.TableName = "Inputs"; r.Name = "Start"; r.DataType = "Bool"; }) },
+                confirm: false);
 
-        var root = JsonDocument.Parse(result).RootElement;
-        Assert.False(root.GetProperty("success").GetBoolean());
-        Assert.Contains("confirm=true", root.GetProperty("error").GetString());
+            var root = JsonDocument.Parse(result).RootElement;
+            Assert.False(root.GetProperty("success").GetBoolean());
+            Assert.Contains("confirm=true", root.GetProperty("error").GetString());
+        }
+        finally
+        {
+            if (Directory.Exists(auditDirectory))
+            {
+                Directory.Delete(auditDirectory, recursive: true);
+            }
+        }
     }
 
     [Fact]
     public async Task ApplyWriteBatch_RejectsInvalidBatchBeforeWorker()
     {
-        var result = await BatchTools.ApplyWriteBatch(
-            workerClient: null!,
-            new[] { Op("a", "get_block_content", r => r.BlockPath = "Main") },
-            confirm: true,
-            safetyToken: "anything");
+        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
+        var safety = CreateSafety(auditDirectory);
+        try
+        {
+            var result = await BatchTools.ApplyWriteBatch(
+                workerClient: null!,
+                safety,
+                new[] { Op("a", "get_block_content", r => r.BlockPath = "Main") },
+                confirm: true,
+                safetyToken: "anything");
 
-        var root = JsonDocument.Parse(result).RootElement;
-        Assert.False(root.GetProperty("success").GetBoolean());
-        Assert.Contains("get_block_content", root.GetProperty("error").GetString());
+            var root = JsonDocument.Parse(result).RootElement;
+            Assert.False(root.GetProperty("success").GetBoolean());
+            Assert.Contains("get_block_content", root.GetProperty("error").GetString());
+        }
+        finally
+        {
+            if (Directory.Exists(auditDirectory))
+            {
+                Directory.Delete(auditDirectory, recursive: true);
+            }
+        }
     }
 
     [Fact]
     public async Task ApplyWriteBatch_RejectsMissingSafetyToken()
     {
-        var result = await BatchTools.ApplyWriteBatch(
-            workerClient: null!,
-            new[] { Op("a", "create_tag", r => { r.TableName = "Inputs"; r.Name = "Start"; r.DataType = "Bool"; }) },
-            confirm: true);
+        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
+        var safety = CreateSafety(auditDirectory);
+        try
+        {
+            var result = await BatchTools.ApplyWriteBatch(
+                workerClient: null!,
+                safety,
+                new[] { Op("a", "create_tag", r => { r.TableName = "Inputs"; r.Name = "Start"; r.DataType = "Bool"; }) },
+                confirm: true);
 
-        Assert.Contains("Safety token required", result);
-        Assert.Contains("preview_write_batch", result);
+            Assert.Contains("Safety token required", result);
+            Assert.Contains("preview_write_batch", result);
+        }
+        finally
+        {
+            if (Directory.Exists(auditDirectory))
+            {
+                Directory.Delete(auditDirectory, recursive: true);
+            }
+        }
     }
 
     [Fact]
     public async Task ApplyWriteBatch_RejectsBadTokenBeforeReadingCurrentState()
     {
-        var operations = new[]
+        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
+        var safety = CreateSafety(auditDirectory);
+        try
         {
-            new BatchOperationRequest { OperationId = "op-1", Operation = "start_plc" }
-        };
+            var operations = new[]
+            {
+                new BatchOperationRequest { OperationId = "op-1", Operation = "start_plc" }
+            };
 
-        // workerClient is null: if the token envelope were checked AFTER the state read,
-        // this call would throw NullReferenceException instead of returning the token error.
-        var result = await BatchTools.ApplyWriteBatch(
-            workerClient: null!,
-            operations,
-            confirm: true,
-            safetyToken: "bogus-token");
+            // workerClient is null: if the token envelope were checked AFTER the state read,
+            // this call would throw NullReferenceException instead of returning the token error.
+            var result = await BatchTools.ApplyWriteBatch(
+                workerClient: null!,
+                safety,
+                operations,
+                confirm: true,
+                safetyToken: "bogus-token");
 
-        Assert.Contains("Safety token", result);
-        Assert.Contains("preview_write_batch", result);
+            Assert.Contains("Safety token", result);
+            Assert.Contains("preview_write_batch", result);
+        }
+        finally
+        {
+            if (Directory.Exists(auditDirectory))
+            {
+                Directory.Delete(auditDirectory, recursive: true);
+            }
+        }
     }
 }

--- a/TiaMcpServer.Tests/BatchToolsTests.cs
+++ b/TiaMcpServer.Tests/BatchToolsTests.cs
@@ -16,9 +16,6 @@ public class BatchToolsTests
         return request;
     }
 
-    private static WriteSafetyService CreateSafety(string auditDirectory)
-        => new(() => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, auditDirectory);
-
     [Theory]
     [InlineData("ExecuteReadBatch", "execute_read_batch")]
     [InlineData("PreviewWriteBatch", "preview_write_batch")]
@@ -60,161 +57,107 @@ public class BatchToolsTests
     [Fact]
     public async Task PreviewWriteBatch_RejectsReadOperation()
     {
-        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
-        var safety = CreateSafety(auditDirectory);
-        try
-        {
-            var result = await BatchTools.PreviewWriteBatch(
-                workerClient: null!,
-                safety,
-                new[] { Op("a", "get_block_content", r => r.BlockPath = "Main") });
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
 
-            var root = JsonDocument.Parse(result).RootElement;
-            Assert.False(root.GetProperty("success").GetBoolean());
-            Assert.Contains("get_block_content", root.GetProperty("error").GetString());
-        }
-        finally
-        {
-            if (Directory.Exists(auditDirectory))
-            {
-                Directory.Delete(auditDirectory, recursive: true);
-            }
-        }
+        var result = await BatchTools.PreviewWriteBatch(
+            workerClient: null!,
+            safety,
+            new[] { Op("a", "get_block_content", r => r.BlockPath = "Main") });
+
+        var root = JsonDocument.Parse(result).RootElement;
+        Assert.False(root.GetProperty("success").GetBoolean());
+        Assert.Contains("get_block_content", root.GetProperty("error").GetString());
     }
 
     [Fact]
     public async Task PreviewWriteBatch_RejectsProjectLifecycleOperation()
     {
-        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
-        var safety = CreateSafety(auditDirectory);
-        try
-        {
-            var result = await BatchTools.PreviewWriteBatch(
-                workerClient: null!,
-                safety,
-                new[] { Op("a", "close_project") });
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
 
-            var root = JsonDocument.Parse(result).RootElement;
-            Assert.False(root.GetProperty("success").GetBoolean());
-            Assert.Contains("close_project", root.GetProperty("error").GetString());
-        }
-        finally
-        {
-            if (Directory.Exists(auditDirectory))
-            {
-                Directory.Delete(auditDirectory, recursive: true);
-            }
-        }
+        var result = await BatchTools.PreviewWriteBatch(
+            workerClient: null!,
+            safety,
+            new[] { Op("a", "close_project") });
+
+        var root = JsonDocument.Parse(result).RootElement;
+        Assert.False(root.GetProperty("success").GetBoolean());
+        Assert.Contains("close_project", root.GetProperty("error").GetString());
     }
 
     [Fact]
     public async Task ApplyWriteBatch_RejectsUnconfirmedRequests()
     {
-        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
-        var safety = CreateSafety(auditDirectory);
-        try
-        {
-            var result = await BatchTools.ApplyWriteBatch(
-                workerClient: null!,
-                safety,
-                new[] { Op("a", "create_tag", r => { r.TableName = "Inputs"; r.Name = "Start"; r.DataType = "Bool"; }) },
-                confirm: false);
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
 
-            var root = JsonDocument.Parse(result).RootElement;
-            Assert.False(root.GetProperty("success").GetBoolean());
-            Assert.Contains("confirm=true", root.GetProperty("error").GetString());
-        }
-        finally
-        {
-            if (Directory.Exists(auditDirectory))
-            {
-                Directory.Delete(auditDirectory, recursive: true);
-            }
-        }
+        var result = await BatchTools.ApplyWriteBatch(
+            workerClient: null!,
+            safety,
+            new[] { Op("a", "create_tag", r => { r.TableName = "Inputs"; r.Name = "Start"; r.DataType = "Bool"; }) },
+            confirm: false);
+
+        var root = JsonDocument.Parse(result).RootElement;
+        Assert.False(root.GetProperty("success").GetBoolean());
+        Assert.Contains("confirm=true", root.GetProperty("error").GetString());
     }
 
     [Fact]
     public async Task ApplyWriteBatch_RejectsInvalidBatchBeforeWorker()
     {
-        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
-        var safety = CreateSafety(auditDirectory);
-        try
-        {
-            var result = await BatchTools.ApplyWriteBatch(
-                workerClient: null!,
-                safety,
-                new[] { Op("a", "get_block_content", r => r.BlockPath = "Main") },
-                confirm: true,
-                safetyToken: "anything");
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
 
-            var root = JsonDocument.Parse(result).RootElement;
-            Assert.False(root.GetProperty("success").GetBoolean());
-            Assert.Contains("get_block_content", root.GetProperty("error").GetString());
-        }
-        finally
-        {
-            if (Directory.Exists(auditDirectory))
-            {
-                Directory.Delete(auditDirectory, recursive: true);
-            }
-        }
+        var result = await BatchTools.ApplyWriteBatch(
+            workerClient: null!,
+            safety,
+            new[] { Op("a", "get_block_content", r => r.BlockPath = "Main") },
+            confirm: true,
+            safetyToken: "anything");
+
+        var root = JsonDocument.Parse(result).RootElement;
+        Assert.False(root.GetProperty("success").GetBoolean());
+        Assert.Contains("get_block_content", root.GetProperty("error").GetString());
     }
 
     [Fact]
     public async Task ApplyWriteBatch_RejectsMissingSafetyToken()
     {
-        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
-        var safety = CreateSafety(auditDirectory);
-        try
-        {
-            var result = await BatchTools.ApplyWriteBatch(
-                workerClient: null!,
-                safety,
-                new[] { Op("a", "create_tag", r => { r.TableName = "Inputs"; r.Name = "Start"; r.DataType = "Bool"; }) },
-                confirm: true);
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
 
-            Assert.Contains("Safety token required", result);
-            Assert.Contains("preview_write_batch", result);
-        }
-        finally
-        {
-            if (Directory.Exists(auditDirectory))
-            {
-                Directory.Delete(auditDirectory, recursive: true);
-            }
-        }
+        var result = await BatchTools.ApplyWriteBatch(
+            workerClient: null!,
+            safety,
+            new[] { Op("a", "create_tag", r => { r.TableName = "Inputs"; r.Name = "Start"; r.DataType = "Bool"; }) },
+            confirm: true);
+
+        Assert.Contains("Safety token required", result);
+        Assert.Contains("preview_write_batch", result);
     }
 
     [Fact]
     public async Task ApplyWriteBatch_RejectsBadTokenBeforeReadingCurrentState()
     {
-        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
-        var safety = CreateSafety(auditDirectory);
-        try
-        {
-            var operations = new[]
-            {
-                new BatchOperationRequest { OperationId = "op-1", Operation = "start_plc" }
-            };
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
 
-            // workerClient is null: if the token envelope were checked AFTER the state read,
-            // this call would throw NullReferenceException instead of returning the token error.
-            var result = await BatchTools.ApplyWriteBatch(
-                workerClient: null!,
-                safety,
-                operations,
-                confirm: true,
-                safetyToken: "bogus-token");
-
-            Assert.Contains("Safety token", result);
-            Assert.Contains("preview_write_batch", result);
-        }
-        finally
+        var operations = new[]
         {
-            if (Directory.Exists(auditDirectory))
-            {
-                Directory.Delete(auditDirectory, recursive: true);
-            }
-        }
+            new BatchOperationRequest { OperationId = "op-1", Operation = "start_plc" }
+        };
+
+        // workerClient is null: if the token envelope were checked AFTER the state read,
+        // this call would throw NullReferenceException instead of returning the token error.
+        var result = await BatchTools.ApplyWriteBatch(
+            workerClient: null!,
+            safety,
+            operations,
+            confirm: true,
+            safetyToken: "bogus-token");
+
+        Assert.Contains("Safety token", result);
+        Assert.Contains("preview_write_batch", result);
     }
 }

--- a/TiaMcpServer.Tests/Cli/VersionCommandTests.cs
+++ b/TiaMcpServer.Tests/Cli/VersionCommandTests.cs
@@ -1,0 +1,20 @@
+using TiaMcpServer.Cli;
+using TiaMcpServer.Tests.Diagnostics;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Cli;
+
+public class VersionCommandTests
+{
+    [Fact]
+    public void Run_WritesHostVersionToOutputAndReturnsZero()
+    {
+        var appInfo = new FakeApplicationInfoService { HostVersion = "2.3.2-local.42.g1d987da" };
+        var output = new StringWriter();
+
+        var exitCode = VersionCommand.Run(output, appInfo);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("2.3.2-local.42.g1d987da" + Environment.NewLine, output.ToString());
+    }
+}

--- a/TiaMcpServer.Tests/McpToolSchemaTests.cs
+++ b/TiaMcpServer.Tests/McpToolSchemaTests.cs
@@ -51,12 +51,15 @@ public class McpToolSchemaTests
             options: new McpServerToolCreateOptions { Services = Services });
 
         var inputSchema = tool.ProtocolTool.InputSchema;
-        if (!inputSchema.TryGetProperty("properties", out var properties))
-        {
-            return Array.Empty<string>();
-        }
+        var names = inputSchema.TryGetProperty("properties", out var properties)
+            ? properties.EnumerateObject().Select(p => p.Name).ToArray()
+            : Array.Empty<string>();
 
-        return properties.EnumerateObject().Select(p => p.Name).ToArray();
+        // A DoesNotContain-only assertion downstream would pass vacuously if schema generation
+        // silently broke for a tool (empty/missing "properties" node) - this makes that a hard
+        // failure instead of a false green.
+        Assert.NotEmpty(names);
+        return names;
     }
 
     [Theory]

--- a/TiaMcpServer.Tests/McpToolSchemaTests.cs
+++ b/TiaMcpServer.Tests/McpToolSchemaTests.cs
@@ -1,0 +1,136 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tools;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+/// <summary>
+/// Verifies the MCP input schema the SDK actually generates for the write tools never exposes
+/// the DI-injected <c>safety</c>/<c>workerClient</c> parameters as model-supplied arguments.
+///
+/// Those tools declare <c>WriteSafetyService safety</c> and <c>OpennessWorkerClient
+/// workerClient</c> as plain typed parameters with no [FromServices]-style attribute, relying
+/// entirely on the MCP SDK inferring "these come from DI, not the model" from
+/// McpServerToolCreateOptions.Services (mirroring exactly how the real host wires tools in
+/// Program.cs via WithToolsFromAssembly). If the SDK ever stopped recognizing that - a version
+/// bump, a change in how Services is threaded through - every write tool's schema would gain a
+/// required object argument no model can ever supply, taking down the entire write surface,
+/// while BatchToolMetadataTests and WriteToolSafetyTokenTests (which only reflect over
+/// [McpServerTool]/[Description] attributes) would stay green.
+///
+/// This is why it has to inspect McpServerTool.Create(...).ProtocolTool.InputSchema - the actual
+/// generated JSON schema - rather than attributes.
+/// </summary>
+public class McpToolSchemaTests
+{
+    private static readonly IServiceProvider Services = BuildServices();
+
+    private static IServiceProvider BuildServices()
+    {
+        var binding = new ProjectSessionBinding(null);
+        var workerClient = new OpennessWorkerClient(binding);
+        var safety = new WriteSafetyService();
+        return new FakeServiceProvider(binding, workerClient, safety);
+    }
+
+    private static string[] SchemaPropertyNames(Type toolType, string methodName)
+    {
+        var method = toolType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var tool = McpServerTool.Create(
+            method!,
+            target: null,
+            options: new McpServerToolCreateOptions { Services = Services });
+
+        var inputSchema = tool.ProtocolTool.InputSchema;
+        if (!inputSchema.TryGetProperty("properties", out var properties))
+        {
+            return Array.Empty<string>();
+        }
+
+        return properties.EnumerateObject().Select(p => p.Name).ToArray();
+    }
+
+    [Theory]
+    [InlineData(nameof(ProjectLifecycleTools.GetProjectStatus))]
+    [InlineData(nameof(ProjectLifecycleTools.OpenProject))]
+    [InlineData(nameof(ProjectLifecycleTools.CreateProject))]
+    [InlineData(nameof(ProjectLifecycleTools.SaveProject))]
+    [InlineData(nameof(ProjectLifecycleTools.SaveProjectAs))]
+    [InlineData(nameof(ProjectLifecycleTools.ArchiveProject))]
+    [InlineData(nameof(ProjectLifecycleTools.CloseProject))]
+    public void ProjectLifecycleTools_SchemaNeverExposesInjectedServiceParameters(string methodName)
+    {
+        var properties = SchemaPropertyNames(typeof(ProjectLifecycleTools), methodName);
+
+        Assert.DoesNotContain("workerClient", properties);
+        Assert.DoesNotContain("safety", properties);
+    }
+
+    [Fact]
+    public void OpenProject_SchemaStillExposesProjectPathAsAModelArgument()
+    {
+        // Negative assertions alone would also pass if the SDK generated an empty schema for
+        // every tool (e.g. a broken reflection path) - this proves it did pick up the real,
+        // model-facing parameters, not just excluded the DI ones.
+        var properties = SchemaPropertyNames(typeof(ProjectLifecycleTools), nameof(ProjectLifecycleTools.OpenProject));
+
+        Assert.Contains("projectPath", properties);
+        Assert.Contains("confirm", properties);
+        Assert.Contains("safetyToken", properties);
+    }
+
+    [Theory]
+    [InlineData(nameof(BatchTools.PreviewWriteBatch))]
+    [InlineData(nameof(BatchTools.ApplyWriteBatch))]
+    public void BatchTools_SchemaNeverExposesInjectedServiceParameters(string methodName)
+    {
+        var properties = SchemaPropertyNames(typeof(BatchTools), methodName);
+
+        Assert.DoesNotContain("workerClient", properties);
+        Assert.DoesNotContain("safety", properties);
+        Assert.Contains("operations", properties);
+    }
+
+    /// <summary>
+    /// Minimal hand-rolled IServiceProvider (rather than pulling in Microsoft.Extensions.DependencyInjection
+    /// for a ServiceCollection) - the schema generator only needs GetService(type) to resolve for
+    /// the exact runtime types the tools declare, mirroring Program.cs's real DI registrations.
+    /// </summary>
+    private sealed class FakeServiceProvider : IServiceProvider, IServiceProviderIsService
+    {
+        private readonly Dictionary<Type, object> _services;
+
+        public FakeServiceProvider(params object[] services)
+            => _services = services.ToDictionary(s => s.GetType(), s => s);
+
+        public object? GetService(Type serviceType)
+        {
+            // The SDK's schema builder does not cast Services to IServiceProviderIsService - it
+            // asks the container to RESOLVE one: options.Services.GetService<IServiceProviderIsService>().
+            // The real Microsoft.Extensions.DependencyInjection ServiceProvider registers itself
+            // as that service internally; a hand-rolled IServiceProvider has to do the same, or
+            // every DI-injected parameter silently falls back to a required schema property
+            // (confirmed empirically before this line was added: "workerClient" showed up as a
+            // required {"type":"object"} property even though this class already implemented
+            // IServiceProviderIsService.IsService below - implementing the interface was not
+            // enough, resolving it through GetService is what the SDK actually calls).
+            if (serviceType == typeof(IServiceProviderIsService))
+            {
+                return this;
+            }
+
+            return _services.TryGetValue(serviceType, out var service) ? service : null;
+        }
+
+        public bool IsService(Type serviceType) => _services.ContainsKey(serviceType);
+    }
+}

--- a/TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs
+++ b/TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs
@@ -241,6 +241,49 @@ public class OpennessWorkerClientIntegrationTests
     }
 
     [Fact]
+    public async Task AlreadyBoundSession_SurfacesAWarningWhenTheWorkerReportsADifferentProject()
+    {
+        var binding = new ProjectSessionBinding(null);
+        Assert.True(binding.Bind("C:\\bound\\Session.ap21", forceRebind: false, out _));
+        using var client = new OpennessWorkerClient(
+            binding,
+            logger: null,
+            workerExecutablePath: FakeWorkerLocator.Locate());
+
+        // No explicit projectPath: TryResolve forwards the bound path itself, so the FakeWorker
+        // scenario key IS the bound path (see the "C:\\bound\\Session.ap21" case).
+        var result = await client.GetProjectStatusAsync(null);
+
+        Assert.True(result.Success);
+        // Finding 1 is containment only: the divergence is surfaced, the session binding itself
+        // is untouched (still bound to what it was bound to before this call).
+        Assert.Equal("C:\\bound\\Session.ap21", binding.BoundProjectPath);
+        Assert.Contains(
+            result.Warnings,
+            w => w.Contains("C:\\bound\\Session.ap21", StringComparison.Ordinal)
+                && w.Contains("C:\\actual\\Other.ap21", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AlreadyBoundSession_NoSpuriousWarningWhenTheWorkerReportsTheSameProject()
+    {
+        var binding = new ProjectSessionBinding(null);
+        Assert.True(binding.Bind("C:\\stable\\Project.ap21", forceRebind: false, out _));
+        using var client = new OpennessWorkerClient(
+            binding,
+            logger: null,
+            workerExecutablePath: FakeWorkerLocator.Locate());
+
+        // Bound path equals the FakeWorker "C:\\stable\\Project.ap21" scenario key, and that
+        // scenario reports the identical resolvedProjectPath back - no divergence.
+        var result = await client.GetProjectStatusAsync(null);
+
+        Assert.True(result.Success);
+        Assert.Equal("C:\\stable\\Project.ap21", binding.BoundProjectPath);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
     public async Task NonExecutableWorkerPath_ProducesActionableWin32Message()
     {
         var bogus = Path.Combine(Path.GetTempPath(), $"tia-fake-{Guid.NewGuid():N}.txt");

--- a/TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs
+++ b/TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs
@@ -153,16 +153,16 @@ public class OpennessWorkerClientIntegrationTests
     }
 
     [Fact]
-    public async Task SuccessfulFirstRequest_KeepsTheSessionBinding()
+    public async Task SuccessfulFirstRequest_BindsToTheResolvedPathAndRejectsADifferentProjectAfterward()
     {
         using var client = CreateClient();
 
-        var succeeded = await client.GetProjectStatusAsync("ok");
+        var succeeded = await client.GetProjectStatusAsync("ok-with-resolved-path");
         var changedProject = await client.GetProjectStatusAsync("worker-error");
 
         Assert.True(succeeded.Success);
         Assert.False(changedProject.Success);
-        Assert.Contains("already bound to project 'ok'", changedProject.Error);
+        Assert.Contains("already bound to project 'C:\\resolved\\Ground.ap21'", changedProject.Error);
     }
 
     [Fact]
@@ -193,6 +193,36 @@ public class OpennessWorkerClientIntegrationTests
         // The protocol-invalid process must be replaced, not reused.
         Assert.True(recovered.Success);
         Assert.Equal("{\"seq\":1}", recovered.Payload);
+    }
+
+    [Fact]
+    public async Task UnboundSession_BindsToTheWorkerReportedPathAfterSuccess()
+    {
+        var binding = new ProjectSessionBinding(null);
+        using var boundClient = new OpennessWorkerClient(
+            binding,
+            logger: null,
+            workerExecutablePath: FakeWorkerLocator.Locate());
+
+        var result = await boundClient.GetProjectStatusAsync("ok-with-resolved-path");
+
+        Assert.True(result.Success);
+        Assert.Equal("C:\\resolved\\Ground.ap21", binding.BoundProjectPath);
+    }
+
+    [Fact]
+    public async Task FailedCall_LeavesTheSessionUnbound()
+    {
+        var binding = new ProjectSessionBinding(null);
+        using var client = new OpennessWorkerClient(
+            binding,
+            logger: null,
+            workerExecutablePath: FakeWorkerLocator.Locate());
+
+        var result = await client.GetProjectStatusAsync("worker-error");
+
+        Assert.False(result.Success);
+        Assert.Null(binding.BoundProjectPath);
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs
+++ b/TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs
@@ -13,67 +13,34 @@ namespace TiaMcpServer.Tests;
 /// </summary>
 public class OpennessWorkerClientIntegrationTests
 {
-    private static string LocateFakeWorker()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null)
-        {
-            foreach (var configuration in new[] { "Debug", "Release" })
-            {
-                var candidate = Path.Combine(
-                    directory.FullName,
-                    "TiaMcpServer.FakeWorker", "bin", configuration, "net8.0",
-                    "TiaMcpServer.FakeWorker.exe");
-                if (File.Exists(candidate))
-                {
-                    return candidate;
-                }
-            }
-
-            directory = directory.Parent!;
-        }
-
-        throw new FileNotFoundException("TiaMcpServer.FakeWorker.exe not found; build the solution first.");
-    }
-
     private static OpennessWorkerClient CreateClient(string? workerPath = null, TimeSpan? requestTimeout = null)
         => new(
             new ProjectSessionBinding(null),
             logger: null,
-            workerExecutablePath: workerPath ?? LocateFakeWorker(),
+            workerExecutablePath: workerPath ?? FakeWorkerLocator.Locate(),
             requestTimeout: requestTimeout);
 
     [Fact]
     public async Task CollapsedOpenProject_PreviewThenApply_RoundTrips()
     {
-        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
-        var safety = new WriteSafetyService(() => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, auditDirectory);
-        try
-        {
-            using var client = CreateClient();
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
+        using var client = CreateClient();
 
-            var preview = await ProjectLifecycleTools.OpenProject(client, safety, projectPath: "ok");
-            using var previewDoc = System.Text.Json.JsonDocument.Parse(preview);
-            var token = previewDoc.RootElement.GetProperty("safetyToken").GetString();
+        var preview = await ProjectLifecycleTools.OpenProject(client, safety, projectPath: "ok");
+        using var previewDoc = System.Text.Json.JsonDocument.Parse(preview);
+        var token = previewDoc.RootElement.GetProperty("safetyToken").GetString();
 
-            var applied = await ProjectLifecycleTools.OpenProject(
-                client,
-                safety,
-                projectPath: "ok",
-                confirm: true,
-                safetyToken: token);
-            using var appliedDoc = System.Text.Json.JsonDocument.Parse(applied);
+        var applied = await ProjectLifecycleTools.OpenProject(
+            client,
+            safety,
+            projectPath: "ok",
+            confirm: true,
+            safetyToken: token);
+        using var appliedDoc = System.Text.Json.JsonDocument.Parse(applied);
 
-            Assert.Equal("open_project", appliedDoc.RootElement.GetProperty("toolName").GetString());
-            Assert.True(appliedDoc.RootElement.GetProperty("success").GetBoolean());
-        }
-        finally
-        {
-            if (Directory.Exists(auditDirectory))
-            {
-                Directory.Delete(auditDirectory, recursive: true);
-            }
-        }
+        Assert.Equal("open_project", appliedDoc.RootElement.GetProperty("toolName").GetString());
+        Assert.True(appliedDoc.RootElement.GetProperty("success").GetBoolean());
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs
+++ b/TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs
@@ -284,6 +284,55 @@ public class OpennessWorkerClientIntegrationTests
     }
 
     [Fact]
+    public async Task AlreadyBoundSession_NoSpuriousWarningWhenTheWorkerReportsAnEquivalentlySpelledPath()
+    {
+        var binding = new ProjectSessionBinding(null);
+        Assert.True(binding.Bind("C:\\equivalent\\Project.ap21", forceRebind: false, out _));
+        using var client = new OpennessWorkerClient(
+            binding,
+            logger: null,
+            workerExecutablePath: FakeWorkerLocator.Locate());
+
+        // Finding 2 regression: the divergence check used a raw string.Equals, which would treat
+        // a forward-vs-back-slash spelling of the identical path as a different project and warn
+        // on every call. ProjectSessionBinding.IsBoundTo canonicalizes both sides (matching
+        // TryResolve/Bind's own "same project?" logic) so an equivalent spelling must NOT warn.
+        var result = await client.GetProjectStatusAsync(null);
+
+        Assert.True(result.Success);
+        Assert.Equal("C:\\equivalent\\Project.ap21", binding.BoundProjectPath);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public async Task SaveProjectAsWithRebind_NoDivergenceWarningWhenTheWorkerReportsTheCopiedProjectPath()
+    {
+        var binding = new ProjectSessionBinding(null);
+        Assert.True(binding.Bind("C:\\bound\\Session.ap21", forceRebind: false, out _));
+        using var client = new OpennessWorkerClient(
+            binding,
+            logger: null,
+            workerExecutablePath: FakeWorkerLocator.Locate());
+
+        // Finding 1 regression: save_project_as with rebind=true deliberately changes which
+        // project is attached (the worker closes the original and opens the copy before this
+        // call returns). Reusing the "C:\\bound\\Session.ap21" FakeWorker scenario - which
+        // reports a genuinely different resolvedProjectPath ("C:\\actual\\Other.ap21") - proves
+        // this documented attachment change no longer produces the divergence warning that an
+        // ordinary bound call gets under the identical worker response (see
+        // AlreadyBoundSession_SurfacesAWarningWhenTheWorkerReportsADifferentProject below, which
+        // exercises the same scenario through GetProjectStatusAsync and still warns).
+        var result = await client.SaveProjectAsAsync(
+            projectPath: null,
+            targetDirectory: "C:\\Target",
+            targetName: "Copy",
+            rebind: true);
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
     public async Task NonExecutableWorkerPath_ProducesActionableWin32Message()
     {
         var bogus = Path.Combine(Path.GetTempPath(), $"tia-fake-{Guid.NewGuid():N}.txt");

--- a/TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs
+++ b/TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs
@@ -226,6 +226,21 @@ public class OpennessWorkerClientIntegrationTests
     }
 
     [Fact]
+    public async Task SuccessfulCallWithoutAResolvedPath_LeavesTheSessionUnbound()
+    {
+        var binding = new ProjectSessionBinding(null);
+        using var client = new OpennessWorkerClient(
+            binding,
+            logger: null,
+            workerExecutablePath: FakeWorkerLocator.Locate());
+
+        var result = await client.GetProjectStatusAsync("ok");
+
+        Assert.True(result.Success);
+        Assert.Null(binding.BoundProjectPath);
+    }
+
+    [Fact]
     public async Task NonExecutableWorkerPath_ProducesActionableWin32Message()
     {
         var bogus = Path.Combine(Path.GetTempPath(), $"tia-fake-{Guid.NewGuid():N}.txt");

--- a/TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs
+++ b/TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs
@@ -1,4 +1,5 @@
 using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
 using TiaMcpServer.Tools;
 using TiaMcpServer.Worker;
 using Xunit;
@@ -45,21 +46,34 @@ public class OpennessWorkerClientIntegrationTests
     [Fact]
     public async Task CollapsedOpenProject_PreviewThenApply_RoundTrips()
     {
-        using var client = CreateClient();
+        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
+        var safety = new WriteSafetyService(() => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, auditDirectory);
+        try
+        {
+            using var client = CreateClient();
 
-        var preview = await ProjectLifecycleTools.OpenProject(client, projectPath: "ok");
-        using var previewDoc = System.Text.Json.JsonDocument.Parse(preview);
-        var token = previewDoc.RootElement.GetProperty("safetyToken").GetString();
+            var preview = await ProjectLifecycleTools.OpenProject(client, safety, projectPath: "ok");
+            using var previewDoc = System.Text.Json.JsonDocument.Parse(preview);
+            var token = previewDoc.RootElement.GetProperty("safetyToken").GetString();
 
-        var applied = await ProjectLifecycleTools.OpenProject(
-            client,
-            projectPath: "ok",
-            confirm: true,
-            safetyToken: token);
-        using var appliedDoc = System.Text.Json.JsonDocument.Parse(applied);
+            var applied = await ProjectLifecycleTools.OpenProject(
+                client,
+                safety,
+                projectPath: "ok",
+                confirm: true,
+                safetyToken: token);
+            using var appliedDoc = System.Text.Json.JsonDocument.Parse(applied);
 
-        Assert.Equal("open_project", appliedDoc.RootElement.GetProperty("toolName").GetString());
-        Assert.True(appliedDoc.RootElement.GetProperty("success").GetBoolean());
+            Assert.Equal("open_project", appliedDoc.RootElement.GetProperty("toolName").GetString());
+            Assert.True(appliedDoc.RootElement.GetProperty("success").GetBoolean());
+        }
+        finally
+        {
+            if (Directory.Exists(auditDirectory))
+            {
+                Directory.Delete(auditDirectory, recursive: true);
+            }
+        }
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/ProjectLifecycleToolTests.cs
+++ b/TiaMcpServer.Tests/ProjectLifecycleToolTests.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Reflection;
 using ModelContextProtocol.Server;
+using TiaMcpServer.Safety;
 using TiaMcpServer.Tools;
 using TiaMcpServer.Worker;
 using Xunit;
@@ -56,14 +57,27 @@ public class ProjectLifecycleToolTests
     [Fact]
     public async Task SaveProjectAsWithTokenButNoConfirm_Rejects()
     {
-        var result = await ProjectLifecycleTools.SaveProjectAs(
-            workerClient: null!,
-            targetDirectory: "C:\\Projects",
-            targetName: "LineCopy",
-            confirm: false,
-            safetyToken: "some-token");
+        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
+        var safety = new WriteSafetyService(() => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, auditDirectory);
+        try
+        {
+            var result = await ProjectLifecycleTools.SaveProjectAs(
+                workerClient: null!,
+                safety,
+                targetDirectory: "C:\\Projects",
+                targetName: "LineCopy",
+                confirm: false,
+                safetyToken: "some-token");
 
-        Assert.Contains("confirm=true", result);
-        Assert.Contains("without safetyToken", result);
+            Assert.Contains("confirm=true", result);
+            Assert.Contains("without safetyToken", result);
+        }
+        finally
+        {
+            if (Directory.Exists(auditDirectory))
+            {
+                Directory.Delete(auditDirectory, recursive: true);
+            }
+        }
     }
 }

--- a/TiaMcpServer.Tests/ProjectLifecycleToolTests.cs
+++ b/TiaMcpServer.Tests/ProjectLifecycleToolTests.cs
@@ -57,27 +57,18 @@ public class ProjectLifecycleToolTests
     [Fact]
     public async Task SaveProjectAsWithTokenButNoConfirm_Rejects()
     {
-        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
-        var safety = new WriteSafetyService(() => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, auditDirectory);
-        try
-        {
-            var result = await ProjectLifecycleTools.SaveProjectAs(
-                workerClient: null!,
-                safety,
-                targetDirectory: "C:\\Projects",
-                targetName: "LineCopy",
-                confirm: false,
-                safetyToken: "some-token");
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
 
-            Assert.Contains("confirm=true", result);
-            Assert.Contains("without safetyToken", result);
-        }
-        finally
-        {
-            if (Directory.Exists(auditDirectory))
-            {
-                Directory.Delete(auditDirectory, recursive: true);
-            }
-        }
+        var result = await ProjectLifecycleTools.SaveProjectAs(
+            workerClient: null!,
+            safety,
+            targetDirectory: "C:\\Projects",
+            targetName: "LineCopy",
+            confirm: false,
+            safetyToken: "some-token");
+
+        Assert.Contains("confirm=true", result);
+        Assert.Contains("without safetyToken", result);
     }
 }

--- a/TiaMcpServer.Tests/ProjectOpenPolicyTests.cs
+++ b/TiaMcpServer.Tests/ProjectOpenPolicyTests.cs
@@ -1,0 +1,45 @@
+using TiaMcpServer.Contracts;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+public class ProjectOpenPolicyTests
+{
+    [Fact]
+    public void NothingAttached_NoRequest_UsesAttached()
+        => Assert.Equal(ProjectOpenDecision.UseAttached, ProjectOpenPolicy.Decide(null, null));
+
+    [Fact]
+    public void NothingAttached_WithRequest_OpensIt()
+        => Assert.Equal(ProjectOpenDecision.OpenRequested, ProjectOpenPolicy.Decide(null, "C:\\a.ap21"));
+
+    [Fact]
+    public void Attached_NoRequest_UsesAttached()
+        => Assert.Equal(ProjectOpenDecision.UseAttached, ProjectOpenPolicy.Decide("C:\\a.ap21", null));
+
+    [Fact]
+    public void Attached_SameRequest_UsesAttached()
+        => Assert.Equal(ProjectOpenDecision.UseAttached, ProjectOpenPolicy.Decide("C:\\a.ap21", "C:\\a.ap21"));
+
+    [Fact]
+    public void Attached_SameRequestDifferentCase_UsesAttached()
+        => Assert.Equal(ProjectOpenDecision.UseAttached, ProjectOpenPolicy.Decide("C:\\A.ap21", "c:\\a.AP21"));
+
+    [Fact]
+    public void Attached_DifferentRequest_Refuses()
+        => Assert.Equal(ProjectOpenDecision.Refuse, ProjectOpenPolicy.Decide("C:\\a.ap21", "C:\\b.ap21"));
+
+    [Fact]
+    public void Attached_WhitespaceRequest_UsesAttached()
+        => Assert.Equal(ProjectOpenDecision.UseAttached, ProjectOpenPolicy.Decide("C:\\a.ap21", "   "));
+
+    [Fact]
+    public void RefusalMessage_NamesBothProjectsAndTheEscapeHatch()
+    {
+        var message = ProjectOpenPolicy.RefusalMessage("C:\\a.ap21", "C:\\b.ap21");
+
+        Assert.Contains("C:\\a.ap21", message);
+        Assert.Contains("C:\\b.ap21", message);
+        Assert.Contains("open_project", message);
+    }
+}

--- a/TiaMcpServer.Tests/ProjectSessionBindingTests.cs
+++ b/TiaMcpServer.Tests/ProjectSessionBindingTests.cs
@@ -18,6 +18,40 @@ public class ProjectSessionBindingTests
     }
 
     [Fact]
+    public void RepeatedSameProjectPath_WithDotDotSegments_IsAcceptedAsTheSameProject()
+    {
+        // Finding 3 regression: the binding stores TIA's canonical Project.Path.FullName, so a
+        // later caller who spells the same project differently (relative segments here, but the
+        // same applies to forward-vs-back slashes or trailing separators) must still match -
+        // Trim()-only comparison previously rejected this as "already bound to a different project".
+        var binding = new ProjectSessionBinding(null);
+        binding.Bind("C:\\Projects\\Line.ap21", forceRebind: false, out _);
+
+        Assert.True(binding.TryResolve(
+            "C:\\Projects\\Other\\..\\Line.ap21",
+            out var effectivePath,
+            out var error));
+
+        Assert.Equal("C:\\Projects\\Line.ap21", effectivePath);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void RepeatedSameProjectPath_WithForwardSlashes_IsAcceptedAsTheSameProject()
+    {
+        var binding = new ProjectSessionBinding(null);
+        binding.Bind("C:\\Projects\\Line.ap21", forceRebind: false, out _);
+
+        Assert.True(binding.TryResolve(
+            "C:/Projects/Line.ap21",
+            out var effectivePath,
+            out var error));
+
+        Assert.Equal("C:\\Projects\\Line.ap21", effectivePath);
+        Assert.Null(error);
+    }
+
+    [Fact]
     public void RepeatedSameProjectPathIsAccepted()
     {
         var binding = new ProjectSessionBinding(null);

--- a/TiaMcpServer.Tests/ProjectSessionBindingTests.cs
+++ b/TiaMcpServer.Tests/ProjectSessionBindingTests.cs
@@ -6,7 +6,7 @@ namespace TiaMcpServer.Tests;
 public class ProjectSessionBindingTests
 {
     [Fact]
-    public void FirstExplicitProjectPathBindsSession()
+    public void FirstExplicitProjectPathResolvesWithoutBindingTheSession()
     {
         var binding = new ProjectSessionBinding(null);
 
@@ -14,14 +14,14 @@ public class ProjectSessionBindingTests
 
         Assert.Equal("C:\\Projects\\Line.ap21", effectivePath);
         Assert.Null(error);
-        Assert.Equal("C:\\Projects\\Line.ap21", binding.BoundProjectPath);
+        Assert.Null(binding.BoundProjectPath);
     }
 
     [Fact]
     public void RepeatedSameProjectPathIsAccepted()
     {
         var binding = new ProjectSessionBinding(null);
-        binding.TryResolve("C:\\Projects\\Line.ap21", out _, out _);
+        binding.Bind("C:\\Projects\\Line.ap21", forceRebind: false, out _);
 
         Assert.True(binding.TryResolve("C:\\Projects\\Line.ap21", out var effectivePath, out var error));
 
@@ -33,7 +33,7 @@ public class ProjectSessionBindingTests
     public void DifferentProjectPathIsRejectedAfterBinding()
     {
         var binding = new ProjectSessionBinding(null);
-        binding.TryResolve("C:\\Projects\\Line.ap21", out _, out _);
+        binding.Bind("C:\\Projects\\Line.ap21", forceRebind: false, out _);
 
         Assert.False(binding.TryResolve("C:\\Projects\\Other.ap21", out var effectivePath, out var error));
 
@@ -171,6 +171,42 @@ public class ProjectSessionBindingTests
         Assert.False(binding.CanBind("   ", forceRebind: false, out var error));
 
         Assert.Equal("Project path is required.", error);
+    }
+
+    [Fact]
+    public void TryResolve_DoesNotAdoptTheRequestedPath()
+    {
+        var binding = new ProjectSessionBinding(null);
+
+        Assert.True(binding.TryResolve("C:\\a.ap21", out var effective, out var error));
+
+        Assert.Equal("C:\\a.ap21", effective);
+        Assert.Null(error);
+        Assert.Null(binding.BoundProjectPath);
+    }
+
+    [Fact]
+    public void TryResolve_LeavesSessionUnboundSoASecondDifferentPathIsStillAccepted()
+    {
+        var binding = new ProjectSessionBinding(null);
+
+        Assert.True(binding.TryResolve("C:\\a.ap21", out _, out _));
+        Assert.True(binding.TryResolve("C:\\b.ap21", out var effective, out var error));
+
+        Assert.Equal("C:\\b.ap21", effective);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryResolve_StillRejectsADifferentPathOnceBound()
+    {
+        var binding = new ProjectSessionBinding(null);
+        Assert.True(binding.Bind("C:\\a.ap21", forceRebind: false, out _));
+
+        Assert.False(binding.TryResolve("C:\\b.ap21", out _, out var error));
+
+        Assert.Contains("already bound", error);
+        Assert.Contains("forceRebind=true", error);
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/TestSupport/FakeWorkerLocator.cs
+++ b/TiaMcpServer.Tests/TestSupport/FakeWorkerLocator.cs
@@ -1,0 +1,31 @@
+namespace TiaMcpServer.Tests;
+
+/// <summary>
+/// Locates the built TiaMcpServer.FakeWorker.exe by walking up from the test assembly's output
+/// directory. Shared by every test that drives OpennessWorkerClient against the fake worker.
+/// </summary>
+internal static class FakeWorkerLocator
+{
+    public static string Locate()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (var configuration in new[] { "Debug", "Release" })
+            {
+                var candidate = Path.Combine(
+                    directory.FullName,
+                    "TiaMcpServer.FakeWorker", "bin", configuration, "net8.0",
+                    "TiaMcpServer.FakeWorker.exe");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent!;
+        }
+
+        throw new FileNotFoundException("TiaMcpServer.FakeWorker.exe not found; build the solution first.");
+    }
+}

--- a/TiaMcpServer.Tests/TestSupport/TempAuditDirectory.cs
+++ b/TiaMcpServer.Tests/TestSupport/TempAuditDirectory.cs
@@ -1,0 +1,38 @@
+using TiaMcpServer.Safety;
+
+namespace TiaMcpServer.Tests;
+
+/// <summary>
+/// Gives a test an isolated, unique-per-instance audit directory for <see cref="WriteSafetyService"/>
+/// and deletes it on dispose. Centralizes the create-directory/try/finally scaffold that used to be
+/// copied into every test touching <see cref="WriteSafetyService"/>, and keeps every call site off the
+/// real %LOCALAPPDATA%\TiaMcpServer\audit directory — including tests that never reach AppendAudit,
+/// since Dispose is a no-op when the directory was never created.
+/// </summary>
+public sealed class TempAuditDirectory : IDisposable
+{
+    public string Path { get; } = System.IO.Path.Combine(
+        System.IO.Path.GetTempPath(),
+        "tia-test-audit-" + Guid.NewGuid().ToString("N"));
+
+    /// <summary>
+    /// Builds a <see cref="WriteSafetyService"/> pointed at this instance's directory. Tests that need
+    /// a controlled clock (e.g. to exercise token expiry) or a non-default lifetime can supply their
+    /// own; both otherwise default to the service's normal production values.
+    /// </summary>
+    public WriteSafetyService CreateSafety(
+        Func<DateTimeOffset>? getUtcNow = null,
+        TimeSpan? tokenLifetime = null)
+        => new(
+            getUtcNow ?? (() => DateTimeOffset.UtcNow),
+            tokenLifetime ?? WriteSafetyService.DefaultTokenLifetime,
+            Path);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(Path))
+        {
+            Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/TiaMcpServer.Tests/TiaJsonTests.cs
+++ b/TiaMcpServer.Tests/TiaJsonTests.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+using TiaMcpServer.Json;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+public class TiaJsonTests
+{
+    [Fact]
+    public void Presentation_IsReadOnly()
+    {
+        Assert.True(TiaJson.Presentation.IsReadOnly);
+    }
+
+    [Fact]
+    public void Presentation_RejectsMutation()
+    {
+        Assert.Throws<InvalidOperationException>(() => TiaJson.Presentation.WriteIndented = true);
+    }
+
+    [Fact]
+    public void Presentation_StillSerializesCamelCaseAndCompact()
+    {
+        var json = JsonSerializer.Serialize(new { ProjectPath = "C:\\p.ap21" }, TiaJson.Presentation);
+
+        Assert.Equal("{\"projectPath\":\"C:\\\\p.ap21\"}", json);
+    }
+}

--- a/TiaMcpServer.Tests/WorkerResponseJsonTests.cs
+++ b/TiaMcpServer.Tests/WorkerResponseJsonTests.cs
@@ -37,4 +37,25 @@ public class WorkerResponseJsonTests
 
         Assert.DoesNotContain("\"warnings\"", json);
     }
+
+    [Fact]
+    public void Deserializes_ResolvedProjectPath()
+    {
+        const string json = """{"success":true,"payload":"{}","resolvedProjectPath":"C:\\proj\\SimpleProject.ap21"}""";
+
+        var response = JsonSerializer.Deserialize<WorkerResponse>(json, JsonOptions);
+
+        Assert.NotNull(response);
+        Assert.Equal("C:\\proj\\SimpleProject.ap21", response!.ResolvedProjectPath);
+    }
+
+    [Fact]
+    public void ResolvedProjectPath_DefaultsToNull()
+    {
+        const string json = """{"success":true,"payload":"{}"}""";
+
+        var response = JsonSerializer.Deserialize<WorkerResponse>(json, JsonOptions);
+
+        Assert.Null(response!.ResolvedProjectPath);
+    }
 }

--- a/TiaMcpServer.Tests/WriteSafetyServiceTests.cs
+++ b/TiaMcpServer.Tests/WriteSafetyServiceTests.cs
@@ -10,7 +10,8 @@ public class WriteSafetyServiceTests
     public void PreviewBindsTokenToToolInputAndCurrentState()
     {
         var now = new DateTimeOffset(2026, 5, 26, 10, 0, 0, TimeSpan.Zero);
-        var safety = new WriteSafetyService(() => now);
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety(() => now);
 
         var previewJson = safety.CreatePreview(
             toolName: "update_block_logic",
@@ -38,7 +39,8 @@ public class WriteSafetyServiceTests
     public void TokenCannotBeReused()
     {
         var now = new DateTimeOffset(2026, 5, 26, 10, 0, 0, TimeSpan.Zero);
-        var safety = new WriteSafetyService(() => now);
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety(() => now);
         var token = ReadToken(safety.CreatePreview(
             "create_tag_table",
             null,
@@ -71,7 +73,8 @@ public class WriteSafetyServiceTests
     public void TokenRejectsChangedInputAndChangedCurrentState()
     {
         var now = new DateTimeOffset(2026, 5, 26, 10, 0, 0, TimeSpan.Zero);
-        var safety = new WriteSafetyService(() => now);
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety(() => now);
         var changedInputToken = ReadToken(safety.CreatePreview(
             "update_tag",
             null,
@@ -112,7 +115,8 @@ public class WriteSafetyServiceTests
     public void TokenExpiresAfterConfiguredLifetime()
     {
         var now = new DateTimeOffset(2026, 5, 26, 10, 0, 0, TimeSpan.Zero);
-        var safety = new WriteSafetyService(() => now, TimeSpan.FromMinutes(10));
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety(() => now, TimeSpan.FromMinutes(10));
         var token = ReadToken(safety.CreatePreview(
             "close_project",
             null,
@@ -137,7 +141,8 @@ public class WriteSafetyServiceTests
     [Fact]
     public void RejectionIncludesRecoveryGuidanceWithPreviewToolName()
     {
-        var safety = new WriteSafetyService(() => DateTimeOffset.UtcNow);
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
 
         var result = safety.ValidateAndConsume(
             "unknown-token",
@@ -157,7 +162,8 @@ public class WriteSafetyServiceTests
     [Fact]
     public void RecoveryGuidanceUsesConfiguredLifetime()
     {
-        var safety = new WriteSafetyService(() => DateTimeOffset.UtcNow, TimeSpan.FromMinutes(2));
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety(tokenLifetime: TimeSpan.FromMinutes(2));
 
         var result = safety.ValidateAndConsume(
             "unknown-token", "apply_write_batch", null, new { }, new { }, "state");
@@ -170,25 +176,15 @@ public class WriteSafetyServiceTests
     [Fact]
     public void AppendAudit_WritesJsonlRecordToConfiguredDirectory()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "tia-mcp-audit-test-" + Guid.NewGuid().ToString("N"));
-        try
-        {
-            var now = new DateTimeOffset(2026, 7, 15, 10, 0, 0, TimeSpan.Zero);
-            var safety = new WriteSafetyService(() => now, TimeSpan.FromMinutes(10), dir);
+        using var audit = new TempAuditDirectory();
+        var now = new DateTimeOffset(2026, 7, 15, 10, 0, 0, TimeSpan.Zero);
+        var safety = audit.CreateSafety(() => now, TimeSpan.FromMinutes(10));
 
-            safety.AppendAudit("apply_write_batch", null, new { }, new { }, "state", "result");
+        safety.AppendAudit("apply_write_batch", null, new { }, new { }, "state", "result");
 
-            var auditPath = Path.Combine(dir, "2026-07-15.jsonl");
-            Assert.True(File.Exists(auditPath));
-            Assert.Contains("apply_write_batch", File.ReadAllText(auditPath));
-        }
-        finally
-        {
-            if (Directory.Exists(dir))
-            {
-                Directory.Delete(dir, recursive: true);
-            }
-        }
+        var auditPath = Path.Combine(audit.Path, "2026-07-15.jsonl");
+        Assert.True(File.Exists(auditPath));
+        Assert.Contains("apply_write_batch", File.ReadAllText(auditPath));
     }
 
     [Fact]
@@ -217,7 +213,8 @@ public class WriteSafetyServiceTests
     public void CreatePreview_EvictsExpiredTokens()
     {
         var now = new DateTimeOffset(2026, 7, 16, 12, 0, 0, TimeSpan.Zero);
-        var service = new WriteSafetyService(() => now, TimeSpan.FromMinutes(10));
+        using var audit = new TempAuditDirectory();
+        var service = audit.CreateSafety(() => now, TimeSpan.FromMinutes(10));
 
         service.CreatePreview("apply_write_batch", null, new { a = 1 }, "s", new { b = 1 }, "state-1");
         service.CreatePreview("apply_write_batch", null, new { a = 2 }, "s", new { b = 2 }, "state-2");
@@ -234,7 +231,8 @@ public class WriteSafetyServiceTests
     public void CreatePreview_KeepsUnexpiredTokens()
     {
         var now = new DateTimeOffset(2026, 7, 16, 12, 0, 0, TimeSpan.Zero);
-        var service = new WriteSafetyService(() => now, TimeSpan.FromMinutes(10));
+        using var audit = new TempAuditDirectory();
+        var service = audit.CreateSafety(() => now, TimeSpan.FromMinutes(10));
 
         service.CreatePreview("apply_write_batch", null, new { a = 1 }, "s", new { b = 1 }, "state-1");
         now = now.AddMinutes(5);
@@ -247,7 +245,8 @@ public class WriteSafetyServiceTests
     public void ValidateEnvelope_AcceptsMatchingTokenWithoutConsumingIt()
     {
         var now = new DateTimeOffset(2026, 7, 16, 12, 0, 0, TimeSpan.Zero);
-        var service = new WriteSafetyService(() => now, TimeSpan.FromMinutes(10));
+        using var audit = new TempAuditDirectory();
+        var service = audit.CreateSafety(() => now, TimeSpan.FromMinutes(10));
         var previewJson = service.CreatePreview("apply_write_batch", "C:\\p.ap21", new { t = 1 }, "s", new { i = 1 }, "state");
         var token = ReadToken(previewJson);
 
@@ -268,7 +267,8 @@ public class WriteSafetyServiceTests
     public void ValidateEnvelope_RejectsUnknownExpiredAndMismatchedTokens()
     {
         var now = new DateTimeOffset(2026, 7, 16, 12, 0, 0, TimeSpan.Zero);
-        var service = new WriteSafetyService(() => now, TimeSpan.FromMinutes(10));
+        using var audit = new TempAuditDirectory();
+        var service = audit.CreateSafety(() => now, TimeSpan.FromMinutes(10));
         var previewJson = service.CreatePreview("apply_write_batch", "C:\\p.ap21", new { t = 1 }, "s", new { i = 1 }, "state");
         var token = ReadToken(previewJson);
 

--- a/TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs
+++ b/TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs
@@ -9,9 +9,6 @@ namespace TiaMcpServer.Tests;
 
 public class WriteToolSafetyTokenTests
 {
-    private static WriteSafetyService CreateSafety(string auditDirectory)
-        => new(() => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, auditDirectory);
-
     [Theory]
     [InlineData("PreviewOpenProject")]
     [InlineData("PreviewCreateProject")]
@@ -46,77 +43,50 @@ public class WriteToolSafetyTokenTests
     [Fact]
     public async Task WriteToolWithoutToken_ReturnsPreviewWithTokenAndInstructions()
     {
-        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
-        var safety = CreateSafety(auditDirectory);
-        try
-        {
-            var result = await ProjectLifecycleTools.OpenProject(
-                workerClient: null!,
-                safety,
-                projectPath: "C:\\Projects\\Line.ap21");
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
 
-            using var doc = JsonDocument.Parse(result);
-            Assert.Equal("open_project", doc.RootElement.GetProperty("toolName").GetString());
-            Assert.False(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("safetyToken").GetString()));
-            Assert.Contains("confirm=true", doc.RootElement.GetProperty("instructions").GetString());
-        }
-        finally
-        {
-            if (Directory.Exists(auditDirectory))
-            {
-                Directory.Delete(auditDirectory, recursive: true);
-            }
-        }
+        var result = await ProjectLifecycleTools.OpenProject(
+            workerClient: null!,
+            safety,
+            projectPath: "C:\\Projects\\Line.ap21");
+
+        using var doc = JsonDocument.Parse(result);
+        Assert.Equal("open_project", doc.RootElement.GetProperty("toolName").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("safetyToken").GetString()));
+        Assert.Contains("confirm=true", doc.RootElement.GetProperty("instructions").GetString());
     }
 
     [Fact]
     public async Task WriteToolWithTokenButNoConfirm_RejectsBeforeAnyWork()
     {
-        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
-        var safety = CreateSafety(auditDirectory);
-        try
-        {
-            var result = await ProjectLifecycleTools.CloseProject(
-                workerClient: null!,
-                safety,
-                confirm: false,
-                safetyToken: "some-token");
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
 
-            Assert.Contains("confirm=true", result);
-            Assert.Contains("without safetyToken", result);
-        }
-        finally
-        {
-            if (Directory.Exists(auditDirectory))
-            {
-                Directory.Delete(auditDirectory, recursive: true);
-            }
-        }
+        var result = await ProjectLifecycleTools.CloseProject(
+            workerClient: null!,
+            safety,
+            confirm: false,
+            safetyToken: "some-token");
+
+        Assert.Contains("confirm=true", result);
+        Assert.Contains("without safetyToken", result);
     }
 
     [Fact]
     public async Task WriteToolWithBadToken_PointsBackAtTheTokenlessCall()
     {
-        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
-        var safety = CreateSafety(auditDirectory);
-        try
-        {
-            var result = await ProjectLifecycleTools.OpenProject(
-                workerClient: null!,
-                safety,
-                projectPath: "C:\\Projects\\Line.ap21",
-                confirm: true,
-                safetyToken: "bogus-token");
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
 
-            Assert.Contains("Safety token", result);
-            Assert.Contains("open_project (without safetyToken)", result);
-        }
-        finally
-        {
-            if (Directory.Exists(auditDirectory))
-            {
-                Directory.Delete(auditDirectory, recursive: true);
-            }
-        }
+        var result = await ProjectLifecycleTools.OpenProject(
+            workerClient: null!,
+            safety,
+            projectPath: "C:\\Projects\\Line.ap21",
+            confirm: true,
+            safetyToken: "bogus-token");
+
+        Assert.Contains("Safety token", result);
+        Assert.Contains("open_project (without safetyToken)", result);
     }
 }

--- a/TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs
+++ b/TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Text.Json;
 using ModelContextProtocol.Server;
+using TiaMcpServer.Safety;
 using TiaMcpServer.Tools;
 using Xunit;
 
@@ -8,6 +9,9 @@ namespace TiaMcpServer.Tests;
 
 public class WriteToolSafetyTokenTests
 {
+    private static WriteSafetyService CreateSafety(string auditDirectory)
+        => new(() => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, auditDirectory);
+
     [Theory]
     [InlineData("PreviewOpenProject")]
     [InlineData("PreviewCreateProject")]
@@ -42,38 +46,77 @@ public class WriteToolSafetyTokenTests
     [Fact]
     public async Task WriteToolWithoutToken_ReturnsPreviewWithTokenAndInstructions()
     {
-        var result = await ProjectLifecycleTools.OpenProject(
-            workerClient: null!,
-            projectPath: "C:\\Projects\\Line.ap21");
+        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
+        var safety = CreateSafety(auditDirectory);
+        try
+        {
+            var result = await ProjectLifecycleTools.OpenProject(
+                workerClient: null!,
+                safety,
+                projectPath: "C:\\Projects\\Line.ap21");
 
-        using var doc = JsonDocument.Parse(result);
-        Assert.Equal("open_project", doc.RootElement.GetProperty("toolName").GetString());
-        Assert.False(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("safetyToken").GetString()));
-        Assert.Contains("confirm=true", doc.RootElement.GetProperty("instructions").GetString());
+            using var doc = JsonDocument.Parse(result);
+            Assert.Equal("open_project", doc.RootElement.GetProperty("toolName").GetString());
+            Assert.False(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("safetyToken").GetString()));
+            Assert.Contains("confirm=true", doc.RootElement.GetProperty("instructions").GetString());
+        }
+        finally
+        {
+            if (Directory.Exists(auditDirectory))
+            {
+                Directory.Delete(auditDirectory, recursive: true);
+            }
+        }
     }
 
     [Fact]
     public async Task WriteToolWithTokenButNoConfirm_RejectsBeforeAnyWork()
     {
-        var result = await ProjectLifecycleTools.CloseProject(
-            workerClient: null!,
-            confirm: false,
-            safetyToken: "some-token");
+        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
+        var safety = CreateSafety(auditDirectory);
+        try
+        {
+            var result = await ProjectLifecycleTools.CloseProject(
+                workerClient: null!,
+                safety,
+                confirm: false,
+                safetyToken: "some-token");
 
-        Assert.Contains("confirm=true", result);
-        Assert.Contains("without safetyToken", result);
+            Assert.Contains("confirm=true", result);
+            Assert.Contains("without safetyToken", result);
+        }
+        finally
+        {
+            if (Directory.Exists(auditDirectory))
+            {
+                Directory.Delete(auditDirectory, recursive: true);
+            }
+        }
     }
 
     [Fact]
     public async Task WriteToolWithBadToken_PointsBackAtTheTokenlessCall()
     {
-        var result = await ProjectLifecycleTools.OpenProject(
-            workerClient: null!,
-            projectPath: "C:\\Projects\\Line.ap21",
-            confirm: true,
-            safetyToken: "bogus-token");
+        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-test-audit-" + Guid.NewGuid().ToString("N"));
+        var safety = CreateSafety(auditDirectory);
+        try
+        {
+            var result = await ProjectLifecycleTools.OpenProject(
+                workerClient: null!,
+                safety,
+                projectPath: "C:\\Projects\\Line.ap21",
+                confirm: true,
+                safetyToken: "bogus-token");
 
-        Assert.Contains("Safety token", result);
-        Assert.Contains("open_project (without safetyToken)", result);
+            Assert.Contains("Safety token", result);
+            Assert.Contains("open_project (without safetyToken)", result);
+        }
+        finally
+        {
+            if (Directory.Exists(auditDirectory))
+            {
+                Directory.Delete(auditDirectory, recursive: true);
+            }
+        }
     }
 }

--- a/TiaMcpServer/Batch/BatchOperationCatalog.cs
+++ b/TiaMcpServer/Batch/BatchOperationCatalog.cs
@@ -11,7 +11,8 @@ public enum BatchOperationCategory
 public sealed record BatchOperationSpec(
     string Name,
     BatchOperationCategory Category,
-    IReadOnlyList<string> RequiredFields);
+    IReadOnlyList<string> RequiredFields,
+    IReadOnlyList<string> OptionalFields);
 
 public sealed record BatchValidationResult(bool IsValid, string Error)
 {
@@ -36,6 +37,9 @@ public static class BatchOperationCatalog
     public static IReadOnlyList<string> ReadOperationNames { get; } = NamesByCategory(BatchOperationCategory.Read);
 
     public static IReadOnlyList<string> WriteOperationNames { get; } = NamesByCategory(BatchOperationCategory.Write);
+
+    /// <summary>Every registered spec. Used by the field-forwarding invariant test.</summary>
+    public static IReadOnlyCollection<BatchOperationSpec> All { get; } = Specs.Values.ToArray();
 
     // Real single tools that exist but are intentionally not available inside a batch, so the
     // caller gets a precise message instead of a generic "unknown operation".
@@ -226,33 +230,33 @@ public static class BatchOperationCatalog
         var specs = new[]
         {
             // Reads
-            new BatchOperationSpec("browse_project_tree", BatchOperationCategory.Read, None),
-            new BatchOperationSpec("read_hardware_config", BatchOperationCategory.Read, None),
-            new BatchOperationSpec("search_equipment_catalog", BatchOperationCategory.Read, new[] { "query" }),
-            new BatchOperationSpec("read_cross_references", BatchOperationCategory.Read, None),
-            new BatchOperationSpec("get_block_content", BatchOperationCategory.Read, new[] { "blockPath" }),
-            new BatchOperationSpec("list_tag_tables", BatchOperationCategory.Read, None),
-            new BatchOperationSpec("compile_check", BatchOperationCategory.Read, None),
-            new BatchOperationSpec("get_project_status", BatchOperationCategory.Read, None),
+            new BatchOperationSpec("browse_project_tree", BatchOperationCategory.Read, None, new[] { "depth", "startPath" }),
+            new BatchOperationSpec("read_hardware_config", BatchOperationCategory.Read, None, None),
+            new BatchOperationSpec("search_equipment_catalog", BatchOperationCategory.Read, new[] { "query" }, new[] { "maxResults" }),
+            new BatchOperationSpec("read_cross_references", BatchOperationCategory.Read, None, new[] { "plcName", "filter", "maxResults" }),
+            new BatchOperationSpec("get_block_content", BatchOperationCategory.Read, new[] { "blockPath" }, None),
+            new BatchOperationSpec("list_tag_tables", BatchOperationCategory.Read, None, new[] { "plcName" }),
+            new BatchOperationSpec("compile_check", BatchOperationCategory.Read, None, new[] { "blockPath", "plcName" }),
+            new BatchOperationSpec("get_project_status", BatchOperationCategory.Read, None, None),
 
             // Data writes
-            new BatchOperationSpec("update_block_logic", BatchOperationCategory.Write, new[] { "blockPath", "yamlContent" }),
-            new BatchOperationSpec("create_tag_table", BatchOperationCategory.Write, new[] { "tableName" }),
-            new BatchOperationSpec("delete_tag_table", BatchOperationCategory.Write, new[] { "tableName" }),
-            new BatchOperationSpec("create_tag", BatchOperationCategory.Write, new[] { "tableName", "name", "dataType" }),
-            new BatchOperationSpec("update_tag", BatchOperationCategory.Write, new[] { "tableName", "name" }),
-            new BatchOperationSpec("delete_tag", BatchOperationCategory.Write, new[] { "tableName", "name" }),
-            new BatchOperationSpec("create_user_constant", BatchOperationCategory.Write, new[] { "tableName", "name", "dataType", "value" }),
-            new BatchOperationSpec("update_user_constant", BatchOperationCategory.Write, new[] { "tableName", "name" }),
-            new BatchOperationSpec("delete_user_constant", BatchOperationCategory.Write, new[] { "tableName", "name" }),
-            new BatchOperationSpec("add_network_device", BatchOperationCategory.Write, new[] { "typeIdentifier", "deviceName" }),
-            new BatchOperationSpec("configure_network_device", BatchOperationCategory.Write, new[] { "deviceName" }),
-            new BatchOperationSpec("create_block", BatchOperationCategory.Write, new[] { "blockPath", "blockType" }),
-            new BatchOperationSpec("delete_block", BatchOperationCategory.Write, new[] { "blockPath" }),
-            new BatchOperationSpec("create_block_group", BatchOperationCategory.Write, new[] { "blockPath" }),
-            new BatchOperationSpec("delete_block_group", BatchOperationCategory.Write, new[] { "blockPath" }),
-            new BatchOperationSpec("start_plc", BatchOperationCategory.Write, None),
-            new BatchOperationSpec("stop_plc", BatchOperationCategory.Write, None),
+            new BatchOperationSpec("update_block_logic", BatchOperationCategory.Write, new[] { "blockPath", "yamlContent" }, None),
+            new BatchOperationSpec("create_tag_table", BatchOperationCategory.Write, new[] { "tableName" }, new[] { "plcName", "folderPath" }),
+            new BatchOperationSpec("delete_tag_table", BatchOperationCategory.Write, new[] { "tableName" }, new[] { "plcName", "folderPath" }),
+            new BatchOperationSpec("create_tag", BatchOperationCategory.Write, new[] { "tableName", "name", "dataType" }, new[] { "plcName", "folderPath", "logicalAddress" }),
+            new BatchOperationSpec("update_tag", BatchOperationCategory.Write, new[] { "tableName", "name" }, new[] { "plcName", "folderPath", "newName", "dataType", "logicalAddress", "externalAccessible", "externalVisible", "externalWritable", "isSafety" }),
+            new BatchOperationSpec("delete_tag", BatchOperationCategory.Write, new[] { "tableName", "name" }, new[] { "plcName", "folderPath" }),
+            new BatchOperationSpec("create_user_constant", BatchOperationCategory.Write, new[] { "tableName", "name", "dataType", "value" }, new[] { "plcName", "folderPath" }),
+            new BatchOperationSpec("update_user_constant", BatchOperationCategory.Write, new[] { "tableName", "name" }, new[] { "plcName", "folderPath", "dataType", "value" }),
+            new BatchOperationSpec("delete_user_constant", BatchOperationCategory.Write, new[] { "tableName", "name" }, new[] { "plcName", "folderPath" }),
+            new BatchOperationSpec("add_network_device", BatchOperationCategory.Write, new[] { "typeIdentifier", "deviceName" }, new[] { "deviceItemName" }),
+            new BatchOperationSpec("configure_network_device", BatchOperationCategory.Write, new[] { "deviceName" }, new[] { "ipAddress", "subnetMask", "pnDeviceName", "subnetName", "ioSystemName" }),
+            new BatchOperationSpec("create_block", BatchOperationCategory.Write, new[] { "blockPath", "blockType" }, new[] { "language", "obEventClass" }),
+            new BatchOperationSpec("delete_block", BatchOperationCategory.Write, new[] { "blockPath" }, None),
+            new BatchOperationSpec("create_block_group", BatchOperationCategory.Write, new[] { "blockPath" }, None),
+            new BatchOperationSpec("delete_block_group", BatchOperationCategory.Write, new[] { "blockPath" }, None),
+            new BatchOperationSpec("start_plc", BatchOperationCategory.Write, None, new[] { "plcName" }),
+            new BatchOperationSpec("stop_plc", BatchOperationCategory.Write, None, new[] { "plcName" }),
         };
 
         return specs.ToDictionary(spec => spec.Name, StringComparer.Ordinal);

--- a/TiaMcpServer/Batch/BatchOperationCatalog.cs
+++ b/TiaMcpServer/Batch/BatchOperationCatalog.cs
@@ -34,6 +34,22 @@ public static class BatchOperationCatalog
 
     private static readonly IReadOnlyDictionary<string, BatchOperationSpec> Specs = BuildSpecs();
 
+    private static readonly IReadOnlySet<string> UniversalFields = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "operationId",
+        "operation",
+        "projectPath",
+    };
+
+    // Cached once: every settable field on the flat request DTO, keyed by its camelCase wire name.
+    private static readonly (string Name, Func<BatchOperationRequest, bool> IsSet)[] AllRequestFields =
+        typeof(BatchOperationRequest)
+            .GetProperties()
+            .Select(property => (
+                Name: char.ToLowerInvariant(property.Name[0]) + property.Name.Substring(1),
+                IsSet: new Func<BatchOperationRequest, bool>(op => property.GetValue(op) is not null)))
+            .ToArray();
+
     public static IReadOnlyList<string> ReadOperationNames { get; } = NamesByCategory(BatchOperationCategory.Read);
 
     public static IReadOnlyList<string> WriteOperationNames { get; } = NamesByCategory(BatchOperationCategory.Write);
@@ -119,6 +135,16 @@ public static class BatchOperationCatalog
                     $"Operation '{op.Operation}' (operationId '{op.OperationId}') is missing required field(s): {string.Join(", ", missing)}.");
             }
 
+            foreach (var field in FindInapplicableFields(op, spec))
+            {
+                var valid = spec.OptionalFields.Count > 0
+                    ? string.Join(", ", spec.OptionalFields)
+                    : "(none)";
+                errors.Add(
+                    $"Operation '{op.Operation}' (operationId '{op.OperationId}'): '{field}' is not valid for "
+                    + $"{op.Operation}. Valid optional fields: {valid}.");
+            }
+
             foreach (var boundsError in ValidateBounds(op))
             {
                 errors.Add($"Operation '{op.Operation}' (operationId '{op.OperationId}'): {boundsError}");
@@ -189,28 +215,24 @@ public static class BatchOperationCatalog
         _ => false,
     };
 
+    private static IEnumerable<string> FindInapplicableFields(BatchOperationRequest op, BatchOperationSpec spec)
+    {
+        foreach (var field in AllRequestFields)
+        {
+            if (UniversalFields.Contains(field.Name) ||
+                spec.RequiredFields.Contains(field.Name) ||
+                spec.OptionalFields.Contains(field.Name) ||
+                !field.IsSet(op))
+            {
+                continue;
+            }
+
+            yield return field.Name;
+        }
+    }
+
     private static IEnumerable<string> ValidateBounds(BatchOperationRequest op)
     {
-        var isTree = string.Equals(op.Operation, "browse_project_tree", StringComparison.Ordinal);
-        var takesMaxResults =
-            string.Equals(op.Operation, "search_equipment_catalog", StringComparison.Ordinal) ||
-            string.Equals(op.Operation, "read_cross_references", StringComparison.Ordinal);
-
-        if (op.Depth is not null && !isTree)
-        {
-            yield return "'depth' is only valid for browse_project_tree.";
-        }
-
-        if (op.StartPath is not null && !isTree)
-        {
-            yield return "'startPath' is only valid for browse_project_tree.";
-        }
-
-        if (op.MaxResults is not null && !takesMaxResults)
-        {
-            yield return "'maxResults' is only valid for search_equipment_catalog and read_cross_references.";
-        }
-
         if (op.Depth is < 1)
         {
             yield return "'depth' must be 1 or greater.";

--- a/TiaMcpServer/Batch/BatchOperationRequest.cs
+++ b/TiaMcpServer/Batch/BatchOperationRequest.cs
@@ -110,5 +110,5 @@ public sealed class BatchOperationRequest
     public string? Language { get; set; }
 
     [Description("OB event class for create_block when blockType=OB. Valid values: ProgramCycle, Startup, TimeDelay, CyclicInterrupt, HardwareInterrupt, Diagnostic, TimeOfDay. Defaults to ProgramCycle.")]
-    public string? OBEventClass { get; set; }
+    public string? ObEventClass { get; set; }
 }

--- a/TiaMcpServer/Batch/BatchOperationRequest.cs
+++ b/TiaMcpServer/Batch/BatchOperationRequest.cs
@@ -85,7 +85,7 @@ public sealed class BatchOperationRequest
     [Description("Device name. Required by add_network_device and configure_network_device.")]
     public string? DeviceName { get; set; }
 
-    [Description("Optional device item name; defaults to deviceName when omitted.")]
+    [Description("Optional device item name for add_network_device; defaults to deviceName when omitted. Not valid for configure_network_device.")]
     public string? DeviceItemName { get; set; }
 
     [Description("Optional IP address for configure_network_device, e.g. 192.168.0.10.")]

--- a/TiaMcpServer/Batch/BatchOperationRequest.cs
+++ b/TiaMcpServer/Batch/BatchOperationRequest.cs
@@ -7,6 +7,10 @@ namespace TiaMcpServer.Batch;
 /// Flat request shape for a single item inside a batch operation. Fields mirror the
 /// scalar parameters of the existing single MCP tools; only the fields relevant to the
 /// chosen <see cref="Operation"/> are read.
+/// This type is public so the MCP SDK can discover and bind tool arguments. The host is
+/// distributed as an executable .NET global tool, not as a reference library: its supported
+/// client contract is the camel-case MCP JSON shape (including <c>obEventClass</c>), not these
+/// CLR property names.
 /// </summary>
 [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
 public sealed class BatchOperationRequest

--- a/TiaMcpServer/Batch/BatchTools.cs
+++ b/TiaMcpServer/Batch/BatchTools.cs
@@ -42,6 +42,7 @@ public static class BatchTools
         + "Valid operations (parentheses list required fields): update_block_logic (blockPath, yamlContent), create_block (blockPath, blockType), delete_block (blockPath), create_block_group (blockPath), delete_block_group (blockPath), create_tag_table (tableName), delete_tag_table (tableName), create_tag (tableName, name, dataType), update_tag (tableName, name), delete_tag (tableName, name), create_user_constant (tableName, name, dataType, value), update_user_constant (tableName, name), delete_user_constant (tableName, name), add_network_device (typeIdentifier, deviceName), configure_network_device (deviceName), start_plc, stop_plc.")]
     public static async Task<string> PreviewWriteBatch(
         OpennessWorkerClient workerClient,
+        WriteSafetyService safety,
         [Description("Ordered list of write operations. Each: { operationId, operation, ...operation parameters }.")] BatchOperationRequest[] operations)
     {
         var validation = BatchOperationCatalog.ValidateWriteBatch(operations);
@@ -61,7 +62,7 @@ public static class BatchTools
         var summary = $"Apply {operations.Length} write operation(s) sequentially; stops on first failure (no rollback). "
             + "The current-state snapshot is read per item and is not an atomic point-in-time view.";
 
-        return WriteSafetyService.Shared.CreatePreview(
+        return safety.CreatePreview(
             ApplyToolName,
             projectPath,
             targets,
@@ -77,6 +78,7 @@ public static class BatchTools
         + "Valid operations (parentheses list required fields): update_block_logic (blockPath, yamlContent), create_block (blockPath, blockType), delete_block (blockPath), create_block_group (blockPath), delete_block_group (blockPath), create_tag_table (tableName), delete_tag_table (tableName), create_tag (tableName, name, dataType), update_tag (tableName, name), delete_tag (tableName, name), create_user_constant (tableName, name, dataType, value), update_user_constant (tableName, name), delete_user_constant (tableName, name), add_network_device (typeIdentifier, deviceName), configure_network_device (deviceName), start_plc, stop_plc.")]
     public static async Task<string> ApplyWriteBatch(
         OpennessWorkerClient workerClient,
+        WriteSafetyService safety,
         [Description("Ordered list of write operations. Must match the list passed to preview_write_batch.")] BatchOperationRequest[] operations,
         [Description("Set to true to confirm the write operations. Required safety flag; operation is rejected when false.")] bool confirm = false,
         [Description("Safety token returned by preview_write_batch for this exact batch.")] string? safetyToken = null)
@@ -105,7 +107,7 @@ public static class BatchTools
         var projectPath = BatchSafetySnapshot.ResolveProjectPath(operations);
 
         // Reject dead/mismatched tokens BEFORE the expensive per-item current-state read.
-        var envelope = WriteSafetyService.Shared.ValidateEnvelope(
+        var envelope = safety.ValidateEnvelope(
             safetyToken,
             ApplyToolName,
             projectPath,
@@ -123,7 +125,7 @@ public static class BatchTools
             return BatchResultFormatter.Error(ApplyToolName, $"Could not read current state before write. {snapshot.Error}");
         }
 
-        var tokenValidation = WriteSafetyService.Shared.ValidateAndConsume(
+        var tokenValidation = safety.ValidateAndConsume(
             safetyToken,
             ApplyToolName,
             projectPath,
@@ -141,7 +143,7 @@ public static class BatchTools
             op => BatchWorkerInvoker.InvokeAsync(workerClient, op)).ConfigureAwait(false);
 
         var resultJson = BatchResultFormatter.ApplyBatch(results);
-        WriteSafetyService.Shared.AppendAudit(ApplyToolName, projectPath, targets, operations, snapshot.CombinedState, resultJson);
+        safety.AppendAudit(ApplyToolName, projectPath, targets, operations, snapshot.CombinedState, resultJson);
         return resultJson;
     }
 

--- a/TiaMcpServer/Batch/BatchWorkerInvoker.cs
+++ b/TiaMcpServer/Batch/BatchWorkerInvoker.cs
@@ -53,7 +53,7 @@ public static class BatchWorkerInvoker
         "delete_user_constant" => client.DeleteUserConstantAsync(op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.ProjectPath),
         "add_network_device" => client.AddNetworkDeviceAsync(op.TypeIdentifier!, op.DeviceName!, ResolveDeviceItemName(op), op.ProjectPath),
         "configure_network_device" => client.ConfigureNetworkDeviceAsync(op.DeviceName!, op.IpAddress, op.SubnetMask, op.PnDeviceName, op.SubnetName, op.IoSystemName, op.ProjectPath),
-        "create_block" => client.CreateBlockAsync(op.BlockPath!, op.BlockType!, op.Language, op.OBEventClass, op.ProjectPath),
+        "create_block" => client.CreateBlockAsync(op.BlockPath!, op.BlockType!, op.Language, op.ObEventClass, op.ProjectPath),
         "delete_block" => client.DeleteBlockAsync(op.BlockPath!, op.ProjectPath),
         "create_block_group" => client.CreateBlockGroupAsync(op.BlockPath!, op.ProjectPath),
         "delete_block_group" => client.DeleteBlockGroupAsync(op.BlockPath!, op.ProjectPath),

--- a/TiaMcpServer/Cli/VersionCommand.cs
+++ b/TiaMcpServer/Cli/VersionCommand.cs
@@ -1,0 +1,15 @@
+using TiaMcpServer.Diagnostics;
+
+namespace TiaMcpServer.Cli;
+
+public static class VersionCommand
+{
+    public static int Run(TextWriter output)
+        => Run(output, ApplicationInfoService.Instance);
+
+    public static int Run(TextWriter output, IApplicationInfoService appInfo)
+    {
+        output.WriteLine(appInfo.HostVersion);
+        return 0;
+    }
+}

--- a/TiaMcpServer/Json/TiaJson.cs
+++ b/TiaMcpServer/Json/TiaJson.cs
@@ -28,4 +28,11 @@ public static class TiaJson
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         WriteIndented = false
     };
+
+    static TiaJson()
+    {
+        // Frozen on purpose: audit records and the safety-token input hash are both derived
+        // through these options, so a formatting change would invalidate outstanding tokens.
+        Presentation.MakeReadOnly(populateMissingResolver: true);
+    }
 }

--- a/TiaMcpServer/Program.cs
+++ b/TiaMcpServer/Program.cs
@@ -21,7 +21,7 @@ namespace TiaMcpServer
             var builder = Host.CreateApplicationBuilder(args);
             builder.Logging.AddConsole(opts => opts.LogToStandardErrorThreshold = LogLevel.Trace);
             builder.Services.AddSingleton(new ProjectSessionBinding(ResolveStartupProjectPath(args)));
-            builder.Services.AddSingleton(WriteSafetyService.Shared);
+            builder.Services.AddSingleton(new WriteSafetyService());
             builder.Services.AddSingleton(sp => new OpennessWorkerClient(
                 sp.GetRequiredService<ProjectSessionBinding>(),
                 sp.GetRequiredService<ILogger<OpennessWorkerClient>>()));

--- a/TiaMcpServer/Program.cs
+++ b/TiaMcpServer/Program.cs
@@ -18,6 +18,12 @@ namespace TiaMcpServer
                 return await DoctorCommand.RunAsync(args[1..]);
             }
 
+            if (args.Length > 0 && (string.Equals(args[0], "--version", StringComparison.OrdinalIgnoreCase) ||
+                                    string.Equals(args[0], "-v", StringComparison.OrdinalIgnoreCase)))
+            {
+                return VersionCommand.Run(Console.Out);
+            }
+
             var builder = Host.CreateApplicationBuilder(args);
             builder.Logging.AddConsole(opts => opts.LogToStandardErrorThreshold = LogLevel.Trace);
             builder.Services.AddSingleton(new ProjectSessionBinding(ResolveStartupProjectPath(args)));

--- a/TiaMcpServer/Safety/WriteSafetyService.cs
+++ b/TiaMcpServer/Safety/WriteSafetyService.cs
@@ -10,8 +10,6 @@ public sealed class WriteSafetyService
 {
     public static readonly TimeSpan DefaultTokenLifetime = TimeSpan.FromMinutes(10);
 
-    public static WriteSafetyService Shared { get; } = new();
-
     private readonly ConcurrentDictionary<string, SafetyTokenEntry> _tokens = new(StringComparer.Ordinal);
     private readonly Func<DateTimeOffset> _getUtcNow;
     private readonly TimeSpan _tokenLifetime;

--- a/TiaMcpServer/Safety/WriteSafetyTooling.cs
+++ b/TiaMcpServer/Safety/WriteSafetyTooling.cs
@@ -8,6 +8,7 @@ namespace TiaMcpServer.Safety;
 public static class WriteSafetyTooling
 {
     public static async Task<WriteSafetyApplyContext> ValidateForApplyAsync(
+        WriteSafetyService safety,
         string? safetyToken,
         string previewToolName,
         string toolName,
@@ -29,7 +30,7 @@ public static class WriteSafetyTooling
                 $"Could not read current state before write. Error: {currentState.Error}");
         }
 
-        var validation = WriteSafetyService.Shared.ValidateAndConsume(
+        var validation = safety.ValidateAndConsume(
             safetyToken,
             toolName,
             projectPath,
@@ -44,6 +45,7 @@ public static class WriteSafetyTooling
     }
 
     public static string CreatePreview(
+        WriteSafetyService safety,
         string toolName,
         string? projectPath,
         object target,
@@ -58,7 +60,7 @@ public static class WriteSafetyTooling
             return $"Could not read current state before preview. Error: {currentState.Error}";
         }
 
-        return WriteSafetyService.Shared.CreatePreview(
+        return safety.CreatePreview(
             toolName,
             projectPath,
             target,

--- a/TiaMcpServer/Tools/ProjectLifecycleTools.cs
+++ b/TiaMcpServer/Tools/ProjectLifecycleTools.cs
@@ -25,96 +25,96 @@ namespace TiaMcpServer.Tools
 
         [McpServerTool(Name = "open_project")]
         [Description("Open a TIA Portal project and bind this MCP session to it. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
-        public static async Task<string> OpenProject(OpennessWorkerClient workerClient, [Description("Path to the .ap21 project file to open.")] string projectPath, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null, [Description("Set true to allow rebinding this MCP session from a previously bound project.")] bool forceRebind = false)
+        public static async Task<string> OpenProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Path to the .ap21 project file to open.")] string projectPath, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null, [Description("Set true to allow rebinding this MCP session from a previously bound project.")] bool forceRebind = false)
         {
             var target = new { projectPath };
             var requestedInput = new { projectPath, forceRebind };
-            if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview("open_project", projectPath, target, $"Open and bind TIA Portal project '{projectPath}'.", requestedInput, WorkerCallResult.Ok(WriteSafetyTooling.DescribePathState(projectPath)), diff: null, instructions: ApplyInstructions("open_project"));
+            if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview(safety, "open_project", projectPath, target, $"Open and bind TIA Portal project '{projectPath}'.", requestedInput, WorkerCallResult.Ok(WriteSafetyTooling.DescribePathState(projectPath)), diff: null, instructions: ApplyInstructions("open_project"));
             if (!confirm) return ConfirmRequired("open_project");
-            var safety = await WriteSafetyTooling.ValidateForApplyAsync(safetyToken, PreviewHint("open_project"), "open_project", projectPath, target, requestedInput, () => Task.FromResult(WorkerCallResult.Ok(WriteSafetyTooling.DescribePathState(projectPath)))).ConfigureAwait(false);
-            if (!safety.IsValid) return safety.Error!;
+            var safetyContext = await WriteSafetyTooling.ValidateForApplyAsync(safety, safetyToken, PreviewHint("open_project"), "open_project", projectPath, target, requestedInput, () => Task.FromResult(WorkerCallResult.Ok(WriteSafetyTooling.DescribePathState(projectPath)))).ConfigureAwait(false);
+            if (!safetyContext.IsValid) return safetyContext.Error!;
             var result = await workerClient.OpenProjectAsync(projectPath, forceRebind).ConfigureAwait(false);
             var status = result.Success ? (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText() : null;
-            WriteSafetyService.Shared.AppendAudit("open_project", projectPath, target, requestedInput, safety.CurrentState, result.ToText());
+            safety.AppendAudit("open_project", projectPath, target, requestedInput, safetyContext.CurrentState, result.ToText());
             return WriteSafetyTooling.BuildApplyResult("open_project", result, "get_project_status", status);
         }
 
         [McpServerTool(Name = "create_project")]
         [Description("Create a new TIA Portal project and bind this MCP session to it. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
-        public static async Task<string> CreateProject(OpennessWorkerClient workerClient, [Description("Directory where the project folder should be created.")] string projectDirectory, [Description("Name of the new TIA Portal project.")] string projectName, [Description("Optional project author metadata.")] string? author = null, [Description("Optional project comment metadata.")] string? comment = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
+        public static async Task<string> CreateProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Directory where the project folder should be created.")] string projectDirectory, [Description("Name of the new TIA Portal project.")] string projectName, [Description("Optional project author metadata.")] string? author = null, [Description("Optional project comment metadata.")] string? comment = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
         {
             var target = new { projectDirectory, projectName };
             var requestedInput = new { projectDirectory, projectName, author, comment };
-            if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview("create_project", null, target, $"Create TIA Portal project '{projectName}' in '{projectDirectory}'.", requestedInput, WorkerCallResult.Ok(WriteSafetyTooling.DescribeProjectCreationState(projectDirectory, projectName)), diff: null, instructions: ApplyInstructions("create_project"));
+            if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview(safety, "create_project", null, target, $"Create TIA Portal project '{projectName}' in '{projectDirectory}'.", requestedInput, WorkerCallResult.Ok(WriteSafetyTooling.DescribeProjectCreationState(projectDirectory, projectName)), diff: null, instructions: ApplyInstructions("create_project"));
             if (!confirm) return ConfirmRequired("create_project");
-            var safety = await WriteSafetyTooling.ValidateForApplyAsync(safetyToken, PreviewHint("create_project"), "create_project", null, target, requestedInput, () => Task.FromResult(WorkerCallResult.Ok(WriteSafetyTooling.DescribeProjectCreationState(projectDirectory, projectName)))).ConfigureAwait(false);
-            if (!safety.IsValid) return safety.Error!;
+            var safetyContext = await WriteSafetyTooling.ValidateForApplyAsync(safety, safetyToken, PreviewHint("create_project"), "create_project", null, target, requestedInput, () => Task.FromResult(WorkerCallResult.Ok(WriteSafetyTooling.DescribeProjectCreationState(projectDirectory, projectName)))).ConfigureAwait(false);
+            if (!safetyContext.IsValid) return safetyContext.Error!;
             var result = await workerClient.CreateProjectAsync(projectDirectory, projectName, author, comment).ConfigureAwait(false);
             var status = result.Success ? (await workerClient.GetProjectStatusAsync(null).ConfigureAwait(false)).ToText() : null;
-            WriteSafetyService.Shared.AppendAudit("create_project", null, target, requestedInput, safety.CurrentState, result.ToText());
+            safety.AppendAudit("create_project", null, target, requestedInput, safetyContext.CurrentState, result.ToText());
             return WriteSafetyTooling.BuildApplyResult("create_project", result, "get_project_status", status);
         }
 
         [McpServerTool(Name = "save_project")]
         [Description("Save the active TIA Portal project. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
-        public static async Task<string> SaveProject(OpennessWorkerClient workerClient, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
+        public static async Task<string> SaveProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
         {
             var target = new { projectPath };
             var requestedInput = new { projectPath };
-            if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview("save_project", projectPath, target, "Save the active TIA Portal project.", requestedInput, await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false), diff: null, instructions: ApplyInstructions("save_project"));
+            if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview(safety, "save_project", projectPath, target, "Save the active TIA Portal project.", requestedInput, await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false), diff: null, instructions: ApplyInstructions("save_project"));
             if (!confirm) return ConfirmRequired("save_project");
-            var safety = await WriteSafetyTooling.ValidateForApplyAsync(safetyToken, PreviewHint("save_project"), "save_project", projectPath, target, requestedInput, () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
-            if (!safety.IsValid) return safety.Error!;
+            var safetyContext = await WriteSafetyTooling.ValidateForApplyAsync(safety, safetyToken, PreviewHint("save_project"), "save_project", projectPath, target, requestedInput, () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
+            if (!safetyContext.IsValid) return safetyContext.Error!;
             var result = await workerClient.SaveProjectAsync(projectPath).ConfigureAwait(false);
             var status = result.Success ? (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText() : null;
-            WriteSafetyService.Shared.AppendAudit("save_project", projectPath, target, requestedInput, safety.CurrentState, result.ToText());
+            safety.AppendAudit("save_project", projectPath, target, requestedInput, safetyContext.CurrentState, result.ToText());
             return WriteSafetyTooling.BuildApplyResult("save_project", result, "get_project_status", status);
         }
 
         [McpServerTool(Name = "save_project_as")]
         [Description("Save the active TIA Portal project to a copy directory. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
-        public static async Task<string> SaveProjectAs(OpennessWorkerClient workerClient, [Description("Parent directory for the copied project.")] string targetDirectory, [Description("Name of the copied project directory.")] string targetName, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Set true to bind this MCP session to the copied project path after save-as.")] bool rebind = true, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
+        public static async Task<string> SaveProjectAs(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Parent directory for the copied project.")] string targetDirectory, [Description("Name of the copied project directory.")] string targetName, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Set true to bind this MCP session to the copied project path after save-as.")] bool rebind = true, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
         {
             var target = new { projectPath, targetDirectory, targetName };
             var requestedInput = new { projectPath, targetDirectory, targetName, rebind };
-            if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview("save_project_as", projectPath, target, $"Save active project as '{targetName}' in '{targetDirectory}'.", requestedInput, await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false), diff: null, instructions: ApplyInstructions("save_project_as"));
+            if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview(safety, "save_project_as", projectPath, target, $"Save active project as '{targetName}' in '{targetDirectory}'.", requestedInput, await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false), diff: null, instructions: ApplyInstructions("save_project_as"));
             if (!confirm) return ConfirmRequired("save_project_as");
-            var safety = await WriteSafetyTooling.ValidateForApplyAsync(safetyToken, PreviewHint("save_project_as"), "save_project_as", projectPath, target, requestedInput, () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
-            if (!safety.IsValid) return safety.Error!;
+            var safetyContext = await WriteSafetyTooling.ValidateForApplyAsync(safety, safetyToken, PreviewHint("save_project_as"), "save_project_as", projectPath, target, requestedInput, () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
+            if (!safetyContext.IsValid) return safetyContext.Error!;
             var result = await workerClient.SaveProjectAsAsync(projectPath, targetDirectory, targetName, rebind).ConfigureAwait(false);
             var status = result.Success ? (await workerClient.GetProjectStatusAsync(rebind ? null : projectPath).ConfigureAwait(false)).ToText() : null;
-            WriteSafetyService.Shared.AppendAudit("save_project_as", projectPath, target, requestedInput, safety.CurrentState, result.ToText());
+            safety.AppendAudit("save_project_as", projectPath, target, requestedInput, safetyContext.CurrentState, result.ToText());
             return WriteSafetyTooling.BuildApplyResult("save_project_as", result, "get_project_status", status);
         }
 
         [McpServerTool(Name = "archive_project")]
         [Description("Archive the active TIA Portal project. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
-        public static async Task<string> ArchiveProject(OpennessWorkerClient workerClient, [Description("Directory where the archive should be written.")] string archiveDirectory, [Description("Archive file name, with or without extension.")] string archiveName, [Description("Archive mode: None, DiscardRestorableData, Compressed, or DiscardRestorableDataAndCompressed.")] string? mode = null, [Description("Save the project before archiving.")] bool saveBeforeArchive = true, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
+        public static async Task<string> ArchiveProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Directory where the archive should be written.")] string archiveDirectory, [Description("Archive file name, with or without extension.")] string archiveName, [Description("Archive mode: None, DiscardRestorableData, Compressed, or DiscardRestorableDataAndCompressed.")] string? mode = null, [Description("Save the project before archiving.")] bool saveBeforeArchive = true, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
         {
             var target = new { projectPath, archiveDirectory, archiveName };
             var requestedInput = new { projectPath, archiveDirectory, archiveName, mode, saveBeforeArchive };
-            if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview("archive_project", projectPath, target, $"Archive active project to '{archiveDirectory}\\{archiveName}'.", requestedInput, await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false), diff: null, instructions: ApplyInstructions("archive_project"));
+            if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview(safety, "archive_project", projectPath, target, $"Archive active project to '{archiveDirectory}\\{archiveName}'.", requestedInput, await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false), diff: null, instructions: ApplyInstructions("archive_project"));
             if (!confirm) return ConfirmRequired("archive_project");
-            var safety = await WriteSafetyTooling.ValidateForApplyAsync(safetyToken, PreviewHint("archive_project"), "archive_project", projectPath, target, requestedInput, () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
-            if (!safety.IsValid) return safety.Error!;
+            var safetyContext = await WriteSafetyTooling.ValidateForApplyAsync(safety, safetyToken, PreviewHint("archive_project"), "archive_project", projectPath, target, requestedInput, () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
+            if (!safetyContext.IsValid) return safetyContext.Error!;
             var result = await workerClient.ArchiveProjectAsync(projectPath, archiveDirectory, archiveName, mode, saveBeforeArchive).ConfigureAwait(false);
             var status = result.Success ? (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText() : null;
-            WriteSafetyService.Shared.AppendAudit("archive_project", projectPath, target, requestedInput, safety.CurrentState, result.ToText());
+            safety.AppendAudit("archive_project", projectPath, target, requestedInput, safetyContext.CurrentState, result.ToText());
             return WriteSafetyTooling.BuildApplyResult("archive_project", result, "get_project_status", status);
         }
 
         [McpServerTool(Name = "close_project")]
         [Description("Close the active TIA Portal project and clear this MCP session binding. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
-        public static async Task<string> CloseProject(OpennessWorkerClient workerClient, [Description("Optional path to a .ap21 project file. If omitted, closes the currently bound/open project.")] string? projectPath = null, [Description("Save the project before closing it.")] bool saveBeforeClose = true, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
+        public static async Task<string> CloseProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Optional path to a .ap21 project file. If omitted, closes the currently bound/open project.")] string? projectPath = null, [Description("Save the project before closing it.")] bool saveBeforeClose = true, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
         {
             var target = new { projectPath };
             var requestedInput = new { projectPath, saveBeforeClose };
-            if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview("close_project", projectPath, target, "Close the active TIA Portal project.", requestedInput, await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false), diff: null, instructions: ApplyInstructions("close_project"));
+            if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview(safety, "close_project", projectPath, target, "Close the active TIA Portal project.", requestedInput, await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false), diff: null, instructions: ApplyInstructions("close_project"));
             if (!confirm) return ConfirmRequired("close_project");
-            var safety = await WriteSafetyTooling.ValidateForApplyAsync(safetyToken, PreviewHint("close_project"), "close_project", projectPath, target, requestedInput, () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
-            if (!safety.IsValid) return safety.Error!;
+            var safetyContext = await WriteSafetyTooling.ValidateForApplyAsync(safety, safetyToken, PreviewHint("close_project"), "close_project", projectPath, target, requestedInput, () => workerClient.GetProjectStatusAsync(projectPath)).ConfigureAwait(false);
+            if (!safetyContext.IsValid) return safetyContext.Error!;
             var result = await workerClient.CloseProjectAsync(projectPath, saveBeforeClose).ConfigureAwait(false);
-            WriteSafetyService.Shared.AppendAudit("close_project", projectPath, target, requestedInput, safety.CurrentState, result.ToText());
+            safety.AppendAudit("close_project", projectPath, target, requestedInput, safetyContext.CurrentState, result.ToText());
             return WriteSafetyTooling.BuildApplyResult("close_project", result, "get_project_status", null);
         }
 

--- a/TiaMcpServer/Worker/OpennessWorkerClient.cs
+++ b/TiaMcpServer/Worker/OpennessWorkerClient.cs
@@ -562,7 +562,11 @@ public class OpennessWorkerClient : IDisposable
                 request.Confirm = true;
                 request.AllowTiaConfirmations = true;
             },
-            "{}").ConfigureAwait(false);
+            "{}",
+            // rebind=true deliberately changes which project is attached (worker closes the
+            // original and opens the copy before this call returns) - the divergence warning
+            // exists to catch unintended drift, not this tool's documented purpose.
+            attachmentChangeExpected: rebind).ConfigureAwait(false);
 
         if (rebind && result.Success)
         {
@@ -628,7 +632,8 @@ public class OpennessWorkerClient : IDisposable
         string method,
         string? projectPath,
         Action<WorkerRequest> configure,
-        string emptyPayload)
+        string emptyPayload,
+        bool attachmentChangeExpected = false)
     {
         var boundProjectPathBeforeCall = _projectSessionBinding.BoundProjectPath;
         var sessionWasUnbound = boundProjectPathBeforeCall is null;
@@ -670,12 +675,21 @@ public class OpennessWorkerClient : IDisposable
                     };
                 }
             }
-            else if (!string.Equals(boundProjectPathBeforeCall, result.ResolvedProjectPath, StringComparison.OrdinalIgnoreCase))
+            else if (!attachmentChangeExpected && !_projectSessionBinding.IsBoundTo(result.ResolvedProjectPath))
             {
                 // Containment only (see docs/superpowers/specs Round 4 design): the root cause -
                 // a zero-confirmation read tool able to attach a different project than the one
                 // this session is bound to - is deferred. Surface the divergence so the caller
                 // (and a human) can see it, rather than silently trusting the bound path.
+                //
+                // attachmentChangeExpected opts out an operation that deliberately changes what
+                // is attached (save_project_as with rebind=true is the only caller today) - for
+                // that operation a "resolved path differs from the bound path" is the documented
+                // outcome, not a signal of drift.
+                //
+                // IsBoundTo canonicalizes both sides (see ProjectPathNormalization) instead of a
+                // raw string compare, so 8.3 short names, junctions/symlinks, and UNC-vs-mapped-drive
+                // spellings of the same project do not misfire this warning on every call.
                 _logger?.LogWarning(
                     "TIA Openness worker: session is bound to '{BoundProjectPath}' but the worker reports it "
                     + "operated on '{ResolvedProjectPath}'.",

--- a/TiaMcpServer/Worker/OpennessWorkerClient.cs
+++ b/TiaMcpServer/Worker/OpennessWorkerClient.cs
@@ -644,11 +644,10 @@ public class OpennessWorkerClient : IDisposable
         configure(request);
 
         var result = await InvokeWorkerAsync(request).ConfigureAwait(false);
-        if (!result.Success && sessionWasUnbound && effectiveProjectPath is not null)
+        if (result.Success && sessionWasUnbound && result.ResolvedProjectPath is not null)
         {
-            // The first implicit binding is provisional until its worker call succeeds.
-            // Do not let a failed attach/crash permanently reserve that project path.
-            _projectSessionBinding.Clear(effectiveProjectPath, out _);
+            // Bind to what the worker actually operated on, never to what the caller asked for.
+            _projectSessionBinding.Bind(result.ResolvedProjectPath, forceRebind: true, out _);
         }
 
         return result.Success && string.IsNullOrEmpty(result.Payload)
@@ -668,7 +667,10 @@ public class OpennessWorkerClient : IDisposable
             }
 
             return response.Success
-                ? WorkerCallResult.Ok(response.Payload ?? string.Empty, warnings)
+                ? WorkerCallResult.Ok(response.Payload ?? string.Empty, warnings) with
+                    {
+                        ResolvedProjectPath = response.ResolvedProjectPath
+                    }
                 : WorkerCallResult.Fail(
                     response.Error ?? "The TIA Openness worker failed without an error message.",
                     warnings);

--- a/TiaMcpServer/Worker/OpennessWorkerClient.cs
+++ b/TiaMcpServer/Worker/OpennessWorkerClient.cs
@@ -630,7 +630,8 @@ public class OpennessWorkerClient : IDisposable
         Action<WorkerRequest> configure,
         string emptyPayload)
     {
-        var sessionWasUnbound = _projectSessionBinding.BoundProjectPath is null;
+        var boundProjectPathBeforeCall = _projectSessionBinding.BoundProjectPath;
+        var sessionWasUnbound = boundProjectPathBeforeCall is null;
         if (!_projectSessionBinding.TryResolve(projectPath, out var effectiveProjectPath, out var bindingError))
         {
             return WorkerCallResult.Fail(bindingError!);
@@ -644,23 +645,66 @@ public class OpennessWorkerClient : IDisposable
         configure(request);
 
         var result = await InvokeWorkerAsync(request).ConfigureAwait(false);
-        if (result.Success && sessionWasUnbound && result.ResolvedProjectPath is not null)
+        if (result.Success && result.ResolvedProjectPath is not null)
         {
-            // Bind to what the worker actually operated on, never to what the caller asked for.
-            // forceRebind is false: if a concurrent OpenProjectAsync/CreateProjectAsync bound the
-            // session while this call was in flight, decline rather than clobber that binding.
-            if (!_projectSessionBinding.Bind(result.ResolvedProjectPath, forceRebind: false, out var bindError))
+            if (sessionWasUnbound)
             {
+                // Bind to what the worker actually operated on, never to what the caller asked for.
+                // forceRebind is false: if a concurrent OpenProjectAsync/CreateProjectAsync bound the
+                // session while this call was in flight, decline rather than clobber that binding.
+                if (!_projectSessionBinding.Bind(result.ResolvedProjectPath, forceRebind: false, out var bindError))
+                {
+                    _logger?.LogWarning(
+                        "TIA Openness worker: could not bind session to resolved project path '{ResolvedProjectPath}': {Error}",
+                        result.ResolvedProjectPath,
+                        bindError);
+                    result = result with
+                    {
+                        Warnings = AppendWarning(
+                            result.Warnings,
+                            $"The TIA Openness worker operated on project '{result.ResolvedProjectPath}', but this MCP "
+                            + $"session could not be bound to it ({bindError}). This call's results describe "
+                            + $"'{result.ResolvedProjectPath}', which may differ from whatever project a later call "
+                            + "without an explicit projectPath resolves to. Pass projectPath explicitly on subsequent "
+                            + "calls until the session's binding is resolved.")
+                    };
+                }
+            }
+            else if (!string.Equals(boundProjectPathBeforeCall, result.ResolvedProjectPath, StringComparison.OrdinalIgnoreCase))
+            {
+                // Containment only (see docs/superpowers/specs Round 4 design): the root cause -
+                // a zero-confirmation read tool able to attach a different project than the one
+                // this session is bound to - is deferred. Surface the divergence so the caller
+                // (and a human) can see it, rather than silently trusting the bound path.
                 _logger?.LogWarning(
-                    "TIA Openness worker: could not bind session to resolved project path '{ResolvedProjectPath}': {Error}",
-                    result.ResolvedProjectPath,
-                    bindError);
+                    "TIA Openness worker: session is bound to '{BoundProjectPath}' but the worker reports it "
+                    + "operated on '{ResolvedProjectPath}'.",
+                    boundProjectPathBeforeCall,
+                    result.ResolvedProjectPath);
+                result = result with
+                {
+                    Warnings = AppendWarning(
+                        result.Warnings,
+                        $"This MCP session is bound to project '{boundProjectPathBeforeCall}', but the TIA Openness "
+                        + $"worker reports it actually operated on '{result.ResolvedProjectPath}' for this call. "
+                        + $"Treat this call's results as describing '{result.ResolvedProjectPath}', not the bound "
+                        + "project. If this is unexpected, verify what is currently open in the TIA Portal UI "
+                        + "before issuing any write, or start a new MCP session bound to the intended project.")
+                };
             }
         }
 
         return result.Success && string.IsNullOrEmpty(result.Payload)
             ? result with { Payload = emptyPayload }
             : result;
+    }
+
+    private static IReadOnlyList<string> AppendWarning(IReadOnlyList<string> warnings, string warning)
+    {
+        var combined = new List<string>(warnings.Count + 1);
+        combined.AddRange(warnings);
+        combined.Add(warning);
+        return combined;
     }
 
     private async Task<WorkerCallResult> InvokeWorkerAsync(WorkerRequest request)

--- a/TiaMcpServer/Worker/OpennessWorkerClient.cs
+++ b/TiaMcpServer/Worker/OpennessWorkerClient.cs
@@ -108,7 +108,7 @@ public class OpennessWorkerClient : IDisposable
 
     public Task<WorkerCallResult> ReadCrossReferencesAsync(string? projectPath, string? plcName, string? filter, int? maxResults = null)
     {
-        // Validate the filter before TryResolve so an invalid filter does not bind the session.
+        // Validate the filter before TryResolve so an invalid filter fails fast without a worker round-trip.
         if (!CrossReferenceFilterNames.TryNormalize(filter, out var normalizedFilter, out var filterError))
         {
             return Task.FromResult(WorkerCallResult.Fail(filterError!));
@@ -647,7 +647,15 @@ public class OpennessWorkerClient : IDisposable
         if (result.Success && sessionWasUnbound && result.ResolvedProjectPath is not null)
         {
             // Bind to what the worker actually operated on, never to what the caller asked for.
-            _projectSessionBinding.Bind(result.ResolvedProjectPath, forceRebind: true, out _);
+            // forceRebind is false: if a concurrent OpenProjectAsync/CreateProjectAsync bound the
+            // session while this call was in flight, decline rather than clobber that binding.
+            if (!_projectSessionBinding.Bind(result.ResolvedProjectPath, forceRebind: false, out var bindError))
+            {
+                _logger?.LogWarning(
+                    "TIA Openness worker: could not bind session to resolved project path '{ResolvedProjectPath}': {Error}",
+                    result.ResolvedProjectPath,
+                    bindError);
+            }
         }
 
         return result.Success && string.IsNullOrEmpty(result.Payload)

--- a/TiaMcpServer/Worker/OpennessWorkerClient.cs
+++ b/TiaMcpServer/Worker/OpennessWorkerClient.cs
@@ -687,9 +687,10 @@ public class OpennessWorkerClient : IDisposable
                 // that operation a "resolved path differs from the bound path" is the documented
                 // outcome, not a signal of drift.
                 //
-                // IsBoundTo canonicalizes both sides (see ProjectPathNormalization) instead of a
-                // raw string compare, so 8.3 short names, junctions/symlinks, and UNC-vs-mapped-drive
-                // spellings of the same project do not misfire this warning on every call.
+                // IsBoundTo lexically canonicalizes both sides with Path.GetFullPath (see
+                // ProjectPathNormalization) instead of comparing the caller's raw spelling.
+                // It does not resolve filesystem identity aliases such as 8.3 short names,
+                // junctions/symlinks, or UNC paths versus mapped drives.
                 _logger?.LogWarning(
                     "TIA Openness worker: session is bound to '{BoundProjectPath}' but the worker reports it "
                     + "operated on '{ResolvedProjectPath}'.",

--- a/TiaMcpServer/Worker/WorkerCallResult.cs
+++ b/TiaMcpServer/Worker/WorkerCallResult.cs
@@ -12,6 +12,12 @@ public sealed record WorkerCallResult(
     string? Error,
     IReadOnlyList<string> Warnings)
 {
+    /// <summary>
+    /// Project the worker actually operated on, when it reported one. Ground truth for session
+    /// binding — see ProjectSessionBinding.
+    /// </summary>
+    public string? ResolvedProjectPath { get; init; }
+
     public static WorkerCallResult Ok(string payload, IReadOnlyList<string>? warnings = null)
         => new(true, payload, null, warnings ?? Array.Empty<string>());
 

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -186,9 +186,33 @@ The consequence is worse than an extra open. After `get_project_status(projectPa
 user has A open: B is opened alongside A, `session.Project` becomes B, the worker stamps
 `ResolvedProjectPath = B`, and the host binds the session to B. A later unqualified
 `preview_write_batch`/`apply_write_batch` then resolves to B and writes there — behind a preview and
-a safety token that are both perfectly consistent with B. Round 4 ships a containment for this
-(`OpennessWorkerClient` warns when an already-bound session's worker-reported path diverges), so the
-state is now visible to the agent, but the root cause is open.
+a safety token that are both perfectly consistent with B.
+
+**This is not contained. Do not assume otherwise.** Round 4 added a divergence warning in
+`OpennessWorkerClient` (fires when an already-bound session's worker-reported path differs from the
+bound one), and it was initially believed to cover this. It does not. The sequence above starts from
+an *unbound* session, so the host takes the bind branch: it binds to B while the worker is attached to
+B, and the two agree. The wrong project is the one both sides agree on, and the host cannot detect
+that by comparing itself against the worker — the worker's attachment is ground truth by construction.
+If the session were already bound to A, `TryResolve("B")` rejects at the host before the worker ever
+sees B. The divergence warning is still worth having for genuine drift; it just does not cover this.
+
+**The signal already exists and is being discarded one layer up.** `TiaPortalSession.OpenProject`'s
+user-opened branch already writes `Leaving user-opened project '{A}' open; opening '{B}' alongside it.`
+to stderr during request handling, which `HandleLineWithCapturedStderr` turns into
+`WorkerResponse.Warnings`. That string is the signal, generated at the moment the defect occurs,
+naming both projects. It reaches `WorkerCallResult.Warnings` and is then dropped, because
+`WorkerCallResult.ToText()` returns only `Payload` or `Error` — and `get_project_status`
+(`ProjectLifecycleTools.cs:24`) returns exactly that. Batch reads surface warnings
+(`BatchResultFormatter.cs:59`) and lifecycle write applies surface them (`WriteSafetyTooling.cs:86`);
+the one confirm-free tool that triggers this does not.
+
+So the cheap containment — separate from the root-cause fix below — is to make `ToText()`, or
+`get_project_status` specifically, carry warnings. Verify one thing first: that the stderr line is
+drained into *this* response's warnings rather than the next one's. It is written early in request
+handling, well before the response is serialized, so it is far safer than the `Stamp` helper's stderr
+write (which happens immediately before the stdout response) — but "far safer" should become
+"verified" before a safety control rests on it.
 
 **Why it is not a one-line fix.** An attempt (commit `150d466`, reverted by `0041d65`) routed
 `get_project_status` through `ProjectOpenPolicy`. That broke `save_project`, `save_project_as`,
@@ -212,6 +236,36 @@ this work exists to prevent, and live V21 testing showed TIA Portal refusing tha
 across `TiaMcpServer.OpennessWorker/` returns the full set in seconds. Round 4's plan scoped Task 5 to
 "read operations," implicitly defined as "whatever goes through `WithProject`" — which is exactly how
 this route was missed.
+
+### Smaller follow-ups from the same review
+
+- **No test for the declined-bind warning branch** in `OpennessWorkerClient`. Reaching it needs a
+  controlled interleaving, not a race: add a `delay` FakeWorker scenario, start the call, and bind
+  from the test thread while the await is provably pending. `ProjectSessionBinding` is `sealed` with
+  non-virtual methods, so the test-double route is closed without touching production code.
+- **`ProjectPathNormalization`'s exception fallback is untested**, and being `internal` it is now
+  harder to reach directly. Note that `Path.GetFullPath`'s throwing behaviour differs between net48
+  (where the worker runs) and net8.0 (where the tests run), so a net8.0 test cannot characterise what
+  the worker actually does with an odd path.
+- **FakeWorker scenario keys are literal Windows paths** (`TiaMcpServer.FakeWorker/Program.cs:286,293`)
+  because `projectPath` doubles as the dispatch key. A separate `scenarioKey` field would age better.
+- **`Stamp`'s comment claims its stderr write lands in this response's warnings**, which depends on
+  drain timing — the same assumption the containment above would rest on. Verify or soften.
+- **Duplicate tests in `ProjectSessionBindingTests.cs`** (`FirstExplicitProjectPathResolvesWithoutBindingTheSession`
+  vs `TryResolve_DoesNotAdoptTheRequestedPath`; `DifferentProjectPathIsRejectedAfterBinding` vs
+  `TryResolve_StillRejectsADifferentPathOnceBound`) — inherited from the plan's mandated test set.
+- **`TiaJson.cs`** — the static-constructor comment duplicates the field's XML-doc rationale.
+- **`GetStatus`'s graceful `IsOpen=false` branch** looks unreachable: `EnsureProject` throws first.
+  Predates Round 4; will be revisited by the read-tool/write-probe split above.
+
+### Process note
+
+The `get_project_status` route was missed because Task 5's scope was defined by *mechanism*
+("operations going through `WithProject`") rather than by *capability* ("everything that can cause a
+project to open"). Two of Round 4's most serious findings — this one and the divergence
+mis-specification above — were only visible from a whole-branch view; neither could have been caught
+by reviewing a single task's diff. Worth budgeting for a broad review pass on any change that spans
+a process boundary.
 
 ## Deferred / explicitly not planned
 

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -71,28 +71,30 @@ well-designed. The three biggest problems, in order of impact:
 ## Session binding now protects the default case — DONE 2026-07-20 (Round 4)
 
 The chosen fix binds a session from the worker-reported active-project path after its first
-successful call; the worker report is the ground truth. Once bound, a call that names a different
-`projectPath` is rejected unless `open_project` uses `forceRebind=true`.
+successful call; the worker report is the ground truth. For project-scoped operations, once bound, a
+call that names a different `projectPath` is rejected unless `open_project` uses `forceRebind=true`.
 
-Read-side project-open policy completes the other half of the fix: a read operation will not switch
-the project currently open in TIA Portal. It returns: "TIA Portal currently has project 'A' open,
-but this request targets 'B'. Read operations never switch projects. Omit projectPath to use the
-open project, or call open_project to switch."
+Read-side project-open policy completes the other half of the fix for project-scoped read paths: they
+will not switch the project currently open in TIA Portal. They return: "TIA Portal currently has
+project 'A' open, but this request targets 'B'. Read operations never switch projects. Omit
+projectPath to use the open project, or call open_project to switch." `get_project_status(projectPath)`
+is a known exception deferred to Round 5 because its lifecycle RPC also serves guarded write-state
+probes; do not use it to switch projects. Use `open_project` for a deliberate session switch.
 
 ## Found during live testing against TIA Portal V21 (2026-07-20)
 
-**The test suite no longer writes into the production audit trail — DONE via 3.5b (Round 4, Task 2).**
+**Pre-Task-2 audit contamination is resolved — DONE via 3.5b (Round 4, Task 2).**
 39 of 42 records in `%LOCALAPPDATA%\TiaMcpServer\audit` were produced by `dotnet test`, not by
-real TIA usage. The audited tool layer now receives `WriteSafetyService` through DI, and tests inject
-a temporary audit directory, so every test run
-appends real records — recognizable by `projectPath` values pointing into `TiaMcpServer.Tests\bin\`
-and FakeWorker scripted keywords (`ok`, `hang`, `worker-error`) in `target`.
+real TIA usage. Before Task 2, the tool layer used the production audit directory, and every test run
+appended real records — recognizable by `projectPath` values pointing into `TiaMcpServer.Tests\bin\`
+and FakeWorker scripted keywords (`ok`, `hang`, `worker-error`) in `target`. The audited tool layer
+now receives `WriteSafetyService` through DI, and tests inject a temporary audit directory.
 
-This dilutes the forensic record for PLC-mutating operations to ~7% signal, and a test run could be
-mistaken for real engineering activity. It is the concrete justification for **3.5b** above: the
-`WriteSafetyService(getUtcNow, tokenLifetime, auditDirectory)` constructor already supports
-redirecting the audit directory, but no test that goes through the tool layer can reach it while the
-tools receive the service through DI; tests now inject a temporary audit directory.
+This diluted the forensic record for PLC-mutating operations to ~7% signal, and a test run could be
+mistaken for real engineering activity. It was the concrete justification for **3.5b** above: the
+`WriteSafetyService(getUtcNow, tokenLifetime, auditDirectory)` constructor already supported
+redirecting the audit directory, but the tool layer could not use that test-specific directory before
+Task 2. DI now makes that isolation available to the tests.
 
 
 Also confirmed live, all working as designed: bounded reads with `depth`/`startPath`/`maxResults`
@@ -145,10 +147,12 @@ Three further follow-ups, all raised by the Phase 3 final review and deliberatel
 
 ## Read-side project-open policy — DONE 2026-07-20 (Round 4)
 
-All user-facing read paths, including `get_project_status`, now use the read-side open policy. A read
-request targeting a project other than the one open in TIA Portal is refused; callers omit
-`projectPath` to use the active project or use `open_project` to switch. Write-side internal state
-probes remain separate from this user-facing policy.
+Project-scoped read paths use the read-side open policy. A request targeting a project other than the
+one open in TIA Portal is refused; callers omit `projectPath` to use the active project or use
+`open_project` to switch. `get_project_status(projectPath)` is the known deferred exception: it still
+uses the lifecycle RPC shared with guarded write-state probes and can request the supplied path. Do
+not rely on it for session switching; use `open_project` instead. Splitting the user-facing status
+read from the write-side probe remains a Round 5 task.
 
 
 

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -171,6 +171,48 @@ Three further follow-ups, all raised by the Phase 3 final review and deliberatel
   but a static constructor calling `MakeReadOnly()` turns the "keep this stable" comment into a
   guarantee.
 
+## Round 5 — `get_project_status` can still open a project alongside the user's
+
+Found in review of Round 4 Task 5, which guarded `WithProject` and `SearchEquipmentCatalog` but not
+this third route. Round 4's `ProjectOpenPolicy` does not reach it.
+
+`get_project_status` is a zero-confirmation read tool (`ProjectLifecycleTools.cs:22` — no `confirm`,
+no `safetyToken`; worker dispatch passes `requiresConfirm: false`). It reaches
+`ProjectLifecycleService.EnsureProject` (`:181-192`), which calls `session.OpenProject(projectPath!)`
+unconditionally whenever the path is non-blank. Round 4's session binding does not stop it either: an
+unbound session forwards the requested path unchanged.
+
+The consequence is worse than an extra open. After `get_project_status(projectPath="B")` while the
+user has A open: B is opened alongside A, `session.Project` becomes B, the worker stamps
+`ResolvedProjectPath = B`, and the host binds the session to B. A later unqualified
+`preview_write_batch`/`apply_write_batch` then resolves to B and writes there — behind a preview and
+a safety token that are both perfectly consistent with B. Round 4 ships a containment for this
+(`OpennessWorkerClient` warns when an already-bound session's worker-reported path diverges), so the
+state is now visible to the agent, but the root cause is open.
+
+**Why it is not a one-line fix.** An attempt (commit `150d466`, reverted by `0041d65`) routed
+`get_project_status` through `ProjectOpenPolicy`. That broke `save_project`, `save_project_as`,
+`archive_project`, and `close_project`: the same `"get_project_status"` worker RPC doubles as their
+internal "read current state" probe, and `WriteSafetyTooling.cs:26-31,58-61` hard-fail the preview
+*and* the apply when that probe returns unsuccessfully. Gating the RPC as a read operation therefore
+kills cross-project writes outright, with a refusal message ("Read operations never switch projects")
+that is actively misleading on a write path.
+
+A fix needs to separate the two roles — the user-facing read tool and the write tools' internal state
+probe — so the policy applies only to the former. Precedent for the probe side already exists:
+`open_project`'s preview uses `WriteSafetyTooling.DescribePathState` rather than
+`GetProjectStatusAsync` (`ProjectLifecycleTools.cs:32`).
+
+Open design question to settle first: whether `save_project(projectPath="B")` while A is attached
+should be supported at all. It only ever worked by opening B alongside A, which is the very thing
+this work exists to prevent, and live V21 testing showed TIA Portal refusing that anyway.
+
+**Do this first, before implementing:** enumerate every worker dispatch path that can reach
+`session.OpenProject` and justify each one's treatment. `grep -n 'session\.OpenProject\|EnsureProject('`
+across `TiaMcpServer.OpennessWorker/` returns the full set in seconds. Round 4's plan scoped Task 5 to
+"read operations," implicitly defined as "whatever goes through `WithProject`" — which is exactly how
+this route was missed.
+
 ## Deferred / explicitly not planned
 
 - Splitting `WorkerRequest` into per-operation DTOs (churn > value while the protocol is stable).

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -65,48 +65,26 @@ well-designed. The three biggest problems, in order of impact:
 | 3.3 | Collapse the double dispatch: `BatchWorkerInvoker` maps operation strings onto 20+ near-identical `OpennessWorkerClient` wrappers that only set `WorkerRequest` fields — build `WorkerRequest` directly from the batch item | `OpennessWorkerClient.cs:25-359`, `BatchWorkerInvoker.cs` | ~250 lines — **DEFERRED 2026-07-20**; design retained in `docs/superpowers/specs/2026-07-20-phase3-simplification-design.md` |
 | 3.4 | ~~Merge `EquipmentCatalogSearcher`'s private reflection helpers (~90 lines) into `OpennessReflection`~~ **DROPPED 2026-07-20** — Phase 1.7 already did the merge. The remaining privates are `HasReadableProperty` (3 lines), `ReadStringProperty` (a 2-line passthrough already delegating to `OpennessReflection`), and two non-reflection helpers. ~10 lines of residual value. | worker Openness/ | Resolved by 1.7 |
 | 3.5 | Share the host presentation `JsonSerializerOptions` (was duplicated byte-identically in 3 files) via `TiaMcpServer/Json/TiaJson.cs`. **Corrected scope:** the original entry claimed one config duplicated in 4 files. There are two distinct configs — presentation (3 host copies, deduped) and wire/IPC (`PersistentWorkerTransport` + worker `Program.cs`, which differ deliberately and live in separate processes; sharing them would require a `System.Text.Json` PackageReference on the dependency-free `Contracts` assembly). Wire options intentionally left per-process. | host | consistency — DONE 2026-07-20 (presentation only) |
-| 3.5b | Inject `WriteSafetyService` via DI instead of the `.Shared` static (registration already exists in `Program.cs`) | host | **PROMOTED 2026-07-20 — fixes a real bug, see below.** Still costs threading the service through the static `WriteSafetyTooling` API and 6 MCP tool signatures |
+| 3.5b | Inject `WriteSafetyService` via DI instead of the static audit path (registration already exists in `Program.cs`) | host | **DONE 2026-07-20 (Round 4, Task 2).** The tool layer receives the service through DI, so tests inject a temporary audit directory. |
 | 3.6 | `WorkerRequest` god DTO (47 fields): defer full split — flat is a defensible MCP trade-off — but group with `#region` per operation family and add a comment mapping fields→operations | Contracts | documentation — DONE 2026-07-20 |
 
-## Session binding does not protect the default case (found live 2026-07-20)
+## Session binding now protects the default case — DONE 2026-07-20 (Round 4)
 
-The session-binding guard is off in the workflow the server itself recommends. `tia-mcp doctor`
-reports "No project binding configured. Tools will use the project currently open in TIA Portal" —
-and in that state the guard never engages, because `ProjectSessionBinding.TryResolve(null)` returns
-the (null) binding without adopting anything. A session that always omits `projectPath` stays
-unbound indefinitely.
+The chosen fix binds a session from the worker-reported active-project path after its first
+successful call; the worker report is the ground truth. Once bound, a call that names a different
+`projectPath` is rejected unless `open_project` uses `forceRebind=true`.
 
-The first call that *does* pass an explicit `projectPath` is then adopted unconditionally, whatever
-it is. Reproduced against a live V21 instance with `SimpleProject.ap21` open in the GUI:
-
-1. `get_project_status` with no `projectPath` — succeeds, session still unbound.
-2. `browse_project_tree` with `projectPath` pointing at an unrelated real project — accepted, and
-   the worker attempted to **open that other project alongside the user's**, warning
-   "Leaving user-opened project '…SimpleProject.ap21' open; opening '…LibReadTest.ap21' alongside it."
-3. Only TIA Portal's own refusal stopped it: "Unable to open project … Another project is already
-   open."
-
-So the sole thing preventing a hallucinated or mistyped path from retargeting the session was an
-external backstop. With no project open in the GUI, step 2 would have silently opened a different
-project and operated on it. The failed attempt also left that session unable to issue write
-previews; a fresh session recovered.
-
-By contrast, once the session *is* explicitly bound, the guard works correctly and rejects before
-attempting anything — verified live, including the unified wording from 3.2:
-"This MCP session is already bound to project 'A' and cannot use 'B'. Call open_project with
-forceRebind=true to rebind this session, or start a new MCP session for a different TIA project."
-
-Candidate fixes (not yet chosen): adopt the active project's path as the binding after the first
-successful call that resolved it — the path is already known, `get_project_status` returns it — or
-require `forceRebind=true` before accepting any explicit path that differs from the project
-currently open in the GUI. Note this is pre-existing behavior, unchanged by Phase 3.
+Read-side project-open policy completes the other half of the fix: a read operation will not switch
+the project currently open in TIA Portal. It returns: "TIA Portal currently has project 'A' open,
+but this request targets 'B'. Read operations never switch projects. Omit projectPath to use the
+open project, or call open_project to switch."
 
 ## Found during live testing against TIA Portal V21 (2026-07-20)
 
-**The test suite writes into the production audit trail.** Measured on a real machine:
+**The test suite no longer writes into the production audit trail — DONE via 3.5b (Round 4, Task 2).**
 39 of 42 records in `%LOCALAPPDATA%\TiaMcpServer\audit` were produced by `dotnet test`, not by
-real TIA usage. `ProjectLifecycleTools` calls `WriteSafetyService.Shared.AppendAudit(...)` on the
-static singleton; `TiaMcpServer.Tests` links that file and exercises those tools, so every test run
+real TIA usage. The audited tool layer now receives `WriteSafetyService` through DI, and tests inject
+a temporary audit directory, so every test run
 appends real records — recognizable by `projectPath` values pointing into `TiaMcpServer.Tests\bin\`
 and FakeWorker scripted keywords (`ok`, `hang`, `worker-error`) in `target`.
 
@@ -114,10 +92,8 @@ This dilutes the forensic record for PLC-mutating operations to ~7% signal, and 
 mistaken for real engineering activity. It is the concrete justification for **3.5b** above: the
 `WriteSafetyService(getUtcNow, tokenLifetime, auditDirectory)` constructor already supports
 redirecting the audit directory, but no test that goes through the tool layer can reach it while the
-tools resolve `.Shared` statically. Fixing 3.5b lets the tests inject a temp directory.
+tools receive the service through DI; tests now inject a temporary audit directory.
 
-Interim mitigation if 3.5b stays deferred: have the audit writer no-op when the process is a test
-host, or point `WriteSafetyService.Shared` at a temp directory from a test fixture.
 
 Also confirmed live, all working as designed: bounded reads with `depth`/`startPath`/`maxResults`
 plus the explicit truncation trailer (2.3); per-item batch isolation, where a failing `compile_check`
@@ -135,107 +111,49 @@ fix addresses a real-hardware failure and that 2.3.0 predates it.
 ## Follow-ups discovered during Phase 3 (2026-07-20)
 
 Documenting the `WorkerRequest` field→operation contract (3.6) surfaced two more instances of the
-same "declared but never forwarded" bug class Phase 0.4 found with `newName`. Neither is fixed —
-both need a decision, and the second needs the real Openness API to answer.
+same "declared but never forwarded" bug class Phase 0.4 found with `newName`. Round 4 resolved the
+software-side behavior and added forwarding coverage for every declared field; the hardware question
+for tag creation remains deferred.
 
 - **`deviceItemName` on `configure_network_device`**: `BatchOperationRequest.cs` describes it
   unscoped ("Optional device item name; defaults to deviceName when omitted"), but
   `ConfigureNetworkDeviceAsync` has no such parameter and `BatchWorkerInvoker` never passes one.
   Only `add_network_device` forwards it. An agent setting it on `configure_network_device` has it
-  silently dropped. Fix is either scoping the description or forwarding the field.
+  silently dropped. **Resolved (Round 4, Task 7):** catalog validation now rejects
+  `deviceItemName` for `configure_network_device` rather than accepting and dropping it.
 - **`externalAccessible` / `externalVisible` / `externalWritable` / `isSafety` on `create_tag`**:
   described as generic "Optional tag attribute", but only `update_tag` forwards them. `create_tag`
-  drops all four. Whether to forward them depends on whether Openness supports setting these at
-  tag-creation time — needs verification on the TIA machine.
+  drops all four. **Resolved interim behavior (Round 4):** `create_tag` now errors when any of
+  these attributes is supplied instead of silently dropping it. Whether Openness supports forwarding
+  them at tag-creation time remains a hardware-gated decision.
 
-A catalog invariant test asserting every operation's declared fields are a subset of its forwarded
-fields would make this class unrepresentable; that assertion is part of the deferred 3.3 design.
+A forwarding test now covers every declared field, preventing another declared-but-unforwarded field
+from silently reaching the worker boundary.
 
 Three further follow-ups, all raised by the Phase 3 final review and deliberately left undone:
 
-- **Enforce the `WorkerRequest` forwarding comments with a test.** The field→operation map can be
-  re-derived deterministically in ~25 lines: walk `OpennessWorkerClient.cs`, extract every
-  `request.X =` inside each `SendBoundProjectRequestAsync` lambda and every `new WorkerRequest`
-  initializer, invert to field→operations, and assert it agrees with the doc comments. The test
-  project already links that source file. This is cheaper than the 3.3 catalog invariant, does not
-  depend on 3.3 landing, and would have caught the `deviceItemName` error above before review.
+- **Enforce the `WorkerRequest` forwarding comments with a test.** **DONE (Round 4):** the field→
+  operation forwarding map is now tested for every declared field.
 - **Collapse `BatchPayloadBudget.ReadBatchResponseLength` into `BatchResultFormatter.ReadBatch`.**
   It currently hand-mirrors that method's envelope purely to predict its output length. Phase 3
   made the two share `TiaJson.Presentation` so they cannot drift on serializer settings, but the
   duplicated envelope shape remains. Replacing the body with
   `BatchResultFormatter.ReadBatch(results).Length` removes it, at the cost of one extra
   serialization per budget probe — measure before adopting.
-- **`TiaJson.Presentation.MakeReadOnly()`.** The field is a public mutable `JsonSerializerOptions`
-  whose formatting feeds the safety-token `requestedInputHash`. Realistic harm is low (mutation only
-  succeeds before first use, and preview/apply share the instance so tokens stay self-consistent),
-  but a static constructor calling `MakeReadOnly()` turns the "keep this stable" comment into a
-  guarantee.
+- **`TiaJson.Presentation.MakeReadOnly()`.** **DONE (Round 4):** presentation serialization options
+  are frozen, protecting the safety-token `requestedInputHash` format.
 
-## Round 5 — `get_project_status` can still open a project alongside the user's
+## Read-side project-open policy — DONE 2026-07-20 (Round 4)
 
-Found in review of Round 4 Task 5, which guarded `WithProject` and `SearchEquipmentCatalog` but not
-this third route. Round 4's `ProjectOpenPolicy` does not reach it.
+All user-facing read paths, including `get_project_status`, now use the read-side open policy. A read
+request targeting a project other than the one open in TIA Portal is refused; callers omit
+`projectPath` to use the active project or use `open_project` to switch. Write-side internal state
+probes remain separate from this user-facing policy.
 
-`get_project_status` is a zero-confirmation read tool (`ProjectLifecycleTools.cs:22` — no `confirm`,
-no `safetyToken`; worker dispatch passes `requiresConfirm: false`). It reaches
-`ProjectLifecycleService.EnsureProject` (`:181-192`), which calls `session.OpenProject(projectPath!)`
-unconditionally whenever the path is non-blank. Round 4's session binding does not stop it either: an
-unbound session forwards the requested path unchanged.
 
-The consequence is worse than an extra open. After `get_project_status(projectPath="B")` while the
-user has A open: B is opened alongside A, `session.Project` becomes B, the worker stamps
-`ResolvedProjectPath = B`, and the host binds the session to B. A later unqualified
-`preview_write_batch`/`apply_write_batch` then resolves to B and writes there — behind a preview and
-a safety token that are both perfectly consistent with B.
 
-**This is not contained. Do not assume otherwise.** Round 4 added a divergence warning in
-`OpennessWorkerClient` (fires when an already-bound session's worker-reported path differs from the
-bound one), and it was initially believed to cover this. It does not. The sequence above starts from
-an *unbound* session, so the host takes the bind branch: it binds to B while the worker is attached to
-B, and the two agree. The wrong project is the one both sides agree on, and the host cannot detect
-that by comparing itself against the worker — the worker's attachment is ground truth by construction.
-If the session were already bound to A, `TryResolve("B")` rejects at the host before the worker ever
-sees B. The divergence warning is still worth having for genuine drift; it just does not cover this.
 
-**The signal already exists and is being discarded one layer up.** `TiaPortalSession.OpenProject`'s
-user-opened branch already writes `Leaving user-opened project '{A}' open; opening '{B}' alongside it.`
-to stderr during request handling, which `HandleLineWithCapturedStderr` turns into
-`WorkerResponse.Warnings`. That string is the signal, generated at the moment the defect occurs,
-naming both projects. It reaches `WorkerCallResult.Warnings` and is then dropped, because
-`WorkerCallResult.ToText()` returns only `Payload` or `Error` — and `get_project_status`
-(`ProjectLifecycleTools.cs:24`) returns exactly that. Batch reads surface warnings
-(`BatchResultFormatter.cs:59`) and lifecycle write applies surface them (`WriteSafetyTooling.cs:86`);
-the one confirm-free tool that triggers this does not.
 
-So the cheap containment — separate from the root-cause fix below — is to make `ToText()`, or
-`get_project_status` specifically, carry warnings. Verify one thing first: that the stderr line is
-drained into *this* response's warnings rather than the next one's. It is written early in request
-handling, well before the response is serialized, so it is far safer than the `Stamp` helper's stderr
-write (which happens immediately before the stdout response) — but "far safer" should become
-"verified" before a safety control rests on it.
-
-**Why it is not a one-line fix.** An attempt (commit `150d466`, reverted by `0041d65`) routed
-`get_project_status` through `ProjectOpenPolicy`. That broke `save_project`, `save_project_as`,
-`archive_project`, and `close_project`: the same `"get_project_status"` worker RPC doubles as their
-internal "read current state" probe, and `WriteSafetyTooling.cs:26-31,58-61` hard-fail the preview
-*and* the apply when that probe returns unsuccessfully. Gating the RPC as a read operation therefore
-kills cross-project writes outright, with a refusal message ("Read operations never switch projects")
-that is actively misleading on a write path.
-
-A fix needs to separate the two roles — the user-facing read tool and the write tools' internal state
-probe — so the policy applies only to the former. Precedent for the probe side already exists:
-`open_project`'s preview uses `WriteSafetyTooling.DescribePathState` rather than
-`GetProjectStatusAsync` (`ProjectLifecycleTools.cs:32`).
-
-Open design question to settle first: whether `save_project(projectPath="B")` while A is attached
-should be supported at all. It only ever worked by opening B alongside A, which is the very thing
-this work exists to prevent, and live V21 testing showed TIA Portal refusing that anyway.
-
-**Do this first, before implementing:** enumerate every worker dispatch path that can reach
-`session.OpenProject` and justify each one's treatment. `grep -n 'session\.OpenProject\|EnsureProject('`
-across `TiaMcpServer.OpennessWorker/` returns the full set in seconds. Round 4's plan scoped Task 5 to
-"read operations," implicitly defined as "whatever goes through `WithProject`" — which is exactly how
-this route was missed.
 
 ### Smaller follow-ups from the same review
 
@@ -273,6 +191,12 @@ a process boundary.
 - MCP protocol-level error signaling instead of text results (needs SDK investigation; revisit after 1.1).
 - `NetworkDeviceConfigurator` speculative-reflection "UNVERIFIED SDK CALL" paths: verify against real
   Openness V21 API on the TIA machine and pin exact method signatures (needs hardware access).
+- **Next round (needs TIA Portal hardware):** forward `externalAccessible`/`externalVisible`/
+  `externalWritable`/`isSafety` on `create_tag` if Openness V21 permits setting them at tag-creation
+  time — Round 4 narrowed this to that single question by making the fields an explicit error
+  instead of a silent drop. Same session should verify the `NetworkDeviceConfigurator`
+  "UNVERIFIED SDK CALL" reflection paths and decide whether `deviceItemName` is meaningful for
+  `configure_network_device`.
 
 ## Testing gaps to close alongside
 

--- a/docs/superpowers/acceptance/2026-07-21-round4-binding-and-contract-integrity.md
+++ b/docs/superpowers/acceptance/2026-07-21-round4-binding-and-contract-integrity.md
@@ -2,7 +2,7 @@
 
 **Spec:** `docs/superpowers/specs/2026-07-20-round4-binding-and-contract-integrity-design.md`
 **Date:** 2026-07-21
-**Status:** Draft
+**Status:** Approved
 
 ---
 

--- a/docs/superpowers/acceptance/2026-07-21-round4-binding-and-contract-integrity.md
+++ b/docs/superpowers/acceptance/2026-07-21-round4-binding-and-contract-integrity.md
@@ -1,0 +1,23 @@
+# Acceptance Criteria: Round 4 — Session Binding and Contract Integrity
+
+**Spec:** `docs/superpowers/specs/2026-07-20-round4-binding-and-contract-integrity-design.md`
+**Date:** 2026-07-21
+**Status:** Draft
+
+---
+
+## Criteria
+
+| ID | Description | Test Type | Preconditions | Expected Result |
+|----|-------------|-----------|---------------|-----------------|
+| AC-001 | Safety-token presentation JSON is immutable after startup. | Logic | `TiaJson` is loaded. | `Presentation.IsReadOnly` is true; mutation throws `InvalidOperationException`; serialization stays compact camel case. |
+| AC-002 | A worker response reports its resolved project path and the host adopts only successful worker-reported ground truth. | Logic | Scripted/FakeWorker response and an unbound `ProjectSessionBinding`. | A successful response with `ResolvedProjectPath` binds to that path; failed or pathless responses do not bind; caller-requested paths are not adopted instead. |
+| AC-003 | Session-path resolution is non-mutating before worker success. | Logic | Cover each bound/requested path pair in the resolve matrix. | An unbound session stays unbound for both null and explicit requests; a bound session resolves its own or matching canonical path; a different requested path returns an error. |
+| AC-004 | Project-open policy makes a deterministic use/open/refuse decision for project-scoped reads. | Logic | Pure `ProjectOpenPolicy.Decide` cases with null, equal (case/path-normalized), and different paths. | No attached project plus explicit path opens; same or omitted path uses attached; a different active project refuses with the documented `open_project` recovery instruction. |
+| AC-005 | Write tools use the injected safety service instead of a process-wide audit singleton. | Logic | Tool-layer preview/apply uses a temporary audit directory. | The temporary directory receives the audit record, the default audit directory is unchanged, no `WriteSafetyService.Shared` reference remains, and injected `safety` is absent from generated MCP input schemas. |
+| AC-006 | The batch catalog declares the exact supported required and optional field surface. | Logic | Enumerate `BatchOperationCatalog.All`. | Exactly 25 expected operation specs exist; every category, required list, and optional list matches the forwarding contract; universal fields are never optional and required/optional lists never overlap. |
+| AC-007 | Batch validation rejects populated fields that the selected operation would discard. | Logic | Validate requests with invalid `deviceItemName`, invalid `create_tag` external attributes, valid `update_tag` attributes, and a range error. | Each invalid field yields one aggregated error naming valid optional fields; valid fields are accepted; depth/max-result range errors remain enforced. |
+| AC-008 | Every declared batch field survives the real host-to-worker request path. | Logic | Build FakeWorker and run each catalog operation through `BatchWorkerInvoker` with its `projectPath` set to `echo`. | FakeWorker echoes the raw worker request; each required/optional sentinel reaches it by value, including the multiplicity of repeated boolean sentinels after subtracting an all-null baseline. |
+| AC-009 | User documentation describes delivered contract behavior and all hardware-gated deferrals accurately. | Logic | Inspect `README.md` and `docs/IMPROVEMENT_PLAN.md`. | Documentation records immutable JSON, DI audit isolation, validation errors, forwarding proof, hardware-gated create-tag attributes, and `open_project` as the deliberate switch mechanism; no stale `WriteSafetyService.Shared` or project-open-alongside claim remains. |
+| AC-010 | The known `get_project_status(projectPath)` lifecycle exception is carried forward explicitly rather than misstated as enforced read policy. | Logic | Inspect README, improvement plan, and the status lifecycle path. | Both documents state that `get_project_status(projectPath)` remains the human-approved Round 5 exception because the RPC also serves write-state probes; they do not present it as a supported switching mechanism. |
+| AC-011 | Deferred scope remains excluded from Round 4 behavior. | Logic | Inspect the change set and improvement plan. | No create-tag external-attribute forwarding, network configurator reflection redesign, double-dispatch collapse, or payload-budget collapse is introduced; hardware follow-up remains listed as deferred. |

--- a/docs/superpowers/acceptance/reports/2026-07-22-01-01-round4-binding-and-contract-integrity.md
+++ b/docs/superpowers/acceptance/reports/2026-07-22-01-01-round4-binding-and-contract-integrity.md
@@ -1,0 +1,180 @@
+# Acceptance Test Report
+
+**Branch:** `1be9f18549cbdb364ce0408296737a86ba9d3250`  
+**AC Document:** `C:\Users\LCZ\Desktop\RnD\TIA-Portal\tia-portal-mcp\docs\superpowers\acceptance\2026-07-21-round4-binding-and-contract-integrity.md`  
+**Date:** 2026-07-22 01:01:11 +02:00  
+**Report:** `C:\Users\LCZ\Desktop\RnD\TIA-Portal\tia-portal-mcp\docs\superpowers\acceptance\reports\2026-07-22-01-01-round4-binding-and-contract-integrity.md`
+
+---
+
+## Commit and dependency checks
+
+- `git rev-parse HEAD` returned `1be9f18549cbdb364ce0408296737a86ba9d3250` before testing and again before report creation.
+- `git status --short` returned no tracked or untracked changes before report creation (Git emitted only a permission warning for the user-global ignore file).
+- All criteria are Logic. No Playwright skill or UI infrastructure is required.
+- No criterion precondition depends on another acceptance criterion. No dependency blocks were recorded.
+
+## Results
+
+| ID | Description | Test Type | Result | Evidence |
+|----|-------------|-----------|--------|----------|
+| AC-001 | Safety-token presentation JSON is immutable after startup. | Logic | PASS | Focused `TiaJsonTests`: 3 passed, 0 failed, 0 skipped. |
+| AC-002 | Worker-resolved path is adopted only after a successful response. | Logic | PASS | Five focused FakeWorker/client integration tests: 5 passed, 0 failed, 0 skipped. |
+| AC-003 | Session-path resolution is non-mutating before worker success. | Logic | PASS | `ProjectSessionBindingTests`: 21 passed, 0 failed, 0 skipped. |
+| AC-004 | Read-side project-open policy makes deterministic use/open/refuse decisions. | Logic | PASS | `ProjectOpenPolicyTests`: 8 passed, 0 failed, 0 skipped. |
+| AC-005 | Write tools use injected safety service and hide it from MCP schemas. | Logic | PASS | `AuditIsolationTests` plus `McpToolSchemaTests`: 11 passed; exact indexed-source search for `WriteSafetyService.Shared`: 0 results. |
+| AC-006 | Batch catalog declares the exact supported required/optional field surface. | Logic | PASS | Eight focused catalog-contract tests: 8 passed, 0 failed, 0 skipped. |
+| AC-007 | Batch validation rejects fields the selected operation would discard. | Logic | PASS | Seven focused validation tests: 7 passed, 0 failed, 0 skipped. |
+| AC-008 | Every declared batch field survives the host-to-worker request path. | Logic | PASS | FakeWorker build: 0 warnings, 0 errors; `BatchFieldForwardingTests`: 26 passed, 0 failed, 0 skipped. |
+| AC-009 | Documentation accurately describes delivered behavior and hardware-gated deferrals. | Logic | PASS | Deterministic documentation harness: 8/8 assertions passed. |
+| AC-010 | `get_project_status(projectPath)` is explicitly carried as the human-approved Round 5 exception. | Logic | **FAIL** | Deterministic lifecycle/documentation harness: 5/6 assertions passed. Code path, exception reason, no-switch guidance, and improvement-plan Round 5 disclosure passed; README Round 5 disclosure failed. |
+| AC-011 | Deferred scope remains excluded from Round 4 behavior. | Logic | PASS | Deterministic code/change-set/documentation harness: 6/6 assertions passed; targeted changed paths were empty. |
+
+## Focused commands and observed output
+
+### AC-001
+
+```powershell
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --filter "FullyQualifiedName~TiaMcpServer.Tests.TiaJsonTests" --logger "console;verbosity=minimal"
+```
+
+Observed: exit 0; 3 passed, 0 failed, 0 skipped, 3 total.
+
+### AC-002
+
+```powershell
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~FailedFirstWorkerResponse_DoesNotBindTheSession|FullyQualifiedName~SuccessfulFirstRequest_BindsToTheResolvedPathAndRejectsADifferentProjectAfterward|FullyQualifiedName~UnboundSession_BindsToTheWorkerReportedPathAfterSuccess|FullyQualifiedName~FailedCall_LeavesTheSessionUnbound|FullyQualifiedName~SuccessfulCallWithoutAResolvedPath_LeavesTheSessionUnbound" --logger "console;verbosity=minimal"
+```
+
+Observed: exit 0; 5 passed, 0 failed, 0 skipped, 5 total.
+
+### AC-003
+
+```powershell
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~TiaMcpServer.Tests.ProjectSessionBindingTests" --logger "console;verbosity=minimal"
+```
+
+Observed: exit 0; 21 passed, 0 failed, 0 skipped, 21 total.
+
+### AC-004
+
+```powershell
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~TiaMcpServer.Tests.ProjectOpenPolicyTests" --logger "console;verbosity=minimal"
+```
+
+Observed: exit 0; 8 passed, 0 failed, 0 skipped, 8 total.
+
+### AC-005
+
+```powershell
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~TiaMcpServer.Tests.AuditIsolationTests|FullyQualifiedName~TiaMcpServer.Tests.McpToolSchemaTests" --logger "console;verbosity=minimal"
+```
+
+Observed: exit 0; 11 passed, 0 failed, 0 skipped, 11 total.
+
+Static assertion command:
+
+```text
+jcodemunch order(action="search_text", args={repo:"Czarnak/tia-portal-mcp", query:"WriteSafetyService.Shared", context_lines:0, max_results:100})
+```
+
+Observed: `result_count: 0`, `results: []` on the index refreshed from the tested HEAD.
+
+### AC-006
+
+```powershell
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~All_ExposesEverySpec|FullyQualifiedName~All_MatchesTheAuthoritativeOperationFieldContract|FullyQualifiedName~ConfigureNetworkDevice_DoesNotDeclareDeviceItemName|FullyQualifiedName~AddNetworkDevice_DeclaresDeviceItemName|FullyQualifiedName~CreateTag_DoesNotDeclareTheExternalAttributes|FullyQualifiedName~UpdateTag_DeclaresTheExternalAttributes|FullyQualifiedName~NoSpecDeclaresAUniversalFieldAsOptional|FullyQualifiedName~RequiredAndOptionalFieldsNeverOverlap" --logger "console;verbosity=minimal"
+```
+
+Observed: exit 0; 8 passed, 0 failed, 0 skipped, 8 total.
+
+### AC-007
+
+```powershell
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~DeviceItemNameOnConfigureNetworkDevice_IsRejected|FullyQualifiedName~ExternalAttributesOnCreateTag_AreRejected|FullyQualifiedName~ExternalAttributesOnUpdateTag_AreAccepted|FullyQualifiedName~InapplicableFieldErrors_AggregateWithOtherErrors|FullyQualifiedName~DepthOnANonTreeOperation_IsStillRejected|FullyQualifiedName~DepthBelowOne_IsStillRejected|FullyQualifiedName~Validate_RejectsOutOfRangeBounds" --logger "console;verbosity=minimal"
+```
+
+Observed: exit 0; 7 passed, 0 failed, 0 skipped, 7 total.
+
+### AC-008
+
+```powershell
+dotnet build TiaMcpServer.FakeWorker\TiaMcpServer.FakeWorker.csproj --no-restore -m:1 --verbosity minimal
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~TiaMcpServer.Tests.BatchFieldForwardingTests" --logger "console;verbosity=minimal"
+```
+
+Observed: build exit 0 with 0 warnings and 0 errors; test exit 0 with 26 passed, 0 failed, 0 skipped, 26 total.
+
+### AC-009 through AC-011
+
+The exact static-assertion command was `ctx_execute(language="javascript", cwd=REPO_ROOT, timeout=30000, code=<below>)`:
+
+```javascript
+const fs=require('fs'),path=require('path'),cp=require('child_process');
+const root='C:\\Users\\LCZ\\Desktop\\RnD\\TIA-Portal\\tia-portal-mcp',read=r=>fs.readFileSync(path.join(root,r),'utf8'),norm=s=>s.replace(/\s+/g,' ').replace(/[`*]/g,'');
+const R=norm(read('README.md')),P=norm(read('docs/IMPROVEMENT_PLAN.md')),raw=read('README.md')+'\n'+read('docs/IMPROVEMENT_PLAN.md');
+const I=read('TiaMcpServer/Batch/BatchWorkerInvoker.cs'),T=read('TiaMcpServer/Tools/ProjectLifecycleTools.cs'),C=read('TiaMcpServer/Worker/OpennessWorkerClient.cs'),L=read('TiaMcpServer.OpennessWorker/Openness/ProjectLifecycleService.cs');
+const create=I.split(/\r?\n/).find(x=>x.includes('"create_tag" =>'))||'',changed=cp.execSync('git diff --name-only c467a97..HEAD -- TiaMcpServer.OpennessWorker/Openness/NetworkDeviceConfigurator.cs TiaMcpServer/Batch/BatchPayloadBudget.cs',{cwd:root,encoding:'utf8'}).trim();
+const groups={
+'AC-009':[
+['immutable JSON',P.includes('TiaJson.Presentation.MakeReadOnly(). DONE (Round 4): presentation serialization options are frozen')],
+['DI audit isolation',P.includes('now receives WriteSafetyService through DI, and tests inject a temporary audit directory')],
+['validation errors',P.includes('catalog validation now rejects deviceItemName')&&P.includes('create_tag now errors when any of these attributes is supplied')],
+['forwarding proof',P.includes('forwarding test now covers every declared field')],
+['hardware-gated create_tag',P.includes('remains a hardware-gated decision')&&P.includes('Next round (needs TIA Portal hardware)')],
+['open_project deliberate switch',R.includes('Use open_project for deliberate session switching.')],
+['no stale Shared singleton',!raw.includes('WriteSafetyService.Shared')],
+['no stale blanket status-policy claim',!P.includes('All user-facing read paths, including get_project_status, now use the read-side open policy.')]],
+'AC-010':[
+['tool forwards projectPath',/GetProjectStatusAsync\(projectPath\)/.test(T)],
+['client uses lifecycle request route',/SendBoundProjectRequestAsync\([\s\S]{0,120}"get_project_status",[\s\S]{0,80}projectPath/.test(C)],
+['lifecycle path can open supplied path',/if \(!string\.IsNullOrWhiteSpace\(projectPath\)\)[\s\S]{0,100}session\.OpenProject\(projectPath!\)/.test(L)],
+['README exception/reason/no-switch',R.includes('get_project_status(projectPath) is currently excluded from that policy because it shares a lifecycle RPC with guarded write-state probes; do not use it to switch projects.')],
+['README Round 5 disclosure',/get_project_status\(projectPath\)[\s\S]{0,500}Round 5/i.test(R)],
+['improvement-plan Round 5 exception/reason/no-switch',/get_project_status\(projectPath\)[\s\S]{0,250}known exception deferred to Round 5[\s\S]{0,250}guarded write-state probes[\s\S]{0,250}do not use it to switch projects/i.test(P)]],
+'AC-011':[
+['create_tag attributes unforwarded',!/ExternalAccessible|ExternalVisible|ExternalWritable|IsSafety/.test(create)],
+['network configurator and payload budget unchanged',changed===''],
+['double dispatch remains',I.includes('op.Operation switch')&&(I.match(/=> client\./g)||[]).length>=25],
+['double-dispatch collapse deferred',/Collapse the double dispatch:[\s\S]{0,300}DEFERRED 2026-07-20/i.test(P)],
+['payload-budget collapse remains undone',P.includes('deliberately left undone')&&P.includes('Collapse BatchPayloadBudget.ReadBatchResponseLength into BatchResultFormatter.ReadBatch')],
+['hardware follow-up deferred',/Next round \(needs TIA Portal hardware\): forward externalAccessible\/\s*externalVisible\/\s*externalWritable\/\s*isSafety on create_tag/i.test(P)]]};
+let fail=false;for(const [ac,a] of Object.entries(groups)){for(const [n,ok] of a){console.log(ac+' '+(ok?'PASS ':'FAIL ')+n);if(!ok)fail=true;}console.log(ac+' '+a.filter(x=>x[1]).length+'/'+a.length+' assertions passed');}console.log('create_tag='+create.trim());console.log('targeted_changed_paths='+(changed||'(none)'));if(fail)process.exitCode=1;
+```
+
+Observed:
+
+```text
+AC-009 8/8 assertions passed
+AC-010 5/6 assertions passed
+AC-010 FAIL README Round 5 disclosure
+AC-011 6/6 assertions passed
+create_tag="create_tag" => client.CreateTagAsync(op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.DataType!, op.LogicalAddress, op.ProjectPath),
+targeted_changed_paths=(none)
+Exit code: 1
+```
+
+The non-zero exit is the deterministic failure signal for AC-010; AC-009 and AC-011 completed all assertions successfully.
+
+## Summary
+
+**Total criteria:** 11  
+**Passed:** 10  
+**Failed:** 1  
+**Blocked:** 0 (0 due to failed dependency, 0 due to missing infrastructure)
+
+## Failed and Blocked Criteria (detail)
+
+**AC-010: The known `get_project_status(projectPath)` lifecycle exception is carried forward explicitly rather than misstated as enforced read policy**
+
+- Result: FAIL
+- Command run: the AC-009 through AC-011 JavaScript static-assertion command above.
+- Output: `AC-010 5/6 assertions passed`; `AC-010 FAIL README Round 5 disclosure`; exit code 1.
+- Reason: the code path still forwards `projectPath` through the lifecycle RPC and can open the supplied path; `docs/IMPROVEMENT_PLAN.md` explicitly calls this the known Round 5 exception and says not to use it for switching. Both duplicated README binding sections disclose the exception, the shared write-state-probe reason, and the prohibition on switching, but neither states that the exception is deferred to Round 5. This does not meet AC-010's requirement that both documents state the Round 5 exception.
+- Suggested fix: update both duplicated README session-binding disclosures to identify `get_project_status(projectPath)` explicitly as the human-approved Round 5 exception while retaining the current reason and `open_project` switching guidance.
+
+No criteria were Blocked.
+
+## Overall Verdict
+
+**FAIL** — 1 criterion did not pass. The main agent must create a fix task in `executing-plans` for AC-010, then rerun review and acceptance testing.

--- a/docs/superpowers/acceptance/reports/2026-07-22-01-14-round4-binding-and-contract-integrity.md
+++ b/docs/superpowers/acceptance/reports/2026-07-22-01-14-round4-binding-and-contract-integrity.md
@@ -1,0 +1,173 @@
+# Acceptance Test Report
+
+**Branch:** `1d987da3cd627dd6f7745a7c14270152010836d7`  
+**AC Document:** `C:\Users\LCZ\Desktop\RnD\TIA-Portal\tia-portal-mcp\docs\superpowers\acceptance\2026-07-21-round4-binding-and-contract-integrity.md`  
+**Date:** 2026-07-22 01:14:58 +02:00  
+**Report:** `C:\Users\LCZ\Desktop\RnD\TIA-Portal\tia-portal-mcp\docs\superpowers\acceptance\reports\2026-07-22-01-14-round4-binding-and-contract-integrity.md`
+
+---
+
+## Commit and dependency checks
+
+- `git rev-parse HEAD` returned `1d987da3cd627dd6f7745a7c14270152010836d7` before testing and again before report creation.
+- Before report creation, `git status --short --untracked-files=all` listed only the prior report `docs/superpowers/acceptance/reports/2026-07-22-01-01-round4-binding-and-contract-integrity.md`; it was not modified.
+- All criteria are Logic. No Playwright skill or UI infrastructure is required.
+- No criterion precondition depends on another acceptance criterion. No dependency blocks were recorded.
+
+## Results
+
+| ID | Description | Test Type | Result | Evidence |
+|----|-------------|-----------|--------|----------|
+| AC-001 | Safety-token presentation JSON is immutable after startup. | Logic | PASS | Focused `TiaJsonTests`: 3 passed, 0 failed, 0 skipped. |
+| AC-002 | Worker-resolved path is adopted only after a successful response. | Logic | PASS | Five focused FakeWorker/client integration tests: 5 passed, 0 failed, 0 skipped. |
+| AC-003 | Session-path resolution is non-mutating before worker success. | Logic | PASS | `ProjectSessionBindingTests`: 21 passed, 0 failed, 0 skipped. |
+| AC-004 | Read-side project-open policy makes deterministic use/open/refuse decisions. | Logic | PASS | `ProjectOpenPolicyTests`: 8 passed, 0 failed, 0 skipped. |
+| AC-005 | Write tools use injected safety service and hide it from MCP schemas. | Logic | PASS | `AuditIsolationTests` plus `McpToolSchemaTests`: 11 passed; exact indexed-source search for `WriteSafetyService.Shared`: 0 results. |
+| AC-006 | Batch catalog declares the exact supported required/optional field surface. | Logic | PASS | Eight focused catalog-contract tests: 8 passed, 0 failed, 0 skipped. |
+| AC-007 | Batch validation rejects fields the selected operation would discard. | Logic | PASS | Seven focused validation tests: 7 passed, 0 failed, 0 skipped. |
+| AC-008 | Every declared batch field survives the host-to-worker request path. | Logic | PASS | FakeWorker build: 0 warnings, 0 errors; `BatchFieldForwardingTests`: 26 passed, 0 failed, 0 skipped. |
+| AC-009 | Documentation accurately describes delivered behavior and hardware-gated deferrals. | Logic | PASS | Deterministic documentation harness: 8/8 assertions passed. |
+| AC-010 | `get_project_status(projectPath)` is explicitly carried as the human-approved Round 5 exception. | Logic | PASS | Deterministic lifecycle/documentation harness: 6/6 assertions passed, including two exact README disclosures and the improvement-plan disclosure. |
+| AC-011 | Deferred scope remains excluded from Round 4 behavior. | Logic | PASS | Deterministic code/change-set/documentation harness: 6/6 assertions passed; targeted changed paths were empty. |
+
+## Focused commands and observed output
+
+### AC-001
+
+```powershell
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --filter "FullyQualifiedName~TiaMcpServer.Tests.TiaJsonTests" --logger "console;verbosity=minimal"
+```
+
+Observed: exit 0; 3 passed, 0 failed, 0 skipped, 3 total.
+
+### AC-002
+
+```powershell
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~FailedFirstWorkerResponse_DoesNotBindTheSession|FullyQualifiedName~SuccessfulFirstRequest_BindsToTheResolvedPathAndRejectsADifferentProjectAfterward|FullyQualifiedName~UnboundSession_BindsToTheWorkerReportedPathAfterSuccess|FullyQualifiedName~FailedCall_LeavesTheSessionUnbound|FullyQualifiedName~SuccessfulCallWithoutAResolvedPath_LeavesTheSessionUnbound" --logger "console;verbosity=minimal"
+```
+
+Observed: exit 0; 5 passed, 0 failed, 0 skipped, 5 total.
+
+### AC-003
+
+```powershell
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~TiaMcpServer.Tests.ProjectSessionBindingTests" --logger "console;verbosity=minimal"
+```
+
+Observed: exit 0; 21 passed, 0 failed, 0 skipped, 21 total.
+
+### AC-004
+
+```powershell
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~TiaMcpServer.Tests.ProjectOpenPolicyTests" --logger "console;verbosity=minimal"
+```
+
+Observed: exit 0; 8 passed, 0 failed, 0 skipped, 8 total.
+
+### AC-005
+
+```powershell
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~TiaMcpServer.Tests.AuditIsolationTests|FullyQualifiedName~TiaMcpServer.Tests.McpToolSchemaTests" --logger "console;verbosity=minimal"
+```
+
+Observed: exit 0; 11 passed, 0 failed, 0 skipped, 11 total.
+
+Static assertion command:
+
+```text
+jcodemunch order(action="search_text", args={repo:"Czarnak/tia-portal-mcp", query:"WriteSafetyService.Shared", context_lines:0, max_results:100})
+```
+
+Observed: `result_count: 0`, `results: []` on the index refreshed from the tested HEAD.
+
+### AC-006
+
+```powershell
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~All_ExposesEverySpec|FullyQualifiedName~All_MatchesTheAuthoritativeOperationFieldContract|FullyQualifiedName~ConfigureNetworkDevice_DoesNotDeclareDeviceItemName|FullyQualifiedName~AddNetworkDevice_DeclaresDeviceItemName|FullyQualifiedName~CreateTag_DoesNotDeclareTheExternalAttributes|FullyQualifiedName~UpdateTag_DeclaresTheExternalAttributes|FullyQualifiedName~NoSpecDeclaresAUniversalFieldAsOptional|FullyQualifiedName~RequiredAndOptionalFieldsNeverOverlap" --logger "console;verbosity=minimal"
+```
+
+Observed: exit 0; 8 passed, 0 failed, 0 skipped, 8 total.
+
+### AC-007
+
+```powershell
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~DeviceItemNameOnConfigureNetworkDevice_IsRejected|FullyQualifiedName~ExternalAttributesOnCreateTag_AreRejected|FullyQualifiedName~ExternalAttributesOnUpdateTag_AreAccepted|FullyQualifiedName~InapplicableFieldErrors_AggregateWithOtherErrors|FullyQualifiedName~DepthOnANonTreeOperation_IsStillRejected|FullyQualifiedName~DepthBelowOne_IsStillRejected|FullyQualifiedName~Validate_RejectsOutOfRangeBounds" --logger "console;verbosity=minimal"
+```
+
+Observed: exit 0; 7 passed, 0 failed, 0 skipped, 7 total.
+
+### AC-008
+
+```powershell
+dotnet build TiaMcpServer.FakeWorker\TiaMcpServer.FakeWorker.csproj --no-restore -m:1 --verbosity minimal
+dotnet test TiaMcpServer.Tests\TiaMcpServer.Tests.csproj --no-restore --no-build --filter "FullyQualifiedName~TiaMcpServer.Tests.BatchFieldForwardingTests" --logger "console;verbosity=minimal"
+```
+
+Observed: build exit 0 with 0 warnings and 0 errors; test exit 0 with 26 passed, 0 failed, 0 skipped, 26 total.
+
+### AC-009 through AC-011
+
+The exact static-assertion command was `ctx_execute(language="javascript", cwd=REPO_ROOT, timeout=30000, code=<below>)`:
+
+```javascript
+const fs=require('fs'),path=require('path'),cp=require('child_process');
+const root='C:\\Users\\LCZ\\Desktop\\RnD\\TIA-Portal\\tia-portal-mcp',read=r=>fs.readFileSync(path.join(root,r),'utf8'),norm=s=>s.replace(/\s+/g,' ').replace(/[`*]/g,'');
+const R=norm(read('README.md')),P=norm(read('docs/IMPROVEMENT_PLAN.md')),raw=read('README.md')+'\n'+read('docs/IMPROVEMENT_PLAN.md');
+const I=read('TiaMcpServer/Batch/BatchWorkerInvoker.cs'),T=read('TiaMcpServer/Tools/ProjectLifecycleTools.cs'),C=read('TiaMcpServer/Worker/OpennessWorkerClient.cs'),L=read('TiaMcpServer.OpennessWorker/Openness/ProjectLifecycleService.cs');
+const create=I.split(/\r?\n/).find(x=>x.includes('"create_tag" =>'))||'',changed=cp.execSync('git diff --name-only c467a97..HEAD -- TiaMcpServer.OpennessWorker/Openness/NetworkDeviceConfigurator.cs TiaMcpServer/Batch/BatchPayloadBudget.cs',{cwd:root,encoding:'utf8'}).trim();
+const readmeDisclosure='get_project_status(projectPath) is the human-approved Round 5 deferral from that policy because it shares a lifecycle RPC with guarded write-state probes; do not use it to switch projects. Use open_project for deliberate session switching.';
+const planDisclosure='get_project_status(projectPath) is a known exception deferred to Round 5 because its lifecycle RPC also serves guarded write-state probes; do not use it to switch projects. Use open_project for a deliberate session switch.';
+const count=(s,x)=>s.split(x).length-1;
+const groups={
+'AC-009':[
+['immutable JSON',P.includes('TiaJson.Presentation.MakeReadOnly(). DONE (Round 4): presentation serialization options are frozen')],
+['DI audit isolation',P.includes('now receives WriteSafetyService through DI, and tests inject a temporary audit directory')],
+['validation errors',P.includes('catalog validation now rejects deviceItemName')&&P.includes('create_tag now errors when any of these attributes is supplied')],
+['forwarding proof',P.includes('forwarding test now covers every declared field')],
+['hardware-gated create_tag',P.includes('remains a hardware-gated decision')&&P.includes('Next round (needs TIA Portal hardware)')],
+['open_project deliberate switch',count(R,'Use open_project for deliberate session switching.')===2],
+['no stale Shared singleton',!raw.includes('WriteSafetyService.Shared')],
+['no stale blanket status-policy claim',!P.includes('All user-facing read paths, including get_project_status, now use the read-side open policy.')]],
+'AC-010':[
+['tool forwards projectPath',/GetProjectStatusAsync\(projectPath\)/.test(T)],
+['client uses lifecycle request route',/SendBoundProjectRequestAsync\([\s\S]{0,120}"get_project_status",[\s\S]{0,80}projectPath/.test(C)],
+['lifecycle path can open supplied path',/if \(!string\.IsNullOrWhiteSpace\(projectPath\)\)[\s\S]{0,100}session\.OpenProject\(projectPath!\)/.test(L)],
+['both README disclosures exact',count(R,readmeDisclosure)===2],
+['improvement-plan disclosure exact',P.includes(planDisclosure)],
+['neither document supports status switching',count(R,'do not use it to switch projects')===2&&P.includes('do not use it to switch projects')&&count(R,'Use open_project for deliberate session switching.')===2&&P.includes('Use open_project for a deliberate session switch.')]],
+'AC-011':[
+['create_tag attributes unforwarded',!/ExternalAccessible|ExternalVisible|ExternalWritable|IsSafety/.test(create)],
+['network configurator and payload budget unchanged',changed===''],
+['double dispatch remains',I.includes('op.Operation switch')&&(I.match(/=> client\./g)||[]).length>=25],
+['double-dispatch collapse deferred',/Collapse the double dispatch:[\s\S]{0,300}DEFERRED 2026-07-20/i.test(P)],
+['payload-budget collapse remains undone',P.includes('deliberately left undone')&&P.includes('Collapse BatchPayloadBudget.ReadBatchResponseLength into BatchResultFormatter.ReadBatch')],
+['hardware follow-up deferred',/Next round \(needs TIA Portal hardware\): forward externalAccessible\/\s*externalVisible\/\s*externalWritable\/\s*isSafety on create_tag/i.test(P)]]};
+let fail=false;for(const [ac,a] of Object.entries(groups)){for(const [n,ok] of a){console.log(ac+' '+(ok?'PASS ':'FAIL ')+n);if(!ok)fail=true;}console.log(ac+' '+a.filter(x=>x[1]).length+'/'+a.length+' assertions passed');}console.log('readme_disclosure_count='+count(R,readmeDisclosure));console.log('create_tag='+create.trim());console.log('targeted_changed_paths='+(changed||'(none)'));if(fail)process.exitCode=1;
+```
+
+Observed:
+
+```text
+AC-009 8/8 assertions passed
+AC-010 6/6 assertions passed
+AC-011 6/6 assertions passed
+readme_disclosure_count=2
+create_tag="create_tag" => client.CreateTagAsync(op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.DataType!, op.LogicalAddress, op.ProjectPath),
+targeted_changed_paths=(none)
+Exit code: 0
+```
+
+## Summary
+
+**Total criteria:** 11  
+**Passed:** 11  
+**Failed:** 0  
+**Blocked:** 0 (0 due to failed dependency, 0 due to missing infrastructure)
+
+## Failed and Blocked Criteria (detail)
+
+None.
+
+## Overall Verdict
+
+**PASS** — All criteria satisfied. Branch is ready for `finishing-a-development-branch`.

--- a/docs/superpowers/plans/2026-07-20-round4-binding-and-contract-integrity.md
+++ b/docs/superpowers/plans/2026-07-20-round4-binding-and-contract-integrity.md
@@ -1,0 +1,1859 @@
+# Round 4 — Session Binding and Contract Integrity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the session-binding gap found in live TIA Portal V21 testing, stop the test suite polluting the production audit trail, and make "field declared but never forwarded" bugs unrepresentable.
+
+**Architecture:** Three independent threads. (1) The worker reports which project it actually operated on; the host binds to that ground truth instead of adopting whatever path the caller asked for, and read operations refuse to open a project alongside a different one. (2) `WriteSafetyService` moves from a static singleton to constructor injection so tests can redirect the audit directory. (3) `BatchOperationSpec` gains a declared-optional-field list, inapplicable fields become validation errors, and a FakeWorker echo test proves that every declared field actually reaches the worker.
+
+**Tech Stack:** C# / .NET 8 (host, tests), .NET Framework 4.8 (Openness worker), netstandard2.0 (Contracts), xunit, `System.Text.Json`, ModelContextProtocol SDK.
+
+**Spec:** `docs/superpowers/specs/2026-07-20-round4-binding-and-contract-integrity-design.md`
+
+## Global Constraints
+
+- **SDK:** `global.json` pins .NET SDK 8.0.400 with `rollForward: latestMajor`. Use `dotnet`, never `dotnet8`.
+- **Build serialization:** always `dotnet build TiaMcpServer.sln -m:1`. The `-m:1` is required — parallel builds conflict over the worker output directory.
+- **Build without TIA Portal installed:** append `/p:UseTiaPortalReferenceStubs=true`. Use this unless you have TIA Portal V21 locally.
+- **`TiaMcpServer.Contracts` is netstandard2.0 and dependency-free.** No `System.Text.Json` package reference, no Siemens types. Anything placed here must compile under those constraints.
+- **`TiaMcpServer.Tests` links host source files** via `<Compile Include>`, not a project reference. Editing files under `TiaMcpServer/Worker/`, `TiaMcpServer/Batch/`, `TiaMcpServer/Safety/`, `TiaMcpServer/Tools/`, `TiaMcpServer/Json/` is picked up automatically. It cannot link worker files that reference Siemens assemblies.
+- **The test project cannot reference the net48 worker.** Worker logic that needs unit tests must be a pure function in `Contracts`.
+- **Commit format:** `<type>: <description>` — types `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`.
+- **Branch:** `fix/round4-binding-and-contract-integrity` (already created; the spec commit `e59377d` is on it).
+- **Immutability:** create new objects rather than mutating. `WorkerCallResult` is a record — use `with` expressions.
+
+## Before You Start
+
+Build the whole solution once. Task 8 needs `TiaMcpServer.FakeWorker.exe` on disk, and several tasks
+run integration tests that launch it.
+
+```powershell
+dotnet build TiaMcpServer.sln -m:1 /p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests
+```
+
+Expected: build succeeds, 341 tests pass. If the baseline is not green, stop and report — do not
+start on top of a red suite.
+
+## File Structure
+
+| File | Change | Responsibility |
+|------|--------|----------------|
+| `TiaMcpServer/Json/TiaJson.cs` | Modify | Freeze `Presentation` options after construction (Task 1) |
+| `TiaMcpServer/Program.cs` | Modify | Register a `WriteSafetyService` instance instead of the static (Task 2) |
+| `TiaMcpServer/Safety/WriteSafetyService.cs` | Modify | Delete the `Shared` static (Task 2) |
+| `TiaMcpServer/Safety/WriteSafetyTooling.cs` | Modify | Accept the service as a parameter (Task 2) |
+| `TiaMcpServer/Tools/ProjectLifecycleTools.cs` | Modify | Accept the injected service on 6 write tools (Task 2) |
+| `TiaMcpServer/Batch/BatchTools.cs` | Modify | Accept the injected service on 2 write tools (Task 2) |
+| `TiaMcpServer.Contracts/WorkerResponse.cs` | Modify | Carry `ResolvedProjectPath` (Task 3) |
+| `TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs` | Modify | Expose the current project path (Task 3) |
+| `TiaMcpServer.OpennessWorker/Program.cs` | Modify | Stamp `ResolvedProjectPath`; apply the open policy (Tasks 3, 5) |
+| `TiaMcpServer/Worker/WorkerCallResult.cs` | Modify | Carry `ResolvedProjectPath` (Task 4) |
+| `TiaMcpServer.Contracts/ProjectSessionBinding.cs` | Modify | Make `TryResolve` non-mutating (Task 4) |
+| `TiaMcpServer/Worker/OpennessWorkerClient.cs` | Modify | Adopt the resolved path after success (Task 4) |
+| `TiaMcpServer.Contracts/ProjectOpenPolicy.cs` | **Create** | Pure decision: use attached / open requested / refuse (Task 5) |
+| `TiaMcpServer/Batch/BatchOperationCatalog.cs` | Modify | `OptionalFields`, `All`, inapplicable-field rejection (Tasks 6, 7) |
+| `TiaMcpServer/Batch/BatchOperationRequest.cs` | Modify | Scope the `deviceItemName` description (Task 7) |
+| `TiaMcpServer.FakeWorker/Program.cs` | Modify | Add the `"echo"` scenario (Task 8) |
+| `TiaMcpServer.Tests/TiaJsonTests.cs` | **Create** | Task 1 |
+| `TiaMcpServer.Tests/AuditIsolationTests.cs` | **Create** | Task 2 |
+| `TiaMcpServer.Tests/ProjectOpenPolicyTests.cs` | **Create** | Task 5 |
+| `TiaMcpServer.Tests/BatchFieldForwardingTests.cs` | **Create** | Task 8 |
+
+---
+
+### Task 1: Freeze `TiaJson.Presentation`
+
+`TiaJson.Presentation` is a public mutable `JsonSerializerOptions` whose formatting feeds the
+safety-token `requestedInputHash`. A formatting change invalidates every outstanding token. The file
+already says "Keep this stable" in a comment; this makes it enforceable.
+
+**Files:**
+- Modify: `TiaMcpServer/Json/TiaJson.cs:26-30`
+- Test: `TiaMcpServer.Tests/TiaJsonTests.cs` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `TiaJson.Presentation` is read-only after static initialization. `JsonSerializerOptions.IsReadOnly` returns `true`. Any later mutation throws `InvalidOperationException`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `TiaMcpServer.Tests/TiaJsonTests.cs`:
+
+```csharp
+using System.Text.Json;
+using TiaMcpServer.Json;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+public class TiaJsonTests
+{
+    [Fact]
+    public void Presentation_IsReadOnly()
+    {
+        Assert.True(TiaJson.Presentation.IsReadOnly);
+    }
+
+    [Fact]
+    public void Presentation_RejectsMutation()
+    {
+        Assert.Throws<InvalidOperationException>(() => TiaJson.Presentation.WriteIndented = true);
+    }
+
+    [Fact]
+    public void Presentation_StillSerializesCamelCaseAndCompact()
+    {
+        var json = JsonSerializer.Serialize(new { ProjectPath = "C:\\p.ap21" }, TiaJson.Presentation);
+
+        Assert.Equal("{\"projectPath\":\"C:\\\\p.ap21\"}", json);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~TiaJsonTests`
+
+Expected: FAIL. `Presentation_IsReadOnly` asserts `False` is `True`, and `Presentation_RejectsMutation` fails because no exception is thrown.
+
+- [ ] **Step 3: Freeze the options**
+
+In `TiaMcpServer/Json/TiaJson.cs`, replace the field initializer (lines 26-30) with a field plus a static constructor:
+
+```csharp
+    public static readonly JsonSerializerOptions Presentation = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    static TiaJson()
+    {
+        // Frozen on purpose: audit records and the safety-token input hash are both derived
+        // through these options, so a formatting change would invalidate outstanding tokens.
+        Presentation.MakeReadOnly();
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~TiaJsonTests`
+
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Run the whole suite**
+
+Run: `dotnet test TiaMcpServer.Tests`
+
+Expected: all tests pass. If anything mutates `Presentation` at runtime it will now throw — fix the mutation, not the freeze.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TiaMcpServer/Json/TiaJson.cs TiaMcpServer.Tests/TiaJsonTests.cs
+git commit -m "fix: freeze TiaJson.Presentation so safety-token hashing cannot drift"
+```
+
+---
+
+### Task 2: Inject `WriteSafetyService` instead of the `Shared` static
+
+`WriteSafetyService.Shared` is reached statically from 12 call sites. `TiaMcpServer.Tests` links
+those files and exercises those tools, so every `dotnet test` run appends records to
+`%LOCALAPPDATA%\TiaMcpServer\audit`. Measured live: 39 of 42 records came from the test suite.
+Deleting the static is the fix — with no static, no test can reach the production directory.
+
+**Files:**
+- Modify: `TiaMcpServer/Safety/WriteSafetyService.cs:13` (delete `Shared`)
+- Modify: `TiaMcpServer/Program.cs:24`
+- Modify: `TiaMcpServer/Safety/WriteSafetyTooling.cs:10,32,46,61`
+- Modify: `TiaMcpServer/Tools/ProjectLifecycleTools.cs` (6 tools)
+- Modify: `TiaMcpServer/Batch/BatchTools.cs:43,64,78,108,126,144`
+- Modify: `TiaMcpServer.Tests/ProjectLifecycleToolTests.cs`, `WriteToolSafetyTokenTests.cs`, `BatchToolsTests.cs`, `OpennessWorkerClientIntegrationTests.cs`
+- Test: `TiaMcpServer.Tests/AuditIsolationTests.cs` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `WriteSafetyService.Shared` no longer exists.
+  - `WriteSafetyTooling.ValidateForApplyAsync(WriteSafetyService safety, string? safetyToken, string previewToolName, string toolName, string? projectPath, object target, object requestedInput, Func<Task<WorkerCallResult>> readCurrentState)` — service is the **first** parameter.
+  - `WriteSafetyTooling.CreatePreview(WriteSafetyService safety, string toolName, string? projectPath, object target, string summary, object requestedInput, WorkerCallResult currentState, string? diff = null, string? instructions = null)` — service is the **first** parameter.
+  - Every `ProjectLifecycleTools` write tool takes `WriteSafetyService safety` as its **second** parameter, after `OpennessWorkerClient workerClient`.
+  - `BatchTools.PreviewWriteBatch(OpennessWorkerClient workerClient, WriteSafetyService safety, BatchOperationRequest[] operations)` and `BatchTools.ApplyWriteBatch(OpennessWorkerClient workerClient, WriteSafetyService safety, BatchOperationRequest[] operations, bool confirm = false, string? safetyToken = null)`.
+  - `WriteSafetyService.NormalizeProjectPath` stays **static** — it is pure. Do not change its call sites.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `TiaMcpServer.Tests/AuditIsolationTests.cs`. This test proves the tool layer writes only where
+it is told to.
+
+```csharp
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tools;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+/// <summary>
+/// The tool layer must never reach a process-wide audit directory. Before DI this was impossible
+/// to assert: ProjectLifecycleTools resolved WriteSafetyService.Shared, so 39 of 42 records in a
+/// real machine's audit trail came from `dotnet test`.
+/// </summary>
+public class AuditIsolationTests
+{
+    private static string LocateFakeWorker()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (var configuration in new[] { "Debug", "Release" })
+            {
+                var candidate = Path.Combine(
+                    directory.FullName,
+                    "TiaMcpServer.FakeWorker", "bin", configuration, "net8.0",
+                    "TiaMcpServer.FakeWorker.exe");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent!;
+        }
+
+        throw new FileNotFoundException("TiaMcpServer.FakeWorker.exe not found; build the solution first.");
+    }
+
+    [Fact]
+    public async Task LifecycleTool_WritesAuditOnlyToTheInjectedDirectory()
+    {
+        var auditDirectory = Path.Combine(Path.GetTempPath(), "tia-audit-" + Guid.NewGuid().ToString("N"));
+        var defaultDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "TiaMcpServer",
+            "audit");
+        var before = Directory.Exists(defaultDirectory)
+            ? Directory.GetFiles(defaultDirectory).Length
+            : 0;
+
+        try
+        {
+            var safety = new WriteSafetyService(
+                () => DateTimeOffset.UtcNow,
+                TimeSpan.FromMinutes(10),
+                auditDirectory);
+
+            using var client = new OpennessWorkerClient(
+                new ProjectSessionBinding(null),
+                logger: null,
+                workerExecutablePath: LocateFakeWorker());
+
+            var preview = await ProjectLifecycleTools.OpenProject(client, safety, projectPath: "ok");
+            using var previewDoc = System.Text.Json.JsonDocument.Parse(preview);
+            var token = previewDoc.RootElement.GetProperty("safetyToken").GetString();
+
+            await ProjectLifecycleTools.OpenProject(
+                client,
+                safety,
+                projectPath: "ok",
+                confirm: true,
+                safetyToken: token);
+
+            Assert.True(Directory.Exists(auditDirectory));
+            Assert.NotEmpty(Directory.GetFiles(auditDirectory));
+
+            var after = Directory.Exists(defaultDirectory)
+                ? Directory.GetFiles(defaultDirectory).Length
+                : 0;
+            Assert.Equal(before, after);
+        }
+        finally
+        {
+            if (Directory.Exists(auditDirectory))
+            {
+                Directory.Delete(auditDirectory, recursive: true);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~AuditIsolationTests`
+
+Expected: FAIL to **compile** — `ProjectLifecycleTools.OpenProject` has no overload taking a `WriteSafetyService`. That compile failure is the red state for this task.
+
+- [ ] **Step 3: Delete the static and thread the service through `WriteSafetyTooling`**
+
+In `TiaMcpServer/Safety/WriteSafetyService.cs`, delete line 13:
+
+```csharp
+    public static WriteSafetyService Shared { get; } = new();
+```
+
+In `TiaMcpServer/Safety/WriteSafetyTooling.cs`, change the two method signatures and their internal
+calls. `ValidateForApplyAsync` becomes:
+
+```csharp
+    public static async Task<WriteSafetyApplyContext> ValidateForApplyAsync(
+        WriteSafetyService safety,
+        string? safetyToken,
+        string previewToolName,
+        string toolName,
+        string? projectPath,
+        object target,
+        object requestedInput,
+        Func<Task<WorkerCallResult>> readCurrentState)
+    {
+```
+
+and its body's `WriteSafetyService.Shared.ValidateAndConsume(` becomes `safety.ValidateAndConsume(`.
+
+`CreatePreview` becomes:
+
+```csharp
+    public static string CreatePreview(
+        WriteSafetyService safety,
+        string toolName,
+        string? projectPath,
+        object target,
+        string summary,
+        object requestedInput,
+        WorkerCallResult currentState,
+        string? diff = null,
+        string? instructions = null)
+    {
+```
+
+and its body's `WriteSafetyService.Shared.CreatePreview(` becomes `safety.CreatePreview(`.
+
+Leave the three `WriteSafetyService.NormalizeProjectPath(...)` calls at lines 130, 167, 169 alone.
+
+- [ ] **Step 4: Update `Program.cs`**
+
+In `TiaMcpServer/Program.cs`, replace line 24:
+
+```csharp
+            builder.Services.AddSingleton(new WriteSafetyService());
+```
+
+- [ ] **Step 5: Thread the service through `ProjectLifecycleTools`**
+
+For each of the six write tools (`OpenProject`, `CreateProject`, `SaveProject`, `SaveProjectAs`,
+`ArchiveProject`, `CloseProject`), add `WriteSafetyService safety` immediately after
+`OpennessWorkerClient workerClient`, then update the three call sites inside each method.
+
+`GetProjectStatus` is a read tool — leave it unchanged.
+
+Worked example for `OpenProject`; apply the same three edits to the other five:
+
+```csharp
+        public static async Task<string> OpenProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Path to the .ap21 project file to open.")] string projectPath, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null, [Description("Set true to allow rebinding this MCP session from a previously bound project.")] bool forceRebind = false)
+        {
+            var target = new { projectPath };
+            var requestedInput = new { projectPath, forceRebind };
+            if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview(safety, "open_project", projectPath, target, $"Open and bind TIA Portal project '{projectPath}'.", requestedInput, WorkerCallResult.Ok(WriteSafetyTooling.DescribePathState(projectPath)), diff: null, instructions: ApplyInstructions("open_project"));
+            if (!confirm) return ConfirmRequired("open_project");
+            var safetyContext = await WriteSafetyTooling.ValidateForApplyAsync(safety, safetyToken, PreviewHint("open_project"), "open_project", projectPath, target, requestedInput, () => Task.FromResult(WorkerCallResult.Ok(WriteSafetyTooling.DescribePathState(projectPath)))).ConfigureAwait(false);
+            if (!safetyContext.IsValid) return safetyContext.Error!;
+            var result = await workerClient.OpenProjectAsync(projectPath, forceRebind).ConfigureAwait(false);
+            var status = result.Success ? (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText() : null;
+            safety.AppendAudit("open_project", projectPath, target, requestedInput, safetyContext.CurrentState, result.ToText());
+            return WriteSafetyTooling.BuildApplyResult("open_project", result, "get_project_status", status);
+        }
+```
+
+Note the local `var safety = await ...` is renamed to `safetyContext` in every method — the parameter
+now owns the name `safety`. Make that rename consistently or the code will not compile.
+
+- [ ] **Step 6: Thread the service through `BatchTools`**
+
+In `TiaMcpServer/Batch/BatchTools.cs`:
+
+- `PreviewWriteBatch`: add `WriteSafetyService safety,` after `OpennessWorkerClient workerClient,`; change `WriteSafetyService.Shared.CreatePreview(` (line 64) to `safety.CreatePreview(`.
+- `ApplyWriteBatch`: add `WriteSafetyService safety,` after `OpennessWorkerClient workerClient,`; change `WriteSafetyService.Shared.ValidateEnvelope(` (line 108) to `safety.ValidateEnvelope(`, `WriteSafetyService.Shared.ValidateAndConsume(` (line 126) to `safety.ValidateAndConsume(`, and `WriteSafetyService.Shared.AppendAudit(` (line 144) to `safety.AppendAudit(`.
+- `ExecuteReadBatch`: unchanged.
+
+- [ ] **Step 7: Update existing tests that call these tools**
+
+Every call to a `ProjectLifecycleTools` write tool or `BatchTools.PreviewWriteBatch`/`ApplyWriteBatch`
+in the test project needs a service argument. Find them:
+
+```bash
+grep -rn "ProjectLifecycleTools\.\|BatchTools.PreviewWriteBatch\|BatchTools.ApplyWriteBatch" TiaMcpServer.Tests/
+```
+
+In each affected test, construct a scoped service and pass it:
+
+```csharp
+    private static WriteSafetyService CreateSafety(string auditDirectory)
+        => new(() => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, auditDirectory);
+```
+
+Give each test class a temp directory it creates and deletes, following the pattern already used in
+`WriteSafetyServiceTests.cs:177`. Do not point tests at the default directory.
+
+- [ ] **Step 8: Build and run the full suite**
+
+Run:
+```powershell
+dotnet build TiaMcpServer.sln -m:1 /p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests
+```
+
+Expected: build succeeds with no reference to `WriteSafetyService.Shared` anywhere, and all tests
+pass including the new `AuditIsolationTests`.
+
+- [ ] **Step 9: Verify the static is really gone**
+
+Run: `grep -rn "WriteSafetyService.Shared" --include=*.cs .`
+
+Expected: no matches. If any remain, they were missed in steps 3-7.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add -A
+git commit -m "fix: inject WriteSafetyService instead of a static so tests stop writing the production audit trail"
+```
+
+---
+
+### Task 3: Worker reports the resolved project path
+
+The host cannot bind to ground truth unless the worker tells it what ground truth is. Stamp the
+answer once, at the dispatch choke point, so all 22 operations get it without each remembering.
+
+**Files:**
+- Modify: `TiaMcpServer.Contracts/WorkerResponse.cs`
+- Modify: `TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs:113`
+- Modify: `TiaMcpServer.OpennessWorker/Program.cs` (the `Execute` helper, ~line 600)
+- Modify: `TiaMcpServer.FakeWorker/Program.cs`
+- Test: `TiaMcpServer.Tests/WorkerResponseJsonTests.cs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `WorkerResponse.ResolvedProjectPath` (`string?`), serialized as `resolvedProjectPath`. Null when no project was attached. Task 4 reads it.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TiaMcpServer.Tests/WorkerResponseJsonTests.cs`:
+
+```csharp
+    [Fact]
+    public void Deserializes_ResolvedProjectPath()
+    {
+        const string json = """{"success":true,"payload":"{}","resolvedProjectPath":"C:\\proj\\SimpleProject.ap21"}""";
+
+        var response = System.Text.Json.JsonSerializer.Deserialize<WorkerResponse>(
+            json,
+            new System.Text.Json.JsonSerializerOptions
+            {
+                PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
+            });
+
+        Assert.NotNull(response);
+        Assert.Equal("C:\\proj\\SimpleProject.ap21", response!.ResolvedProjectPath);
+    }
+
+    [Fact]
+    public void ResolvedProjectPath_DefaultsToNull()
+    {
+        const string json = """{"success":true,"payload":"{}"}""";
+
+        var response = System.Text.Json.JsonSerializer.Deserialize<WorkerResponse>(
+            json,
+            new System.Text.Json.JsonSerializerOptions
+            {
+                PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
+            });
+
+        Assert.Null(response!.ResolvedProjectPath);
+    }
+```
+
+If `WorkerResponseJsonTests.cs` already declares serializer options as a helper, reuse it instead of
+inlining new options.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~WorkerResponseJsonTests`
+
+Expected: FAIL to compile — `WorkerResponse` has no `ResolvedProjectPath`.
+
+- [ ] **Step 3: Add the contract property**
+
+In `TiaMcpServer.Contracts/WorkerResponse.cs`, after `Warnings`:
+
+```csharp
+    /// <summary>
+    /// Absolute path of the project the worker actually operated on, or null when no project was
+    /// attached. This is ground truth for session binding: the host binds to THIS, never to the
+    /// path the caller requested, so a mistyped-but-real path cannot silently retarget a session.
+    /// </summary>
+    public string? ResolvedProjectPath { get; set; }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~WorkerResponseJsonTests`
+
+Expected: PASS.
+
+- [ ] **Step 5: Expose the current path on the session**
+
+In `TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs`, the private helper
+`TryReadCurrentProjectPath()` at line 113 becomes publicly reachable. Add alongside it:
+
+```csharp
+    /// <summary>Absolute path of the attached project, or null when nothing is attached.</summary>
+    public string? CurrentProjectPath => TryReadCurrentProjectPath();
+```
+
+Leave `TryReadCurrentProjectPath` private; the property is the public surface.
+
+Naming note: worker `Program.cs:6` declares `using WorkerTiaPortalSession = TiaMcpServer.OpennessWorker.Openness.TiaPortalSession;`.
+`WorkerTiaPortalSession` and `TiaPortalSession` are the **same type** under two names — adding the
+property to `TiaPortalSession` makes it available on `WorkerTiaPortalSession` in `Program.cs`.
+
+- [ ] **Step 6: Stamp the response at the dispatch choke point**
+
+In `TiaMcpServer.OpennessWorker/Program.cs`, the `Execute` helper (around line 600) is the single
+place every response passes through. Stamp there:
+
+```csharp
+    private static WorkerResponse Execute(Func<WorkerResponse> body)
+    {
+        try
+        {
+            return Stamp(body());
+        }
+        catch (EngineeringException ex)
+        {
+            return Failure($"TIA Portal operation failed: {ex.Message}");
+        }
+        // ... remaining catch clauses unchanged ...
+    }
+
+    /// <summary>
+    /// Records which project the worker actually operated on. Stamped in one place so all
+    /// operations report it without each remembering to.
+    /// </summary>
+    private static WorkerResponse Stamp(WorkerResponse response)
+    {
+        if (response.Success)
+        {
+            response.ResolvedProjectPath = _sharedSession.CurrentProjectPath;
+        }
+
+        return response;
+    }
+```
+
+Keep the existing catch clauses exactly as they are — failures carry no resolved path.
+
+- [ ] **Step 7: Teach FakeWorker to report a resolved path**
+
+In `TiaMcpServer.FakeWorker/Program.cs`, add a scenario before `default:` so Task 4 has something to
+drive:
+
+```csharp
+        case "ok-with-resolved-path":
+            Respond("""{"success":true,"payload":"{}","resolvedProjectPath":"C:\\resolved\\Ground.ap21"}""");
+            break;
+```
+
+- [ ] **Step 8: Build and run the full suite**
+
+Run:
+```powershell
+dotnet build TiaMcpServer.sln -m:1 /p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+git commit -m "feat: report the resolved project path from the Openness worker"
+```
+
+---
+
+### Task 4: Host binds to the resolved path, not the requested one
+
+Today `TryResolve` adopts the first explicit path unconditionally
+(`ProjectSessionBinding.cs:61-66`), and a session that never passes `projectPath` never binds at all
+— which is the workflow `tia-mcp doctor` recommends. Make resolution non-mutating and bind after
+success from the worker's ground truth.
+
+**Files:**
+- Modify: `TiaMcpServer/Worker/WorkerCallResult.cs`
+- Modify: `TiaMcpServer.Contracts/ProjectSessionBinding.cs:49-76`
+- Modify: `TiaMcpServer/Worker/OpennessWorkerClient.cs:627-687`
+- Test: `TiaMcpServer.Tests/ProjectSessionBindingTests.cs` (rewrite affected cases), `TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: `WorkerResponse.ResolvedProjectPath` (Task 3), FakeWorker scenario `"ok-with-resolved-path"` (Task 3).
+- Produces:
+  - `WorkerCallResult.ResolvedProjectPath` — `string?`, **init-only property**, defaults to null.
+  - `ProjectSessionBinding.TryResolve` no longer mutates. Signature unchanged.
+
+**Expected `TryResolve` behaviour after this task:**
+
+| `BoundProjectPath` | `requestedProjectPath` | `effectiveProjectPath` | binds? | result |
+|---|---|---|---|---|
+| null | null | null | no | true |
+| null | `X` | `X` | **no** (was: yes) | true |
+| `A` | null | `A` | no | true |
+| `A` | `A` | `A` | no | true |
+| `A` | `B` | null | no | false, already-bound error |
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `TiaMcpServer.Tests/ProjectSessionBindingTests.cs`:
+
+```csharp
+    [Fact]
+    public void TryResolve_DoesNotAdoptTheRequestedPath()
+    {
+        var binding = new ProjectSessionBinding(null);
+
+        Assert.True(binding.TryResolve("C:\\a.ap21", out var effective, out var error));
+
+        Assert.Equal("C:\\a.ap21", effective);
+        Assert.Null(error);
+        Assert.Null(binding.BoundProjectPath);
+    }
+
+    [Fact]
+    public void TryResolve_LeavesSessionUnboundSoASecondDifferentPathIsStillAccepted()
+    {
+        var binding = new ProjectSessionBinding(null);
+
+        Assert.True(binding.TryResolve("C:\\a.ap21", out _, out _));
+        Assert.True(binding.TryResolve("C:\\b.ap21", out var effective, out var error));
+
+        Assert.Equal("C:\\b.ap21", effective);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryResolve_StillRejectsADifferentPathOnceBound()
+    {
+        var binding = new ProjectSessionBinding(null);
+        Assert.True(binding.Bind("C:\\a.ap21", forceRebind: false, out _));
+
+        Assert.False(binding.TryResolve("C:\\b.ap21", out _, out var error));
+
+        Assert.Contains("already bound", error);
+        Assert.Contains("forceRebind=true", error);
+    }
+```
+
+Add to `TiaMcpServer.Tests/OpennessWorkerClientIntegrationTests.cs`:
+
+```csharp
+    [Fact]
+    public async Task UnboundSession_BindsToTheWorkerReportedPathAfterSuccess()
+    {
+        var binding = new ProjectSessionBinding(null);
+        using var boundClient = new OpennessWorkerClient(
+            binding,
+            logger: null,
+            workerExecutablePath: LocateFakeWorker());
+
+        var result = await boundClient.GetProjectStatusAsync("ok-with-resolved-path");
+
+        Assert.True(result.Success);
+        Assert.Equal("C:\\resolved\\Ground.ap21", binding.BoundProjectPath);
+    }
+
+    [Fact]
+    public async Task FailedCall_LeavesTheSessionUnbound()
+    {
+        var binding = new ProjectSessionBinding(null);
+        using var client = new OpennessWorkerClient(
+            binding,
+            logger: null,
+            workerExecutablePath: LocateFakeWorker());
+
+        var result = await client.GetProjectStatusAsync("worker-error");
+
+        Assert.False(result.Success);
+        Assert.Null(binding.BoundProjectPath);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test TiaMcpServer.Tests --filter "FullyQualifiedName~ProjectSessionBindingTests|FullyQualifiedName~OpennessWorkerClientIntegrationTests"`
+
+Expected: FAIL. `TryResolve_DoesNotAdoptTheRequestedPath` fails because `BoundProjectPath` is
+`"C:\a.ap21"`, and `UnboundSession_BindsToTheWorkerReportedPathAfterSuccess` fails because
+`BoundProjectPath` is `"ok-with-resolved-path"`.
+
+Existing tests that assert adopt-on-resolve will also fail. That is expected — they encode the bug.
+Rewrite them to the table above rather than deleting them.
+
+- [ ] **Step 3: Carry the resolved path on `WorkerCallResult`**
+
+In `TiaMcpServer/Worker/WorkerCallResult.cs`, add an init-only property to the record body. Do **not**
+add a fifth positional parameter — that would force every `Ok`/`Fail` call site to change.
+
+```csharp
+public sealed record WorkerCallResult(
+    bool Success,
+    string Payload,
+    string? Error,
+    IReadOnlyList<string> Warnings)
+{
+    /// <summary>
+    /// Project the worker actually operated on, when it reported one. Ground truth for session
+    /// binding — see ProjectSessionBinding.
+    /// </summary>
+    public string? ResolvedProjectPath { get; init; }
+
+    // ... existing Ok / Fail / ToText members unchanged ...
+}
+```
+
+- [ ] **Step 4: Make `TryResolve` non-mutating**
+
+In `TiaMcpServer.Contracts/ProjectSessionBinding.cs`, replace the `_boundProjectPath is null` branch
+(lines 61-66) so it resolves without binding:
+
+```csharp
+        if (_boundProjectPath is null)
+        {
+            // Deliberately does NOT adopt: a mistyped-but-real path must not retarget the session.
+            // OpennessWorkerClient binds after the call succeeds, using the worker-reported path.
+            effectiveProjectPath = requested;
+            return true;
+        }
+```
+
+- [ ] **Step 5: Propagate and adopt in the client**
+
+In `TiaMcpServer/Worker/OpennessWorkerClient.cs`, `InvokeWorkerAsync` must carry the value through.
+Change the success branch:
+
+```csharp
+            return response.Success
+                ? WorkerCallResult.Ok(response.Payload ?? string.Empty, warnings) with
+                    {
+                        ResolvedProjectPath = response.ResolvedProjectPath
+                    }
+                : WorkerCallResult.Fail(
+                    response.Error ?? "The TIA Openness worker failed without an error message.",
+                    warnings);
+```
+
+Then replace the provisional-clear block in `SendBoundProjectRequestAsync` (lines 646-652) with
+adoption:
+
+```csharp
+        var result = await InvokeWorkerAsync(request).ConfigureAwait(false);
+        if (result.Success && sessionWasUnbound && result.ResolvedProjectPath is not null)
+        {
+            // Bind to what the worker actually operated on, never to what the caller asked for.
+            _projectSessionBinding.Bind(result.ResolvedProjectPath, forceRebind: true, out _);
+        }
+```
+
+The old comment about provisional bindings and the `Clear(effectiveProjectPath, out _)` call are
+deleted — nothing is bound provisionally any more, so there is nothing to roll back.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `dotnet test TiaMcpServer.Tests --filter "FullyQualifiedName~ProjectSessionBindingTests|FullyQualifiedName~OpennessWorkerClientIntegrationTests"`
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `dotnet test TiaMcpServer.Tests`
+
+Expected: all tests pass. Any remaining failure is an old test encoding adopt-on-resolve — rewrite it
+against the table in this task's header.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "fix: bind the MCP session to the worker-reported project, not the requested path"
+```
+
+---
+
+### Task 5: Read operations never open a project alongside another
+
+`WithProject` (`TiaMcpServer.OpennessWorker/Program.cs:573-591`) calls `session.OpenProject(...)` for
+every read tool, and `TiaPortalSession.cs:99-107` then opens the requested project *alongside* the
+user's. Live, only TIA Portal's own refusal stopped it. The policy goes in `Contracts` as a pure
+function so it is unit-testable — the net8.0 test project cannot link Siemens-referencing worker files.
+
+`TiaPortalSession.OpenProject` is **not** changed: the alongside branch stays reachable from
+`open_project`, which is token-gated.
+
+**Files:**
+- Create: `TiaMcpServer.Contracts/ProjectOpenPolicy.cs`
+- Modify: `TiaMcpServer.OpennessWorker/Program.cs:166-173` (`SearchEquipmentCatalog`), `:573-591` (`WithProject`)
+- Test: `TiaMcpServer.Tests/ProjectOpenPolicyTests.cs` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `public enum ProjectOpenDecision { UseAttached, OpenRequested, Refuse }`
+  - `public static ProjectOpenDecision ProjectOpenPolicy.Decide(string? currentPath, string? requestedPath)`
+  - `public static string ProjectOpenPolicy.RefusalMessage(string currentPath, string requestedPath)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `TiaMcpServer.Tests/ProjectOpenPolicyTests.cs`:
+
+```csharp
+using TiaMcpServer.Contracts;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+public class ProjectOpenPolicyTests
+{
+    [Fact]
+    public void NothingAttached_NoRequest_UsesAttached()
+        => Assert.Equal(ProjectOpenDecision.UseAttached, ProjectOpenPolicy.Decide(null, null));
+
+    [Fact]
+    public void NothingAttached_WithRequest_OpensIt()
+        => Assert.Equal(ProjectOpenDecision.OpenRequested, ProjectOpenPolicy.Decide(null, "C:\\a.ap21"));
+
+    [Fact]
+    public void Attached_NoRequest_UsesAttached()
+        => Assert.Equal(ProjectOpenDecision.UseAttached, ProjectOpenPolicy.Decide("C:\\a.ap21", null));
+
+    [Fact]
+    public void Attached_SameRequest_UsesAttached()
+        => Assert.Equal(ProjectOpenDecision.UseAttached, ProjectOpenPolicy.Decide("C:\\a.ap21", "C:\\a.ap21"));
+
+    [Fact]
+    public void Attached_SameRequestDifferentCase_UsesAttached()
+        => Assert.Equal(ProjectOpenDecision.UseAttached, ProjectOpenPolicy.Decide("C:\\A.ap21", "c:\\a.AP21"));
+
+    [Fact]
+    public void Attached_DifferentRequest_Refuses()
+        => Assert.Equal(ProjectOpenDecision.Refuse, ProjectOpenPolicy.Decide("C:\\a.ap21", "C:\\b.ap21"));
+
+    [Fact]
+    public void Attached_WhitespaceRequest_UsesAttached()
+        => Assert.Equal(ProjectOpenDecision.UseAttached, ProjectOpenPolicy.Decide("C:\\a.ap21", "   "));
+
+    [Fact]
+    public void RefusalMessage_NamesBothProjectsAndTheEscapeHatch()
+    {
+        var message = ProjectOpenPolicy.RefusalMessage("C:\\a.ap21", "C:\\b.ap21");
+
+        Assert.Contains("C:\\a.ap21", message);
+        Assert.Contains("C:\\b.ap21", message);
+        Assert.Contains("open_project", message);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~ProjectOpenPolicyTests`
+
+Expected: FAIL to compile — `ProjectOpenPolicy` does not exist.
+
+- [ ] **Step 3: Write the policy**
+
+Create `TiaMcpServer.Contracts/ProjectOpenPolicy.cs`. Remember: netstandard2.0, no dependencies.
+
+```csharp
+using System;
+using System.IO;
+
+namespace TiaMcpServer.Contracts;
+
+public enum ProjectOpenDecision
+{
+    /// <summary>Operate on whatever is already attached.</summary>
+    UseAttached,
+
+    /// <summary>Nothing is attached; opening the requested project cannot clobber anything.</summary>
+    OpenRequested,
+
+    /// <summary>A different project is attached; refuse rather than open one alongside it.</summary>
+    Refuse
+}
+
+/// <summary>
+/// Decides whether a non-lifecycle operation may cause TIA Portal to open a project. Read
+/// operations must never open a second project alongside one the user already has open — live
+/// testing against V21 showed a read tool doing exactly that, stopped only by TIA Portal's own
+/// refusal. Pure so the net8.0 test project can cover it; the worker is net48 and references
+/// Siemens assemblies the tests cannot load.
+/// </summary>
+public static class ProjectOpenPolicy
+{
+    public static ProjectOpenDecision Decide(string? currentPath, string? requestedPath)
+    {
+        var requested = Normalize(requestedPath);
+        if (requested is null)
+        {
+            return ProjectOpenDecision.UseAttached;
+        }
+
+        var current = Normalize(currentPath);
+        if (current is null)
+        {
+            return ProjectOpenDecision.OpenRequested;
+        }
+
+        return string.Equals(current, requested, StringComparison.OrdinalIgnoreCase)
+            ? ProjectOpenDecision.UseAttached
+            : ProjectOpenDecision.Refuse;
+    }
+
+    public static string RefusalMessage(string currentPath, string requestedPath)
+        => $"TIA Portal currently has project '{currentPath}' open, but this request targets "
+            + $"'{requestedPath}'. Read operations never switch projects. Omit projectPath to use "
+            + "the open project, or call open_project to switch.";
+
+    private static string? Normalize(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        var trimmed = path!.Trim();
+        try
+        {
+            return Path.GetFullPath(trimmed);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            // Not a resolvable path (a FakeWorker scenario keyword, for instance). Compare literally.
+            return trimmed;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~ProjectOpenPolicyTests`
+
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Apply the policy in `WithProject`**
+
+In `TiaMcpServer.OpennessWorker/Program.cs`, replace the body of `WithProject` (lines 573-591):
+
+```csharp
+    /// <summary>Opens an Openness session, ensures a project is available, then runs <paramref name="body"/>.</summary>
+    private static WorkerResponse WithProject(WorkerRequest request, Func<Project, WorkerResponse> body)
+    {
+        return WithSession(request, session =>
+        {
+            session.EnsureConnected();
+
+            var failure = EnsureRequestedProjectOpen(session, request.ProjectPath);
+            if (failure is not null)
+            {
+                return failure;
+            }
+
+            if (session.Project is null)
+            {
+                return Failure("No project is open. Provide a projectPath argument or open a project in TIA Portal.");
+            }
+
+            return body(session.Project);
+        });
+    }
+
+    /// <summary>
+    /// Applies <see cref="ProjectOpenPolicy"/> before any non-lifecycle operation may open a
+    /// project. Returns null to continue, or the failure response to return to the host.
+    /// </summary>
+    private static WorkerResponse? EnsureRequestedProjectOpen(WorkerTiaPortalSession session, string? requestedProjectPath)
+    {
+        var currentPath = session.CurrentProjectPath;
+        switch (ProjectOpenPolicy.Decide(currentPath, requestedProjectPath))
+        {
+            case ProjectOpenDecision.OpenRequested:
+                session.OpenProject(requestedProjectPath!);
+                return null;
+            case ProjectOpenDecision.Refuse:
+                return Failure(ProjectOpenPolicy.RefusalMessage(currentPath!, requestedProjectPath!));
+            default:
+                return null;
+        }
+    }
+```
+
+- [ ] **Step 6: Apply the policy in `SearchEquipmentCatalog`**
+
+`SearchEquipmentCatalog` uses `WithSession` and opens the project itself. Replace lines 170-173:
+
+```csharp
+            var failure = EnsureRequestedProjectOpen(session, request.ProjectPath);
+            if (failure is not null)
+            {
+                return failure;
+            }
+```
+
+- [ ] **Step 7: Confirm no other unguarded open remains**
+
+Run: `grep -n "session.OpenProject" TiaMcpServer.OpennessWorker/Program.cs`
+
+Expected: exactly one match, inside `EnsureRequestedProjectOpen`. The two matches in
+`ProjectLifecycleService.cs` and the one in `TiaPortalSession.cs` are the token-gated lifecycle path
+and are intentionally untouched.
+
+- [ ] **Step 8: Build and run the full suite**
+
+Run:
+```powershell
+dotnet build TiaMcpServer.sln -m:1 /p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+git commit -m "fix: stop read operations opening a project alongside a user-opened one"
+```
+
+---
+
+### Task 6: Declare each operation's optional field surface
+
+`BatchOperationSpec` carries only `RequiredFields`. Each operation's *optional* surface exists solely
+as `[Description]` prose, which nothing checks against `BatchWorkerInvoker`. That is how
+`deviceItemName` came to be described unscoped while only `add_network_device` forwards it.
+
+The tables below are transcribed directly from `BatchWorkerInvoker.InvokeAsync`
+(`BatchWorkerInvoker.cs:32-64`) — one line per operation, the authoritative forwarding map. The
+universal fields `operationId`, `operation`, and `projectPath` are excluded from every table.
+
+**Files:**
+- Modify: `TiaMcpServer/Batch/BatchOperationCatalog.cs:11-14,34,224-259`
+- Test: `TiaMcpServer.Tests/BatchOperationCatalogTests.cs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `BatchOperationSpec(string Name, BatchOperationCategory Category, IReadOnlyList<string> RequiredFields, IReadOnlyList<string> OptionalFields)`
+  - `public static IReadOnlyCollection<BatchOperationSpec> BatchOperationCatalog.All`
+  - Field names are camelCase strings matching `BatchOperationRequest` property names with a lowercase first letter (`blockPath`, `obEventClass` for `OBEventClass`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TiaMcpServer.Tests/BatchOperationCatalogTests.cs`:
+
+```csharp
+    [Fact]
+    public void All_ExposesEverySpec()
+    {
+        // 8 reads + 17 writes.
+        Assert.Equal(25, BatchOperationCatalog.All.Count);
+    }
+
+    [Fact]
+    public void ConfigureNetworkDevice_DoesNotDeclareDeviceItemName()
+    {
+        Assert.True(BatchOperationCatalog.TryGetSpec("configure_network_device", out var spec));
+
+        Assert.DoesNotContain("deviceItemName", spec!.OptionalFields);
+        Assert.Contains("ipAddress", spec.OptionalFields);
+        Assert.Contains("subnetMask", spec.OptionalFields);
+        Assert.Contains("pnDeviceName", spec.OptionalFields);
+        Assert.Contains("subnetName", spec.OptionalFields);
+        Assert.Contains("ioSystemName", spec.OptionalFields);
+    }
+
+    [Fact]
+    public void AddNetworkDevice_DeclaresDeviceItemName()
+    {
+        Assert.True(BatchOperationCatalog.TryGetSpec("add_network_device", out var spec));
+
+        Assert.Contains("deviceItemName", spec!.OptionalFields);
+    }
+
+    [Fact]
+    public void CreateTag_DoesNotDeclareTheExternalAttributes()
+    {
+        Assert.True(BatchOperationCatalog.TryGetSpec("create_tag", out var spec));
+
+        Assert.DoesNotContain("externalAccessible", spec!.OptionalFields);
+        Assert.DoesNotContain("externalVisible", spec.OptionalFields);
+        Assert.DoesNotContain("externalWritable", spec.OptionalFields);
+        Assert.DoesNotContain("isSafety", spec.OptionalFields);
+    }
+
+    [Fact]
+    public void UpdateTag_DeclaresTheExternalAttributes()
+    {
+        Assert.True(BatchOperationCatalog.TryGetSpec("update_tag", out var spec));
+
+        Assert.Contains("externalAccessible", spec!.OptionalFields);
+        Assert.Contains("externalVisible", spec.OptionalFields);
+        Assert.Contains("externalWritable", spec.OptionalFields);
+        Assert.Contains("isSafety", spec.OptionalFields);
+        Assert.Contains("newName", spec.OptionalFields);
+    }
+
+    [Fact]
+    public void NoSpecDeclaresAUniversalFieldAsOptional()
+    {
+        foreach (var spec in BatchOperationCatalog.All)
+        {
+            Assert.DoesNotContain("operationId", spec.OptionalFields);
+            Assert.DoesNotContain("operation", spec.OptionalFields);
+            Assert.DoesNotContain("projectPath", spec.OptionalFields);
+        }
+    }
+
+    [Fact]
+    public void RequiredAndOptionalFieldsNeverOverlap()
+    {
+        foreach (var spec in BatchOperationCatalog.All)
+        {
+            Assert.Empty(spec.RequiredFields.Intersect(spec.OptionalFields));
+        }
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~BatchOperationCatalogTests`
+
+Expected: FAIL to compile — `BatchOperationSpec` has no `OptionalFields` and the catalog has no `All`.
+
+- [ ] **Step 3: Extend the spec record and expose `All`**
+
+In `TiaMcpServer/Batch/BatchOperationCatalog.cs`:
+
+```csharp
+public sealed record BatchOperationSpec(
+    string Name,
+    BatchOperationCategory Category,
+    IReadOnlyList<string> RequiredFields,
+    IReadOnlyList<string> OptionalFields);
+```
+
+and, next to `ReadOperationNames`:
+
+```csharp
+    /// <summary>Every registered spec. Used by the field-forwarding invariant test.</summary>
+    public static IReadOnlyCollection<BatchOperationSpec> All { get; } = Specs.Values.ToArray();
+```
+
+- [ ] **Step 4: Fill in the tables**
+
+Replace the `specs` array in `BuildSpecs()` (lines 226-256). Every `OptionalFields` entry below is
+the set of non-universal parameters that operation's line in `BatchWorkerInvoker.InvokeAsync`
+actually passes to the client.
+
+```csharp
+        var specs = new[]
+        {
+            // Reads
+            new BatchOperationSpec("browse_project_tree", BatchOperationCategory.Read, None, new[] { "depth", "startPath" }),
+            new BatchOperationSpec("read_hardware_config", BatchOperationCategory.Read, None, None),
+            new BatchOperationSpec("search_equipment_catalog", BatchOperationCategory.Read, new[] { "query" }, new[] { "maxResults" }),
+            new BatchOperationSpec("read_cross_references", BatchOperationCategory.Read, None, new[] { "plcName", "filter", "maxResults" }),
+            new BatchOperationSpec("get_block_content", BatchOperationCategory.Read, new[] { "blockPath" }, None),
+            new BatchOperationSpec("list_tag_tables", BatchOperationCategory.Read, None, new[] { "plcName" }),
+            new BatchOperationSpec("compile_check", BatchOperationCategory.Read, None, new[] { "blockPath", "plcName" }),
+            new BatchOperationSpec("get_project_status", BatchOperationCategory.Read, None, None),
+
+            // Data writes
+            new BatchOperationSpec("update_block_logic", BatchOperationCategory.Write, new[] { "blockPath", "yamlContent" }, None),
+            new BatchOperationSpec("create_tag_table", BatchOperationCategory.Write, new[] { "tableName" }, new[] { "plcName", "folderPath" }),
+            new BatchOperationSpec("delete_tag_table", BatchOperationCategory.Write, new[] { "tableName" }, new[] { "plcName", "folderPath" }),
+            new BatchOperationSpec("create_tag", BatchOperationCategory.Write, new[] { "tableName", "name", "dataType" }, new[] { "plcName", "folderPath", "logicalAddress" }),
+            new BatchOperationSpec("update_tag", BatchOperationCategory.Write, new[] { "tableName", "name" }, new[] { "plcName", "folderPath", "newName", "dataType", "logicalAddress", "externalAccessible", "externalVisible", "externalWritable", "isSafety" }),
+            new BatchOperationSpec("delete_tag", BatchOperationCategory.Write, new[] { "tableName", "name" }, new[] { "plcName", "folderPath" }),
+            new BatchOperationSpec("create_user_constant", BatchOperationCategory.Write, new[] { "tableName", "name", "dataType", "value" }, new[] { "plcName", "folderPath" }),
+            new BatchOperationSpec("update_user_constant", BatchOperationCategory.Write, new[] { "tableName", "name" }, new[] { "plcName", "folderPath", "dataType", "value" }),
+            new BatchOperationSpec("delete_user_constant", BatchOperationCategory.Write, new[] { "tableName", "name" }, new[] { "plcName", "folderPath" }),
+            new BatchOperationSpec("add_network_device", BatchOperationCategory.Write, new[] { "typeIdentifier", "deviceName" }, new[] { "deviceItemName" }),
+            new BatchOperationSpec("configure_network_device", BatchOperationCategory.Write, new[] { "deviceName" }, new[] { "ipAddress", "subnetMask", "pnDeviceName", "subnetName", "ioSystemName" }),
+            new BatchOperationSpec("create_block", BatchOperationCategory.Write, new[] { "blockPath", "blockType" }, new[] { "language", "obEventClass" }),
+            new BatchOperationSpec("delete_block", BatchOperationCategory.Write, new[] { "blockPath" }, None),
+            new BatchOperationSpec("create_block_group", BatchOperationCategory.Write, new[] { "blockPath" }, None),
+            new BatchOperationSpec("delete_block_group", BatchOperationCategory.Write, new[] { "blockPath" }, None),
+            new BatchOperationSpec("start_plc", BatchOperationCategory.Write, None, new[] { "plcName" }),
+            new BatchOperationSpec("stop_plc", BatchOperationCategory.Write, None, new[] { "plcName" }),
+        };
+```
+
+That is 8 read specs and 17 write specs, 25 in total — matching the `All_ExposesEverySpec` assertion
+in Step 1. If you add or remove a spec, update that assertion in the same commit.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~BatchOperationCatalogTests`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `dotnet test TiaMcpServer.Tests`
+
+Expected: all tests pass. Validation behaviour has not changed yet — this task only declares.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat: declare each batch operation's optional field surface in the catalog"
+```
+
+---
+
+### Task 7: Reject fields that the chosen operation ignores
+
+With the surface declared, a field set on an operation that never forwards it can be an error instead
+of a silent drop. `ValidateBounds` already does this for exactly three fields (`depth`, `startPath`,
+`maxResults`); the generic check replaces those three, keeping the range checks.
+
+This makes `deviceItemName` on `configure_network_device` an error, and likewise
+`externalAccessible`/`externalVisible`/`externalWritable`/`isSafety` on `create_tag` — honest about
+`BatchWorkerInvoker.cs:48`, which discards all four today.
+
+**Files:**
+- Modify: `TiaMcpServer/Batch/BatchOperationCatalog.cs` (`Validate`, `ValidateBounds`)
+- Modify: `TiaMcpServer/Batch/BatchOperationRequest.cs:88`
+- Test: `TiaMcpServer.Tests/BatchOperationCatalogTests.cs`
+
+**Interfaces:**
+- Consumes: `BatchOperationSpec.OptionalFields`, `BatchOperationCatalog.All` (Task 6).
+- Produces: `ValidateReadBatch`/`ValidateWriteBatch` reject inapplicable fields, aggregated with all other errors (one error line per offending field).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TiaMcpServer.Tests/BatchOperationCatalogTests.cs`:
+
+```csharp
+    [Fact]
+    public void DeviceItemNameOnConfigureNetworkDevice_IsRejected()
+    {
+        var result = BatchOperationCatalog.ValidateWriteBatch(new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "a",
+                Operation = "configure_network_device",
+                DeviceName = "PLC_1",
+                DeviceItemName = "PROFINET interface_1"
+            }
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("deviceItemName", result.Error);
+        Assert.Contains("configure_network_device", result.Error);
+        Assert.Contains("ipAddress", result.Error);
+    }
+
+    [Fact]
+    public void ExternalAttributesOnCreateTag_AreRejected()
+    {
+        var result = BatchOperationCatalog.ValidateWriteBatch(new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "a",
+                Operation = "create_tag",
+                TableName = "Default tag table",
+                Name = "Motor",
+                DataType = "Bool",
+                ExternalAccessible = true,
+                IsSafety = false
+            }
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("externalAccessible", result.Error);
+        Assert.Contains("isSafety", result.Error);
+    }
+
+    [Fact]
+    public void ExternalAttributesOnUpdateTag_AreAccepted()
+    {
+        var result = BatchOperationCatalog.ValidateWriteBatch(new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "a",
+                Operation = "update_tag",
+                TableName = "Default tag table",
+                Name = "Motor",
+                ExternalAccessible = true,
+                IsSafety = false
+            }
+        });
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void InapplicableFieldErrors_AggregateWithOtherErrors()
+    {
+        var result = BatchOperationCatalog.ValidateWriteBatch(new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "a",
+                Operation = "create_tag",
+                TableName = "Default tag table",
+                ExternalAccessible = true
+            }
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("missing required field(s)", result.Error);
+        Assert.Contains("externalAccessible", result.Error);
+    }
+
+    [Fact]
+    public void UniversalFields_AreNeverRejected()
+    {
+        var result = BatchOperationCatalog.ValidateReadBatch(new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "a",
+                Operation = "get_project_status",
+                ProjectPath = "C:\\p.ap21"
+            }
+        });
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void DepthOnANonTreeOperation_IsStillRejected()
+    {
+        var result = BatchOperationCatalog.ValidateReadBatch(new[]
+        {
+            new BatchOperationRequest { OperationId = "a", Operation = "read_hardware_config", Depth = 2 }
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("depth", result.Error);
+    }
+
+    [Fact]
+    public void DepthBelowOne_IsStillRejected()
+    {
+        var result = BatchOperationCatalog.ValidateReadBatch(new[]
+        {
+            new BatchOperationRequest { OperationId = "a", Operation = "browse_project_tree", Depth = 0 }
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("1 or greater", result.Error);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~BatchOperationCatalogTests`
+
+Expected: FAIL. `DeviceItemNameOnConfigureNetworkDevice_IsRejected`,
+`ExternalAttributesOnCreateTag_AreRejected`, and
+`InapplicableFieldErrors_AggregateWithOtherErrors` fail because validation currently accepts those
+fields. The `Depth` tests still pass — they cover the existing `ValidateBounds` behaviour that must
+survive.
+
+- [ ] **Step 3: Add the reflection-backed field reader**
+
+In `TiaMcpServer/Batch/BatchOperationCatalog.cs`, add near the other private statics. Every
+`BatchOperationRequest` field is nullable, so "non-null" is a sufficient "was it set?" test. The
+reflection result is computed once.
+
+```csharp
+    private static readonly IReadOnlySet<string> UniversalFields = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "operationId",
+        "operation",
+        "projectPath",
+    };
+
+    // Cached once: every settable field on the flat request DTO, keyed by its camelCase wire name.
+    private static readonly (string Name, Func<BatchOperationRequest, bool> IsSet)[] AllRequestFields =
+        typeof(BatchOperationRequest)
+            .GetProperties()
+            .Select(property => (
+                Name: char.ToLowerInvariant(property.Name[0]) + property.Name.Substring(1),
+                IsSet: new Func<BatchOperationRequest, bool>(op => property.GetValue(op) is not null)))
+            .ToArray();
+
+    private static IEnumerable<string> FindInapplicableFields(BatchOperationRequest op, BatchOperationSpec spec)
+    {
+        foreach (var field in AllRequestFields)
+        {
+            if (UniversalFields.Contains(field.Name) ||
+                spec.RequiredFields.Contains(field.Name) ||
+                spec.OptionalFields.Contains(field.Name) ||
+                !field.IsSet(op))
+            {
+                continue;
+            }
+
+            yield return field.Name;
+        }
+    }
+```
+
+`OperationId` and `Operation` are non-nullable `string` defaulting to `string.Empty`, so they are
+always "set"; `UniversalFields` short-circuits them before that matters.
+
+- [ ] **Step 4: Wire the check into `Validate`**
+
+In `Validate`, immediately after the existing missing-required-fields block (line 116) and before the
+`ValidateBounds` loop:
+
+```csharp
+            foreach (var field in FindInapplicableFields(op, spec))
+            {
+                var valid = spec.OptionalFields.Count > 0
+                    ? string.Join(", ", spec.OptionalFields)
+                    : "(none)";
+                errors.Add(
+                    $"Operation '{op.Operation}' (operationId '{op.OperationId}'): '{field}' is not valid for "
+                    + $"{op.Operation}. Valid optional fields: {valid}.");
+            }
+```
+
+- [ ] **Step 5: Drop the three now-redundant `ValidateBounds` checks**
+
+The generic check covers `depth`, `startPath`, and `maxResults` on the wrong operation, and would
+otherwise emit a second error for the same mistake. In `ValidateBounds`, delete the `isTree`,
+`takesMaxResults` locals and the three `yield return` blocks that use them, keeping only the range
+checks:
+
+```csharp
+    private static IEnumerable<string> ValidateBounds(BatchOperationRequest op)
+    {
+        // Scope ("'depth' is only valid for browse_project_tree") is enforced generically by
+        // FindInapplicableFields via BatchOperationSpec.OptionalFields. Only ranges remain here.
+        if (op.Depth is < 1)
+        {
+            yield return "'depth' must be 1 or greater.";
+        }
+
+        if (op.MaxResults is < 1)
+        {
+            yield return "'maxResults' must be 1 or greater.";
+        }
+    }
+```
+
+- [ ] **Step 6: Scope the `deviceItemName` description**
+
+In `TiaMcpServer/Batch/BatchOperationRequest.cs`, replace the attribute on line 88:
+
+```csharp
+    [Description("Optional device item name for add_network_device; defaults to deviceName when omitted. Not valid for configure_network_device.")]
+    public string? DeviceItemName { get; set; }
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~BatchOperationCatalogTests`
+
+Expected: PASS.
+
+- [ ] **Step 8: Run the full suite**
+
+Run: `dotnet test TiaMcpServer.Tests`
+
+Expected: all tests pass. If an existing test asserts the old `"'depth' is only valid for
+browse_project_tree."` wording, update it to the new generic message — the behaviour (rejection) is
+unchanged, only the text.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+git commit -m "fix: reject batch fields the chosen operation would silently discard"
+```
+
+---
+
+### Task 8: Prove declared fields actually reach the worker
+
+Tasks 6 and 7 declare and enforce the field surface, but nothing yet proves the declaration matches
+what `BatchWorkerInvoker` forwards. This test drives the real pipeline — `BatchWorkerInvoker` →
+`OpennessWorkerClient` → FakeWorker — and fails if any declared field is dropped en route.
+
+It tests behaviour, not source text, so it survives the deferred 3.3 refactor and will validate it
+when it lands.
+
+**Files:**
+- Modify: `TiaMcpServer.FakeWorker/Program.cs`
+- Test: `TiaMcpServer.Tests/BatchFieldForwardingTests.cs` (create)
+
+**Interfaces:**
+- Consumes: `BatchOperationCatalog.All`, `BatchOperationSpec.OptionalFields` (Task 6); `BatchWorkerInvoker.InvokeAsync` (existing).
+- Produces: nothing consumed downstream.
+
+- [ ] **Step 1: Add the echo scenario to FakeWorker**
+
+FakeWorker already selects its scenario from the request's `projectPath`
+(`TiaMcpServer.FakeWorker/Program.cs:11-24`). Reuse that idiom — an environment variable would be
+process-global and could leak between xunit classes running in parallel.
+
+Add before `default:`:
+
+```csharp
+        case "echo":
+            // Returns the received request verbatim so tests can assert which fields survived
+            // the BatchOperationRequest -> WorkerRequest hop.
+            Respond(JsonSerializer.Serialize(new { success = true, payload = line }));
+            break;
+```
+
+`line` is the raw request JSON; serializing it as a string value escapes it correctly.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `TiaMcpServer.Tests/BatchFieldForwardingTests.cs`:
+
+```csharp
+using System.Reflection;
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+/// <summary>
+/// Every field an operation declares must actually reach the worker. Two live instances of the
+/// opposite — deviceItemName on configure_network_device, and the external* attributes on
+/// create_tag — were silently discarded for months because nothing checked. Asserts by VALUE, not
+/// by property name, so renaming either side of the boundary cannot make this pass vacuously.
+/// </summary>
+public class BatchFieldForwardingTests
+{
+    private static string LocateFakeWorker()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (var configuration in new[] { "Debug", "Release" })
+            {
+                var candidate = Path.Combine(
+                    directory.FullName,
+                    "TiaMcpServer.FakeWorker", "bin", configuration, "net8.0",
+                    "TiaMcpServer.FakeWorker.exe");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent!;
+        }
+
+        throw new FileNotFoundException("TiaMcpServer.FakeWorker.exe not found; build the solution first.");
+    }
+
+    // This test calls BatchWorkerInvoker directly, so BatchOperationCatalog.Validate is NOT in the
+    // path — but OpennessWorkerClient validates some values itself (see the filter check in
+    // ReadCrossReferencesAsync). Those fields carry a real allowed value; a sentinel string would
+    // be rejected before reaching the worker. The assertion still checks that the value arrives.
+    private static readonly Dictionary<string, object> ValidatedFieldValues = new(StringComparer.Ordinal)
+    {
+        ["filter"] = "UnusedObjects",
+        ["blockType"] = "FB",
+        ["language"] = "SCL",
+        ["obEventClass"] = "CyclicInterrupt",
+        ["dataType"] = "Bool",
+        ["depth"] = 7,
+        ["maxResults"] = 4242,
+    };
+
+    private static object SentinelFor(PropertyInfo property, string fieldName)
+    {
+        if (ValidatedFieldValues.TryGetValue(fieldName, out var known))
+        {
+            return known;
+        }
+
+        var type = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+        if (type == typeof(bool))
+        {
+            return true;
+        }
+
+        if (type == typeof(int))
+        {
+            return 4243;
+        }
+
+        return $"__sentinel_{fieldName}__";
+    }
+
+    private static (BatchOperationRequest Request, List<object> Expected) Build(BatchOperationSpec spec)
+    {
+        var request = new BatchOperationRequest
+        {
+            OperationId = "item-1",
+            Operation = spec.Name,
+            ProjectPath = "echo"
+        };
+
+        var expected = new List<object>();
+        foreach (var fieldName in spec.RequiredFields.Concat(spec.OptionalFields))
+        {
+            var propertyName = char.ToUpperInvariant(fieldName[0]) + fieldName.Substring(1);
+            var property = typeof(BatchOperationRequest).GetProperty(propertyName)
+                ?? throw new InvalidOperationException(
+                    $"Spec '{spec.Name}' declares field '{fieldName}' with no matching BatchOperationRequest property.");
+
+            var value = SentinelFor(property, fieldName);
+            property.SetValue(request, value);
+            expected.Add(value);
+        }
+
+        return (request, expected);
+    }
+
+    public static TheoryData<string> AllOperations()
+    {
+        var data = new TheoryData<string>();
+        foreach (var spec in BatchOperationCatalog.All)
+        {
+            data.Add(spec.Name);
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(AllOperations))]
+    public async Task EveryDeclaredField_ReachesTheWorker(string operationName)
+    {
+        Assert.True(BatchOperationCatalog.TryGetSpec(operationName, out var spec));
+        var (request, expected) = Build(spec!);
+
+        using var client = new OpennessWorkerClient(
+            new ProjectSessionBinding(null),
+            logger: null,
+            workerExecutablePath: LocateFakeWorker());
+
+        var result = await BatchWorkerInvoker.InvokeAsync(client, request);
+
+        Assert.True(result.Success, result.Error);
+
+        foreach (var value in expected)
+        {
+            var rendered = value switch
+            {
+                bool b => b ? "true" : "false",
+                int i => i.ToString(),
+                _ => JsonSerializer.Serialize(value).Trim('"')
+            };
+
+            Assert.True(
+                result.Payload.Contains(rendered, StringComparison.Ordinal),
+                $"Operation '{operationName}' declares a field whose value '{rendered}' never reached "
+                + $"the worker. Echoed request: {result.Payload}");
+        }
+    }
+
+    [Fact]
+    public void EveryDeclaredField_HasAMatchingRequestProperty()
+    {
+        foreach (var spec in BatchOperationCatalog.All)
+        {
+            foreach (var fieldName in spec.RequiredFields.Concat(spec.OptionalFields))
+            {
+                var propertyName = char.ToUpperInvariant(fieldName[0]) + fieldName.Substring(1);
+                Assert.NotNull(typeof(BatchOperationRequest).GetProperty(propertyName));
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run:
+```powershell
+dotnet build TiaMcpServer.sln -m:1 /p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~BatchFieldForwardingTests
+```
+
+Expected: FAIL before Step 1 is applied (no `echo` scenario → `unknown scenario 'echo'`). After
+Step 1, all cases should pass, because Task 6's tables were transcribed from the forwarding map.
+
+**If a case fails here, that is a real finding, not a test bug.** It means Task 6's table declares a
+field the invoker does not forward. Fix by either removing it from `OptionalFields` or forwarding it
+in `BatchWorkerInvoker` — and record which you chose in the commit message.
+
+- [ ] **Step 4: Handle the `obEventClass` naming check**
+
+`BatchOperationRequest.OBEventClass` does not follow the `Xxx` → `xxx` convention — naive
+lower-casing of the first character yields `oBEventClass`, and `char.ToUpperInvariant` on
+`obEventClass` yields `ObEventClass`, neither of which resolves.
+
+Confirm which name the catalog and the reflection helper agree on by running:
+
+```powershell
+dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~BatchFieldForwardingTests.EveryDeclaredField_HasAMatchingRequestProperty
+```
+
+If it fails, resolve it by renaming the property to `ObEventClass` in
+`TiaMcpServer/Batch/BatchOperationRequest.cs:113` and updating the single reference in
+`BatchWorkerInvoker.cs:56` (`op.OBEventClass` → `op.ObEventClass`). The JSON wire name is
+`obEventClass` either way under `JsonNamingPolicy.CamelCase`, so no client-visible change — verify
+with the existing `BatchOperationRequestJsonTests`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet test TiaMcpServer.Tests --filter FullyQualifiedName~BatchFieldForwardingTests`
+
+Expected: PASS, one case per catalog operation plus the naming check.
+
+- [ ] **Step 6: Run the full suite**
+
+Run:
+```powershell
+dotnet build TiaMcpServer.sln -m:1 /p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "test: prove every declared batch field reaches the worker"
+```
+
+---
+
+### Task 9: Update the improvement plan and README
+
+The plan document is the project's running record of what is done and what is outstanding. Leaving it
+stale is how items get re-litigated.
+
+**Files:**
+- Modify: `docs/IMPROVEMENT_PLAN.md`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: outcomes of Tasks 1-8.
+- Produces: nothing consumed downstream.
+
+- [ ] **Step 1: Mark the completed items**
+
+In `docs/IMPROVEMENT_PLAN.md`:
+
+- Row `3.5b`: append `— DONE 2026-07-20 (Round 4, Task 2)`.
+- Row `3.6` follow-ups section: mark the `deviceItemName` bullet resolved by catalog rejection (Task 7), and note that `externalAccessible`/`externalVisible`/`externalWritable`/`isSafety` on `create_tag` now **error** rather than being silently dropped, with the forwarding decision still pending hardware.
+- The "Session binding does not protect the default case" section: record that the chosen fix was worker-reported ground truth plus a read-side open policy, and that it is DONE.
+- The "test suite writes into the production audit trail" section: record DONE via 3.5b, and delete the interim-mitigation paragraph — it no longer applies.
+- The `TiaJson.Presentation.MakeReadOnly()` follow-up: mark DONE.
+- Leave the `BatchPayloadBudget` collapse and 3.3 follow-ups untouched — still deferred.
+
+- [ ] **Step 2: Add the next-round note**
+
+Add to `## Deferred / explicitly not planned`:
+
+```markdown
+- **Next round (needs TIA Portal hardware):** forward `externalAccessible`/`externalVisible`/
+  `externalWritable`/`isSafety` on `create_tag` if Openness V21 permits setting them at tag-creation
+  time — Round 4 narrowed this to that single question by making the fields an explicit error
+  instead of a silent drop. Same session should verify the `NetworkDeviceConfigurator`
+  "UNVERIFIED SDK CALL" reflection paths and decide whether `deviceItemName` is meaningful for
+  `configure_network_device`.
+```
+
+- [ ] **Step 3: Update the README where behaviour changed**
+
+Two user-visible changes need documenting:
+
+- Read operations now refuse to open a project while a different one is open. Document the message and that `open_project` is the way to switch.
+- A session binds to the active project after its first successful call, so a later call naming a different project is rejected. Mention `forceRebind`.
+
+Find the section covering project binding:
+
+```bash
+grep -n "forceRebind\|binding\|projectPath" README.md
+```
+
+- [ ] **Step 4: Verify no stale claims remain**
+
+Run: `grep -n "Shared\|alongside" README.md docs/IMPROVEMENT_PLAN.md`
+
+Expected: no references to `WriteSafetyService.Shared`, and no documentation claiming projects open alongside one another.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/IMPROVEMENT_PLAN.md README.md
+git commit -m "docs: record Round 4 outcomes and the hardware-gated next round"
+```
+
+---
+
+## Final Verification
+
+- [ ] Run the full build and suite one last time:
+
+```powershell
+dotnet build TiaMcpServer.sln -m:1 /p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests
+```
+
+Expected: build succeeds, all tests pass (341 baseline plus roughly 45 new).
+
+- [ ] Confirm the statics and hazards are gone:
+
+```bash
+grep -rn "WriteSafetyService.Shared" --include=*.cs .
+grep -n "session.OpenProject" TiaMcpServer.OpennessWorker/Program.cs
+```
+
+Expected: no matches for the first; exactly one match for the second, inside `EnsureRequestedProjectOpen`.
+
+- [ ] Confirm the audit directory was not touched by the test run. Note the file count in
+`%LOCALAPPDATA%\TiaMcpServer\audit` before and after `dotnet test`:
+
+```powershell
+(Get-ChildItem "$env:LOCALAPPDATA\TiaMcpServer\audit" -ErrorAction SilentlyContinue).Count
+```
+
+Expected: unchanged across a full test run. This is the concrete outcome Task 2 exists for.
+
+## What This Plan Does Not Cover
+
+Recorded so the next session does not have to rediscover the boundary:
+
+- **Item D** — forwarding `externalAccessible`/`externalVisible`/`externalWritable`/`isSafety` on `create_tag`. Needs Openness V21 to answer whether they are settable at creation time. Round 4 turns the silent drop into an error, which is the honest interim state.
+- **Item I** — `NetworkDeviceConfigurator` "UNVERIFIED SDK CALL" reflection paths. Needs hardware.
+- **Item F (3.3)** — collapsing the `BatchWorkerInvoker` → `OpennessWorkerClient` double dispatch (~250 lines). Design retained in `docs/superpowers/specs/2026-07-20-phase3-simplification-design.md`. Task 8's echo test will validate it when it lands.
+- **Item G** — collapsing `BatchPayloadBudget.ReadBatchResponseLength` into `BatchResultFormatter.ReadBatch`. Needs a measurement of the extra serialization per budget probe first.

--- a/docs/superpowers/specs/2026-07-20-round4-binding-and-contract-integrity-design.md
+++ b/docs/superpowers/specs/2026-07-20-round4-binding-and-contract-integrity-design.md
@@ -240,9 +240,14 @@ these four attributes at tag-creation time?*
 
 ### E — Echo test
 
-`TiaMcpServer.FakeWorker` gains an echo mode, selected by the `TIA_FAKEWORKER_MODE=echo` environment
-variable so it applies to every method uniformly: the worker returns the received `WorkerRequest`,
-serialized, as its payload.
+`TiaMcpServer.FakeWorker` gains an `"echo"` scenario that returns the received `WorkerRequest` line,
+verbatim, as its payload. This reuses the harness's existing idiom — FakeWorker already selects its
+scenario from the request's `projectPath` field (`TiaMcpServer.FakeWorker/Program.cs:11-24`) — rather
+than introducing an environment variable, which would be process-global and could leak between
+xunit test classes running in parallel.
+
+`projectPath` is a universal field, excluded from every per-operation table, so pinning it to
+`"echo"` for the whole test costs no coverage.
 
 The catalog needs an enumerator over its specs. `BatchOperationCatalog` exposes `ReadOperationNames`,
 `WriteOperationNames`, and `TryGetSpec` today but no way to walk every spec, so add

--- a/docs/superpowers/specs/2026-07-20-round4-binding-and-contract-integrity-design.md
+++ b/docs/superpowers/specs/2026-07-20-round4-binding-and-contract-integrity-design.md
@@ -1,0 +1,303 @@
+# Round 4 — Session binding and contract integrity (design)
+
+Date: 2026-07-20
+Source: outstanding items in `docs/IMPROVEMENT_PLAN.md` after Phase 3 merged (PR #10, `c467a97`).
+
+## Scope
+
+In scope: **A** session-binding gap, **B** `WriteSafetyService` via DI (item 3.5b, and the audit-trail
+pollution it causes), **C** `deviceItemName` declared-but-not-forwarded, **E** an invariant test that
+makes that bug class unrepresentable, **H** `TiaJson.Presentation.MakeReadOnly()`.
+
+Out of scope, with reasons:
+
+| Item | Why not now |
+|------|-------------|
+| **D** — forward `externalAccessible`/`externalVisible`/`externalWritable`/`isSafety` on `create_tag` | Needs real Openness V21 to know whether these are settable at tag-creation time. |
+| **I** — `NetworkDeviceConfigurator` "UNVERIFIED SDK CALL" reflection paths | Needs hardware to pin exact method signatures. |
+| **F** — 3.3 double-dispatch collapse (~250 lines) | Deliberately deferred once already; the `OptionalFields` work below is a down payment on it. |
+| **G** — collapse `BatchPayloadBudget.ReadBatchResponseLength` | The plan itself says measure the extra serialization cost first. |
+
+**D and I are the next round**, gated on TIA machine access. Section C below narrows D's remaining
+question to a single yes/no that one hardware session can answer.
+
+## A — Session binding
+
+### Problem
+
+Reproduced live against V21 on 2026-07-20 and confirmed in code:
+
+1. A session that never passes `projectPath` stays unbound forever.
+   `ProjectSessionBinding.TryResolve(null)` returns the (null) binding without adopting anything.
+   This is the workflow `tia-mcp doctor` actively recommends.
+2. The first call that *does* pass an explicit path is adopted unconditionally
+   (`ProjectSessionBinding.cs:61-66`), so a mistyped-but-real path silently retargets the session.
+3. That path then reaches `WithProject` (`TiaMcpServer.OpennessWorker/Program.cs:573-591`), which
+   calls `session.OpenProject(...)` for **every read tool**. `TiaPortalSession.cs:99-107` then opens
+   the requested project *alongside* the user's rather than refusing. Only TIA Portal's own
+   "Another project is already open" refusal stopped it live.
+
+`TiaPortalSession.cs:61-64` already rejects non-existent paths via `File.Exists`, so a purely
+hallucinated path fails. The residual exposure is a **mistyped-but-real** path.
+
+### A1 — The worker reports ground truth
+
+`WorkerResponse` gains:
+
+```csharp
+/// <summary>
+/// Absolute path of the project the worker actually operated on, or null when no project was
+/// attached. Ground truth for session binding: the host binds to this, never to the requested path.
+/// </summary>
+public string? ResolvedProjectPath { get; set; }
+```
+
+It is stamped in **one place** — the dispatch choke point in worker `Program.cs`, which reaches the
+static `_sharedSession` — so every method gets it without 22 methods each remembering to set it.
+
+Requires exposing `TiaPortalSession.TryReadCurrentProjectPath` (private today at
+`TiaPortalSession.cs:113`) as an internal/public `CurrentProjectPath` property.
+
+### A2 — The host adopts the resolved path, never the requested one
+
+`WorkerCallResult` gains `ResolvedProjectPath` as an **init-only property**, not a fifth positional
+parameter. The record is positional (`WorkerCallResult.cs:9-13`); an init-only property leaves the
+`Ok`/`Fail` factories and every construction site untouched, and `InvokeWorkerAsync` sets it with a
+`with` expression.
+
+`ProjectSessionBinding.TryResolve` becomes **non-mutating**:
+
+| Bound | Requested | Today | After |
+|-------|-----------|-------|-------|
+| null | null | effective = null, stays unbound | unchanged |
+| null | X | **adopts X**, effective = X | effective = X, **stays unbound** |
+| A | null | effective = A | unchanged |
+| A | A | effective = A | unchanged |
+| A | B | error | unchanged |
+
+`SendBoundProjectRequestAsync` binds *after* success:
+
+```csharp
+var result = await InvokeWorkerAsync(request);
+if (result.Success && sessionWasUnbound && result.ResolvedProjectPath is not null)
+{
+    _projectSessionBinding.Bind(result.ResolvedProjectPath, forceRebind: true, out _);
+}
+```
+
+The provisional-binding cleanup at `OpennessWorkerClient.cs:647-652` is **deleted**. Nothing is bound
+provisionally any more, so there is nothing to roll back — a net simplification, not an addition.
+
+Payoff: `get_project_status` with no `projectPath` now binds the session to whatever the GUI has
+open, so the default recommended workflow is protected from the second call onward. The live repro's
+step 2 is then rejected locally by the existing guard and never reaches the worker.
+
+### A3 — Reads never open a project alongside another
+
+The policy is a pure function in `TiaMcpServer.Contracts`, so it is unit-testable from
+`TiaMcpServer.Tests` (net8.0, which cannot link Siemens-referencing worker files):
+
+```csharp
+public enum ProjectOpenDecision { UseAttached, OpenRequested, Refuse }
+
+public static class ProjectOpenPolicy
+{
+    public static ProjectOpenDecision Decide(string? currentPath, string? requestedPath);
+}
+```
+
+| currentPath | requestedPath | Decision |
+|-------------|---------------|----------|
+| null | null | `UseAttached` (caller then fails with the existing "No project is open" message) |
+| null | X | `OpenRequested` — nothing to clobber |
+| A | null | `UseAttached` |
+| A | A (case-insensitive, full-path-normalized) | `UseAttached` |
+| A | B | `Refuse` |
+
+Both call sites use it, replacing two copies of the same unguarded `session.OpenProject(...)`:
+
+- `WithProject` (`Program.cs:573-591`)
+- `SearchEquipmentCatalog`'s hand-rolled equivalent (`Program.cs:166-173`)
+
+`Refuse` returns:
+
+> `TIA Portal currently has project 'A' open, but this request targets 'B'. Read operations never
+> switch projects. Omit projectPath to use the open project, or call open_project to switch.`
+
+`TiaPortalSession.OpenProject` is **unchanged**. The open-alongside branch stays reachable from
+`open_project`, which is token-gated — consistent with the write-safety model, where changing what
+TIA Portal has open is a previewed, confirmed operation.
+
+### Resulting behaviour
+
+| Situation | After this change |
+|-----------|-------------------|
+| Unbound, `SimpleProject` open in GUI, `get_project_status` with no path | Succeeds; session binds to `SimpleProject`. |
+| …then `browse_project_tree(path=LibReadTest)` | Rejected locally by the binding guard; never reaches the worker. |
+| Unbound, nothing open in GUI, `browse_project_tree(path=LibReadTest)` | Worker opens it (nothing to clobber); session binds to it. |
+| …then `browse_project_tree(path=Other)` | Rejected by the binding guard. |
+| Any read tool while a *different* project is open | Refused by `ProjectOpenPolicy`, with the message above. |
+
+### Regression risk
+
+Existing tests assert adopt-on-resolve. `ProjectSessionBinding` tests and the provisional-clear
+integration test need **rewriting, not tweaking**. This is expected work, called out so it is not
+mistaken for breakage during implementation.
+
+## B — `WriteSafetyService` via DI
+
+### Problem
+
+`WriteSafetyService.Shared` is reached statically from 12 call sites — 6 in `ProjectLifecycleTools`
+(lines 38, 54, 70, 86, 102, 117), 4 in `BatchTools` (64, 108, 126, 144), 2 in `WriteSafetyTooling`
+(32, 61) — plus the registration at `Program.cs:24`. `TiaMcpServer.Tests` links those files and exercises
+those tools, so every `dotnet test` run appends real records to `%LOCALAPPDATA%\TiaMcpServer\audit`.
+Measured live: 39 of 42 records were produced by the test suite, diluting the forensic record for
+PLC-mutating operations to ~7% signal.
+
+The `WriteSafetyService(getUtcNow, tokenLifetime, auditDirectory)` constructor already supports
+redirecting the audit directory. No test going through the tool layer can reach it while the tools
+resolve `.Shared` statically.
+
+### Change
+
+- `Program.cs:24` becomes `builder.Services.AddSingleton(new WriteSafetyService());`
+- **Delete `WriteSafetyService.Shared`.** The deletion is the enforcement: with no static, no test can
+  reach the production audit directory by accident. Leaving it in place and merely not using it would
+  let the pollution return.
+- `WriteSafetyTooling.ValidateForApplyAsync` and `CreatePreview` take `WriteSafetyService safety` as
+  their first parameter.
+- `WriteSafetyService.NormalizeProjectPath` stays static — it is pure, so `BatchOperationCatalog.cs:128`
+  and the three uses inside `WriteSafetyTooling` are untouched.
+- The 6 `ProjectLifecycleTools` write tools and `BatchTools.PreviewWriteBatch` / `ApplyWriteBatch` gain
+  a `WriteSafetyService safety` parameter after `OpennessWorkerClient workerClient`. The MCP SDK
+  injects registered DI services into tool parameters — the same mechanism that already supplies
+  `workerClient`, so no new wiring.
+- `BatchTools.ExecuteReadBatch` is unaffected (reads write no audit records).
+
+### Testing
+
+Tool-layer tests construct `new WriteSafetyService(() => now, lifetime, tempDir)`. Add one test
+asserting that a tool-layer run leaves the default `%LOCALAPPDATA%\TiaMcpServer\audit` directory
+untouched.
+
+## C + E — Catalog field surface, rejection, and the echo test
+
+### Problem
+
+`BatchOperationSpec` (`BatchOperationCatalog.cs:11-14`) carries `Name`, `Category`, `RequiredFields`
+— there is no declared-optional-field map. Each operation's optional surface exists only as
+`[Description]` prose on `BatchOperationRequest` properties, which cannot be checked against what
+`BatchWorkerInvoker` actually forwards. Two live instances of the resulting drift:
+
+- `deviceItemName` is described unscoped but only `add_network_device` forwards it
+  (`BatchWorkerInvoker.cs:54` vs `:55`).
+- `externalAccessible`/`externalVisible`/`externalWritable`/`isSafety` are described as generic tag
+  attributes but only `update_tag` forwards them (`BatchWorkerInvoker.cs:49` vs `:48`).
+
+Phase 0.4 found the same bug class with `newName`.
+
+### C1 — `OptionalFields` on the spec
+
+```csharp
+public sealed record BatchOperationSpec(
+    string Name,
+    BatchOperationCategory Category,
+    IReadOnlyList<string> RequiredFields,
+    IReadOnlyList<string> OptionalFields);
+```
+
+Universal fields — `operationId`, `operation`, `projectPath` — are excluded from every per-operation
+table and checked once. The per-operation tables are transcribed directly from
+`BatchWorkerInvoker.InvokeAsync` (`BatchWorkerInvoker.cs:32-64`), which is one line per operation and
+is the authoritative forwarding map. That makes the table cheap to author and easy to review.
+
+### C2 — Reject inapplicable fields
+
+`Validate()` reflects over `BatchOperationRequest` (flat, all-nullable, so `prop.GetValue(op) is not
+null` is a sufficient "was it set?" test) and produces an aggregated error for any non-null property
+outside `Universal ∪ Required ∪ Optional`:
+
+> `deviceItemName is not valid for configure_network_device. Valid optional fields: ipAddress,
+> subnetMask, pnDeviceName, subnetName, ioSystemName.`
+
+This follows 0.2's aggregate-all-errors rule and 0.1's list-the-valid-names precedent. The reflection
+result is computed once and cached.
+
+`deviceItemName`'s `[Description]` in `BatchOperationRequest` is scoped to `add_network_device` so
+the prose matches the mechanism.
+
+### C3 — Behaviour change this forces on `create_tag`
+
+Setting `externalAccessible`/`externalVisible`/`externalWritable`/`isSafety` on `create_tag` becomes
+an **error** rather than a silent drop. That is honest about today's behaviour — those four values
+are discarded at `BatchWorkerInvoker.cs:48`. Erroring is strictly better than silent loss, and it is
+reversible: item D's hardware round decides whether to move them into `create_tag`'s `OptionalFields`
+and forward them.
+
+This narrows D to a single question a hardware session can answer: *does Openness V21 allow setting
+these four attributes at tag-creation time?*
+
+### E — Echo test
+
+`TiaMcpServer.FakeWorker` gains an echo mode, selected by the `TIA_FAKEWORKER_MODE=echo` environment
+variable so it applies to every method uniformly: the worker returns the received `WorkerRequest`,
+serialized, as its payload.
+
+The catalog needs an enumerator over its specs. `BatchOperationCatalog` exposes `ReadOperationNames`,
+`WriteOperationNames`, and `TryGetSpec` today but no way to walk every spec, so add
+`public static IReadOnlyCollection<BatchOperationSpec> All => Specs.Values;`.
+
+The test drives the real pipeline — `BatchWorkerInvoker` → `OpennessWorkerClient` (constructed with
+its existing `workerExecutablePath` override) → fake worker — once per catalog operation:
+
+```
+foreach (spec in BatchOperationCatalog.All)
+    request  = BuildWithSentinels(spec)          // every Required + Optional field
+    echoed   = await BatchWorkerInvoker.InvokeAsync(client, request)
+    foreach (field in spec.RequiredFields ∪ spec.OptionalFields)
+        Assert.Contains(sentinelFor(field), echoed)
+```
+
+Assertions are **by value, not by property name**, so the test survives renaming on either side of
+the boundary.
+
+Two implementation details that would otherwise bite:
+
+1. **Sentinels cannot be blind.** `filter`, `blockType`, `language`, `dataType`, and `mode` are
+   validated host-side; a `"__sentinel__"` string is rejected before reaching the worker. The builder
+   needs a field → valid-sample-value map, defaulting to a distinctive sentinel string for
+   unvalidated fields, `true` for booleans, and a distinctive number for integers.
+2. **`ResolveDeviceItemName` (`BatchWorkerInvoker.cs:66-67`) is the only value transform** in the
+   whole map — it defaults `deviceItemName` to `deviceName`. Distinct sentinels for the two fields
+   make it a non-issue.
+
+This test tests behaviour rather than source text, so it survives the deferred 3.3 refactor and will
+independently validate it when it lands.
+
+## H — `TiaJson.Presentation.MakeReadOnly()`
+
+`TiaJson.Presentation` is a public mutable `JsonSerializerOptions` whose formatting feeds the
+safety-token `requestedInputHash`. A static constructor calls `MakeReadOnly()` after configuration;
+one test asserts `IsReadOnly`. This turns the existing "keep this stable" comment into a guarantee.
+
+## Sequencing
+
+1. **H** — isolated, two lines plus a test.
+2. **B** — unblocks clean tool-layer testing for everything after it.
+3. **A1 + A2**, then **A3** — A3 is independent of A1/A2 but shares the same test surface.
+4. **C + E** — C1 first (the spec table), then C2 (rejection), then E (the echo test that proves both).
+
+## Testing
+
+| Change | Coverage |
+|--------|----------|
+| A1 | Echo/scripted FakeWorker response carries `ResolvedProjectPath`; host reads it. |
+| A2 | `ProjectSessionBinding` unit tests for the non-mutating resolve matrix; integration test that an unbound session binds after the first successful pathless call. |
+| A3 | `ProjectOpenPolicy.Decide` unit tests over the full decision matrix, including case and path-normalization equivalence. |
+| B | Tool-layer tests inject a temp audit directory; one test asserts the default directory is untouched. |
+| C1/C2 | Catalog validation tests: inapplicable field rejected, error names the valid optional fields, multiple errors aggregate. |
+| E | The echo test itself, one case per catalog operation. |
+| H | `Assert.True(TiaJson.Presentation.IsReadOnly)`. |
+
+Existing tests that assert adopt-on-resolve behaviour are rewritten as part of A2.


### PR DESCRIPTION
## Summary

Round 4 hardening pass for MCP session/project binding and batch-operation contract integrity, plus a manual end-to-end QA pass over every exposed tool and its documented findings.

- **Session binding correctness**: bind the MCP session to the worker-reported active project rather than the blindly-requested path; decline concurrent binding overwrites; stop read operations from opening a project alongside one the user already has open; surface worker path divergence and canonicalize project-path comparisons so drift is caught instead of silently accepted.
- **`get_project_status` policy**: route through `ProjectOpenPolicy`, then revert after review showed it needed to stay a documented exception (shares a lifecycle RPC with guarded write-state probes) — see the Round 5 lifecycle exception note in the README.
- **Batch operation contract integrity**: declare each batch operation's optional field surface in an explicit catalog, reject batch fields the chosen operation would otherwise silently discard, preserve `create_block`'s OB event-class validation, and lock the exact field catalog down with schema tests so the contract can't silently drift.
- **`--version`/`-v` flag**: prints host version and exits without starting the MCP server.
- **Test hardening**: audit-isolation tests with a shared temp-audit-directory helper (stop tests from writing to the production audit trail), full batch field-forwarding coverage, and additional schema/session-binding/write-safety tests.
- **Docs**: Round 4 design, task list, and acceptance-criteria/report docs under `docs/superpowers/plans` and `.superpowers/sdd`; `docs/IMPROVEMENT_PLAN.md` updated for Round 4 outcomes and the hardware-gated next round.
- **New in this PR**: a `## Known Issues` section in the README documenting three bugs found via manual end-to-end testing of all 10 tools against a live TIA Portal project:
  - `create_block` fails unconditionally for `language: "SCL"` (works fine for `LAD`).
  - `update_block_logic` fails unconditionally, even on a byte-for-byte no-op round-trip of content just read via `get_block_content` (non-destructive, but currently unusable).
  - `save_project_as` with `rebind: false` can strand the MCP session with no recovery path once Siemens' `SaveAs` switches the actually-open project — reproduced live; recovery required closing/reopening the project by hand in the TIA Portal UI.

## Test plan

- [x] `dotnet build TiaMcpServer.sln -m:1` (CI/stub and local-TIA configurations)
- [x] `dotnet test TiaMcpServer.Tests` — all suites referenced above pass
- [x] Manual end-to-end pass: every one of the 10 exposed MCP tools exercised against a live, open TIA Portal V21 project (reads, batched tag/tag-table/block/device writes, project lifecycle tools); tag/tag-table/block/block-group test writes round-tripped with no residue; project verified clean and compiling (0 errors/warnings) at the end
- [x] Reviewer: confirm the three newly-documented bugs (`create_block` SCL, `update_block_logic`, `save_project_as rebind:false`) against the linked repro steps before merge, since they're currently undocumented-elsewhere and unfixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)