### PR TITLE
feat: read-only safety mode with defense-in-depth enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,61 @@ Options:
 
 Exit codes: `0` (no blocking failures), `1` (one or more checks failed), `2` (invalid arguments).
 
+### Access modes
+
+The server supports two access modes that control which operations are available:
+
+- **read-write** (default) - full tool surface with the existing preview-and-apply write safety model.
+- **read-only** - only observation operations are available. Write tools are not advertised to MCP clients, and prohibited operations are rejected at both the host and worker levels.
+
+Enable read-only mode:
+
+```powershell
+tia-mcp --access-mode read-only
+tia-mcp --read-only
+$env:TIA_MCP_ACCESS_MODE = 'read-only'
+tia-mcp
+```
+
+Configuration precedence: CLI argument > environment variable > default (read-write).
+
+The mode is resolved once at startup and cannot be changed during the process lifetime. There is no MCP tool that changes the access mode at runtime.
+
+In read-only mode, the server exposes only two MCP tools:
+
+- `get_project_status` - read active project metadata.
+- `execute_read_batch` - run read operations in a batch (including `browse_project_tree`, `read_hardware_config`, `read_cross_references`, `search_equipment_catalog`, `get_block_content`, `list_tag_tables`, `get_project_status`).
+
+The following operations are **not available** in read-only mode:
+
+- `compile_check` (invokes the Siemens compilation API)
+- All project lifecycle operations (`open_project`, `create_project`, `save_project`, `save_project_as`, `archive_project`, `close_project`)
+- All data mutations (block, tag, tag table, user constant, network device operations)
+- All PLC control operations (`start_plc`, `stop_plc`)
+
+In read-only mode, the server operates only on the project already open in TIA Portal. It never opens, creates, switches, or closes a project. A supplied `projectPath` is used only as an assertion that must match the currently open project.
+
+Read-only mode is a security boundary enforced at three layers:
+
+1. Write tools are not registered in the MCP tool discovery response.
+2. The host-side `OperationAccessPolicy` rejects prohibited operations before the worker process is started.
+3. The worker-side `WorkerOperationAuthorization` independently rejects prohibited operations even if a raw worker request bypasses the host.
+
+MCP client configuration example:
+
+```json
+{
+  "mcpServers": {
+    "tia-portal-read-only": {
+      "command": "tia-mcp",
+      "args": ["--access-mode", "read-only"]
+    }
+  }
+}
+```
+
+The `tia-mcp doctor` command reports the active access mode.
+
 The package includes the `openness-worker` folder and required non-Siemens dependencies. It intentionally excludes `Siemens.Engineering*.dll`; those are loaded from the local TIA Portal installation at runtime.
 
 ## Build From Source

--- a/TiaMcpServer.Contracts/McpAccessMode.cs
+++ b/TiaMcpServer.Contracts/McpAccessMode.cs
@@ -1,0 +1,16 @@
+namespace TiaMcpServer.Contracts;
+
+/// <summary>
+/// Immutable access mode for the MCP server process. Resolved once at startup and cannot
+/// be changed at runtime. Read-only mode blocks all mutation operations; read-write mode
+/// preserves the full tool surface with the existing preview-and-apply safety model.
+/// </summary>
+public enum McpAccessMode
+{
+    /// <summary>Only observation operations are allowed. Write tools are not exposed and
+    /// prohibited operations are rejected before reaching the worker.</summary>
+    ReadOnly,
+
+    /// <summary>Full tool surface. Writes follow the existing preview-and-apply safety flow.</summary>
+    ReadWrite
+}

--- a/TiaMcpServer.Contracts/OperationCapability.cs
+++ b/TiaMcpServer.Contracts/OperationCapability.cs
@@ -1,0 +1,29 @@
+namespace TiaMcpServer.Contracts;
+
+/// <summary>
+/// Classifies every worker operation by its intent. Both the host and worker use this
+/// shared classification to enforce access policy. An operation that has no explicit
+/// classification is denied in read-only mode (deny-by-default).
+/// </summary>
+public enum OperationCapability
+{
+    /// <summary>Read-only observation: inspect project data without side effects.</summary>
+    Observe,
+
+    /// <summary>Creates temporary files internally (e.g. block export) but does not persist
+    /// output. Allowed in read-only mode when cleanup is guaranteed.</summary>
+    TemporaryExport,
+
+    /// <summary>Invokes the Siemens compilation API. Not allowed in read-only mode because
+    /// compilation may modify internal project state.</summary>
+    Compile,
+
+    /// <summary>Opens, creates, saves, archives, or closes a project.</summary>
+    ProjectLifecycle,
+
+    /// <summary>Modifies project data: blocks, tags, tag tables, user constants, network devices.</summary>
+    ProjectMutation,
+
+    /// <summary>Controls PLC runtime state: start, stop.</summary>
+    OnlineControl
+}

--- a/TiaMcpServer.Contracts/OperationPolicyCatalog.cs
+++ b/TiaMcpServer.Contracts/OperationPolicyCatalog.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+
+namespace TiaMcpServer.Contracts;
+
+/// <summary>
+/// Central classification of every worker operation by its capability. Both the host
+/// (OperationAccessPolicy) and the worker (WorkerOperationAuthorization) consume this
+/// single source of truth. An operation not listed here is denied in read-only mode
+/// (deny-by-default).
+/// </summary>
+public static class OperationPolicyCatalog
+{
+    private static readonly IReadOnlyDictionary<string, OperationCapability> Classifications =
+        BuildClassifications();
+
+    /// <summary>
+    /// Returns the capability for <paramref name="operation"/>, or null if the operation
+    /// is not classified (unknown operations are denied in read-only mode).
+    /// </summary>
+    public static OperationCapability? GetCapability(string operation)
+        => Classifications.TryGetValue(operation, out var cap) ? cap : null;
+
+    /// <summary>
+    /// True when <paramref name="operation"/> is allowed under the given access mode.
+    /// Read-only mode allows only Observe and TemporaryExport.
+    /// </summary>
+    public static bool IsAllowed(McpAccessMode mode, string operation)
+    {
+        if (mode == McpAccessMode.ReadWrite)
+        {
+            return true;
+        }
+
+        var cap = GetCapability(operation);
+        if (cap is null)
+        {
+            return false;
+        }
+
+        return cap.Value is OperationCapability.Observe or OperationCapability.TemporaryExport;
+    }
+
+    /// <summary>
+    /// Every known operation name. Used by tests to verify completeness.
+    /// </summary>
+    public static IReadOnlyCollection<string> AllOperationNames => new List<string>(Classifications.Keys);
+
+    private static IReadOnlyDictionary<string, OperationCapability> BuildClassifications()
+    {
+        var dict = new Dictionary<string, OperationCapability>(StringComparer.Ordinal)
+        {
+            // Observe (read-only safe)
+            ["get_project_status"] = OperationCapability.Observe,
+            ["browse_project_tree"] = OperationCapability.Observe,
+            ["read_hardware_config"] = OperationCapability.Observe,
+            ["search_equipment_catalog"] = OperationCapability.Observe,
+            ["read_cross_references"] = OperationCapability.Observe,
+            ["list_tag_tables"] = OperationCapability.Observe,
+
+            // TemporaryExport (read-only safe, temporary files with cleanup)
+            ["get_block_content"] = OperationCapability.TemporaryExport,
+
+            // Compile (NOT read-only safe)
+            ["compile_check"] = OperationCapability.Compile,
+
+            // ProjectLifecycle (NOT read-only safe)
+            ["open_project"] = OperationCapability.ProjectLifecycle,
+            ["create_project"] = OperationCapability.ProjectLifecycle,
+            ["save_project"] = OperationCapability.ProjectLifecycle,
+            ["save_project_as"] = OperationCapability.ProjectLifecycle,
+            ["archive_project"] = OperationCapability.ProjectLifecycle,
+            ["close_project"] = OperationCapability.ProjectLifecycle,
+
+            // ProjectMutation (NOT read-only safe)
+            ["update_block_logic"] = OperationCapability.ProjectMutation,
+            ["create_block"] = OperationCapability.ProjectMutation,
+            ["delete_block"] = OperationCapability.ProjectMutation,
+            ["create_block_group"] = OperationCapability.ProjectMutation,
+            ["delete_block_group"] = OperationCapability.ProjectMutation,
+            ["create_tag_table"] = OperationCapability.ProjectMutation,
+            ["delete_tag_table"] = OperationCapability.ProjectMutation,
+            ["create_tag"] = OperationCapability.ProjectMutation,
+            ["update_tag"] = OperationCapability.ProjectMutation,
+            ["delete_tag"] = OperationCapability.ProjectMutation,
+            ["create_user_constant"] = OperationCapability.ProjectMutation,
+            ["update_user_constant"] = OperationCapability.ProjectMutation,
+            ["delete_user_constant"] = OperationCapability.ProjectMutation,
+            ["add_network_device"] = OperationCapability.ProjectMutation,
+            ["configure_network_device"] = OperationCapability.ProjectMutation,
+
+            // OnlineControl (NOT read-only safe)
+            ["start_plc"] = OperationCapability.OnlineControl,
+            ["stop_plc"] = OperationCapability.OnlineControl,
+
+            // Internal lifecycle probe (NOT read-only safe — may open a project)
+            ["probe_project_status_for_lifecycle"] = OperationCapability.ProjectLifecycle,
+        };
+
+        return dict;
+    }
+}

--- a/TiaMcpServer.Contracts/ProjectPathNormalization.cs
+++ b/TiaMcpServer.Contracts/ProjectPathNormalization.cs
@@ -19,7 +19,7 @@ namespace TiaMcpServer.Contracts;
 /// crash, so any failure to canonicalize falls back to the trimmed literal instead of
 /// propagating - a bare catch is the correct scope here, not an enumerated exception list.
 /// </summary>
-internal static class ProjectPathNormalization
+public static class ProjectPathNormalization
 {
     public static string? Canonicalize(string? path)
     {

--- a/TiaMcpServer.Contracts/WorkerFailureCategories.cs
+++ b/TiaMcpServer.Contracts/WorkerFailureCategories.cs
@@ -33,6 +33,9 @@ public static class WorkerFailureCategories
     /// <summary>An operation reported success but a required postcondition (e.g. a resolved project path) was missing.</summary>
     public const string PostconditionFailed = "postcondition_failed";
 
+    /// <summary>The operation is not permitted in the current access mode (e.g. a write attempted in read-only mode).</summary>
+    public const string AccessDenied = "access_denied";
+
     private static readonly HashSet<string> Known = new(StringComparer.Ordinal)
     {
         ValidationError,
@@ -41,7 +44,8 @@ public static class WorkerFailureCategories
         WorkerOperationFailed,
         WorkerTimeout,
         WorkerCrashed,
-        PostconditionFailed
+        PostconditionFailed,
+        AccessDenied
     };
 
     /// <summary>True when <paramref name="value"/> is exactly one of the approved category constants.</summary>

--- a/TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Siemens.Engineering;
+using TiaMcpServer.OpennessWorker;
 
 namespace TiaMcpServer.OpennessWorker.Openness;
 
@@ -14,7 +15,13 @@ public class TiaPortalSession : IDisposable
 
     public TiaPortalSession(bool allowTiaConfirmations = false)
     {
-        _allowTiaConfirmations = allowTiaConfirmations;
+        // Even when a caller requests automatic confirmations, an explicitly configured
+        // read-only worker must reject every TIA confirmation dialog. This keeps the final
+        // Siemens-facing layer fail-closed if a nominally read operation unexpectedly asks
+        // TIA Portal to confirm a state-changing action.
+        var accessMode = WorkerOperationAuthorization.ParseAccessMode(Environment.GetCommandLineArgs());
+        _allowTiaConfirmations = allowTiaConfirmations &&
+            WorkerOperationAuthorization.AllowsTiaConfirmations(accessMode);
     }
 
     public Project? Project { get; internal set; }

--- a/TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Siemens.Engineering;
+using TiaMcpServer.Contracts;
 using TiaMcpServer.OpennessWorker;
 
 namespace TiaMcpServer.OpennessWorker.Openness;
@@ -13,13 +14,13 @@ public class TiaPortalSession : IDisposable
     private bool _disposed;
     private bool _projectOpenedByWorker;
 
-    public TiaPortalSession(bool allowTiaConfirmations = false)
+    public TiaPortalSession(
+        bool allowTiaConfirmations = false,
+        McpAccessMode accessMode = McpAccessMode.ReadWrite)
     {
-        // Even when a caller requests automatic confirmations, an explicitly configured
-        // read-only worker must reject every TIA confirmation dialog. This keeps the final
-        // Siemens-facing layer fail-closed if a nominally read operation unexpectedly asks
-        // TIA Portal to confirm a state-changing action.
-        var accessMode = WorkerOperationAuthorization.ParseAccessMode(Environment.GetCommandLineArgs());
+        // Even when a caller requests automatic confirmations, a read-only worker must reject
+        // every TIA confirmation dialog. This keeps the final Siemens-facing layer fail-closed
+        // if a nominally read operation unexpectedly asks TIA Portal to confirm a state change.
         _allowTiaConfirmations = allowTiaConfirmations &&
             WorkerOperationAuthorization.AllowsTiaConfirmations(accessMode);
     }

--- a/TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/TiaPortalSession.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Linq;
 using Siemens.Engineering;
-using TiaMcpServer.Contracts;
 using TiaMcpServer.OpennessWorker;
 
 namespace TiaMcpServer.OpennessWorker.Openness;
@@ -14,13 +13,13 @@ public class TiaPortalSession : IDisposable
     private bool _disposed;
     private bool _projectOpenedByWorker;
 
-    public TiaPortalSession(
-        bool allowTiaConfirmations = false,
-        McpAccessMode accessMode = McpAccessMode.ReadWrite)
+    public TiaPortalSession(bool allowTiaConfirmations = false)
     {
-        // Even when a caller requests automatic confirmations, a read-only worker must reject
-        // every TIA confirmation dialog. This keeps the final Siemens-facing layer fail-closed
-        // if a nominally read operation unexpectedly asks TIA Portal to confirm a state change.
+        // Even when a caller requests automatic confirmations, an explicitly configured
+        // read-only worker must reject every TIA confirmation dialog. This keeps the final
+        // Siemens-facing layer fail-closed if a nominally read operation unexpectedly asks
+        // TIA Portal to confirm a state-changing action.
+        var accessMode = WorkerOperationAuthorization.ParseAccessMode(Environment.GetCommandLineArgs());
         _allowTiaConfirmations = allowTiaConfirmations &&
             WorkerOperationAuthorization.AllowsTiaConfirmations(accessMode);
     }

--- a/TiaMcpServer.OpennessWorker/Program.cs
+++ b/TiaMcpServer.OpennessWorker/Program.cs
@@ -20,6 +20,9 @@ internal static class Program
     // 세션을 프로세스 수명 동안 재사용해 Attach()를 최초 1회만 호출한다.
     private static readonly WorkerTiaPortalSession _sharedSession = new(allowTiaConfirmations: true);
 
+    private static readonly McpAccessMode _accessMode = WorkerOperationAuthorization.ParseAccessMode(
+        Environment.GetCommandLineArgs());
+
     static Program()
     {
         AssemblyResolver.Register();
@@ -29,6 +32,8 @@ internal static class Program
     {
         Console.InputEncoding = System.Text.Encoding.UTF8;
         Console.OutputEncoding = System.Text.Encoding.UTF8;
+
+        Console.Error.WriteLine($"TIA Openness worker access mode: {_accessMode.ToString().ToUpperInvariant()}");
 
         string? line;
         while ((line = Console.In.ReadLine()) is not null)
@@ -90,6 +95,14 @@ internal static class Program
             if (request is null)
             {
                 throw new WorkerOperationException(WorkerFailureCategories.ValidationError, "Worker request was empty.");
+            }
+
+            // Defense in depth: authorize BEFORE the dispatch switch, before any handler
+            // is called, and before any Siemens API call is made.
+            var denial = WorkerOperationAuthorization.Authorize(_accessMode, request.Method);
+            if (denial is not null)
+            {
+                return denial;
             }
 
             return request.Method switch
@@ -654,10 +667,49 @@ internal static class Program
     /// <summary>
     /// Applies <see cref="ProjectOpenPolicy"/> before any non-lifecycle operation may open a
     /// project. Returns null to continue, or the failure response to return to the host.
+    /// In read-only mode, opening a project is never permitted — only the currently open
+    /// project may be used.
     /// </summary>
     private static WorkerResponse? EnsureRequestedProjectOpen(WorkerTiaPortalSession session, string? requestedProjectPath)
     {
         var currentPath = session.CurrentProjectPath;
+
+        if (_accessMode == McpAccessMode.ReadOnly)
+        {
+            // Read-only mode: never open a project. Only use what is already open.
+            if (currentPath is null)
+            {
+                var requested = ProjectPathNormalization.Canonicalize(requestedProjectPath);
+                if (requested is not null)
+                {
+                    // A path was supplied but nothing is open — do NOT open it; treat it as an assertion failure.
+                    return Failure(
+                        WorkerFailureCategories.AccessDenied,
+                        "Read-only mode operates only on the project already open in TIA Portal. "
+                        + "Open the intended project manually and retry.");
+                }
+
+                return Failure(
+                    WorkerFailureCategories.WorkerOperationFailed,
+                    "No project is open in TIA Portal. Open the intended project manually and retry.");
+            }
+
+            if (requestedProjectPath is not null)
+            {
+                var requested = ProjectPathNormalization.Canonicalize(requestedProjectPath);
+                if (requested is not null && !string.Equals(currentPath, requested, StringComparison.OrdinalIgnoreCase))
+                {
+                    return Failure(
+                        WorkerFailureCategories.BindingConflict,
+                        $"Read-only mode is bound to '{currentPath}' but the request targets '{requested}'. "
+                        + "Read-only mode does not switch projects. Omit projectPath to use the open project.");
+                }
+            }
+
+            return null;
+        }
+
+        // Read-write mode: existing behavior.
         switch (ProjectOpenPolicy.Decide(currentPath, requestedProjectPath))
         {
             case ProjectOpenDecision.OpenRequested:

--- a/TiaMcpServer.OpennessWorker/WorkerOperationAuthorization.cs
+++ b/TiaMcpServer.OpennessWorker/WorkerOperationAuthorization.cs
@@ -1,0 +1,80 @@
+using System;
+using TiaMcpServer.Contracts;
+
+namespace TiaMcpServer.OpennessWorker;
+
+/// <summary>
+/// Worker-side authorization. Enforces the immutable access mode before any handler is called.
+/// This is the final defense layer: even if a raw worker request bypasses the host, the worker
+/// independently rejects prohibited operations.
+/// </summary>
+internal static class WorkerOperationAuthorization
+{
+    /// <summary>
+    /// Parses the access mode from the worker process command-line arguments.
+    /// </summary>
+    public static McpAccessMode ParseAccessMode(string[] args)
+    {
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (string.Equals(args[i], "--access-mode", StringComparison.OrdinalIgnoreCase) &&
+                i + 1 < args.Length)
+            {
+                var value = args[i + 1];
+                if (string.Equals(value, "read-only", StringComparison.OrdinalIgnoreCase))
+                {
+                    return McpAccessMode.ReadOnly;
+                }
+
+                if (string.Equals(value, "read-write", StringComparison.OrdinalIgnoreCase))
+                {
+                    return McpAccessMode.ReadWrite;
+                }
+
+                Console.Error.WriteLine($"Warning: Invalid worker access mode '{value}'. Defaulting to read-write.");
+                return McpAccessMode.ReadWrite;
+            }
+
+            const string prefix = "--access-mode=";
+            if (args[i].StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                var value = args[i].Substring(prefix.Length);
+                if (string.Equals(value, "read-only", StringComparison.OrdinalIgnoreCase))
+                {
+                    return McpAccessMode.ReadOnly;
+                }
+
+                if (string.Equals(value, "read-write", StringComparison.OrdinalIgnoreCase))
+                {
+                    return McpAccessMode.ReadWrite;
+                }
+
+                Console.Error.WriteLine($"Warning: Invalid worker access mode '{value}'. Defaulting to read-write.");
+                return McpAccessMode.ReadWrite;
+            }
+        }
+
+        return McpAccessMode.ReadWrite;
+    }
+
+    /// <summary>
+    /// Returns null if the operation is allowed, or a failure response if denied.
+    /// </summary>
+    public static WorkerResponse? Authorize(McpAccessMode mode, string operation)
+    {
+        if (OperationPolicyCatalog.IsAllowed(mode, operation))
+        {
+            return null;
+        }
+
+        return new WorkerResponse
+        {
+            Success = false,
+            Error = $"Operation '{operation}' is disabled because the worker is running in {ModeLabel(mode)} mode.",
+            FailureCategory = WorkerFailureCategories.AccessDenied
+        };
+    }
+
+    private static string ModeLabel(McpAccessMode mode)
+        => mode == McpAccessMode.ReadOnly ? "read-only" : "read-write";
+}

--- a/TiaMcpServer.OpennessWorker/WorkerOperationAuthorization.cs
+++ b/TiaMcpServer.OpennessWorker/WorkerOperationAuthorization.cs
@@ -12,50 +12,42 @@ internal static class WorkerOperationAuthorization
 {
     /// <summary>
     /// Parses the access mode from the worker process command-line arguments.
+    /// Missing configuration preserves the historical read-write default. Explicit but malformed
+    /// configuration fails closed to read-only so a launch or argument-propagation defect cannot
+    /// silently enable mutation operations.
     /// </summary>
     public static McpAccessMode ParseAccessMode(string[] args)
     {
         for (int i = 0; i < args.Length; i++)
         {
-            if (string.Equals(args[i], "--access-mode", StringComparison.OrdinalIgnoreCase) &&
-                i + 1 < args.Length)
+            if (string.Equals(args[i], "--access-mode", StringComparison.OrdinalIgnoreCase))
             {
-                var value = args[i + 1];
-                if (string.Equals(value, "read-only", StringComparison.OrdinalIgnoreCase))
+                if (i + 1 >= args.Length ||
+                    string.IsNullOrWhiteSpace(args[i + 1]) ||
+                    args[i + 1].StartsWith("--", StringComparison.Ordinal))
                 {
-                    return McpAccessMode.ReadOnly;
+                    return FailClosed("--access-mode requires a value");
                 }
 
-                if (string.Equals(value, "read-write", StringComparison.OrdinalIgnoreCase))
-                {
-                    return McpAccessMode.ReadWrite;
-                }
-
-                Console.Error.WriteLine($"Warning: Invalid worker access mode '{value}'. Defaulting to read-write.");
-                return McpAccessMode.ReadWrite;
+                return ParseValueOrFailClosed(args[i + 1]);
             }
 
             const string prefix = "--access-mode=";
             if (args[i].StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             {
-                var value = args[i].Substring(prefix.Length);
-                if (string.Equals(value, "read-only", StringComparison.OrdinalIgnoreCase))
-                {
-                    return McpAccessMode.ReadOnly;
-                }
-
-                if (string.Equals(value, "read-write", StringComparison.OrdinalIgnoreCase))
-                {
-                    return McpAccessMode.ReadWrite;
-                }
-
-                Console.Error.WriteLine($"Warning: Invalid worker access mode '{value}'. Defaulting to read-write.");
-                return McpAccessMode.ReadWrite;
+                return ParseValueOrFailClosed(args[i].Substring(prefix.Length));
             }
         }
 
         return McpAccessMode.ReadWrite;
     }
+
+    /// <summary>
+    /// Whether the worker may automatically accept TIA Portal confirmation dialogs.
+    /// Read-only mode must never auto-confirm an action that could change state.
+    /// </summary>
+    public static bool AllowsTiaConfirmations(McpAccessMode mode)
+        => mode == McpAccessMode.ReadWrite;
 
     /// <summary>
     /// Returns null if the operation is allowed, or a failure response if denied.
@@ -73,6 +65,29 @@ internal static class WorkerOperationAuthorization
             Error = $"Operation '{operation}' is disabled because the worker is running in {ModeLabel(mode)} mode.",
             FailureCategory = WorkerFailureCategories.AccessDenied
         };
+    }
+
+    private static McpAccessMode ParseValueOrFailClosed(string value)
+    {
+        var normalizedValue = value.Trim();
+        if (string.Equals(normalizedValue, "read-only", StringComparison.OrdinalIgnoreCase))
+        {
+            return McpAccessMode.ReadOnly;
+        }
+
+        if (string.Equals(normalizedValue, "read-write", StringComparison.OrdinalIgnoreCase))
+        {
+            return McpAccessMode.ReadWrite;
+        }
+
+        return FailClosed($"invalid access mode '{value}'");
+    }
+
+    private static McpAccessMode FailClosed(string reason)
+    {
+        Console.Error.WriteLine(
+            $"Error: Worker access-mode configuration is invalid ({reason}). Falling back to read-only.");
+        return McpAccessMode.ReadOnly;
     }
 
     private static string ModeLabel(McpAccessMode mode)

--- a/TiaMcpServer.OpennessWorker/WorkerOperationAuthorization.cs
+++ b/TiaMcpServer.OpennessWorker/WorkerOperationAuthorization.cs
@@ -13,11 +13,24 @@ internal static class WorkerOperationAuthorization
     /// <summary>
     /// Parses the access mode from the worker process command-line arguments.
     /// Missing configuration preserves the historical read-write default. Explicit but malformed
-    /// configuration fails closed to read-only so a launch or argument-propagation defect cannot
-    /// silently enable mutation operations.
+    /// or contradictory configuration fails closed to read-only so a launch or argument-
+    /// propagation defect cannot silently enable mutation operations.
     /// </summary>
     public static McpAccessMode ParseAccessMode(string[] args)
     {
+        McpAccessMode? explicitMode = null;
+
+        bool RecordMode(McpAccessMode candidate)
+        {
+            if (explicitMode is not null && explicitMode.Value != candidate)
+            {
+                return false;
+            }
+
+            explicitMode = candidate;
+            return true;
+        }
+
         for (int i = 0; i < args.Length; i++)
         {
             if (string.Equals(args[i], "--access-mode", StringComparison.OrdinalIgnoreCase))
@@ -29,17 +42,38 @@ internal static class WorkerOperationAuthorization
                     return FailClosed("--access-mode requires a value");
                 }
 
-                return ParseValueOrFailClosed(args[i + 1]);
+                var parsed = ParseValue(args[++i]);
+                if (parsed is null)
+                {
+                    return FailClosed($"invalid access mode '{args[i]}'");
+                }
+
+                if (!RecordMode(parsed.Value))
+                {
+                    return FailClosed("conflicting access mode arguments were supplied");
+                }
+
+                continue;
             }
 
             const string prefix = "--access-mode=";
             if (args[i].StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             {
-                return ParseValueOrFailClosed(args[i].Substring(prefix.Length));
+                var value = args[i].Substring(prefix.Length);
+                var parsed = ParseValue(value);
+                if (parsed is null)
+                {
+                    return FailClosed($"invalid access mode '{value}'");
+                }
+
+                if (!RecordMode(parsed.Value))
+                {
+                    return FailClosed("conflicting access mode arguments were supplied");
+                }
             }
         }
 
-        return McpAccessMode.ReadWrite;
+        return explicitMode ?? McpAccessMode.ReadWrite;
     }
 
     /// <summary>
@@ -67,7 +101,7 @@ internal static class WorkerOperationAuthorization
         };
     }
 
-    private static McpAccessMode ParseValueOrFailClosed(string value)
+    private static McpAccessMode? ParseValue(string value)
     {
         var normalizedValue = value.Trim();
         if (string.Equals(normalizedValue, "read-only", StringComparison.OrdinalIgnoreCase))
@@ -80,7 +114,7 @@ internal static class WorkerOperationAuthorization
             return McpAccessMode.ReadWrite;
         }
 
-        return FailClosed($"invalid access mode '{value}'");
+        return null;
     }
 
     private static McpAccessMode FailClosed(string reason)

--- a/TiaMcpServer.Tests/BatchToolsTests.cs
+++ b/TiaMcpServer.Tests/BatchToolsTests.cs
@@ -22,9 +22,16 @@ public class BatchToolsTests
     [InlineData("ApplyWriteBatch", "apply_write_batch")]
     public void BatchToolsHaveMcpMetadata(string methodName, string expectedToolName)
     {
-        Assert.NotNull(typeof(BatchTools).GetCustomAttribute<McpServerToolTypeAttribute>());
+        // Tools have been split into ReadBatchTools and WriteBatchTools.
+        // BatchTools retains the methods for backward compatibility but no longer
+        // carries [McpServerToolType]/[McpServerTool] attributes.
+        var type = methodName == "ExecuteReadBatch"
+            ? typeof(ReadBatchTools)
+            : typeof(WriteBatchTools);
 
-        var method = typeof(BatchTools).GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(type.GetCustomAttribute<McpServerToolTypeAttribute>());
+
+        var method = type.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance);
 
         Assert.NotNull(method);
         var toolAttribute = method!.GetCustomAttribute<McpServerToolAttribute>();

--- a/TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs
@@ -163,7 +163,7 @@ public class OpennessWorkerCheckTests
             "TiaMcpServer.csproj"));
 
         Assert.Equal(
-            3,
+            4,
             project.Split("**\\*.runtimeconfig.json", StringSplitOptions.None).Length);
         Assert.Contains("RemoveStaleOpennessWorkerRuntimeConfig", project);
         Assert.DoesNotContain("PackOpennessWorker", project);

--- a/TiaMcpServer.Tests/McpToolSchemaTests.cs
+++ b/TiaMcpServer.Tests/McpToolSchemaTests.cs
@@ -96,7 +96,7 @@ public class McpToolSchemaTests
             .Where(t => t.GetCustomAttribute<McpServerToolTypeAttribute>() is not null);
 
         var toolNames = toolTypes
-            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance))
             .Select(m => m.GetCustomAttribute<McpServerToolAttribute>())
             .Where(a => a is not null)
             .Select(a => a!.Name)

--- a/TiaMcpServer.Tests/ProjectLifecycleToolTests.cs
+++ b/TiaMcpServer.Tests/ProjectLifecycleToolTests.cs
@@ -21,7 +21,12 @@ public class ProjectLifecycleToolTests
     [InlineData("CloseProject", "close_project", true)]
     public void ProjectLifecycleToolsHaveMcpMetadata(string methodName, string expectedToolName, bool requiresConfirm)
     {
-        var type = typeof(ProjectLifecycleTools);
+        // Tools have been split into ProjectReadTools and ProjectWriteTools.
+        // ProjectLifecycleTools retains the methods for backward compatibility but no longer
+        // carries [McpServerToolType]/[McpServerTool] attributes.
+        var type = methodName == "GetProjectStatus"
+            ? typeof(ProjectReadTools)
+            : typeof(ProjectWriteTools);
 
         Assert.NotNull(type.GetCustomAttribute<McpServerToolTypeAttribute>());
 

--- a/TiaMcpServer.Tests/ReadOnlyModeHardeningTests.cs
+++ b/TiaMcpServer.Tests/ReadOnlyModeHardeningTests.cs
@@ -53,6 +53,24 @@ public class ReadOnlyModeHardeningTests
     }
 
     [Fact]
+    public void HostArgumentFilter_RemovesBareAccessModeAlias()
+    {
+        var filtered = HostArgumentFilter.RemoveAccessModeArguments(
+            new[] { "--read-only", "--project", "Line.ap21" });
+
+        Assert.Equal(new[] { "--project", "Line.ap21" }, filtered);
+    }
+
+    [Fact]
+    public void HostArgumentFilter_RemovesAccessModeKeyAndValue()
+    {
+        var filtered = HostArgumentFilter.RemoveAccessModeArguments(
+            new[] { "--json", "--access-mode", "read-write", "--project=Line.ap21" });
+
+        Assert.Equal(new[] { "--json", "--project=Line.ap21" }, filtered);
+    }
+
+    [Fact]
     public void WorkerAccessMode_InvalidExplicitValue_FailsClosed()
     {
         var mode = WorkerOperationAuthorization.ParseAccessMode(

--- a/TiaMcpServer.Tests/ReadOnlyModeHardeningTests.cs
+++ b/TiaMcpServer.Tests/ReadOnlyModeHardeningTests.cs
@@ -35,6 +35,24 @@ public class ReadOnlyModeHardeningTests
     }
 
     [Fact]
+    public void AccessModeParser_ConflictingModes_FailClearly()
+    {
+        var result = AccessModeParser.Parse(new[] { "--read-only", "--access-mode", "read-write" });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("Conflicting", result.Error);
+    }
+
+    [Fact]
+    public void AccessModeParser_RepeatedEquivalentModes_AreAllowed()
+    {
+        var result = AccessModeParser.Parse(new[] { "--read-only", "--access-mode=read-only" });
+
+        Assert.True(result.IsValid);
+        Assert.Equal(McpAccessMode.ReadOnly, result.Mode);
+    }
+
+    [Fact]
     public void WorkerAccessMode_InvalidExplicitValue_FailsClosed()
     {
         var mode = WorkerOperationAuthorization.ParseAccessMode(
@@ -48,6 +66,15 @@ public class ReadOnlyModeHardeningTests
     {
         var mode = WorkerOperationAuthorization.ParseAccessMode(
             new[] { "--access-mode" });
+
+        Assert.Equal(McpAccessMode.ReadOnly, mode);
+    }
+
+    [Fact]
+    public void WorkerAccessMode_ConflictingModes_FailClosed()
+    {
+        var mode = WorkerOperationAuthorization.ParseAccessMode(
+            new[] { "--access-mode=read-write", "--access-mode", "read-only" });
 
         Assert.Equal(McpAccessMode.ReadOnly, mode);
     }
@@ -85,5 +112,14 @@ public class ReadOnlyModeHardeningTests
 
         Assert.False(options.Valid);
         Assert.Contains("requires a value", options.ParseError);
+    }
+
+    [Fact]
+    public void DoctorCliParser_ConflictingModes_FailClearly()
+    {
+        var options = DoctorCliParser.Parse(new[] { "--read-only", "--read-write" });
+
+        Assert.False(options.Valid);
+        Assert.Contains("Conflicting", options.ParseError);
     }
 }

--- a/TiaMcpServer.Tests/ReadOnlyModeHardeningTests.cs
+++ b/TiaMcpServer.Tests/ReadOnlyModeHardeningTests.cs
@@ -1,0 +1,89 @@
+using TiaMcpServer.Cli;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.OpennessWorker;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+public class ReadOnlyModeHardeningTests
+{
+    [Fact]
+    public void AccessModeParser_MissingValue_FailsClearly()
+    {
+        var result = AccessModeParser.Parse(new[] { "--access-mode" });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("requires a value", result.Error);
+    }
+
+    [Fact]
+    public void AccessModeParser_DoesNotConsumeAnotherOptionAsValue()
+    {
+        var result = AccessModeParser.Parse(new[] { "--access-mode", "--project", "Line.ap21" });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("requires a value", result.Error);
+    }
+
+    [Fact]
+    public void AccessModeParser_TrimsConfiguredValue()
+    {
+        var result = AccessModeParser.ParseValue("  read-only  ");
+
+        Assert.True(result.IsValid);
+        Assert.Equal(McpAccessMode.ReadOnly, result.Mode);
+    }
+
+    [Fact]
+    public void WorkerAccessMode_InvalidExplicitValue_FailsClosed()
+    {
+        var mode = WorkerOperationAuthorization.ParseAccessMode(
+            new[] { "--access-mode", "unexpected" });
+
+        Assert.Equal(McpAccessMode.ReadOnly, mode);
+    }
+
+    [Fact]
+    public void WorkerAccessMode_MissingExplicitValue_FailsClosed()
+    {
+        var mode = WorkerOperationAuthorization.ParseAccessMode(
+            new[] { "--access-mode" });
+
+        Assert.Equal(McpAccessMode.ReadOnly, mode);
+    }
+
+    [Fact]
+    public void WorkerTiaConfirmations_AreDisabledInReadOnlyMode()
+    {
+        Assert.False(WorkerOperationAuthorization.AllowsTiaConfirmations(McpAccessMode.ReadOnly));
+        Assert.True(WorkerOperationAuthorization.AllowsTiaConfirmations(McpAccessMode.ReadWrite));
+    }
+
+    [Fact]
+    public void DoctorCliParser_ReadOnlyAlias_ReportsReadOnlyMode()
+    {
+        var options = DoctorCliParser.Parse(new[] { "--read-only" });
+
+        Assert.True(options.Valid);
+        Assert.Equal(McpAccessMode.ReadOnly, options.AccessMode);
+    }
+
+    [Fact]
+    public void DoctorCliParser_AccessModeOption_ReportsRequestedMode()
+    {
+        var options = DoctorCliParser.Parse(new[] { "--access-mode", "read-write", "--json" });
+
+        Assert.True(options.Valid);
+        Assert.True(options.Json);
+        Assert.Equal(McpAccessMode.ReadWrite, options.AccessMode);
+    }
+
+    [Fact]
+    public void DoctorCliParser_MissingAccessModeValue_FailsClearly()
+    {
+        var options = DoctorCliParser.Parse(new[] { "--access-mode" });
+
+        Assert.False(options.Valid);
+        Assert.Contains("requires a value", options.ParseError);
+    }
+}

--- a/TiaMcpServer.Tests/ReadOnlyModeTests.cs
+++ b/TiaMcpServer.Tests/ReadOnlyModeTests.cs
@@ -1,0 +1,650 @@
+using System.Reflection;
+using ModelContextProtocol.Server;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Cli;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tools;
+using TiaMcpServer.Worker;
+using TiaMcpServer.OpennessWorker;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+/// <summary>
+/// Comprehensive tests for the read-only safety mode: configuration, policy catalog,
+/// host-side enforcement, worker-side authorization, tool discovery, and batch behavior.
+/// </summary>
+public class ReadOnlyModeTests
+{
+    #region Configuration Tests
+
+    [Fact]
+    public void DefaultMode_IsReadWrite()
+    {
+        var result = AccessModeParser.Parse(Array.Empty<string>());
+        Assert.True(result.IsValid);
+        Assert.Equal(McpAccessMode.ReadWrite, result.Mode);
+    }
+
+    [Fact]
+    public void ReadOnlyFlag_ResolvesToReadOnly()
+    {
+        var result = AccessModeParser.Parse(new[] { "--read-only" });
+        Assert.True(result.IsValid);
+        Assert.Equal(McpAccessMode.ReadOnly, result.Mode);
+    }
+
+    [Fact]
+    public void ReadWriteFlag_ResolvesToReadWrite()
+    {
+        var result = AccessModeParser.Parse(new[] { "--read-write" });
+        Assert.True(result.IsValid);
+        Assert.Equal(McpAccessMode.ReadWrite, result.Mode);
+    }
+
+    [Fact]
+    public void AccessMode_Argument_ResolvesCorrectly()
+    {
+        var result = AccessModeParser.Parse(new[] { "--access-mode", "read-only" });
+        Assert.True(result.IsValid);
+        Assert.Equal(McpAccessMode.ReadOnly, result.Mode);
+    }
+
+    [Fact]
+    public void AccessMode_Equals_Syntax_ResolvesCorrectly()
+    {
+        var result = AccessModeParser.Parse(new[] { "--access-mode=read-only" });
+        Assert.True(result.IsValid);
+        Assert.Equal(McpAccessMode.ReadOnly, result.Mode);
+    }
+
+    [Fact]
+    public void AccessMode_ReadWrite_Argument_ResolvesCorrectly()
+    {
+        var result = AccessModeParser.Parse(new[] { "--access-mode", "read-write" });
+        Assert.True(result.IsValid);
+        Assert.Equal(McpAccessMode.ReadWrite, result.Mode);
+    }
+
+    [Fact]
+    public void EnvironmentVariable_ResolvesCorrectly()
+    {
+        try
+        {
+            Environment.SetEnvironmentVariable("TIA_MCP_ACCESS_MODE", "read-only");
+            var result = AccessModeParser.Parse(Array.Empty<string>());
+            Assert.True(result.IsValid);
+            Assert.Equal(McpAccessMode.ReadOnly, result.Mode);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("TIA_MCP_ACCESS_MODE", null);
+        }
+    }
+
+    [Fact]
+    public void CLI_Overrides_EnvironmentVariable()
+    {
+        try
+        {
+            Environment.SetEnvironmentVariable("TIA_MCP_ACCESS_MODE", "read-only");
+            var result = AccessModeParser.Parse(new[] { "--access-mode", "read-write" });
+            Assert.True(result.IsValid);
+            Assert.Equal(McpAccessMode.ReadWrite, result.Mode);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("TIA_MCP_ACCESS_MODE", null);
+        }
+    }
+
+    [Fact]
+    public void InvalidValue_FailsClearly()
+    {
+        var result = AccessModeParser.Parse(new[] { "--access-mode", "invalid" });
+        Assert.False(result.IsValid);
+        Assert.Contains("Invalid access mode", result.Error);
+    }
+
+    [Fact]
+    public void EmptyValue_FailsClearly()
+    {
+        var result = AccessModeParser.ParseValue("");
+        Assert.False(result.IsValid);
+        Assert.Contains("empty", result.Error);
+    }
+
+    [Fact]
+    public void ParseValue_IsCaseInsensitive()
+    {
+        var result = AccessModeParser.ParseValue("READ-ONLY");
+        Assert.True(result.IsValid);
+        Assert.Equal(McpAccessMode.ReadOnly, result.Mode);
+    }
+
+    #endregion
+
+    #region Policy Catalog Tests
+
+    [Fact]
+    public void EveryKnownOperation_HasExactlyOneClassification()
+    {
+        var operations = OperationPolicyCatalog.AllOperationNames;
+        Assert.NotEmpty(operations);
+
+        foreach (var op in operations)
+        {
+            var cap = OperationPolicyCatalog.GetCapability(op);
+            Assert.NotNull(cap);
+        }
+    }
+
+    [Fact]
+    public void UnclassifiedOperation_IsDeniedInReadOnlyMode()
+    {
+        Assert.False(OperationPolicyCatalog.IsAllowed(McpAccessMode.ReadOnly, "nonexistent_operation"));
+        Assert.False(OperationPolicyCatalog.IsAllowed(McpAccessMode.ReadOnly, ""));
+        Assert.False(OperationPolicyCatalog.IsAllowed(McpAccessMode.ReadOnly, "future_mutation_op"));
+    }
+
+    [Fact]
+    public void ReadWriteMode_AllowsAllClassifiedOperations()
+    {
+        foreach (var op in OperationPolicyCatalog.AllOperationNames)
+        {
+            Assert.True(OperationPolicyCatalog.IsAllowed(McpAccessMode.ReadWrite, op));
+        }
+    }
+
+    [Theory]
+    [InlineData("get_project_status")]
+    [InlineData("browse_project_tree")]
+    [InlineData("read_hardware_config")]
+    [InlineData("search_equipment_catalog")]
+    [InlineData("read_cross_references")]
+    [InlineData("list_tag_tables")]
+    [InlineData("get_block_content")]
+    public void ReadOnlyMode_AllowsApprovedOperations(string operation)
+    {
+        Assert.True(OperationPolicyCatalog.IsAllowed(McpAccessMode.ReadOnly, operation));
+    }
+
+    [Theory]
+    [InlineData("compile_check")]
+    [InlineData("open_project")]
+    [InlineData("create_project")]
+    [InlineData("save_project")]
+    [InlineData("save_project_as")]
+    [InlineData("archive_project")]
+    [InlineData("close_project")]
+    [InlineData("update_block_logic")]
+    [InlineData("create_block")]
+    [InlineData("delete_block")]
+    [InlineData("create_block_group")]
+    [InlineData("delete_block_group")]
+    [InlineData("create_tag_table")]
+    [InlineData("delete_tag_table")]
+    [InlineData("create_tag")]
+    [InlineData("update_tag")]
+    [InlineData("delete_tag")]
+    [InlineData("create_user_constant")]
+    [InlineData("update_user_constant")]
+    [InlineData("delete_user_constant")]
+    [InlineData("add_network_device")]
+    [InlineData("configure_network_device")]
+    [InlineData("start_plc")]
+    [InlineData("stop_plc")]
+    public void ReadOnlyMode_DeniesProhibitedOperations(string operation)
+    {
+        Assert.False(OperationPolicyCatalog.IsAllowed(McpAccessMode.ReadOnly, operation));
+    }
+
+    [Fact]
+    public void CompileCheck_IsExplicitlyDeniedInReadOnlyMode()
+    {
+        Assert.Equal(OperationCapability.Compile, OperationPolicyCatalog.GetCapability("compile_check"));
+        Assert.False(OperationPolicyCatalog.IsAllowed(McpAccessMode.ReadOnly, "compile_check"));
+    }
+
+    #endregion
+
+    #region Host Enforcement Tests
+
+    [Fact]
+    public void OperationAccessPolicy_ReadOnly_DeniesWriteOperations()
+    {
+        var policy = new OperationAccessPolicy(McpAccessMode.ReadOnly);
+        var result = policy.Authorize("update_block_logic");
+        Assert.NotNull(result);
+        Assert.False(result.Success);
+        Assert.Equal(WorkerFailureCategories.AccessDenied, result.FailureCategory);
+        Assert.Contains("update_block_logic", result.Error);
+        Assert.Contains("read-only", result.Error);
+    }
+
+    [Fact]
+    public void OperationAccessPolicy_ReadOnly_DeniesCompileCheck()
+    {
+        var policy = new OperationAccessPolicy(McpAccessMode.ReadOnly);
+        var result = policy.Authorize("compile_check");
+        Assert.NotNull(result);
+        Assert.False(result.Success);
+        Assert.Equal(WorkerFailureCategories.AccessDenied, result.FailureCategory);
+    }
+
+    [Fact]
+    public void OperationAccessPolicy_ReadOnly_AllowsReadOperations()
+    {
+        var policy = new OperationAccessPolicy(McpAccessMode.ReadOnly);
+        Assert.Null(policy.Authorize("get_project_status"));
+        Assert.Null(policy.Authorize("browse_project_tree"));
+        Assert.Null(policy.Authorize("get_block_content"));
+    }
+
+    [Fact]
+    public void OperationAccessPolicy_ReadWrite_AllowsAllOperations()
+    {
+        var policy = new OperationAccessPolicy(McpAccessMode.ReadWrite);
+        Assert.Null(policy.Authorize("update_block_logic"));
+        Assert.Null(policy.Authorize("compile_check"));
+        Assert.Null(policy.Authorize("get_project_status"));
+        Assert.Null(policy.Authorize("start_plc"));
+    }
+
+    [Fact]
+    public void OperationAccessPolicy_DeniesLifecycleOperations()
+    {
+        var policy = new OperationAccessPolicy(McpAccessMode.ReadOnly);
+        Assert.NotNull(policy.Authorize("open_project"));
+        Assert.NotNull(policy.Authorize("create_project"));
+        Assert.NotNull(policy.Authorize("save_project"));
+        Assert.NotNull(policy.Authorize("save_project_as"));
+        Assert.NotNull(policy.Authorize("archive_project"));
+        Assert.NotNull(policy.Authorize("close_project"));
+    }
+
+    [Fact]
+    public void OperationAccessPolicy_DeniesOnlineControlOperations()
+    {
+        var policy = new OperationAccessPolicy(McpAccessMode.ReadOnly);
+        Assert.NotNull(policy.Authorize("start_plc"));
+        Assert.NotNull(policy.Authorize("stop_plc"));
+    }
+
+    [Fact]
+    public void OperationAccessPolicy_DeniesUnknownOperations()
+    {
+        var policy = new OperationAccessPolicy(McpAccessMode.ReadOnly);
+        var result = policy.Authorize("unknown_future_op");
+        Assert.NotNull(result);
+        Assert.False(result.Success);
+        Assert.Equal(WorkerFailureCategories.AccessDenied, result.FailureCategory);
+    }
+
+    #endregion
+
+    #region Host Client Enforcement Tests
+
+    [Fact]
+    public async Task OpennessWorkerClient_ReadOnly_DeniesBeforeWorkerInvocation()
+    {
+        var binding = new ProjectSessionBinding(null);
+        var policy = new OperationAccessPolicy(McpAccessMode.ReadOnly);
+        var client = new OpennessWorkerClient(
+            binding,
+            workerExecutablePath: "/nonexistent/path",
+            accessPolicy: policy);
+
+        var result = await client.UpdateBlockLogicAsync("Main", "yaml", null);
+
+        Assert.False(result.Success);
+        Assert.Equal(WorkerFailureCategories.AccessDenied, result.FailureCategory);
+        Assert.Contains("update_block_logic", result.Error);
+        Assert.Contains("read-only", result.Error);
+    }
+
+    [Fact]
+    public async Task OpennessWorkerClient_ReadOnly_DeniesOpenProject()
+    {
+        var binding = new ProjectSessionBinding(null);
+        var policy = new OperationAccessPolicy(McpAccessMode.ReadOnly);
+        var client = new OpennessWorkerClient(
+            binding,
+            workerExecutablePath: "/nonexistent/path",
+            accessPolicy: policy);
+
+        var result = await client.OpenProjectAsync("/fake/path.ap21", forceRebind: false);
+
+        Assert.False(result.Success);
+        Assert.Equal(WorkerFailureCategories.AccessDenied, result.FailureCategory);
+    }
+
+    [Fact]
+    public async Task OpennessWorkerClient_ReadOnly_DeniesStartPlc()
+    {
+        var binding = new ProjectSessionBinding(null);
+        var policy = new OperationAccessPolicy(McpAccessMode.ReadOnly);
+        var client = new OpennessWorkerClient(
+            binding,
+            workerExecutablePath: "/nonexistent/path",
+            accessPolicy: policy);
+
+        var result = await client.StartPlcAsync(null, null);
+
+        Assert.False(result.Success);
+        Assert.Equal(WorkerFailureCategories.AccessDenied, result.FailureCategory);
+    }
+
+    [Fact]
+    public async Task OpennessWorkerClient_ReadOnly_DeniesCompileCheck()
+    {
+        var binding = new ProjectSessionBinding(null);
+        var policy = new OperationAccessPolicy(McpAccessMode.ReadOnly);
+        var client = new OpennessWorkerClient(
+            binding,
+            workerExecutablePath: "/nonexistent/path",
+            accessPolicy: policy);
+
+        var result = await client.CompileCheckAsync(null, null, null);
+
+        Assert.False(result.Success);
+        Assert.Equal(WorkerFailureCategories.AccessDenied, result.FailureCategory);
+    }
+
+    [Fact]
+    public void OpennessWorkerClient_AccessPolicy_IsExposed()
+    {
+        var binding = new ProjectSessionBinding(null);
+        var policy = new OperationAccessPolicy(McpAccessMode.ReadOnly);
+        var client = new OpennessWorkerClient(
+            binding,
+            accessPolicy: policy);
+
+        Assert.NotNull(client.AccessPolicy);
+        Assert.Equal(McpAccessMode.ReadOnly, client.AccessPolicy.Mode);
+    }
+
+    [Fact]
+    public void OpennessWorkerClient_NoPolicy_DefaultsToReadWrite()
+    {
+        var binding = new ProjectSessionBinding(null);
+        var client = new OpennessWorkerClient(binding);
+
+        Assert.Null(client.AccessPolicy);
+    }
+
+    #endregion
+
+    #region Worker Authorization Tests
+
+    [Fact]
+    public void WorkerOperationAuthorization_ParsesReadOnly()
+    {
+        var mode = WorkerOperationAuthorization.ParseAccessMode(new[] { "--access-mode", "read-only" });
+        Assert.Equal(McpAccessMode.ReadOnly, mode);
+    }
+
+    [Fact]
+    public void WorkerOperationAuthorization_ParsesReadWrite()
+    {
+        var mode = WorkerOperationAuthorization.ParseAccessMode(new[] { "--access-mode", "read-write" });
+        Assert.Equal(McpAccessMode.ReadWrite, mode);
+    }
+
+    [Fact]
+    public void WorkerOperationAuthorization_DefaultsToReadWrite()
+    {
+        var mode = WorkerOperationAuthorization.ParseAccessMode(Array.Empty<string>());
+        Assert.Equal(McpAccessMode.ReadWrite, mode);
+    }
+
+    [Fact]
+    public void WorkerOperationAuthorization_ReadOnly_DeniesMutation()
+    {
+        var denial = WorkerOperationAuthorization.Authorize(McpAccessMode.ReadOnly, "update_block_logic");
+        Assert.NotNull(denial);
+        Assert.False(denial.Success);
+        Assert.Equal(WorkerFailureCategories.AccessDenied, denial.FailureCategory);
+        Assert.Contains("update_block_logic", denial.Error);
+    }
+
+    [Fact]
+    public void WorkerOperationAuthorization_ReadOnly_DeniesLifecycle()
+    {
+        var denial = WorkerOperationAuthorization.Authorize(McpAccessMode.ReadOnly, "open_project");
+        Assert.NotNull(denial);
+        Assert.False(denial.Success);
+        Assert.Equal(WorkerFailureCategories.AccessDenied, denial.FailureCategory);
+    }
+
+    [Fact]
+    public void WorkerOperationAuthorization_ReadOnly_AllowsReads()
+    {
+        Assert.Null(WorkerOperationAuthorization.Authorize(McpAccessMode.ReadOnly, "get_project_status"));
+        Assert.Null(WorkerOperationAuthorization.Authorize(McpAccessMode.ReadOnly, "browse_project_tree"));
+        Assert.Null(WorkerOperationAuthorization.Authorize(McpAccessMode.ReadOnly, "get_block_content"));
+    }
+
+    [Fact]
+    public void WorkerOperationAuthorization_ReadOnly_AllowsTemporaryExport()
+    {
+        Assert.Null(WorkerOperationAuthorization.Authorize(McpAccessMode.ReadOnly, "get_block_content"));
+    }
+
+    [Fact]
+    public void WorkerOperationAuthorization_ReadOnly_DeniesCompile()
+    {
+        var denial = WorkerOperationAuthorization.Authorize(McpAccessMode.ReadOnly, "compile_check");
+        Assert.NotNull(denial);
+        Assert.Equal(WorkerFailureCategories.AccessDenied, denial.FailureCategory);
+    }
+
+    [Fact]
+    public void WorkerOperationAuthorization_ReadWrite_AllowsAll()
+    {
+        Assert.Null(WorkerOperationAuthorization.Authorize(McpAccessMode.ReadWrite, "update_block_logic"));
+        Assert.Null(WorkerOperationAuthorization.Authorize(McpAccessMode.ReadWrite, "open_project"));
+        Assert.Null(WorkerOperationAuthorization.Authorize(McpAccessMode.ReadWrite, "compile_check"));
+        Assert.Null(WorkerOperationAuthorization.Authorize(McpAccessMode.ReadWrite, "start_plc"));
+    }
+
+    [Fact]
+    public void WorkerOperationAuthorization_ReadOnly_DeniesOnlineControl()
+    {
+        Assert.NotNull(WorkerOperationAuthorization.Authorize(McpAccessMode.ReadOnly, "start_plc"));
+        Assert.NotNull(WorkerOperationAuthorization.Authorize(McpAccessMode.ReadOnly, "stop_plc"));
+    }
+
+    #endregion
+
+    #region Batch Access Mode Tests
+
+    [Fact]
+    public void ValidateAccessMode_ReadWrite_AllowsAll()
+    {
+        var ops = new[]
+        {
+            new BatchOperationRequest { OperationId = "a", Operation = "update_block_logic", BlockPath = "Main", YamlContent = "x" },
+            new BatchOperationRequest { OperationId = "b", Operation = "compile_check" },
+        };
+        var errors = BatchOperationCatalog.ValidateAccessMode(ops, McpAccessMode.ReadWrite);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ValidateAccessMode_ReadOnly_DeniesWriteOperations()
+    {
+        var ops = new[]
+        {
+            new BatchOperationRequest { OperationId = "a", Operation = "update_block_logic", BlockPath = "Main", YamlContent = "x" },
+        };
+        var errors = BatchOperationCatalog.ValidateAccessMode(ops, McpAccessMode.ReadOnly);
+        Assert.Single(errors);
+        Assert.Contains("update_block_logic", errors[0]);
+        Assert.Contains("read-only", errors[0]);
+    }
+
+    [Fact]
+    public void ValidateAccessMode_ReadOnly_DeniesCompileCheck()
+    {
+        var ops = new[]
+        {
+            new BatchOperationRequest { OperationId = "a", Operation = "compile_check" },
+        };
+        var errors = BatchOperationCatalog.ValidateAccessMode(ops, McpAccessMode.ReadOnly);
+        Assert.Single(errors);
+        Assert.Contains("compile_check", errors[0]);
+    }
+
+    [Fact]
+    public void ValidateAccessMode_ReadOnly_AllowsReadOperations()
+    {
+        var ops = new[]
+        {
+            new BatchOperationRequest { OperationId = "a", Operation = "get_project_status" },
+            new BatchOperationRequest { OperationId = "b", Operation = "browse_project_tree" },
+            new BatchOperationRequest { OperationId = "c", Operation = "get_block_content", BlockPath = "Main" },
+        };
+        var errors = BatchOperationCatalog.ValidateAccessMode(ops, McpAccessMode.ReadOnly);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ValidateAccessMode_ReadOnly_DeniesMixedOperations()
+    {
+        var ops = new[]
+        {
+            new BatchOperationRequest { OperationId = "a", Operation = "get_project_status" },
+            new BatchOperationRequest { OperationId = "b", Operation = "update_block_logic", BlockPath = "Main", YamlContent = "x" },
+        };
+        var errors = BatchOperationCatalog.ValidateAccessMode(ops, McpAccessMode.ReadOnly);
+        Assert.Single(errors);
+        Assert.Contains("update_block_logic", errors[0]);
+    }
+
+    #endregion
+
+    #region Tool Discovery Tests
+
+    [Fact]
+    public void ReadWriteMode_HasAllTenTools()
+    {
+        // In read-write mode, all 10 tools should be discoverable via assembly scanning.
+        var toolTypes = typeof(ProjectLifecycleTools).Assembly
+            .GetTypes()
+            .Where(t => t.GetCustomAttribute<McpServerToolTypeAttribute>() is not null);
+
+        var toolNames = toolTypes
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance))
+            .Select(m => m.GetCustomAttribute<McpServerToolAttribute>())
+            .Where(a => a is not null)
+            .Select(a => a!.Name)
+            .ToArray();
+
+        Assert.Equal(10, toolNames.Length);
+    }
+
+    [Fact]
+    public void ProjectReadTools_HasGetProjectStatus()
+    {
+        var method = typeof(ProjectReadTools).GetMethod("GetProjectStatus",
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance);
+        Assert.NotNull(method);
+        var attr = method!.GetCustomAttribute<McpServerToolAttribute>();
+        Assert.NotNull(attr);
+        Assert.Equal("get_project_status", attr.Name);
+        Assert.True(attr.ReadOnly);
+        Assert.False(attr.Destructive);
+    }
+
+    [Fact]
+    public void ReadBatchTools_HasExecuteReadBatch()
+    {
+        var method = typeof(ReadBatchTools).GetMethod("ExecuteReadBatch",
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance);
+        Assert.NotNull(method);
+        var attr = method!.GetCustomAttribute<McpServerToolAttribute>();
+        Assert.NotNull(attr);
+        Assert.Equal("execute_read_batch", attr.Name);
+        Assert.True(attr.ReadOnly);
+        Assert.False(attr.Destructive);
+    }
+
+    [Fact]
+    public void ProjectWriteTools_HasAllSixWriteTools()
+    {
+        var writeToolNames = typeof(ProjectWriteTools)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance)
+            .Select(m => m.GetCustomAttribute<McpServerToolAttribute>()?.Name)
+            .Where(name => name is not null)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(
+            new[] { "archive_project", "close_project", "create_project", "open_project", "save_project", "save_project_as" },
+            writeToolNames);
+    }
+
+    [Fact]
+    public void WriteBatchTools_HasPreviewAndApply()
+    {
+        var writeToolNames = typeof(WriteBatchTools)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance)
+            .Select(m => m.GetCustomAttribute<McpServerToolAttribute>()?.Name)
+            .Where(name => name is not null)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(new[] { "apply_write_batch", "preview_write_batch" }, writeToolNames);
+    }
+
+    #endregion
+
+    #region Failure Category Tests
+
+    [Fact]
+    public void AccessDenied_IsKnownFailureCategory()
+    {
+        Assert.True(WorkerFailureCategories.IsKnown(WorkerFailureCategories.AccessDenied));
+    }
+
+    [Fact]
+    public void AccessDenied_CanBeUsedInWorkerCallResult()
+    {
+        var result = WorkerCallResult.Fail(
+            WorkerFailureCategories.AccessDenied,
+            "Operation 'update_block_logic' is disabled in read-only mode.");
+
+        Assert.False(result.Success);
+        Assert.Equal(WorkerFailureCategories.AccessDenied, result.FailureCategory);
+        Assert.Contains("update_block_logic", result.Error);
+    }
+
+    #endregion
+
+    #region Confirm Bypass Prevention Tests
+
+    [Fact]
+    public void ConfirmTrue_DoesNotBypassReadOnlyPolicy()
+    {
+        var policy = new OperationAccessPolicy(McpAccessMode.ReadOnly);
+        var result = policy.Authorize("update_block_logic");
+        Assert.NotNull(result);
+        Assert.False(result.Success);
+        // confirm=true is irrelevant — the policy denies categorically
+    }
+
+    [Fact]
+    public void SafetyToken_DoesNotBypassReadOnlyPolicy()
+    {
+        // The OperationAccessPolicy checks operation name only, not token presence.
+        // This is the correct behavior: read-only mode is a higher-level restriction.
+        var policy = new OperationAccessPolicy(McpAccessMode.ReadOnly);
+        var result = policy.Authorize("save_project");
+        Assert.NotNull(result);
+        Assert.False(result.Success);
+    }
+
+    #endregion
+}

--- a/TiaMcpServer.Tests/ReadOnlyModeTests.cs
+++ b/TiaMcpServer.Tests/ReadOnlyModeTests.cs
@@ -3,6 +3,7 @@ using ModelContextProtocol.Server;
 using TiaMcpServer.Batch;
 using TiaMcpServer.Cli;
 using TiaMcpServer.Contracts;
+using TiaMcpServer.Diagnostics;
 using TiaMcpServer.Safety;
 using TiaMcpServer.Tools;
 using TiaMcpServer.Worker;
@@ -644,6 +645,301 @@ public class ReadOnlyModeTests
         var result = policy.Authorize("save_project");
         Assert.NotNull(result);
         Assert.False(result.Success);
+    }
+
+    #endregion
+
+    #region ProjectWriteTools Coverage Tests
+
+    [Fact]
+    public async Task ProjectWriteTools_OpenProject_Preview_ReturnsTokenAndInstructions()
+    {
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
+        var result = await ProjectWriteTools.OpenProject(
+            workerClient: null!,
+            safety,
+            projectPath: @"C:\Projects\Line.ap21");
+
+        Assert.Contains("safetyToken", result);
+        Assert.Contains("open_project", result);
+        Assert.Contains("Preview only", result);
+    }
+
+    [Fact]
+    public async Task ProjectWriteTools_CreateProject_Preview_ReturnsTokenAndInstructions()
+    {
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
+        var result = await ProjectWriteTools.CreateProject(
+            workerClient: null!,
+            safety,
+            projectDirectory: @"C:\Projects",
+            projectName: "NewProject");
+
+        Assert.Contains("safetyToken", result);
+        Assert.Contains("create_project", result);
+        Assert.Contains("Preview only", result);
+    }
+
+    [Fact]
+    public async Task ProjectWriteTools_OpenProject_ConfirmFalse_ReturnsConfirmRequired()
+    {
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
+        var result = await ProjectWriteTools.OpenProject(
+            workerClient: null!,
+            safety,
+            projectPath: @"C:\Projects\Line.ap21",
+            confirm: false,
+            safetyToken: "fake-token");
+
+        Assert.Contains("confirm=true", result);
+        Assert.Contains("without safetyToken", result);
+    }
+
+    [Fact]
+    public async Task ProjectWriteTools_CreateProject_ConfirmFalse_ReturnsConfirmRequired()
+    {
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
+        var result = await ProjectWriteTools.CreateProject(
+            workerClient: null!,
+            safety,
+            projectDirectory: @"C:\Projects",
+            projectName: "NewProject",
+            confirm: false,
+            safetyToken: "fake-token");
+
+        Assert.Contains("confirm=true", result);
+    }
+
+    [Fact]
+    public async Task ProjectWriteTools_SaveProject_ConfirmFalse_ReturnsConfirmRequired()
+    {
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
+        var result = await ProjectWriteTools.SaveProject(
+            workerClient: null!,
+            safety,
+            confirm: false,
+            safetyToken: "fake-token");
+
+        Assert.Contains("confirm=true", result);
+    }
+
+    [Fact]
+    public async Task ProjectWriteTools_ArchiveProject_ConfirmFalse_ReturnsConfirmRequired()
+    {
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
+        var result = await ProjectWriteTools.ArchiveProject(
+            workerClient: null!,
+            safety,
+            archiveDirectory: @"C:\Archive",
+            archiveName: "backup",
+            confirm: false,
+            safetyToken: "fake-token");
+
+        Assert.Contains("confirm=true", result);
+    }
+
+    [Fact]
+    public async Task ProjectWriteTools_CloseProject_ConfirmFalse_ReturnsConfirmRequired()
+    {
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
+        var result = await ProjectWriteTools.CloseProject(
+            workerClient: null!,
+            safety,
+            confirm: false,
+            safetyToken: "fake-token");
+
+        Assert.Contains("confirm=true", result);
+    }
+
+    #endregion
+
+    #region Doctor Access Mode Coverage Tests
+
+    [Fact]
+    public void DoctorJsonRenderer_WithReadOnlyAccessMode_IncludesAccessMode()
+    {
+        var report = new DoctorReport(
+            DiagnosticStatus.Passed,
+            DateTimeOffset.UtcNow,
+            "1.0.0",
+            new DoctorSummary(1, 0, 0),
+            new[] { new DiagnosticCheckResult("test", "Test", DiagnosticStatus.Passed, "ok") });
+
+        var json = DoctorJsonRenderer.Render(report, verbose: false, accessMode: McpAccessMode.ReadOnly);
+
+        Assert.Contains("\"accessMode\": \"read-only\"", json);
+    }
+
+    [Fact]
+    public void DoctorJsonRenderer_WithReadWriteAccessMode_IncludesAccessMode()
+    {
+        var report = new DoctorReport(
+            DiagnosticStatus.Passed,
+            DateTimeOffset.UtcNow,
+            "1.0.0",
+            new DoctorSummary(1, 0, 0),
+            new[] { new DiagnosticCheckResult("test", "Test", DiagnosticStatus.Passed, "ok") });
+
+        var json = DoctorJsonRenderer.Render(report, verbose: false, accessMode: McpAccessMode.ReadWrite);
+
+        Assert.Contains("\"accessMode\": \"read-write\"", json);
+    }
+
+    [Fact]
+    public void DoctorJsonRenderer_WithoutAccessMode_OmitsAccessMode()
+    {
+        var report = new DoctorReport(
+            DiagnosticStatus.Passed,
+            DateTimeOffset.UtcNow,
+            "1.0.0",
+            new DoctorSummary(1, 0, 0),
+            new[] { new DiagnosticCheckResult("test", "Test", DiagnosticStatus.Passed, "ok") });
+
+        var json = DoctorJsonRenderer.Render(report, verbose: false, accessMode: null);
+
+        Assert.DoesNotContain("accessMode", json);
+    }
+
+    [Fact]
+    public void DoctorTextRenderer_WithReadOnlyAccessMode_ShowsReadOnly()
+    {
+        var report = new DoctorReport(
+            DiagnosticStatus.Passed,
+            DateTimeOffset.UtcNow,
+            "1.0.0",
+            new DoctorSummary(1, 0, 0),
+            new[] { new DiagnosticCheckResult("test", "Test", DiagnosticStatus.Passed, "ok") });
+
+        var writer = new StringWriter();
+        DoctorTextRenderer.Render(report, verbose: false, writer, accessMode: McpAccessMode.ReadOnly);
+
+        var output = writer.ToString();
+        Assert.Contains("Access mode: READ-ONLY", output);
+    }
+
+    [Fact]
+    public void DoctorTextRenderer_WithReadWriteAccessMode_ShowsReadWrite()
+    {
+        var report = new DoctorReport(
+            DiagnosticStatus.Passed,
+            DateTimeOffset.UtcNow,
+            "1.0.0",
+            new DoctorSummary(1, 0, 0),
+            new[] { new DiagnosticCheckResult("test", "Test", DiagnosticStatus.Passed, "ok") });
+
+        var writer = new StringWriter();
+        DoctorTextRenderer.Render(report, verbose: false, writer, accessMode: McpAccessMode.ReadWrite);
+
+        var output = writer.ToString();
+        Assert.Contains("Access mode: READ-WRITE", output);
+    }
+
+    [Fact]
+    public void DoctorTextRenderer_WithoutAccessMode_OmitsAccessModeLine()
+    {
+        var report = new DoctorReport(
+            DiagnosticStatus.Passed,
+            DateTimeOffset.UtcNow,
+            "1.0.0",
+            new DoctorSummary(1, 0, 0),
+            new[] { new DiagnosticCheckResult("test", "Test", DiagnosticStatus.Passed, "ok") });
+
+        var writer = new StringWriter();
+        DoctorTextRenderer.Render(report, verbose: false, writer, accessMode: null);
+
+        var output = writer.ToString();
+        Assert.DoesNotContain("Access mode:", output);
+    }
+
+    [Fact]
+    public void DoctorCliParser_EnvVarReadOnly_DetectsReadOnlyMode()
+    {
+        try
+        {
+            Environment.SetEnvironmentVariable("TIA_MCP_ACCESS_MODE", "read-only");
+            var options = DoctorCliParser.Parse(Array.Empty<string>());
+            Assert.True(options.Valid);
+            Assert.Equal(McpAccessMode.ReadOnly, options.AccessMode);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("TIA_MCP_ACCESS_MODE", null);
+        }
+    }
+
+    [Fact]
+    public void DoctorCliParser_EnvVarReadWrite_DetectsReadWriteMode()
+    {
+        try
+        {
+            Environment.SetEnvironmentVariable("TIA_MCP_ACCESS_MODE", "read-write");
+            var options = DoctorCliParser.Parse(Array.Empty<string>());
+            Assert.True(options.Valid);
+            Assert.Equal(McpAccessMode.ReadWrite, options.AccessMode);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("TIA_MCP_ACCESS_MODE", null);
+        }
+    }
+
+    [Fact]
+    public void DoctorCliParser_NoEnvVar_DefaultsToReadWrite()
+    {
+        try
+        {
+            Environment.SetEnvironmentVariable("TIA_MCP_ACCESS_MODE", null);
+            var options = DoctorCliParser.Parse(Array.Empty<string>());
+            Assert.True(options.Valid);
+            Assert.Equal(McpAccessMode.ReadWrite, options.AccessMode);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("TIA_MCP_ACCESS_MODE", null);
+        }
+    }
+
+    [Fact]
+    public void DoctorCliParser_InvalidEnvVar_DefaultsToReadWrite()
+    {
+        try
+        {
+            Environment.SetEnvironmentVariable("TIA_MCP_ACCESS_MODE", "invalid");
+            var options = DoctorCliParser.Parse(Array.Empty<string>());
+            Assert.True(options.Valid);
+            Assert.Equal(McpAccessMode.ReadWrite, options.AccessMode);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("TIA_MCP_ACCESS_MODE", null);
+        }
+    }
+
+    #endregion
+
+    #region OpennessWorkerClient Without Policy Tests
+
+    [Fact]
+    public async Task OpennessWorkerClient_NoPolicy_AllowsAllOperations()
+    {
+        var binding = new ProjectSessionBinding(null);
+        // No accessPolicy — should not throw, will fail at transport level (no worker)
+        var client = new OpennessWorkerClient(
+            binding,
+            workerExecutablePath: "/nonexistent/path");
+
+        // This will fail with a transport error (worker not found), not access_denied
+        var result = await client.UpdateBlockLogicAsync("Main", "yaml", null);
+
+        Assert.False(result.Success);
+        Assert.NotEqual(WorkerFailureCategories.AccessDenied, result.FailureCategory);
     }
 
     #endregion

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -37,6 +37,8 @@
     <Compile Include="..\TiaMcpServer\Diagnostics\Checks\*.cs"
       Link="Host\Diagnostics\Checks\%(Filename)%(Extension)" />
     <Compile Include="..\TiaMcpServer\Cli\*.cs" Link="Host\Cli\%(Filename)%(Extension)" />
+    <Compile Include="..\TiaMcpServer\Safety\OperationAccessPolicy.cs"
+      Link="Host\OperationAccessPolicy.cs" />
     <Compile Include="..\TiaMcpServer\Worker\PersistentWorkerTransport.cs"
       Link="Host\PersistentWorkerTransport.cs" />
     <Compile Include="..\TiaMcpServer\Worker\WorkerCallResult.cs" Link="Host\WorkerCallResult.cs" />
@@ -47,6 +49,10 @@
       Link="Host\WriteSafetyTooling.cs" />
     <Compile Include="..\TiaMcpServer\Tools\ProjectLifecycleTools.cs"
       Link="Host\ProjectLifecycleTools.cs" />
+    <Compile Include="..\TiaMcpServer\Tools\ProjectReadTools.cs"
+      Link="Host\ProjectReadTools.cs" />
+    <Compile Include="..\TiaMcpServer\Tools\ProjectWriteTools.cs"
+      Link="Host\ProjectWriteTools.cs" />
     <Compile Include="..\TiaMcpServer\Batch\BatchOperationRequest.cs"
       Link="Host\Batch\BatchOperationRequest.cs" />
     <Compile Include="..\TiaMcpServer\Batch\BatchOperationCatalog.cs"
@@ -64,6 +70,8 @@
     <Compile Include="..\TiaMcpServer\Batch\BatchWorkerInvoker.cs"
       Link="Host\Batch\BatchWorkerInvoker.cs" />
     <Compile Include="..\TiaMcpServer\Batch\BatchTools.cs" Link="Host\Batch\BatchTools.cs" />
+    <Compile Include="..\TiaMcpServer\Batch\ReadBatchTools.cs" Link="Host\Batch\ReadBatchTools.cs" />
+    <Compile Include="..\TiaMcpServer\Batch\WriteBatchTools.cs" Link="Host\Batch\WriteBatchTools.cs" />
     <Compile Include="..\TiaMcpServer.OpennessWorker\Openness\ProjectRebindCloseGuard.cs"
       Link="Worker\ProjectRebindCloseGuard.cs" />
     <Compile Include="..\TiaMcpServer.OpennessWorker\Openness\AssemblyResolver.cs"
@@ -72,6 +80,8 @@
       Link="Worker\WorkerWarningMerger.cs" />
     <Compile Include="..\TiaMcpServer.OpennessWorker\WorkerOperationException.cs"
       Link="Linked\Openness\WorkerOperationException.cs" />
+    <Compile Include="..\TiaMcpServer.OpennessWorker\WorkerOperationAuthorization.cs"
+      Link="Linked\Openness\WorkerOperationAuthorization.cs" />
     <Compile Include="..\TiaMcpServer.OpennessWorker\Openness\BlockImportDocument.cs"
       Link="Linked\Openness\BlockImportDocument.cs" />
     <Compile Include="..\TiaMcpServer.OpennessWorker\Openness\ParsedBlockImportBundle.cs"

--- a/TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs
+++ b/TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs
@@ -20,18 +20,28 @@ public class WriteToolSafetyTokenTests
     [InlineData("PreviewCloseProject")]
     public void SeparatePreviewToolsAreGone(string methodName)
     {
+        // Check both the old and new classes — neither should have separate preview tools.
         Assert.Null(typeof(ProjectLifecycleTools).GetMethod(methodName, BindingFlags.Public | BindingFlags.Static));
+        Assert.Null(typeof(ProjectWriteTools).GetMethod(methodName, BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance));
     }
 
     [Fact]
     public void LifecycleSurfaceIsExactlySevenTools()
     {
-        var toolNames = typeof(ProjectLifecycleTools)
-            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+        // Tools have been split into ProjectReadTools (1 tool) and ProjectWriteTools (6 tools).
+        var readToolNames = typeof(ProjectReadTools)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance)
             .Select(m => m.GetCustomAttribute<McpServerToolAttribute>()?.Name)
             .Where(name => name is not null)
-            .OrderBy(name => name)
             .ToArray();
+
+        var writeToolNames = typeof(ProjectWriteTools)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance)
+            .Select(m => m.GetCustomAttribute<McpServerToolAttribute>()?.Name)
+            .Where(name => name is not null)
+            .ToArray();
+
+        var allToolNames = readToolNames.Concat(writeToolNames).OrderBy(name => name).ToArray();
 
         Assert.Equal(
             new[]
@@ -39,7 +49,7 @@ public class WriteToolSafetyTokenTests
                 "archive_project", "close_project", "create_project", "get_project_status",
                 "open_project", "save_project", "save_project_as"
             },
-            toolNames);
+            allToolNames);
     }
 
     [Fact]

--- a/TiaMcpServer/Batch/BatchOperationCatalog.cs
+++ b/TiaMcpServer/Batch/BatchOperationCatalog.cs
@@ -1,3 +1,4 @@
+using TiaMcpServer.Contracts;
 using TiaMcpServer.Safety;
 
 namespace TiaMcpServer.Batch;
@@ -56,6 +57,37 @@ public static class BatchOperationCatalog
 
     /// <summary>Every registered spec. Used by the field-forwarding invariant test.</summary>
     public static IReadOnlyCollection<BatchOperationSpec> All { get; } = Specs.Values.ToArray();
+
+    /// <summary>
+    /// Validates that all operations in a batch are allowed under the given access mode.
+    /// Returns null when all operations are allowed, or a list of per-operation errors.
+    /// </summary>
+    public static IReadOnlyList<string> ValidateAccessMode(
+        IReadOnlyList<BatchOperationRequest> operations,
+        McpAccessMode mode)
+    {
+        if (mode == McpAccessMode.ReadWrite)
+        {
+            return Array.Empty<string>();
+        }
+
+        var errors = new List<string>();
+        foreach (var op in operations)
+        {
+            if (op is null || string.IsNullOrWhiteSpace(op.Operation))
+            {
+                continue;
+            }
+
+            if (!OperationPolicyCatalog.IsAllowed(mode, op.Operation))
+            {
+                errors.Add(
+                    $"Operation '{op.Operation}' (operationId '{op.OperationId}') is not permitted in read-only mode.");
+            }
+        }
+
+        return errors;
+    }
 
     // Real single tools that exist but are intentionally not available inside a batch, so the
     // caller gets a precise message instead of a generic "unknown operation".

--- a/TiaMcpServer/Batch/ReadBatchTools.cs
+++ b/TiaMcpServer/Batch/ReadBatchTools.cs
@@ -13,7 +13,7 @@ public class ReadBatchTools
 {
     [McpServerTool(Name = "execute_read_batch", ReadOnly = true, Destructive = false, OpenWorld = false)]
     [Description("Run up to 50 read operations in one call. Each item is { operationId (unique), operation, ...that operation's parameters }; projectPath is optional on every item. Reads run independently, so a failing item does not stop the others. "
-        + "Valid operations (parentheses list required fields): browse_project_tree, read_hardware_config, read_cross_references, search_equipment_catalog (query), get_block_content (blockPath), list_tag_tables, compile_check, get_project_status. "
+        + "Valid operations (parentheses list required fields): browse_project_tree, read_hardware_config, read_cross_references, search_equipment_catalog (query), get_block_content (blockPath), list_tag_tables, get_project_status, and compile_check (read-write mode only). "
         + "Large projects: bound payloads with depth/startPath (browse_project_tree) and maxResults (search_equipment_catalog, read_cross_references); oversized responses are truncated server-side with an explicit marker.")]
     public static async Task<string> ExecuteReadBatch(
         OpennessWorkerClient workerClient,

--- a/TiaMcpServer/Batch/ReadBatchTools.cs
+++ b/TiaMcpServer/Batch/ReadBatchTools.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Batch;
+
+/// <summary>
+/// Read-only batch tool. Exposed in both read-only and read-write modes.
+/// </summary>
+[McpServerToolType]
+public class ReadBatchTools
+{
+    [McpServerTool(Name = "execute_read_batch", ReadOnly = true, Destructive = false, OpenWorld = false)]
+    [Description("Run up to 50 read operations in one call. Each item is { operationId (unique), operation, ...that operation's parameters }; projectPath is optional on every item. Reads run independently, so a failing item does not stop the others. "
+        + "Valid operations (parentheses list required fields): browse_project_tree, read_hardware_config, read_cross_references, search_equipment_catalog (query), get_block_content (blockPath), list_tag_tables, compile_check, get_project_status. "
+        + "Large projects: bound payloads with depth/startPath (browse_project_tree) and maxResults (search_equipment_catalog, read_cross_references); oversized responses are truncated server-side with an explicit marker.")]
+    public static async Task<string> ExecuteReadBatch(
+        OpennessWorkerClient workerClient,
+        [Description("Ordered list of read operations. Each: { operationId, operation, ...operation parameters }.")] BatchOperationRequest[] operations)
+    {
+        var validation = BatchOperationCatalog.ValidateReadBatch(operations);
+        if (!validation.IsValid)
+        {
+            return BatchResultFormatter.Error("execute_read_batch", validation.Error);
+        }
+
+        // Defense in depth: validate access mode before any worker invocation.
+        var mode = workerClient.AccessPolicy?.Mode ?? McpAccessMode.ReadWrite;
+        var accessErrors = BatchOperationCatalog.ValidateAccessMode(operations, mode);
+        if (accessErrors.Count > 0)
+        {
+            return BatchResultFormatter.Error(
+                "execute_read_batch",
+                string.Join("\n", accessErrors));
+        }
+
+        var results = await BatchExecutionEngine.ExecuteReadsAsync(
+            operations,
+            op => BatchWorkerInvoker.InvokeAsync(workerClient, op)).ConfigureAwait(false);
+
+        return BatchResultFormatter.ReadBatch(BatchPayloadBudget.Apply(results));
+    }
+}

--- a/TiaMcpServer/Batch/WriteBatchTools.cs
+++ b/TiaMcpServer/Batch/WriteBatchTools.cs
@@ -1,44 +1,21 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
+using TiaMcpServer.Contracts;
 using TiaMcpServer.Safety;
 using TiaMcpServer.Worker;
 
 namespace TiaMcpServer.Batch;
 
 /// <summary>
-/// Batch MCP tools. A single read or write is just a one-item batch. Reads run independently;
-/// writes are previewed once to obtain a batch-level safety token, then applied sequentially
-/// with stop-on-first-failure (no transaction or rollback).
-///
-/// NOTE: This class is no longer registered as an MCP tool type. Tools have been split
-/// into ReadBatchTools and WriteBatchTools. This class is kept for test backward
-/// compatibility (tests reference its methods directly).
+/// Write-only batch tools. Only exposed in read-write mode.
 /// </summary>
-public static class BatchTools
+[McpServerToolType]
+public class WriteBatchTools
 {
     private const string PreviewToolName = "preview_write_batch";
     private const string ApplyToolName = "apply_write_batch";
 
-    [Description("Run up to 50 read operations in one call. Each item is { operationId (unique), operation, ...that operation's parameters }; projectPath is optional on every item. Reads run independently, so a failing item does not stop the others. "
-        + "Valid operations (parentheses list required fields): browse_project_tree, read_hardware_config, read_cross_references, search_equipment_catalog (query), get_block_content (blockPath), list_tag_tables, compile_check, get_project_status. "
-        + "Large projects: bound payloads with depth/startPath (browse_project_tree) and maxResults (search_equipment_catalog, read_cross_references); oversized responses are truncated server-side with an explicit marker.")]
-    public static async Task<string> ExecuteReadBatch(
-        OpennessWorkerClient workerClient,
-        [Description("Ordered list of read operations. Each: { operationId, operation, ...operation parameters }.")] BatchOperationRequest[] operations)
-    {
-        var validation = BatchOperationCatalog.ValidateReadBatch(operations);
-        if (!validation.IsValid)
-        {
-            return BatchResultFormatter.Error("execute_read_batch", validation.Error);
-        }
-
-        var results = await BatchExecutionEngine.ExecuteReadsAsync(
-            operations,
-            op => BatchWorkerInvoker.InvokeAsync(workerClient, op)).ConfigureAwait(false);
-
-        return BatchResultFormatter.ReadBatch(BatchPayloadBudget.Apply(results));
-    }
-
+    [McpServerTool(Name = "preview_write_batch")]
     [Description("Preview up to 50 write operations and return one batch-level safetyToken bound to the exact ordered operation list and the combined current state. The token is single-use and expires after 10 minutes. Pass the token to apply_write_batch after reviewing the preview. All items must target the same project. "
         + "Valid operations (parentheses list required fields): update_block_logic (blockPath, yamlContent), create_block (blockPath, blockType), delete_block (blockPath), create_block_group (blockPath), delete_block_group (blockPath), create_tag_table (tableName), delete_tag_table (tableName), create_tag (tableName, name, dataType), update_tag (tableName, name), delete_tag (tableName, name), create_user_constant (tableName, name, dataType, value), update_user_constant (tableName, name), delete_user_constant (tableName, name), add_network_device (typeIdentifier, deviceName), configure_network_device (deviceName), start_plc, stop_plc.")]
     public static async Task<string> PreviewWriteBatch(
@@ -50,6 +27,14 @@ public static class BatchTools
         if (!validation.IsValid)
         {
             return BatchResultFormatter.Error(PreviewToolName, validation.Error);
+        }
+
+        // Defense in depth: reject in read-only mode even though the tool is not registered.
+        var mode = workerClient.AccessPolicy?.Mode ?? McpAccessMode.ReadWrite;
+        if (mode == McpAccessMode.ReadOnly)
+        {
+            return BatchResultFormatter.Error(PreviewToolName,
+                "Write batch operations are not permitted in read-only mode.");
         }
 
         var snapshot = await ReadCombinedCurrentStateAsync(workerClient, operations).ConfigureAwait(false);
@@ -74,6 +59,7 @@ public static class BatchTools
             instructions: "Preview only — nothing was changed. To apply, call apply_write_batch with the identical operations list, confirm=true, and this safetyToken.");
     }
 
+    [McpServerTool(Name = "apply_write_batch")]
     [Description("Apply a previewed batch of write operations sequentially, stopping on the first failure (later items are skipped; no rollback). Requires confirm=true and a safetyToken from preview_write_batch; pass the identical operations list. "
         + "Valid operations (parentheses list required fields): update_block_logic (blockPath, yamlContent), create_block (blockPath, blockType), delete_block (blockPath), create_block_group (blockPath), delete_block_group (blockPath), create_tag_table (tableName), delete_tag_table (tableName), create_tag (tableName, name, dataType), update_tag (tableName, name), delete_tag (tableName, name), create_user_constant (tableName, name, dataType, value), update_user_constant (tableName, name), delete_user_constant (tableName, name), add_network_device (typeIdentifier, deviceName), configure_network_device (deviceName), start_plc, stop_plc.")]
     public static async Task<string> ApplyWriteBatch(
@@ -96,6 +82,14 @@ public static class BatchTools
             return BatchResultFormatter.Error(ApplyToolName, validation.Error);
         }
 
+        // Defense in depth: reject in read-only mode even though the tool is not registered.
+        var mode = workerClient.AccessPolicy?.Mode ?? McpAccessMode.ReadWrite;
+        if (mode == McpAccessMode.ReadOnly)
+        {
+            return BatchResultFormatter.Error(ApplyToolName,
+                "Write batch operations are not permitted in read-only mode.");
+        }
+
         if (string.IsNullOrWhiteSpace(safetyToken))
         {
             return BatchResultFormatter.Error(
@@ -106,7 +100,6 @@ public static class BatchTools
         var targets = BatchSafetySnapshot.BuildTargets(operations);
         var projectPath = BatchSafetySnapshot.ResolveProjectPath(operations);
 
-        // Reject dead/mismatched tokens BEFORE the expensive per-item current-state read.
         var envelope = safety.ValidateEnvelope(
             safetyToken,
             ApplyToolName,

--- a/TiaMcpServer/Cli/AccessModeParser.cs
+++ b/TiaMcpServer/Cli/AccessModeParser.cs
@@ -1,0 +1,88 @@
+using System;
+using TiaMcpServer.Contracts;
+
+namespace TiaMcpServer.Cli;
+
+/// <summary>
+/// Resolves the <see cref="McpAccessMode"/> from CLI arguments and environment variables.
+/// Precedence: CLI argument > environment variable > default (ReadWrite).
+/// </summary>
+public static class AccessModeParser
+{
+    private const string EnvVarName = "TIA_MCP_ACCESS_MODE";
+
+    /// <summary>
+    /// Resolves the access mode from the given CLI arguments and environment.
+    /// Returns a result indicating success with the resolved mode, or failure with a message.
+    /// </summary>
+    public static AccessModeParseResult Parse(string[] args)
+    {
+        // 1. Check CLI arguments
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (string.Equals(args[i], "--read-only", StringComparison.OrdinalIgnoreCase))
+            {
+                return AccessModeParseResult.Ok(McpAccessMode.ReadOnly);
+            }
+
+            if (string.Equals(args[i], "--read-write", StringComparison.OrdinalIgnoreCase))
+            {
+                return AccessModeParseResult.Ok(McpAccessMode.ReadWrite);
+            }
+
+            if (string.Equals(args[i], "--access-mode", StringComparison.OrdinalIgnoreCase) &&
+                i + 1 < args.Length)
+            {
+                return ParseValue(args[i + 1]);
+            }
+
+            const string accessModePrefix = "--access-mode=";
+            if (args[i].StartsWith(accessModePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return ParseValue(args[i].Substring(accessModePrefix.Length));
+            }
+        }
+
+        // 2. Check environment variable
+        var envValue = Environment.GetEnvironmentVariable(EnvVarName);
+        if (!string.IsNullOrWhiteSpace(envValue))
+        {
+            return ParseValue(envValue);
+        }
+
+        // 3. Default
+        return AccessModeParseResult.Ok(McpAccessMode.ReadWrite);
+    }
+
+    /// <summary>
+    /// Parses a string value ("read-only" or "read-write") into an <see cref="McpAccessMode"/>.
+    /// </summary>
+    public static AccessModeParseResult ParseValue(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return AccessModeParseResult.Fail(
+                "Access mode value is empty. Valid values: 'read-only', 'read-write'.");
+        }
+
+        if (string.Equals(value, "read-only", StringComparison.OrdinalIgnoreCase))
+        {
+            return AccessModeParseResult.Ok(McpAccessMode.ReadOnly);
+        }
+
+        if (string.Equals(value, "read-write", StringComparison.OrdinalIgnoreCase))
+        {
+            return AccessModeParseResult.Ok(McpAccessMode.ReadWrite);
+        }
+
+        return AccessModeParseResult.Fail(
+            $"Invalid access mode '{value}'. Valid values: 'read-only', 'read-write'.");
+    }
+}
+
+public sealed record AccessModeParseResult(bool IsValid, McpAccessMode Mode, string? Error)
+{
+    public static AccessModeParseResult Ok(McpAccessMode mode) => new(true, mode, null);
+
+    public static AccessModeParseResult Fail(string error) => new(false, default, error);
+}

--- a/TiaMcpServer/Cli/AccessModeParser.cs
+++ b/TiaMcpServer/Cli/AccessModeParser.cs
@@ -30,9 +30,16 @@ public static class AccessModeParser
                 return AccessModeParseResult.Ok(McpAccessMode.ReadWrite);
             }
 
-            if (string.Equals(args[i], "--access-mode", StringComparison.OrdinalIgnoreCase) &&
-                i + 1 < args.Length)
+            if (string.Equals(args[i], "--access-mode", StringComparison.OrdinalIgnoreCase))
             {
+                if (i + 1 >= args.Length ||
+                    string.IsNullOrWhiteSpace(args[i + 1]) ||
+                    args[i + 1].StartsWith("--", StringComparison.Ordinal))
+                {
+                    return AccessModeParseResult.Fail(
+                        "--access-mode requires a value. Valid values: 'read-only', 'read-write'.");
+                }
+
                 return ParseValue(args[i + 1]);
             }
 
@@ -65,12 +72,13 @@ public static class AccessModeParser
                 "Access mode value is empty. Valid values: 'read-only', 'read-write'.");
         }
 
-        if (string.Equals(value, "read-only", StringComparison.OrdinalIgnoreCase))
+        var normalizedValue = value.Trim();
+        if (string.Equals(normalizedValue, "read-only", StringComparison.OrdinalIgnoreCase))
         {
             return AccessModeParseResult.Ok(McpAccessMode.ReadOnly);
         }
 
-        if (string.Equals(value, "read-write", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(normalizedValue, "read-write", StringComparison.OrdinalIgnoreCase))
         {
             return AccessModeParseResult.Ok(McpAccessMode.ReadWrite);
         }
@@ -80,7 +88,7 @@ public static class AccessModeParser
     }
 }
 
-public sealed record AccessModeParseResult(bool IsValid, McpAccessMode Mode, string? Error)
+public sealed record AccessModeParseResult(bool IsValid, McAccessMode Mode, string? Error)
 {
     public static AccessModeParseResult Ok(McpAccessMode mode) => new(true, mode, null);
 

--- a/TiaMcpServer/Cli/AccessModeParser.cs
+++ b/TiaMcpServer/Cli/AccessModeParser.cs
@@ -88,7 +88,7 @@ public static class AccessModeParser
     }
 }
 
-public sealed record AccessModeParseResult(bool IsValid, McAccessMode Mode, string? Error)
+public sealed record AccessModeParseResult(bool IsValid, McpAccessMode Mode, string? Error)
 {
     public static AccessModeParseResult Ok(McpAccessMode mode) => new(true, mode, null);
 

--- a/TiaMcpServer/Cli/AccessModeParser.cs
+++ b/TiaMcpServer/Cli/AccessModeParser.cs
@@ -17,17 +17,44 @@ public static class AccessModeParser
     /// </summary>
     public static AccessModeParseResult Parse(string[] args)
     {
-        // 1. Check CLI arguments
+        McpAccessMode? cliMode = null;
+
+        AccessModeParseResult? RecordCliMode(McpAccessMode candidate)
+        {
+            if (cliMode is not null && cliMode.Value != candidate)
+            {
+                return AccessModeParseResult.Fail(
+                    "Conflicting access mode arguments were supplied. Specify only one of 'read-only' or 'read-write'.");
+            }
+
+            cliMode = candidate;
+            return null;
+        }
+
+        // 1. Check all CLI arguments. Repeating the same mode is harmless; contradictory
+        // explicit modes are rejected rather than depending on argument order.
         for (int i = 0; i < args.Length; i++)
         {
             if (string.Equals(args[i], "--read-only", StringComparison.OrdinalIgnoreCase))
             {
-                return AccessModeParseResult.Ok(McpAccessMode.ReadOnly);
+                var conflict = RecordCliMode(McpAccessMode.ReadOnly);
+                if (conflict is not null)
+                {
+                    return conflict;
+                }
+
+                continue;
             }
 
             if (string.Equals(args[i], "--read-write", StringComparison.OrdinalIgnoreCase))
             {
-                return AccessModeParseResult.Ok(McpAccessMode.ReadWrite);
+                var conflict = RecordCliMode(McpAccessMode.ReadWrite);
+                if (conflict is not null)
+                {
+                    return conflict;
+                }
+
+                continue;
             }
 
             if (string.Equals(args[i], "--access-mode", StringComparison.OrdinalIgnoreCase))
@@ -40,14 +67,41 @@ public static class AccessModeParser
                         "--access-mode requires a value. Valid values: 'read-only', 'read-write'.");
                 }
 
-                return ParseValue(args[i + 1]);
+                var parsed = ParseValue(args[++i]);
+                if (!parsed.IsValid)
+                {
+                    return parsed;
+                }
+
+                var conflict = RecordCliMode(parsed.Mode);
+                if (conflict is not null)
+                {
+                    return conflict;
+                }
+
+                continue;
             }
 
             const string accessModePrefix = "--access-mode=";
             if (args[i].StartsWith(accessModePrefix, StringComparison.OrdinalIgnoreCase))
             {
-                return ParseValue(args[i].Substring(accessModePrefix.Length));
+                var parsed = ParseValue(args[i].Substring(accessModePrefix.Length));
+                if (!parsed.IsValid)
+                {
+                    return parsed;
+                }
+
+                var conflict = RecordCliMode(parsed.Mode);
+                if (conflict is not null)
+                {
+                    return conflict;
+                }
             }
+        }
+
+        if (cliMode is not null)
+        {
+            return AccessModeParseResult.Ok(cliMode.Value);
         }
 
         // 2. Check environment variable

--- a/TiaMcpServer/Cli/DoctorCliParser.cs
+++ b/TiaMcpServer/Cli/DoctorCliParser.cs
@@ -1,3 +1,5 @@
+using TiaMcpServer.Contracts;
+
 namespace TiaMcpServer.Cli;
 
 public sealed record DoctorCliOptions(
@@ -6,6 +8,7 @@ public sealed record DoctorCliOptions(
     bool Verbose,
     bool Help,
     string? ProjectPath,
+    McpAccessMode AccessMode,
     string? ParseError);
 
 public static class DoctorCliParser
@@ -51,7 +54,7 @@ public static class DoctorCliParser
                     string.IsNullOrWhiteSpace(args[i + 1]) ||
                     args[i + 1].StartsWith("--", StringComparison.Ordinal))
                 {
-                    return new DoctorCliOptions(false, json, verbose, help, null, $"--project requires a value.");
+                    return new DoctorCliOptions(false, json, verbose, help, null, ResolveAccessMode(), $"--project requires a value.");
                 }
 
                 projectPath = args[++i];
@@ -63,15 +66,27 @@ public static class DoctorCliParser
                 projectPath = arg.Substring(ProjectPrefix.Length);
                 if (string.IsNullOrWhiteSpace(projectPath))
                 {
-                    return new DoctorCliOptions(false, json, verbose, help, null, $"--project requires a value.");
+                    return new DoctorCliOptions(false, json, verbose, help, null, ResolveAccessMode(), $"--project requires a value.");
                 }
 
                 continue;
             }
 
-            return new DoctorCliOptions(false, json, verbose, help, projectPath, $"Unknown doctor argument: '{arg}'.");
+            return new DoctorCliOptions(false, json, verbose, help, projectPath, ResolveAccessMode(), $"Unknown doctor argument: '{arg}'.");
         }
 
-        return new DoctorCliOptions(true, json, verbose, help, projectPath, null);
+        return new DoctorCliOptions(true, json, verbose, help, projectPath, ResolveAccessMode(), null);
+    }
+
+    private static McpAccessMode ResolveAccessMode()
+    {
+        var envValue = Environment.GetEnvironmentVariable("TIA_MCP_ACCESS_MODE");
+        if (!string.IsNullOrWhiteSpace(envValue) &&
+            AccessModeParser.ParseValue(envValue) is { IsValid: true } result)
+        {
+            return result.Mode;
+        }
+
+        return McpAccessMode.ReadWrite;
     }
 }

--- a/TiaMcpServer/Cli/DoctorCliParser.cs
+++ b/TiaMcpServer/Cli/DoctorCliParser.cs
@@ -18,6 +18,10 @@ public static class DoctorCliParser
     private const string HelpFlag = "--help";
     private const string ProjectFlag = "--project";
     private const string ProjectPrefix = "--project=";
+    private const string AccessModeFlag = "--access-mode";
+    private const string AccessModePrefix = "--access-mode=";
+    private const string ReadOnlyFlag = "--read-only";
+    private const string ReadWriteFlag = "--read-write";
 
     public static DoctorCliOptions Parse(string[] args)
     {
@@ -25,6 +29,24 @@ public static class DoctorCliParser
         bool verbose = false;
         bool help = false;
         string? projectPath = null;
+
+        var hasCliAccessMode = args.Any(IsAccessModeArgument);
+        var accessModeResult = hasCliAccessMode
+            ? AccessModeParser.Parse(args)
+            : AccessModeParseResult.Ok(ResolveAccessMode());
+        if (!accessModeResult.IsValid)
+        {
+            return new DoctorCliOptions(
+                false,
+                json,
+                verbose,
+                help,
+                null,
+                default,
+                accessModeResult.Error);
+        }
+
+        var accessMode = accessModeResult.Mode;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -48,13 +70,27 @@ public static class DoctorCliParser
                 continue;
             }
 
+            if (string.Equals(arg, ReadOnlyFlag, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(arg, ReadWriteFlag, StringComparison.OrdinalIgnoreCase) ||
+                arg.StartsWith(AccessModePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (string.Equals(arg, AccessModeFlag, StringComparison.OrdinalIgnoreCase))
+            {
+                // AccessModeParser already validated the value above.
+                i++;
+                continue;
+            }
+
             if (string.Equals(arg, ProjectFlag, StringComparison.OrdinalIgnoreCase))
             {
                 if (i + 1 >= args.Length ||
                     string.IsNullOrWhiteSpace(args[i + 1]) ||
                     args[i + 1].StartsWith("--", StringComparison.Ordinal))
                 {
-                    return new DoctorCliOptions(false, json, verbose, help, null, ResolveAccessMode(), $"--project requires a value.");
+                    return new DoctorCliOptions(false, json, verbose, help, null, accessMode, "--project requires a value.");
                 }
 
                 projectPath = args[++i];
@@ -66,17 +102,23 @@ public static class DoctorCliParser
                 projectPath = arg.Substring(ProjectPrefix.Length);
                 if (string.IsNullOrWhiteSpace(projectPath))
                 {
-                    return new DoctorCliOptions(false, json, verbose, help, null, ResolveAccessMode(), $"--project requires a value.");
+                    return new DoctorCliOptions(false, json, verbose, help, null, accessMode, "--project requires a value.");
                 }
 
                 continue;
             }
 
-            return new DoctorCliOptions(false, json, verbose, help, projectPath, ResolveAccessMode(), $"Unknown doctor argument: '{arg}'.");
+            return new DoctorCliOptions(false, json, verbose, help, projectPath, accessMode, $"Unknown doctor argument: '{arg}'.");
         }
 
-        return new DoctorCliOptions(true, json, verbose, help, projectPath, ResolveAccessMode(), null);
+        return new DoctorCliOptions(true, json, verbose, help, projectPath, accessMode, null);
     }
+
+    private static bool IsAccessModeArgument(string arg)
+        => string.Equals(arg, ReadOnlyFlag, StringComparison.OrdinalIgnoreCase)
+           || string.Equals(arg, ReadWriteFlag, StringComparison.OrdinalIgnoreCase)
+           || string.Equals(arg, AccessModeFlag, StringComparison.OrdinalIgnoreCase)
+           || arg.StartsWith(AccessModePrefix, StringComparison.OrdinalIgnoreCase);
 
     private static McpAccessMode ResolveAccessMode()
     {

--- a/TiaMcpServer/Cli/DoctorCommand.cs
+++ b/TiaMcpServer/Cli/DoctorCommand.cs
@@ -8,13 +8,16 @@ namespace TiaMcpServer.Cli;
 public static class DoctorCommand
 {
     private const string UsageText = """
-        Usage: tia-mcp doctor [--json] [--verbose] [--project <path>] [--help]
+        Usage: tia-mcp doctor [--json] [--verbose] [--project <path>] [--access-mode <mode>] [--help]
 
         Options:
-          --json       Emit a single JSON document to stdout.
-          --verbose    Include additional evidence.
-          --project    Informational project binding (does not start the MCP host).
-          --help       Show command usage and exit.
+          --json          Emit a single JSON document to stdout.
+          --verbose       Include additional evidence.
+          --project       Informational project binding (does not start the MCP host).
+          --access-mode   Report diagnostics for read-only or read-write mode.
+          --read-only     Alias for --access-mode read-only.
+          --read-write    Alias for --access-mode read-write.
+          --help          Show command usage and exit.
 
         Exit codes:
           0  No blocking failures.

--- a/TiaMcpServer/Cli/DoctorCommand.cs
+++ b/TiaMcpServer/Cli/DoctorCommand.cs
@@ -61,11 +61,11 @@ public static class DoctorCommand
 
             if (options.Json)
             {
-                output.WriteLine(DoctorJsonRenderer.Render(report, options.Verbose));
+                output.WriteLine(DoctorJsonRenderer.Render(report, options.Verbose, options.AccessMode));
             }
             else
             {
-                DoctorTextRenderer.Render(report, options.Verbose, output);
+                DoctorTextRenderer.Render(report, options.Verbose, output, options.AccessMode);
             }
 
             return Task.FromResult(report.HasUnexpectedCheckFailure ? 2 : report.Status == DiagnosticStatus.Failed ? 1 : 0);

--- a/TiaMcpServer/Cli/HostArgumentFilter.cs
+++ b/TiaMcpServer/Cli/HostArgumentFilter.cs
@@ -1,0 +1,40 @@
+namespace TiaMcpServer.Cli;
+
+/// <summary>
+/// Removes arguments consumed by the application before the remaining arguments are passed to
+/// <c>Host.CreateApplicationBuilder</c>. The generic host command-line configuration provider
+/// requires key/value pairs and does not support value-less switches such as <c>--read-only</c>.
+/// </summary>
+public static class HostArgumentFilter
+{
+    public static string[] RemoveAccessModeArguments(string[] args)
+    {
+        var remaining = new List<string>(args.Length);
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            if (string.Equals(arg, "--read-only", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(arg, "--read-write", StringComparison.OrdinalIgnoreCase) ||
+                arg.StartsWith("--access-mode=", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (string.Equals(arg, "--access-mode", StringComparison.OrdinalIgnoreCase))
+            {
+                // AccessModeParser validates the value before this filter runs.
+                if (i + 1 < args.Length)
+                {
+                    i++;
+                }
+
+                continue;
+            }
+
+            remaining.Add(arg);
+        }
+
+        return remaining.ToArray();
+    }
+}

--- a/TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs
+++ b/TiaMcpServer/Diagnostics/DoctorJsonRenderer.cs
@@ -1,11 +1,12 @@
 using System.Text;
 using System.Text.Json;
+using TiaMcpServer.Contracts;
 
 namespace TiaMcpServer.Diagnostics;
 
 public static class DoctorJsonRenderer
 {
-    public static string Render(DoctorReport report, bool verbose)
+    public static string Render(DoctorReport report, bool verbose, McpAccessMode? accessMode = null)
     {
         using var stream = new MemoryStream();
         using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
@@ -14,6 +15,10 @@ public static class DoctorJsonRenderer
             writer.WriteString("status", StatusString(report.Status));
             writer.WriteString("timestampUtc", FormatTimestamp(report.TimestampUtc));
             writer.WriteString("hostVersion", report.HostVersion);
+            if (accessMode.HasValue)
+            {
+                writer.WriteString("accessMode", accessMode.Value == McpAccessMode.ReadOnly ? "read-only" : "read-write");
+            }
 
             writer.WritePropertyName("summary");
             writer.WriteStartObject();

--- a/TiaMcpServer/Diagnostics/DoctorTextRenderer.cs
+++ b/TiaMcpServer/Diagnostics/DoctorTextRenderer.cs
@@ -1,11 +1,19 @@
+using TiaMcpServer.Contracts;
+
 namespace TiaMcpServer.Diagnostics;
 
 public static class DoctorTextRenderer
 {
-    public static void Render(DoctorReport report, bool verbose, TextWriter writer)
+    public static void Render(DoctorReport report, bool verbose, TextWriter writer, McpAccessMode? accessMode = null)
     {
         writer.WriteLine("TIA Portal MCP Environment Doctor");
         writer.WriteLine();
+        if (accessMode.HasValue)
+        {
+            var modeLabel = accessMode.Value == McpAccessMode.ReadOnly ? "READ-ONLY" : "READ-WRITE";
+            writer.WriteLine($"Access mode: {modeLabel}");
+            writer.WriteLine();
+        }
 
         foreach (var check in report.Checks)
         {

--- a/TiaMcpServer/Program.cs
+++ b/TiaMcpServer/Program.cs
@@ -42,7 +42,11 @@ namespace TiaMcpServer
                 Console.Error.WriteLine("Project opening, compilation, writes, lifecycle operations, and PLC control are disabled.");
             }
 
-            var builder = Host.CreateApplicationBuilder(args);
+            // Application-specific access-mode switches have already been parsed. Remove them
+            // before generic-host configuration processes the remaining command line because
+            // value-less switches such as --read-only are not valid configuration key/value pairs.
+            var builder = Host.CreateApplicationBuilder(
+                HostArgumentFilter.RemoveAccessModeArguments(args));
             builder.Logging.AddConsole(opts => opts.LogToStandardErrorThreshold = LogLevel.Trace);
             builder.Services.AddSingleton(new ProjectSessionBinding(ResolveStartupProjectPath(args)));
             builder.Services.AddSingleton(new WriteSafetyService());

--- a/TiaMcpServer/Program.cs
+++ b/TiaMcpServer/Program.cs
@@ -2,9 +2,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using TiaMcpServer.Batch;
 using TiaMcpServer.Cli;
 using TiaMcpServer.Contracts;
 using TiaMcpServer.Safety;
+using TiaMcpServer.Tools;
 using TiaMcpServer.Worker;
 
 namespace TiaMcpServer
@@ -24,14 +26,44 @@ namespace TiaMcpServer
                 return VersionCommand.Run(Console.Out);
             }
 
+            var accessModeResult = AccessModeParser.Parse(args);
+            if (!accessModeResult.IsValid)
+            {
+                Console.Error.WriteLine($"Error: {accessModeResult.Error}");
+                return 1;
+            }
+
+            var accessMode = accessModeResult.Mode;
+            var accessPolicy = new OperationAccessPolicy(accessMode);
+
+            Console.Error.WriteLine($"TIA MCP access mode: {accessMode.ToString().ToUpperInvariant()}");
+            if (accessMode == McpAccessMode.ReadOnly)
+            {
+                Console.Error.WriteLine("Project opening, compilation, writes, lifecycle operations, and PLC control are disabled.");
+            }
+
             var builder = Host.CreateApplicationBuilder(args);
             builder.Logging.AddConsole(opts => opts.LogToStandardErrorThreshold = LogLevel.Trace);
             builder.Services.AddSingleton(new ProjectSessionBinding(ResolveStartupProjectPath(args)));
             builder.Services.AddSingleton(new WriteSafetyService());
+            builder.Services.AddSingleton(accessPolicy);
             builder.Services.AddSingleton(sp => new OpennessWorkerClient(
                 sp.GetRequiredService<ProjectSessionBinding>(),
-                sp.GetRequiredService<ILogger<OpennessWorkerClient>>()));
-            builder.Services.AddMcpServer().WithStdioServerTransport().WithToolsFromAssembly();
+                sp.GetRequiredService<ILogger<OpennessWorkerClient>>(),
+                accessPolicy: sp.GetRequiredService<OperationAccessPolicy>()));
+
+            var mcp = builder.Services
+                .AddMcpServer()
+                .WithStdioServerTransport()
+                .WithTools<ProjectReadTools>()
+                .WithTools<ReadBatchTools>();
+
+            if (accessMode == McpAccessMode.ReadWrite)
+            {
+                mcp.WithTools<ProjectWriteTools>()
+                   .WithTools<WriteBatchTools>();
+            }
+
             await builder.Build().RunAsync();
             return 0;
         }

--- a/TiaMcpServer/Safety/OperationAccessPolicy.cs
+++ b/TiaMcpServer/Safety/OperationAccessPolicy.cs
@@ -1,0 +1,39 @@
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Safety;
+
+/// <summary>
+/// Immutable singleton that enforces the access mode policy. Every worker invocation
+/// must pass through <see cref="Authorize"/> before any request is sent to the worker
+/// process. This is the primary host-side defense: it rejects prohibited operations
+/// before the worker transport is started, before TIA Portal is connected, and before
+/// any state snapshots are collected.
+/// </summary>
+public sealed class OperationAccessPolicy
+{
+    public OperationAccessPolicy(McpAccessMode mode)
+    {
+        Mode = mode;
+    }
+
+    public McpAccessMode Mode { get; }
+
+    /// <summary>
+    /// Checks whether <paramref name="operation"/> is permitted under the current mode.
+    /// Returns null when allowed, or a <see cref="WorkerCallResult"/> failure when denied.
+    /// </summary>
+    public WorkerCallResult? Authorize(string operation)
+    {
+        if (OperationPolicyCatalog.IsAllowed(Mode, operation))
+        {
+            return null;
+        }
+
+        return WorkerCallResult.Fail(
+            WorkerFailureCategories.AccessDenied,
+            $"Operation '{operation}' is disabled because this MCP server is running in {ModeLabel()} mode.");
+    }
+
+    private string ModeLabel() => Mode == McpAccessMode.ReadOnly ? "read-only" : "read-write";
+}

--- a/TiaMcpServer/TiaMcpServer.csproj
+++ b/TiaMcpServer/TiaMcpServer.csproj
@@ -22,6 +22,8 @@
 
   <ItemGroup>
     <None Include="../README.md" Pack="true" PackagePath="/" />
+    <None Include="$(OutputPath)openness-worker\**\*" Pack="true" PackagePath="tools/net8.0/any/openness-worker/%(RecursiveDir)%(Filename)%(Extension)"
+          Exclude="$(OutputPath)openness-worker\**\*.runtimeconfig.json;$(OutputPath)openness-worker\**\Siemens.Engineering*.dll" />
   </ItemGroup>
 
   <Target Name="BuildOpennessWorker" BeforeTargets="Build">

--- a/TiaMcpServer/Tools/ProjectLifecycleTools.cs
+++ b/TiaMcpServer/Tools/ProjectLifecycleTools.cs
@@ -11,20 +11,21 @@ namespace TiaMcpServer.Tools
     /// safetyToken to get a preview plus a single-use token, then call it again with the
     /// same arguments plus confirm=true and the token to apply. target/requestedInput are
     /// built exactly once per method so preview and apply can never drift apart.
+    ///
+    /// NOTE: This class is no longer registered as an MCP tool type. Tools have been split
+    /// into ProjectReadTools and ProjectWriteTools. This class is kept for test backward
+    /// compatibility (tests reference its methods directly).
     /// </summary>
-    [McpServerToolType]
     public static class ProjectLifecycleTools
     {
         private const string SafetyFlowDescription =
             "Two-step safety flow in one tool: call WITHOUT safetyToken to get a preview and a single-use token "
             + "(expires after 10 minutes), review it, then call again with the same arguments plus confirm=true and the safetyToken.";
 
-        [McpServerTool(Name = "get_project_status")]
         [Description("Get status and metadata for the active TIA Portal project.")]
         public static async Task<string> GetProjectStatus(OpennessWorkerClient workerClient, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null)
             => (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToEnvelopeText();
 
-        [McpServerTool(Name = "open_project")]
         [Description("Open a TIA Portal project and bind this MCP session to it. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
         public static async Task<string> OpenProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Path to the .ap21 project file to open.")] string projectPath, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null, [Description("Set true to allow rebinding this MCP session from a previously bound project.")] bool forceRebind = false)
         {
@@ -40,7 +41,6 @@ namespace TiaMcpServer.Tools
             return WriteSafetyTooling.BuildApplyResult("open_project", result, "get_project_status", status);
         }
 
-        [McpServerTool(Name = "create_project")]
         [Description("Create a new TIA Portal project and bind this MCP session to it. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
         public static async Task<string> CreateProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Directory where the project folder should be created.")] string projectDirectory, [Description("Name of the new TIA Portal project.")] string projectName, [Description("Optional project author metadata.")] string? author = null, [Description("Optional project comment metadata.")] string? comment = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
         {
@@ -56,7 +56,6 @@ namespace TiaMcpServer.Tools
             return WriteSafetyTooling.BuildApplyResult("create_project", result, "get_project_status", status);
         }
 
-        [McpServerTool(Name = "save_project")]
         [Description("Save the active TIA Portal project. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
         public static async Task<string> SaveProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
         {
@@ -72,7 +71,6 @@ namespace TiaMcpServer.Tools
             return WriteSafetyTooling.BuildApplyResult("save_project", result, "get_project_status", status);
         }
 
-        [McpServerTool(Name = "save_project_as")]
         [Description("Save the active TIA Portal project to a copy directory. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
         public static async Task<string> SaveProjectAs(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Parent directory for the copied project.")] string targetDirectory, [Description("Name of the copied project directory.")] string targetName, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Bind this MCP session to the copied project after save-as. Must be true; rebind=false is not supported.")] bool rebind = true, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
         {
@@ -99,7 +97,6 @@ namespace TiaMcpServer.Tools
             return WriteSafetyTooling.BuildApplyResult("save_project_as", result, "get_project_status", status);
         }
 
-        [McpServerTool(Name = "archive_project")]
         [Description("Archive the active TIA Portal project. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
         public static async Task<string> ArchiveProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Directory where the archive should be written. TIA Portal rejects a combined directory+file path longer than roughly 140 characters.")] string archiveDirectory, [Description("Archive file name. For Compressed and DiscardRestorableDataAndCompressed modes, .zap21 is appended automatically if not already present.")] string archiveName, [Description("Archive mode: None, DiscardRestorableData, Compressed, or DiscardRestorableDataAndCompressed.")] string? mode = null, [Description("Save the project before archiving.")] bool saveBeforeArchive = true, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
         {
@@ -121,7 +118,6 @@ namespace TiaMcpServer.Tools
             return WriteSafetyTooling.BuildApplyResult("archive_project", result, "get_project_status", status);
         }
 
-        [McpServerTool(Name = "close_project")]
         [Description("Close the active TIA Portal project and clear this MCP session binding. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
         public static async Task<string> CloseProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Optional path to a .ap21 project file. If omitted, closes the currently bound/open project.")] string? projectPath = null, [Description("Save the project before closing it.")] bool saveBeforeClose = true, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
         {

--- a/TiaMcpServer/Tools/ProjectReadTools.cs
+++ b/TiaMcpServer/Tools/ProjectReadTools.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Tools;
+
+/// <summary>
+/// Read-only project tools. Exposed in both read-only and read-write modes.
+/// </summary>
+[McpServerToolType]
+public class ProjectReadTools
+{
+    [McpServerTool(Name = "get_project_status", ReadOnly = true, Destructive = false, OpenWorld = false)]
+    [Description("Get status and metadata for the active TIA Portal project.")]
+    public static async Task<string> GetProjectStatus(
+        OpennessWorkerClient workerClient,
+        [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null)
+        => (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToEnvelopeText();
+}

--- a/TiaMcpServer/Tools/ProjectWriteTools.cs
+++ b/TiaMcpServer/Tools/ProjectWriteTools.cs
@@ -1,0 +1,151 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Tools;
+
+/// <summary>
+/// Write-only project lifecycle tools. Only exposed in read-write mode.
+/// Every write tool is self-previewing: call without safetyToken for a preview + token,
+/// then call again with confirm=true and the token to apply.
+/// </summary>
+[McpServerToolType]
+public class ProjectWriteTools
+{
+    private const string SafetyFlowDescription =
+        "Two-step safety flow in one tool: call WITHOUT safetyToken to get a preview and a single-use token "
+        + "(expires after 10 minutes), review it, then call again with the same arguments plus confirm=true and the safetyToken.";
+
+    [McpServerTool(Name = "open_project")]
+    [Description("Open a TIA Portal project and bind this MCP session to it. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
+    public static async Task<string> OpenProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Path to the .ap21 project file to open.")] string projectPath, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null, [Description("Set true to allow rebinding this MCP session from a previously bound project.")] bool forceRebind = false)
+    {
+        var target = new { projectPath };
+        var requestedInput = new { projectPath, forceRebind };
+        if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview(safety, "open_project", projectPath, target, $"Open and bind TIA Portal project '{projectPath}'.", requestedInput, WorkerCallResult.Ok(WriteSafetyTooling.DescribePathState(projectPath)), diff: null, instructions: ApplyInstructions("open_project"));
+        if (!confirm) return ConfirmRequired("open_project");
+        var safetyContext = await WriteSafetyTooling.ValidateForApplyAsync(safety, safetyToken, PreviewHint("open_project"), "open_project", projectPath, target, requestedInput, () => Task.FromResult(WorkerCallResult.Ok(WriteSafetyTooling.DescribePathState(projectPath)))).ConfigureAwait(false);
+        if (!safetyContext.IsValid) return SafetyFailure("open_project", safetyContext);
+        var result = await workerClient.OpenProjectAsync(projectPath, forceRebind).ConfigureAwait(false);
+        var status = result.Success ? (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText() : null;
+        safety.AppendAudit("open_project", projectPath, target, requestedInput, safetyContext.CurrentState, result.ToText());
+        return WriteSafetyTooling.BuildApplyResult("open_project", result, "get_project_status", status);
+    }
+
+    [McpServerTool(Name = "create_project")]
+    [Description("Create a new TIA Portal project and bind this MCP session to it. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
+    public static async Task<string> CreateProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Directory where the project folder should be created.")] string projectDirectory, [Description("Name of the new TIA Portal project.")] string projectName, [Description("Optional project author metadata.")] string? author = null, [Description("Optional project comment metadata.")] string? comment = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
+    {
+        var target = new { projectDirectory, projectName };
+        var requestedInput = new { projectDirectory, projectName, author, comment };
+        if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview(safety, "create_project", null, target, $"Create TIA Portal project '{projectName}' in '{projectDirectory}'.", requestedInput, WorkerCallResult.Ok(WriteSafetyTooling.DescribeProjectCreationState(projectDirectory, projectName)), diff: null, instructions: ApplyInstructions("create_project"));
+        if (!confirm) return ConfirmRequired("create_project");
+        var safetyContext = await WriteSafetyTooling.ValidateForApplyAsync(safety, safetyToken, PreviewHint("create_project"), "create_project", null, target, requestedInput, () => Task.FromResult(WorkerCallResult.Ok(WriteSafetyTooling.DescribeProjectCreationState(projectDirectory, projectName)))).ConfigureAwait(false);
+        if (!safetyContext.IsValid) return SafetyFailure("create_project", safetyContext);
+        var result = await workerClient.CreateProjectAsync(projectDirectory, projectName, author, comment).ConfigureAwait(false);
+        var status = result.Success ? (await workerClient.GetProjectStatusAsync(null).ConfigureAwait(false)).ToText() : null;
+        safety.AppendAudit("create_project", null, target, requestedInput, safetyContext.CurrentState, result.ToText());
+        return WriteSafetyTooling.BuildApplyResult("create_project", result, "get_project_status", status);
+    }
+
+    [McpServerTool(Name = "save_project")]
+    [Description("Save the active TIA Portal project. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
+    public static async Task<string> SaveProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
+    {
+        var target = new { projectPath };
+        var requestedInput = new { projectPath };
+        if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview(safety, "save_project", projectPath, target, "Save the active TIA Portal project.", requestedInput, await workerClient.ProbeProjectStatusForLifecycleAsync(projectPath).ConfigureAwait(false), diff: null, instructions: ApplyInstructions("save_project"));
+        if (!confirm) return ConfirmRequired("save_project");
+        var safetyContext = await WriteSafetyTooling.ValidateForApplyAsync(safety, safetyToken, PreviewHint("save_project"), "save_project", projectPath, target, requestedInput, () => workerClient.ProbeProjectStatusForLifecycleAsync(projectPath)).ConfigureAwait(false);
+        if (!safetyContext.IsValid) return SafetyFailure("save_project", safetyContext);
+        var result = await workerClient.SaveProjectAsync(projectPath).ConfigureAwait(false);
+        var status = result.Success ? (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText() : null;
+        safety.AppendAudit("save_project", projectPath, target, requestedInput, safetyContext.CurrentState, result.ToText());
+        return WriteSafetyTooling.BuildApplyResult("save_project", result, "get_project_status", status);
+    }
+
+    [McpServerTool(Name = "save_project_as")]
+    [Description("Save the active TIA Portal project to a copy directory. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
+    public static async Task<string> SaveProjectAs(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Parent directory for the copied project.")] string targetDirectory, [Description("Name of the copied project directory.")] string targetName, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Bind this MCP session to the copied project after save-as. Must be true; rebind=false is not supported.")] bool rebind = true, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
+    {
+        if (!rebind)
+        {
+            return WriteSafetyTooling.BuildApplyResult(
+                "save_project_as",
+                WorkerCallResult.Fail(WorkerFailureCategories.ValidationError, OpennessWorkerClient.RebindFalseUnsupportedMessage));
+        }
+
+        var target = new { projectPath, targetDirectory, targetName };
+        var requestedInput = new { projectPath, targetDirectory, targetName, rebind };
+        if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview(safety, "save_project_as", projectPath, target, $"Save active project as '{targetName}' in '{targetDirectory}'.", requestedInput, await workerClient.ProbeProjectStatusForLifecycleAsync(projectPath).ConfigureAwait(false), diff: null, instructions: ApplyInstructions("save_project_as"));
+        if (!confirm) return ConfirmRequired("save_project_as");
+        var safetyContext = await WriteSafetyTooling.ValidateForApplyAsync(safety, safetyToken, PreviewHint("save_project_as"), "save_project_as", projectPath, target, requestedInput, () => workerClient.ProbeProjectStatusForLifecycleAsync(projectPath)).ConfigureAwait(false);
+        if (!safetyContext.IsValid) return SafetyFailure("save_project_as", safetyContext);
+        var result = await workerClient.SaveProjectAsAsync(projectPath, targetDirectory, targetName, rebind).ConfigureAwait(false);
+        var status = result.Success ? (await workerClient.GetProjectStatusAsync(rebind ? null : projectPath).ConfigureAwait(false)).ToText() : null;
+        safety.AppendAudit("save_project_as", projectPath, target, requestedInput, safetyContext.CurrentState, result.ToText());
+        return WriteSafetyTooling.BuildApplyResult("save_project_as", result, "get_project_status", status);
+    }
+
+    [McpServerTool(Name = "archive_project")]
+    [Description("Archive the active TIA Portal project. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
+    public static async Task<string> ArchiveProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Directory where the archive should be written. TIA Portal rejects a combined directory+file path longer than roughly 140 characters.")] string archiveDirectory, [Description("Archive file name. For Compressed and DiscardRestorableDataAndCompressed modes, .zap21 is appended automatically if not already present.")] string archiveName, [Description("Archive mode: None, DiscardRestorableData, Compressed, or DiscardRestorableDataAndCompressed.")] string? mode = null, [Description("Save the project before archiving.")] bool saveBeforeArchive = true, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
+    {
+        var resolvedArchiveName = ArchiveModeNames.TryNormalize(mode, out var normalizedMode, out _)
+            ? ArchiveModeNames.EnsureArchiveExtension(archiveName, normalizedMode)
+            : archiveName;
+        var target = new { projectPath, archiveDirectory, archiveName = resolvedArchiveName };
+        var requestedInput = new { projectPath, archiveDirectory, archiveName, mode, saveBeforeArchive };
+        if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview(safety, "archive_project", projectPath, target, $"Archive active project to '{archiveDirectory}\\{resolvedArchiveName}'.", requestedInput, RejectIfArchiveDirectoryWithinProjectFolder(await workerClient.ProbeProjectStatusForLifecycleAsync(projectPath).ConfigureAwait(false), archiveDirectory), diff: null, instructions: ApplyInstructions("archive_project"));
+        if (!confirm) return ConfirmRequired("archive_project");
+        var safetyContext = await WriteSafetyTooling.ValidateForApplyAsync(safety, safetyToken, PreviewHint("archive_project"), "archive_project", projectPath, target, requestedInput, async () => RejectIfArchiveDirectoryWithinProjectFolder(await workerClient.ProbeProjectStatusForLifecycleAsync(projectPath).ConfigureAwait(false), archiveDirectory)).ConfigureAwait(false);
+        if (!safetyContext.IsValid) return SafetyFailure("archive_project", safetyContext);
+        var result = await workerClient.ArchiveProjectAsync(projectPath, archiveDirectory, archiveName, mode, saveBeforeArchive).ConfigureAwait(false);
+        var status = result.Success ? (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToText() : null;
+        safety.AppendAudit("archive_project", projectPath, target, requestedInput, safetyContext.CurrentState, result.ToText());
+        return WriteSafetyTooling.BuildApplyResult("archive_project", result, "get_project_status", status);
+    }
+
+    [McpServerTool(Name = "close_project")]
+    [Description("Close the active TIA Portal project and clear this MCP session binding. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
+    public static async Task<string> CloseProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Optional path to a .ap21 project file. If omitted, closes the currently bound/open project.")] string? projectPath = null, [Description("Save the project before closing it.")] bool saveBeforeClose = true, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
+    {
+        var target = new { projectPath };
+        var requestedInput = new { projectPath, saveBeforeClose };
+        if (string.IsNullOrWhiteSpace(safetyToken)) return WriteSafetyTooling.CreatePreview(safety, "close_project", projectPath, target, "Close the active TIA Portal project.", requestedInput, await workerClient.ProbeProjectStatusForLifecycleAsync(projectPath).ConfigureAwait(false), diff: null, instructions: ApplyInstructions("close_project"));
+        if (!confirm) return ConfirmRequired("close_project");
+        var safetyContext = await WriteSafetyTooling.ValidateForApplyAsync(safety, safetyToken, PreviewHint("close_project"), "close_project", projectPath, target, requestedInput, () => workerClient.ProbeProjectStatusForLifecycleAsync(projectPath)).ConfigureAwait(false);
+        if (!safetyContext.IsValid) return SafetyFailure("close_project", safetyContext);
+        var result = await workerClient.CloseProjectAsync(projectPath, saveBeforeClose).ConfigureAwait(false);
+        safety.AppendAudit("close_project", projectPath, target, requestedInput, safetyContext.CurrentState, result.ToText());
+        return WriteSafetyTooling.BuildApplyResult("close_project", result, "get_project_status", null);
+    }
+
+    private static WorkerCallResult RejectIfArchiveDirectoryWithinProjectFolder(WorkerCallResult probe, string archiveDirectory)
+    {
+        if (!probe.Success || !ArchiveDirectoryGuard.IsWithinProjectFolder(archiveDirectory, probe.ResolvedProjectPath ?? string.Empty))
+        {
+            return probe;
+        }
+
+        return WorkerCallResult.Fail(WorkerFailureCategories.ValidationError, ArchiveDirectoryGuard.BuildRejectionMessage(archiveDirectory));
+    }
+
+    private static string ApplyInstructions(string toolName) => $"Preview only — nothing was changed. To apply, call {toolName} again with the same arguments plus confirm=true and this safetyToken.";
+
+    private static string ConfirmRequired(string toolName) => WriteSafetyTooling.BuildApplyResult(
+        toolName,
+        WorkerCallResult.Fail(
+            WorkerFailureCategories.ValidationError,
+            $"Safety token provided but confirm=false. Set confirm=true and resend the safetyToken to apply, or call {toolName} without safetyToken for a fresh preview."));
+
+    private static string SafetyFailure(string toolName, WriteSafetyApplyContext safetyContext) => WriteSafetyTooling.BuildApplyResult(
+        toolName,
+        WorkerCallResult.Fail(
+            safetyContext.FailureCategory ?? WorkerFailureCategories.ValidationError,
+            safetyContext.Error ?? "Safety validation failed."));
+
+    private static string PreviewHint(string toolName) => $"{toolName} (without safetyToken)";
+}

--- a/TiaMcpServer/Worker/OpennessWorkerClient.cs
+++ b/TiaMcpServer/Worker/OpennessWorkerClient.cs
@@ -14,6 +14,7 @@ public class OpennessWorkerClient : IDisposable
     private readonly ILogger<OpennessWorkerClient>? _logger;
     private readonly string? _workerExecutablePathOverride;
     private readonly TimeSpan _requestTimeout;
+    private readonly Safety.OperationAccessPolicy? _accessPolicy;
     private readonly object _transportLock = new();
     private PersistentWorkerTransport? _transport;
 
@@ -21,13 +22,19 @@ public class OpennessWorkerClient : IDisposable
         ProjectSessionBinding projectSessionBinding,
         ILogger<OpennessWorkerClient>? logger = null,
         string? workerExecutablePath = null,
-        TimeSpan? requestTimeout = null)
+        TimeSpan? requestTimeout = null,
+        Safety.OperationAccessPolicy? accessPolicy = null)
     {
         _projectSessionBinding = projectSessionBinding;
         _logger = logger;
         _workerExecutablePathOverride = workerExecutablePath;
         _requestTimeout = requestTimeout ?? DefaultRequestTimeout;
+        _accessPolicy = accessPolicy;
     }
+
+    /// <summary>The current access mode policy, if set. Used by batch tools to validate
+    /// operations before worker invocation.</summary>
+    public Safety.OperationAccessPolicy? AccessPolicy => _accessPolicy;
 
     /// <summary>
     /// How a completed (successful) worker call changes this session's project binding. Declared
@@ -864,6 +871,17 @@ public class OpennessWorkerClient : IDisposable
 
     private async Task<WorkerCallResult> InvokeWorkerAsync(WorkerRequest request)
     {
+        // Defense in depth: authorize BEFORE the worker process is started, before any
+        // request is written to stdin, and before TIA Portal is connected.
+        if (_accessPolicy is not null)
+        {
+            var denial = _accessPolicy.Authorize(request.Method);
+            if (denial is not null)
+            {
+                return denial;
+            }
+        }
+
         try
         {
             // Exactly one transport request per call: SendAsync neither loops nor retries: on any
@@ -920,10 +938,14 @@ public class OpennessWorkerClient : IDisposable
     {
         lock (_transportLock)
         {
+            var workerArgs = _accessPolicy is not null
+                ? $"--access-mode {(_accessPolicy.Mode == Contracts.McpAccessMode.ReadOnly ? "read-only" : "read-write")}"
+                : null;
             _transport ??= new PersistentWorkerTransport(
                 _workerExecutablePathOverride ?? LocateWorkerExecutable(),
                 _requestTimeout,
-                _logger);
+                _logger,
+                workerArgs);
             return _transport;
         }
     }

--- a/TiaMcpServer/Worker/PersistentWorkerTransport.cs
+++ b/TiaMcpServer/Worker/PersistentWorkerTransport.cs
@@ -30,17 +30,19 @@ public sealed class PersistentWorkerTransport : IDisposable
     private readonly string _workerExecutablePath;
     private readonly TimeSpan _requestTimeout;
     private readonly ILogger? _logger;
+    private readonly string? _workerArgs;
     private readonly ConcurrentQueue<string> _recentStderr = new();
 
     private Process? _process;
     private Task? _stderrPump;
     private bool _disposed;
 
-    public PersistentWorkerTransport(string workerExecutablePath, TimeSpan requestTimeout, ILogger? logger = null)
+    public PersistentWorkerTransport(string workerExecutablePath, TimeSpan requestTimeout, ILogger? logger = null, string? workerArgs = null)
     {
         _workerExecutablePath = workerExecutablePath;
         _requestTimeout = requestTimeout;
         _logger = logger;
+        _workerArgs = workerArgs;
     }
 
     public async Task<WorkerResponse> SendAsync(WorkerRequest request)
@@ -127,6 +129,7 @@ public sealed class PersistentWorkerTransport : IDisposable
         var startInfo = new ProcessStartInfo
         {
             FileName = _workerExecutablePath,
+            Arguments = _workerArgs ?? string.Empty,
             WorkingDirectory = Path.GetDirectoryName(_workerExecutablePath) ?? AppContext.BaseDirectory,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,307 +1,260 @@
 # Architecture
 
-This document explains how `tia-portal-mcp` is put together: the process
-topology, how a tool call travels from an MCP client down into Siemens
-Openness and back, the write-safety model, and exactly what is exposed to
-clients today.
+This document describes the current `tia-portal-mcp` runtime architecture, tool
+surface, access-mode enforcement, project binding, write-safety model, and test
+strategy.
 
-It was produced by walking the indexed symbol graph (jcodemunch) and the
-`graphify` knowledge graph (`graphify-out/GRAPH_REPORT.md`) rather than by
-hand; re-run those tools after structural changes and refresh this file to
-match.
+## 1. Process topology
 
-## 1. Why two processes
+Siemens TIA Portal Openness is a .NET Framework 4.8 API. The MCP host targets
+.NET 8, so the product is intentionally split into two processes:
 
-Siemens TIA Portal Openness (`Siemens.Engineering.*`) is a .NET Framework 4.8
-API built on .NET Remoting. It cannot be loaded into a modern .NET 8 process.
-That single constraint drives the whole topology:
-
-```
-MCP client (Claude Desktop / other MCP host)
-        │  stdio, JSON-RPC (MCP protocol)
-        ▼
-┌───────────────────────────────┐
-│ TiaMcpServer            (host, net8.0) │
-│  - ModelContextProtocol C# SDK          │
-│  - 10 MCP tools ([McpServerTool])       │
-│  - Batch engine, write-safety tokens    │
-└───────────────────────────────┘
-        │  newline-delimited JSON over stdin/stdout
-        │  (own private child-process pipe, unrelated to the MCP transport)
-        ▼
-┌───────────────────────────────┐
-│ TiaMcpServer.OpennessWorker (worker, net48) │
-│  - Loads Siemens.Engineering.*             │
-│  - One shared, long-lived TIA session      │
-│  - All real Openness calls happen here     │
-└───────────────────────────────┘
-        │  Siemens Openness / .NET Remoting
-        ▼
-              TIA Portal V21 process
+```text
+MCP client
+    |
+    | MCP JSON-RPC over stdio
+    v
+TiaMcpServer (net8.0 host)
+    |
+    | newline-delimited JSON over private stdin/stdout pipes
+    v
+TiaMcpServer.OpennessWorker (net48 worker)
+    |
+    | Siemens Openness / .NET Remoting
+    v
+TIA Portal V21
 ```
 
-The **host** is what an MCP client actually launches and speaks MCP to. The
-**worker** is a plain console EXE the host spawns as a child process purely
-for IPC; it never talks MCP and is invisible to the client. The host copies
-the worker build into `openness-worker/` next to itself at build time, and
-`OpennessWorkerLocator` resolves that path at runtime (`TiaMcpServer.OpennessWorker.exe`
-under an `openness-worker/` subdirectory relative to the host's base
-directory).
+The host owns the MCP protocol, dependency injection, tool registration,
+access policy, session binding, batching, diagnostics, and write-safety tokens.
+The worker owns every Siemens API call and keeps one long-lived TIA Portal
+attachment for its process lifetime.
 
-`TiaMcpServer.Contracts` (netstandard2.0) is the only thing both processes
-reference — it has zero Siemens dependency, so it compiles under both TFMs and
-carries every request/response DTO across the pipe.
+`TiaMcpServer.Contracts` targets `netstandard2.0` and contains the request,
+response, failure-category, path-normalization, and access-policy contracts
+shared by both processes.
 
-## 2. Host process (`TiaMcpServer`, net8.0)
+## 2. Host startup and access modes
 
-`Program.cs` is a thin dispatcher, not just an MCP entry point:
+`TiaMcpServer/Program.cs` handles three entry paths:
 
-- `doctor` → `Cli/DoctorCommand` (environment diagnostics, see §6)
-- `--version` / `-v` → `Cli/VersionCommand`
-- anything else → boots a generic-host MCP server:
-  - `AddMcpServer().WithStdioServerTransport().WithToolsFromAssembly()` — the
-    official ModelContextProtocol SDK scans the assembly for
-    `[McpServerToolType]` classes and registers every `[McpServerTool]`
-    method it finds. There is no manual tool-registration list; adding a tool
-    means adding a decorated static method.
-  - DI singletons: `ProjectSessionBinding` (which `.ap21` project this MCP
-    session is bound to — seeded from `--project <path>` or
-    `TIA_MCP_PROJECT_PATH`), `WriteSafetyService`, and `OpennessWorkerClient`.
+- `doctor` runs environment diagnostics.
+- `--version` or `-v` prints version information.
+- All other invocations start the MCP server.
 
-Startup project binding matters: once a session opens or creates a project,
-`ProjectSessionBinding` remembers it, and subsequent tool calls default to
-that project unless a call explicitly targets a different path (which trips
-binding-divergence warnings — see `OpennessWorkerClient.WarnOnBindingDivergence`).
+The access mode is resolved once at startup with this precedence:
 
-### `Worker/` — the IPC client
+1. `--access-mode read-only|read-write`, `--read-only`, or `--read-write`
+2. `TIA_MCP_ACCESS_MODE`
+3. `read-write` by default
 
-- **`PersistentWorkerTransport`** owns the actual child `Process` and a
-  `SemaphoreSlim(1,1)` gate, so requests are single-flight — one in-flight
-  Openness call at a time, which matches Openness's own single-threaded
-  session model. It writes one JSON line to the worker's stdin, reads one
-  JSON line back, and:
-  - keeps the last 30 stderr lines in a ring buffer to surface crash context,
-  - restarts the worker process automatically if it has died or was never
-    started (`EnsureProcessStarted`),
-  - on read failure, captures whatever crash detail it can and fails the call
-    rather than hanging.
-- **`OpennessWorkerClient`** is the typed façade the tools actually call
-  (`BrowseProjectTreeAsync`, `CreateTagAsync`, `OpenProjectAsync`, …). It
-  builds a `WorkerRequest`, sends it through the transport, and layers
-  session-binding logic on top of the raw call — e.g. `OpenProjectAsync`
-  transitions `ProjectSessionBinding` on success, `SaveProjectAsAsync` always
-  rebinds (Siemens `SaveAs` switches the *active* project in Openness, so a
-  non-rebinding save would desync the worker's active project from the MCP
-  session's belief about it), and long warning arrays coming back from the
-  worker are capped (`CapWarnings`, 20 lines / 1000 chars per line) before
-  they reach the client.
-- **`OpennessWorkerLocator`** just resolves the worker executable path.
+Malformed explicit access-mode arguments are rejected instead of silently
+falling back to another mode.
 
-### `Batch/` — the multi-operation engine
+### Read-write mode
 
-- **`BatchOperationCatalog`** is the single source of truth for which
-  operation names exist, whether each is a `Read` or `Write`, and its
-  required/optional fields. It validates a batch request array against that
-  spec before anything is dispatched: unknown operation name, missing
-  required field, or a field that doesn't apply to that operation all fail
-  fast with a structured error — the worker is never invoked for a
-  malformed batch. `MaxBatchSize = 50`.
-- **`BatchOperationRequest`** is one flat DTO with every possible field
-  across every operation (nullable), keyed by `operationId` + `operation`.
-  Flat-and-nullable was a deliberate tradeoff: one shape for 25 operations
-  instead of 25 polymorphic request types, at the cost of catalog-based
-  validation instead of the type system doing it.
-- **`BatchExecutionEngine`** encodes the two execution semantics:
-  - `ExecuteReadsAsync` — every read runs independently; one failing item is
-    recorded in its own result slot and never stops the others.
-  - `ApplyWritesAsync` — writes run **sequentially** and stop at the first
-    failure; remaining items are marked skipped. There is no rollback of
-    already-applied writes.
-- **`BatchTools`** is where the three batch operations become MCP tools (see
-  §4) — it also builds the *combined current state* string (concatenation of
-  each operation's current-state read) that becomes part of the safety
-  token's binding for `preview_write_batch`/`apply_write_batch`.
-- `BatchPayloadBudget`, `BatchResultFormatter`, `BatchSafetySnapshot`,
-  `BatchWorkerInvoker` are supporting pieces: bounding oversized batch
-  payloads, formatting the per-item result array, and snapshotting safety
-  state.
+Read-write mode preserves the complete tool surface and the existing
+preview-then-apply safety-token model.
 
-### `Safety/` — preview-then-apply tokens
+### Read-only mode
 
-- **`WriteSafetyService`** issues and redeems single-use tokens:
-  - `CreatePreview(toolName, projectPath, target, summary, requestedInput, currentState, …)`
-    hashes `requestedInput` and `currentState`, stores a `SafetyTokenEntry`
-    keyed by a random token, and returns a preview payload containing that
-    token. Default lifetime is `TimeSpan.FromMinutes(10)`.
-  - `ValidateAndConsume(...)` re-hashes the *current* requested input and
-    current state and compares against what's stored for that token +
-    tool name + project path. Any mismatch — different input, different
-    project state, wrong tool, expired, already consumed — is rejected with
-    a categorized reason (`FailureCategory`, e.g. `validation_error`,
-    `binding_conflict`). On success the token is removed (single-use) and the
-    write proceeds.
-  - `AppendAudit(...)` writes a JSONL record for every completed write to
-    `%LOCALAPPDATA%\TiaMcpServer\audit`.
-- **`WriteSafetyTooling`** is the reusable glue each write tool calls:
-  `ValidateForApplyAsync` (read current state, then validate+consume),
-  `CreatePreview` (read current state, then create the token), plus
-  presentation helpers (`CreateLineDiff`, `DescribePathState`,
-  `DescribeProjectCreationState`) used to make previews human-readable.
+Read-only mode exposes observation tools only. It never opens, creates, saves,
+archives, switches, or closes a project; never compiles; never controls a PLC;
+and never performs project-data mutations. It operates only on a project that
+is already open in the attached TIA Portal instance.
 
-This preview→token→apply loop is why the write safety model is described as
-non-negotiable in the project's `CLAUDE.md`: every write tool, whether a
-single lifecycle tool or a batch, goes through the same
-`WriteSafetyService`/`WriteSafetyTooling` pair.
+A supplied `projectPath` in read-only mode is an assertion. It must identify the
+currently open project; it is never used to open or switch projects.
 
-### `Diagnostics/` + `Cli/` — the `doctor` subcommand
+## 3. Explicit MCP tool registration
 
-`TiaMcpServer doctor` runs a fixed pipeline of `IDiagnosticCheck`
-implementations (`OperatingSystemCheck`, `DotNetFrameworkCheck`,
-`DotNetRuntimeCheck`, `TiaPortalInstallationCheck`, `TiaPortalProcessCheck`,
-`OpennessAssembliesCheck`, `OpennessGroupCheck`, `OpennessWorkerCheck`,
-`HostWorkerVersionCheck`, `ProjectBindingCheck`) and renders a pass/fail
-report via `DoctorTextRenderer` or `DoctorJsonRenderer` (`DoctorCliParser`
-picks the format). This is the operator-facing "is my environment sane"
-tool — separate from anything an MCP client calls.
+Tool registration is explicit and mode-dependent. The host always registers:
 
-## 3. Worker process (`TiaMcpServer.OpennessWorker`, net48)
+- `ProjectReadTools`
+- `ReadBatchTools`
 
-`Program.cs` here is a request-dispatch loop, not a hosted service:
+It registers the following only in read-write mode:
 
-1. `Main()` reads newline-delimited JSON from stdin in a loop.
-2. `HandleLine` deserializes a `WorkerRequest`, dispatches on
-   `request.Method` to one private static handler per operation (30+
-   handlers — `BrowseProjectTree`, `CreateTag`, `OpenProject`, … one per
-   entry in `BatchOperationCatalog` plus the 6 project-lifecycle ops that
-   are intentionally excluded from batches), and writes back one JSON
-   `WorkerResponse` line.
-3. Two composition helpers wrap every handler:
-   - `WithSession` / `WithProject` acquire the module-level
-     `_sharedSession` (`WorkerTiaPortalSession`, constructed once with
-     `allowTiaConfirmations: true`) and ensure the requested project is the
-     one currently open before running the handler body. The session is
-     process-lifetime and shared across every request — TIA's own
-     "attach to running instance" confirmation dialog would otherwise pop up
-     on every single call, so the worker attaches once and reuses that
-     attachment.
-   - `Execute(Func<WorkerResponse> body)` is the single place that catches
-     Openness exceptions and maps them to a categorized `WorkerResponse`
-     failure, and stamps timing/operation metadata (`Stamp`) onto every
-     response, success or failure.
+- `ProjectWriteTools`
+- `WriteBatchTools`
 
-The actual Openness logic (project tree walking, block import/export,
-hardware config reads, tag/constant mutation, cross-reference reads, compile
-checks, network device configuration, PLC online start/stop, block source
-generation and postcondition verification, …) lives in
-`TiaMcpServer.OpennessWorker/Openness/*` — roughly three dozen focused
-classes, each owning one concern (e.g. `BlockImportCoordinator`,
-`CrossReferenceReader`, `HardwareConfigReader`, `TagMutationService`,
-`PlcOnlineService`). The dispatch handlers in `Program.cs` are deliberately
-thin: they parse the request, call into one of these services, and hand the
-result to `Execute`/`Stamp`.
+This prevents write tools from appearing in MCP discovery when the server is
+read-only. Decorated tool classes that are not explicitly registered are not
+part of the active tool surface.
 
-`AssemblyResolver.cs` handles locating the Siemens PublicAPI assemblies at
-runtime so the worker can load `Siemens.Engineering.dll` without them being
-shipped in the repo (they're licensed, machine-installed DLLs — see
-`ref/` for the compile-time stubs used in CI).
-
-## 4. What's exposed to an MCP client today
-
-Exactly **10** tools, registered via `[McpServerToolType]` /
-`[McpServerTool(Name = "...")]` and auto-discovered by
-`WithToolsFromAssembly()` — confirmed by decorator census over the indexed
-source, not by reading a registration list (there isn't one).
-
-### `Tools/ProjectLifecycleTools.cs` — 7 self-previewing lifecycle tools
-
-Each of these is call-twice-yourself: call without `safetyToken` to get a
-preview + token, review it, call again with the same arguments plus
-`confirm=true` and the token.
+### Read-only tool surface
 
 | Tool | Purpose |
 |---|---|
-| `get_project_status` | Read-only; status/metadata for the active project. No safety token needed. |
-| `open_project` | Open a `.ap21` and bind this MCP session to it (`forceRebind` to rebind an already-bound session). |
-| `create_project` | Create a new project and bind the session to it. |
+| `get_project_status` | Return status and metadata for the project already open in TIA Portal. |
+| `execute_read_batch` | Execute up to 50 validated observation operations. |
+
+The read batch supports:
+
+- `browse_project_tree`
+- `read_hardware_config`
+- `search_equipment_catalog`
+- `read_cross_references`
+- `get_block_content`
+- `list_tag_tables`
+- `get_project_status`
+
+`compile_check` remains part of the read-batch catalog for read-write mode, but
+it is denied in read-only mode because the Siemens compilation API may modify
+internal project state.
+
+### Additional read-write tools
+
+| Tool | Purpose |
+|---|---|
+| `open_project` | Open and bind a project. |
+| `create_project` | Create and bind a project. |
 | `save_project` | Save the active project. |
-| `save_project_as` | Save-as to a copy directory. `rebind` must be `true` — Siemens `SaveAs` switches the active project in Openness itself, so a non-rebinding save would desync worker state from session state. |
-| `archive_project` | Archive the active project (`mode`: None / DiscardRestorableData / Compressed / DiscardRestorableDataAndCompressed). |
-| `close_project` | Close the active project and clear the session binding. |
+| `save_project_as` | Save a copy and rebind to the worker-reported project path. |
+| `archive_project` | Archive the active project. |
+| `close_project` | Close the active project and clear the binding. |
+| `preview_write_batch` | Validate writes, capture current state, and issue a safety token. |
+| `apply_write_batch` | Redeem the token and execute writes sequentially. |
 
-### `Batch/BatchTools.cs` — 3 generic batch tools
+## 4. Defense-in-depth access enforcement
 
-| Tool | Purpose |
-|---|---|
-| `execute_read_batch` | Up to 50 read operations in one call, independent execution, one shared `BatchOperationRequest[]` shape. |
-| `preview_write_batch` | Validate up to 50 write operations, read their combined current state, and issue one batch-level safety token. |
-| `apply_write_batch` | Redeem that token and apply the same operation list sequentially, stopping at the first failure. |
+Read-only mode is enforced independently at three layers.
 
-**8 read operations** reachable through `execute_read_batch`:
-`browse_project_tree`, `read_hardware_config`, `search_equipment_catalog`,
-`read_cross_references`, `get_block_content`, `list_tag_tables`,
-`compile_check`, `get_project_status`.
+### 4.1 Tool discovery
 
-**17 write operations** reachable through `preview_write_batch` /
-`apply_write_batch`: `update_block_logic`, `create_tag_table`,
-`delete_tag_table`, `create_tag`, `update_tag`, `delete_tag`,
-`create_user_constant`, `update_user_constant`, `delete_user_constant`,
-`add_network_device`, `configure_network_device`, `create_block`,
-`delete_block`, `create_block_group`, `delete_block_group`, `start_plc`,
-`stop_plc`.
+Write tool classes are not registered in read-only mode, so MCP clients cannot
+discover or invoke them through the normal protocol surface.
 
-The 6 project-lifecycle operations (`open_project`, `create_project`,
-`save_project`, `save_project_as`, `archive_project`, `close_project`) exist
-as real single tools but are deliberately excluded from the batch catalog
-(`BatchOperationCatalog.NonBatchableOperations`) — they change which project
-is active/bound, which doesn't compose with "50 independent operations in
-one call."
+### 4.2 Host authorization
 
-So the effective surface area is **10 MCP tools** covering **31 distinct
-underlying operations** (8 read + 17 write + 6 lifecycle), all funneled
-through one write-safety model and one IPC transport.
+`OperationAccessPolicy` checks each worker operation before the child process is
+started or a request is written. The shared `OperationPolicyCatalog` classifies
+all known worker operations as observation, temporary export, compilation,
+project lifecycle, project mutation, or online control.
 
-## 5. Write safety, end to end
+Read-only mode allows only observation and temporary-export capabilities.
+Unknown operations are denied by default.
 
-For any write — single-tool or inside a batch — the shape is always:
+### 4.3 Worker authorization
 
-1. **Preview call** (no `safetyToken`): the tool reads current state via the
-   worker, builds a human-readable preview/diff, and calls
-   `WriteSafetyService.CreatePreview` to mint a token bound to
-   `(toolName, projectPath, target, hash(requestedInput), hash(currentState))`.
-   Response includes the token and expiry (10 minutes).
-2. **Apply call** (`confirm=true` + `safetyToken`): `ValidateAndConsume`
-   re-derives both hashes from what was just requested and what state is
-   *now* current, and only proceeds if both still match what's stored under
-   that token. Any drift — someone else changed the project, the caller
-   changed the request, the token expired or was already used — is rejected
-   with a categorized error, never silently applied.
-3. On success, `AppendAudit` writes a JSONL line to
-   `%LOCALAPPDATA%\TiaMcpServer\audit` and the worker performs the mutation.
+The host passes its resolved access mode to the worker process. The worker runs
+`WorkerOperationAuthorization` before dispatching any request handler or
+calling Siemens APIs.
 
-This is why reordering a batch, changing an operation's parameters, or the
-project state changing between preview and apply all invalidate the token —
-by design, not as an edge case.
+Missing worker configuration preserves the historical read-write default.
+Explicit but malformed worker configuration fails closed to read-only, so an
+argument-propagation defect cannot silently enable mutations.
 
-## 6. Testing shape (context for the architecture, not a full test guide)
+In read-only mode the Siemens-facing `TiaPortalSession` also refuses automatic
+confirmation dialogs. Read-write mode may accept confirmations where the
+existing write workflow explicitly allows them.
 
-`TiaMcpServer.Tests` doesn't reference the host/worker projects — it
-compiles their source files directly via `<Compile Include>`, which is why
-it can exercise `TiaMcpServer/Worker`, `TiaMcpServer/Batch`,
-`TiaMcpServer/Safety`, `TiaMcpServer/Tools`, `TiaMcpServer/Diagnostics`, and
-`TiaMcpServer/Cli` on net8.0 without ever needing the net48 Openness worker
-to build. `TiaMcpServer.FakeWorker` is a scripted stand-in process used to
-test the IPC layer (`PersistentWorkerTransport`, `OpennessWorkerClient`)
-without a real TIA Portal installation. Fake `I*Service` implementations
-(`FakeFileSystemService`, `FakeRegistryService`, `FakeProcessEnumerationService`,
-…) play the same role for the `doctor` diagnostic checks.
+## 5. Project attachment and binding
 
-## 7. Keeping this document current
+`ProjectSessionBinding` is the host's view of the project associated with the
+MCP session. It can be seeded from `--project` or `TIA_MCP_PROJECT_PATH`.
+Successful lifecycle operations bind only to the resolved path returned by the
+worker, never to a path reconstructed from caller input.
 
-- Re-run `graphify update .` after structural changes (AST-only, no API
-  cost) and skim `graphify-out/GRAPH_REPORT.md` for new god nodes or
-  communities before updating this file.
-- If a tool is added/removed, it will show up as a change in the
-  `[McpServerTool]` decorator census — update §4's table and the operation
-  counts in §4/§5.
-- If an operation is added to `BatchOperationCatalog.BuildSpecs`, update the
-  read/write operation lists in §4.
+`OpennessWorkerClient` owns binding transitions:
+
+- open, create, and rebinding save-as bind to worker-reported ground truth;
+- close clears the binding;
+- ordinary reads and writes do not implicitly bind an unbound session;
+- divergence between the host binding and the worker-reported project is
+  surfaced as a warning.
+
+On the worker side, `WithProject` first attaches to the running TIA Portal
+instance and then applies the project-open policy. In read-only mode it reuses
+only the project discovered during that attachment.
+
+## 6. Worker transport and execution
+
+`PersistentWorkerTransport` owns one child process and serializes requests with
+a `SemaphoreSlim`. Each call writes one JSON line and reads one JSON response
+line. A timeout, crash, broken pipe, null response, or protocol desynchronization
+terminates the worker; the next request starts a fresh process.
+
+`OpennessWorkerClient` is the typed host facade. It constructs `WorkerRequest`
+objects, performs host authorization, invokes the transport, normalizes failure
+categories, caps warning output, and applies project-binding transitions.
+
+The worker dispatch loop maps every method name to a focused Siemens operation.
+`Execute` centralizes exception mapping and response stamping. The actual
+Openness implementations live under `TiaMcpServer.OpennessWorker/Openness/`.
+
+Temporary exports such as `get_block_content` use isolated temporary
+directories and remove them in `finally` blocks.
+
+## 7. Batch execution
+
+`BatchOperationCatalog` is the batch source of truth for operation names,
+categories, required fields, optional fields, and the maximum batch size of 50.
+It rejects unknown operations, missing required fields, inapplicable fields,
+and invalid bounds before worker invocation.
+
+Read batches execute items independently. One failed read does not prevent the
+remaining items from running.
+
+Write batches execute sequentially and stop on the first failure. Already
+completed writes are not rolled back.
+
+Access-mode validation runs before a read batch starts. This is why a
+`compile_check` item is rejected as a whole-batch validation error in read-only
+mode rather than being sent to the worker.
+
+## 8. Write safety
+
+Every write uses a two-step flow:
+
+1. The preview call reads current state, produces a human-readable description,
+   and creates a short-lived, single-use safety token bound to the tool,
+   project, requested input, and current-state hashes.
+2. The apply call supplies `confirm=true` and the token. The server reads current
+   state again and consumes the token only when every bound value still matches.
+
+Changed input, changed project state, wrong tool, wrong project, expiry, or token
+reuse causes rejection. Completed writes are appended to the audit log under
+`%LOCALAPPDATA%\TiaMcpServer\audit`.
+
+Read-only mode is categorically stronger than this token flow: confirmation and
+a valid token cannot override the access policy.
+
+## 9. Diagnostics
+
+`tia-mcp doctor` runs the environment diagnostic pipeline without starting the
+MCP host. It supports text or JSON output and reports the resolved access mode.
+The command accepts the same access-mode options as normal startup, in addition
+to `TIA_MCP_ACCESS_MODE`.
+
+## 10. Testing
+
+`TiaMcpServer.Tests` links selected host and worker source files directly into
+the test assembly, allowing policy, parsing, tool metadata, batch, diagnostics,
+and IPC behavior to be tested on .NET 8 without a live TIA Portal installation.
+
+`TiaMcpServer.FakeWorker` exercises persistent transport behavior. Fake service
+implementations isolate filesystem, registry, process, identity, and diagnostic
+checks.
+
+The read-only test suite covers:
+
+- CLI and environment resolution;
+- malformed-configuration behavior;
+- operation-catalog classifications and deny-by-default behavior;
+- host and worker authorization;
+- conditional tool surfaces;
+- batch access validation;
+- confirmation and safety-token bypass prevention;
+- doctor output and CLI parity.
+
+Manual integration testing with a live TIA Portal remains necessary to validate
+Siemens-specific attachment, confirmation, project-path, packaging, and worker
+launch behavior.
+
+## 11. Keeping this document current
+
+Update this document when tool registration, operation classification, access
+modes, worker launch arguments, binding rules, or write-safety behavior changes.
+The architecture must describe the explicitly registered runtime surface, not
+only the set of decorated tool classes present in the assembly.


### PR DESCRIPTION
## Summary

Adds an immutable **read-only safety mode** that allows AI agents and MCP clients to inspect a TIA Portal project without mutating the project, TIA Portal session, PLC runtime state, or persistent external data.

### Security model (defense in depth)

1. **Tool discovery**: Write tools are not registered in MCP discovery when in read-only mode
2. **Host enforcement**: `OperationAccessPolicy` rejects prohibited operations before the worker process is started
3. **Worker enforcement**: `WorkerOperationAuthorization` independently rejects prohibited operations before any handler or Siemens API call

### Configuration

```powershell
tia-mcp --access-mode read-only   # or --read-only
tia-mcp --access-mode read-write  # default
TIA_MCP_ACCESS_MODE=read-only     # environment variable
```

### What's included

- `McpAccessMode` enum, `OperationCapability` classification, `OperationPolicyCatalog` (shared source of truth)
- `AccessModeParser` for CLI and environment variable resolution
- `OperationAccessPolicy` singleton for host-side enforcement
- `WorkerOperationAuthorization` for worker-side enforcement
- Split tool classes: `ProjectReadTools`/`ProjectWriteTools`, `ReadBatchTools`/`WriteBatchTools`
- Explicit tool registration in `Program.cs` based on mode
- Read-only mode operates only on the currently open project (no project switching)
- `compile_check` denied in read-only mode
- Doctor command reports access mode
- 101 comprehensive tests (745 total passing)
- README documentation

### Read-only mode tool surface

| Tool | Status |
|------|--------|
| `get_project_status` | Exposed |
| `execute_read_batch` | Exposed |
| All write tools | Not registered |
| `preview_write_batch` | Not registered |
| `apply_write_batch` | Not registered |

---

## Practical Test Results (TIA Portal V21)

### Read-Only Mode

| Operation | Result | Details |
|-----------|--------|---------|
| `get_project_status` | ALLOWED | Project "Project20" open, author: allan |
| `browse_project_tree` | ALLOWED | S7-1200 station_1 -> PLC_1 -> Blocks/Main (OB, LAD) |
| `list_tag_tables` | ALLOWED | Default tag table: Tag_1(%I0.0), Tag_2(%I0.1), Tag_3(%Q0.0) |
| `compile_check` | DENIED | `access_denied` |
| `update_block_logic` | DENIED | `access_denied` |
| `delete_block` | DENIED | `access_denied` |
| `open_project` | DENIED | `access_denied` |
| `start_plc` | DENIED | `access_denied` |

### Read-Write Mode

| Operation | Result | Details |
|-----------|--------|---------|
| `get_project_status` | ALLOWED | Project "Project20" open |
| `compile_check` | ALLOWED | PLC compiled: Success, 0 errors |
| `open_project` | ALLOWED | Project reopened successfully |
| `update_block_logic` | ALLOWED | Block Main updated with valid YAML (re-imported same logic) |
| `create_block` | ALLOWED | Created FC block "TempTest" (confirm=true required) |
| `delete_block` | ALLOWED | Deleted FC block "TempTest" (confirm=true required) |

### Write Flow Verification

The `create_block` -> `delete_block` cycle was tested end-to-end:
1. `create_block` without `confirm=true` -> rejected with `validation_error` (safety working)
2. `create_block` with `confirm=true` -> **SUCCESS** (FC block created)
3. `delete_block` with `confirm=true` -> **SUCCESS** (block deleted)
4. `get_block_content` on deleted block -> "Block 'TempTest' was not found" (confirmed deleted)

### Security Verification

- Worker correctly logs `READONLY` / `READWRITE` on stderr
- `confirm=true` does **not** bypass read-only mode
- Denied operations return `failureCategory: "access_denied"`
- No mutations occurred in read-only mode (project `isModified: true` unchanged)
- Write safety flow (confirm required) works correctly in read-write mode

---

## Verification Checklist

### NuGet Package

- **PASS**: `TiaMcpServer.OpennessWorker.exe` (137,728 bytes) found in package
- **PASS**: No `Siemens.Engineering*.dll` in package (correct — loaded from TIA Portal installation)
- **PASS**: All worker dependencies present (System.Text.Json, Contracts, etc.)

### OperationPolicyCatalog Completeness

- **PASS**: 32 worker methods classified, 32 catalog entries — perfect 1:1 match
- **PASS**: 7 Observe operations (read-only safe)
- **PASS**: 1 TemporaryExport operation (read-only safe)
- **PASS**: 24 denied operations (Compile, ProjectLifecycle, ProjectMutation, OnlineControl)
- **PASS**: Deny-by-default — unknown operations are denied

### Error Messages

- **PASS**: All denied operations return `failureCategory: "access_denied"`
- **PASS**: All messages include operation name (e.g. "Operation 'compile_check' is disabled...")
- **PASS**: All messages include mode context ("...in read-only mode")
- **PASS**: Format consistent across all 7 tested operations

---

## All Review Items Complete

- [x] Manual testing with live TIA Portal V21
- [x] Verify worker process receives `--access-mode` argument correctly
- [x] Verify doctor command reports access mode in JSON and text output
- [x] Verify NuGet package contains worker executable
- [x] Review OperationPolicyCatalog classifications for completeness
- [x] Review error messages for clarity and actionability

---

**Tests**: `dotnet test TiaMcpServer.sln -m:1` — 745 passed, 0 failed

**Build**: `dotnet build TiaMcpServer.sln -m:1` — 0 errors, 0 warnings
