### PR TITLE
feat(install): add native MCP client installation command for claude-code, codex, opencode, mimocode

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,50 @@ Options:
 
 Exit codes: `0` (no blocking failures), `1` (one or more checks failed), `2` (invalid arguments).
 
+### Register with an MCP client
+
+The `tia-mcp install` command registers the TIA Portal MCP server with a supported MCP client by invoking the client's native CLI. It does not edit configuration files directly.
+
+Supported clients: Claude Code, Codex, OpenCode, MiMoCode.
+
+```powershell
+tia-mcp install claude-code
+tia-mcp install codex
+tia-mcp install opencode
+tia-mcp install mimocode
+```
+
+Aliases: `claude` (Claude Code), `mimo` (MiMoCode).
+
+Options:
+
+- `--name <name>` - server registration name (default: `tia-portal`).
+- `--access-mode <mode>` - access mode: `read-only` or `read-write` (default: `read-only`).
+- `--tia-project <path>` - bind to a specific TIA Portal project.
+- `--server-path <path>` - explicit path to the `tia-mcp` executable.
+- `--dry-run` - print the install command without executing.
+- `--json` - emit JSON output (not supported with MiMoCode).
+
+Examples:
+
+```powershell
+# Register with Codex using read-write mode
+tia-mcp install codex --access-mode read-write
+
+# Register with Claude Code bound to a specific project
+tia-mcp install claude-code --tia-project C:\Projects\Line.ap21
+
+# Preview the install command without running it
+tia-mcp install codex --dry-run
+
+# JSON output for automation
+tia-mcp install codex --json
+```
+
+MiMoCode uses interactive mode and will prompt for values. The `--json` flag is not supported with MiMoCode.
+
+Exit codes: `0` (success), `1` (general failure), `2` (invalid arguments), `3` (unsupported client), `4` (client not found), `5` (tia-mcp executable not found), `6` (native command failed), `7` (verification failed), `8` (unsupported option combination).
+
 ### Access modes
 
 The server supports two access modes that control which operations are available:

--- a/TiaMcpServer.Tests/Cli/ClientAliasResolverTests.cs
+++ b/TiaMcpServer.Tests/Cli/ClientAliasResolverTests.cs
@@ -1,0 +1,58 @@
+using TiaMcpServer.Cli.Install;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Cli;
+
+public class ClientAliasResolverTests
+{
+    [Theory]
+    [InlineData("claude-code", ClientKind.ClaudeCode)]
+    [InlineData("claude", ClientKind.ClaudeCode)]
+    [InlineData("codex", ClientKind.Codex)]
+    [InlineData("opencode", ClientKind.OpenCode)]
+    [InlineData("mimocode", ClientKind.MiMoCode)]
+    [InlineData("mimo", ClientKind.MiMoCode)]
+    public void MapToClientKind_KnownAliases_ReturnsExpected(string alias, ClientKind expected)
+    {
+        var result = ClientAliasResolver.MapToClientKind(alias);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("CLAUDE")]
+    [InlineData("Claude")]
+    [InlineData("CODEX")]
+    [InlineData("Codex")]
+    [InlineData("MIMO")]
+    [InlineData("Mimo")]
+    [InlineData("OPENCODE")]
+    [InlineData("OpenCode")]
+    public void MapToClientKind_CaseInsensitive_ReturnsExpected(string alias)
+    {
+        var result = ClientAliasResolver.MapToClientKind(alias);
+
+        Assert.NotNull(result);
+    }
+
+    [Theory]
+    [InlineData("vscode")]
+    [InlineData("unknown")]
+    [InlineData("emacs")]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void MapToClientKind_UnknownOrNull_ReturnsNull(string alias)
+    {
+        var result = ClientAliasResolver.MapToClientKind(alias);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void MapToClientKind_WithWhitespace_TrimsCorrectly()
+    {
+        var result = ClientAliasResolver.MapToClientKind("  claude  ");
+
+        Assert.Equal(ClientKind.ClaudeCode, result);
+    }
+}

--- a/TiaMcpServer.Tests/Cli/ClientInstallerTests.cs
+++ b/TiaMcpServer.Tests/Cli/ClientInstallerTests.cs
@@ -1,0 +1,277 @@
+using TiaMcpServer.Cli.Install;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Cli;
+
+public class ClientInstallerTests
+{
+    private static McpLaunchSpec CreateSpec(string name = "tia-portal", string? project = null)
+    {
+        var args = new List<string> { "--access-mode", "read-only" };
+        if (project is not null)
+        {
+            args.Add("--project");
+            args.Add(project);
+        }
+
+        return new McpLaunchSpec(name, @"C:\Users\User\.dotnet\tools\tia-mcp.exe", args);
+    }
+
+    private static InstallOptions CreateOptions(string accessMode = "read-only", string? project = null, string? serverPath = null, bool json = false, bool dryRun = false)
+    {
+        return new InstallOptions(true, ClientKind.Codex, "tia-portal", accessMode, project, serverPath, dryRun, json, false, null);
+    }
+
+    [Fact]
+    public void ClaudeCode_ReadOnly_BuildsCorrectCommand()
+    {
+        var installer = new ClaudeCodeInstaller();
+        var spec = CreateSpec();
+        var options = CreateOptions();
+
+        var cmd = installer.BuildInstallCommand(options, spec);
+
+        Assert.Equal("claude", cmd.Executable);
+        Assert.False(cmd.Interactive);
+        Assert.Equal(new[] { "mcp", "add", "--scope", "user", "tia-portal", "--", @"C:\Users\User\.dotnet\tools\tia-mcp.exe", "--access-mode", "read-only" }, cmd.Arguments);
+    }
+
+    [Fact]
+    public void ClaudeCode_ReadWrite_BuildsCorrectCommand()
+    {
+        var installer = new ClaudeCodeInstaller();
+        var spec = CreateSpec();
+        var options = CreateOptions("read-write");
+
+        var cmd = installer.BuildInstallCommand(options, spec);
+
+        Assert.Equal("claude", cmd.Executable);
+        Assert.Contains("--access-mode", cmd.Arguments);
+        Assert.Contains("read-write", cmd.Arguments);
+    }
+
+    [Fact]
+    public void ClaudeCode_CustomServerName_UsesName()
+    {
+        var installer = new ClaudeCodeInstaller();
+        var spec = CreateSpec("my-tia-server");
+        var options = CreateOptions();
+
+        var cmd = installer.BuildInstallCommand(options, spec);
+
+        Assert.Contains("my-tia-server", cmd.Arguments);
+    }
+
+    [Fact]
+    public void ClaudeCode_WithTiaProject_IncludesProjectFlag()
+    {
+        var installer = new ClaudeCodeInstaller();
+        var spec = CreateSpec(project: @"C:\Projects\Line.ap21");
+        var options = CreateOptions(project: @"C:\Projects\Line.ap21");
+
+        var cmd = installer.BuildInstallCommand(options, spec);
+
+        Assert.Contains("--project", cmd.Arguments);
+        Assert.Contains(@"C:\Projects\Line.ap21", cmd.Arguments);
+    }
+
+    [Fact]
+    public void ClaudeCode_VerificationCommand_UsesGet()
+    {
+        var installer = new ClaudeCodeInstaller();
+        var spec = CreateSpec();
+        var options = CreateOptions();
+
+        var cmd = installer.BuildVerificationCommand(options, spec);
+
+        Assert.NotNull(cmd);
+        Assert.Equal("claude", cmd!.Executable);
+        Assert.Equal(new[] { "mcp", "get", "tia-portal" }, cmd.Arguments);
+    }
+
+    [Fact]
+    public void Codex_ReadOnly_BuildsCorrectCommand()
+    {
+        var installer = new CodexInstaller();
+        var spec = CreateSpec();
+        var options = CreateOptions();
+
+        var cmd = installer.BuildInstallCommand(options, spec);
+
+        Assert.Equal("codex", cmd.Executable);
+        Assert.False(cmd.Interactive);
+        Assert.Equal(new[] { "mcp", "add", "tia-portal", "--", @"C:\Users\User\.dotnet\tools\tia-mcp.exe", "--access-mode", "read-only" }, cmd.Arguments);
+    }
+
+    [Fact]
+    public void Codex_ReadWrite_BuildsCorrectCommand()
+    {
+        var installer = new CodexInstaller();
+        var spec = CreateSpec();
+        var options = CreateOptions("read-write");
+
+        var cmd = installer.BuildInstallCommand(options, spec);
+
+        Assert.Equal("codex", cmd.Executable);
+        Assert.Contains("read-write", cmd.Arguments);
+    }
+
+    [Fact]
+    public void Codex_WithTiaProject_IncludesProjectFlag()
+    {
+        var installer = new CodexInstaller();
+        var spec = CreateSpec(project: @"C:\Projects\Line.ap21");
+        var options = CreateOptions(project: @"C:\Projects\Line.ap21");
+
+        var cmd = installer.BuildInstallCommand(options, spec);
+
+        Assert.Contains("--project", cmd.Arguments);
+        Assert.Contains(@"C:\Projects\Line.ap21", cmd.Arguments);
+    }
+
+    [Fact]
+    public void Codex_VerificationCommand_UsesGetJson()
+    {
+        var installer = new CodexInstaller();
+        var spec = CreateSpec();
+        var options = CreateOptions();
+
+        var cmd = installer.BuildVerificationCommand(options, spec);
+
+        Assert.NotNull(cmd);
+        Assert.Equal("codex", cmd!.Executable);
+        Assert.Equal(new[] { "mcp", "get", "tia-portal", "--json" }, cmd.Arguments);
+    }
+
+    [Fact]
+    public void OpenCode_ReadOnly_BuildsCorrectCommand()
+    {
+        var installer = new OpenCodeInstaller();
+        var spec = CreateSpec();
+        var options = CreateOptions();
+
+        var cmd = installer.BuildInstallCommand(options, spec);
+
+        Assert.Equal("opencode", cmd.Executable);
+        Assert.False(cmd.Interactive);
+        Assert.Equal(new[] { "mcp", "add", "tia-portal", "--", @"C:\Users\User\.dotnet\tools\tia-mcp.exe", "--access-mode", "read-only" }, cmd.Arguments);
+    }
+
+    [Fact]
+    public void OpenCode_WithTiaProject_IncludesProjectFlag()
+    {
+        var installer = new OpenCodeInstaller();
+        var spec = CreateSpec(project: @"C:\Projects\Line.ap21");
+        var options = CreateOptions(project: @"C:\Projects\Line.ap21");
+
+        var cmd = installer.BuildInstallCommand(options, spec);
+
+        Assert.Contains("--project", cmd.Arguments);
+        Assert.Contains(@"C:\Projects\Line.ap21", cmd.Arguments);
+    }
+
+    [Fact]
+    public void OpenCode_VerificationCommand_UsesList()
+    {
+        var installer = new OpenCodeInstaller();
+        var spec = CreateSpec();
+        var options = CreateOptions();
+
+        var cmd = installer.BuildVerificationCommand(options, spec);
+
+        Assert.NotNull(cmd);
+        Assert.Equal("opencode", cmd!.Executable);
+        Assert.Equal(new[] { "mcp", "list" }, cmd.Arguments);
+    }
+
+    [Fact]
+    public void MiMoCode_BuildsInteractiveCommand()
+    {
+        var installer = new MiMoCodeInstaller();
+        var spec = CreateSpec();
+        var options = CreateOptions();
+
+        var cmd = installer.BuildInstallCommand(options, spec);
+
+        Assert.Equal("mimo", cmd.Executable);
+        Assert.True(cmd.Interactive);
+        Assert.Equal(new[] { "mcp", "add" }, cmd.Arguments);
+    }
+
+    [Fact]
+    public void MiMoCode_VerificationCommand_UsesList()
+    {
+        var installer = new MiMoCodeInstaller();
+        var spec = CreateSpec();
+        var options = CreateOptions();
+
+        var cmd = installer.BuildVerificationCommand(options, spec);
+
+        Assert.NotNull(cmd);
+        Assert.Equal("mimo", cmd!.Executable);
+        Assert.Equal(new[] { "mcp", "list" }, cmd.Arguments);
+    }
+
+    [Fact]
+    public void ExecutablePathWithSpaces_IsPreserved()
+    {
+        var installer = new CodexInstaller();
+        var spec = new McpLaunchSpec("tia-portal", @"C:\Program Files\Tools\tia-mcp.exe", new[] { "--access-mode", "read-only" });
+        var options = CreateOptions();
+
+        var cmd = installer.BuildInstallCommand(options, spec);
+
+        Assert.Contains(@"C:\Program Files\Tools\tia-mcp.exe", cmd.Arguments);
+    }
+
+    [Fact]
+    public void ProjectPathWithSpaces_IsPreserved()
+    {
+        var installer = new CodexInstaller();
+        var projectPath = @"C:\My Projects\TIA Portal\Line.ap21";
+        var spec = CreateSpec(project: projectPath);
+        var options = CreateOptions(project: projectPath);
+
+        var cmd = installer.BuildInstallCommand(options, spec);
+
+        Assert.Contains(projectPath, cmd.Arguments);
+    }
+
+    [Fact]
+    public void Registry_AllKinds_ReturnInstaller()
+    {
+        foreach (ClientKind kind in Enum.GetValues(typeof(ClientKind)))
+        {
+            var installer = ClientInstallerRegistry.GetInstaller(kind);
+            Assert.Equal(kind, installer.Client);
+        }
+    }
+
+    [Fact]
+    public void ClaudeCode_DetectAsync_UsesWhereExe()
+    {
+        var installer = new ClaudeCodeInstaller();
+        Assert.Equal(ClientKind.ClaudeCode, installer.Client);
+    }
+
+    [Fact]
+    public void Codex_DetectAsync_UsesWhereExe()
+    {
+        var installer = new CodexInstaller();
+        Assert.Equal(ClientKind.Codex, installer.Client);
+    }
+
+    [Fact]
+    public void OpenCode_DetectAsync_UsesWhereExe()
+    {
+        var installer = new OpenCodeInstaller();
+        Assert.Equal(ClientKind.OpenCode, installer.Client);
+    }
+
+    [Fact]
+    public void MiMoCode_DetectAsync_UsesWhereExe()
+    {
+        var installer = new MiMoCodeInstaller();
+        Assert.Equal(ClientKind.MiMoCode, installer.Client);
+    }
+}

--- a/TiaMcpServer.Tests/Cli/ExecutableResolverTests.cs
+++ b/TiaMcpServer.Tests/Cli/ExecutableResolverTests.cs
@@ -1,0 +1,72 @@
+using TiaMcpServer.Cli.Install;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Cli;
+
+public class ExecutableResolverTests
+{
+    [Fact]
+    public void ResolveServerExecutable_ExplicitPath_ReturnsPath()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var result = ExecutableResolver.ResolveServerExecutable(tempFile);
+
+            Assert.NotNull(result);
+            Assert.Equal(Path.GetFullPath(tempFile), result);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ResolveServerExecutable_MissingExplicitPath_ReturnsNull()
+    {
+        var result = ExecutableResolver.ResolveServerExecutable(@"C:\nonexistent\path\tia-mcp.exe");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ResolveServerExecutable_NullOrEmpty_FallsThroughResolution()
+    {
+        // This test verifies that null input doesn't throw and falls through to other resolution methods.
+        // The actual result depends on whether tia-mcp is installed on the test machine.
+        var result = ExecutableResolver.ResolveServerExecutable(null);
+
+        // We can't assert a specific value since it depends on the environment,
+        // but it should not throw.
+    }
+
+    [Fact]
+    public void FindClientExecutable_NonexistentClient_ReturnsNull()
+    {
+        var result = ExecutableResolver.FindClientExecutable("nonexistent_client_xyz");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ResolveServerExecutable_ExplicitPathWithSpaces_IsResolved()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "test dir with spaces");
+        Directory.CreateDirectory(tempDir);
+        var tempFile = Path.Combine(tempDir, "tia-mcp.exe");
+        File.WriteAllText(tempFile, "");
+        try
+        {
+            var result = ExecutableResolver.ResolveServerExecutable(tempFile);
+
+            Assert.NotNull(result);
+            Assert.Equal(Path.GetFullPath(tempFile), result);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+            Directory.Delete(tempDir);
+        }
+    }
+}

--- a/TiaMcpServer.Tests/Cli/InstallCliParserTests.cs
+++ b/TiaMcpServer.Tests/Cli/InstallCliParserTests.cs
@@ -1,0 +1,230 @@
+using TiaMcpServer.Cli.Install;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Cli;
+
+public class InstallCliParserTests
+{
+    [Theory]
+    [InlineData("claude-code", ClientKind.ClaudeCode)]
+    [InlineData("claude", ClientKind.ClaudeCode)]
+    [InlineData("codex", ClientKind.Codex)]
+    [InlineData("opencode", ClientKind.OpenCode)]
+    [InlineData("mimocode", ClientKind.MiMoCode)]
+    [InlineData("mimo", ClientKind.MiMoCode)]
+    public void Parse_CanonicalClientNames_SetsClient(string name, ClientKind expected)
+    {
+        var result = InstallCliParser.Parse(new[] { name });
+
+        Assert.True(result.Valid);
+        Assert.Equal(expected, result.Client);
+    }
+
+    [Theory]
+    [InlineData("CLAUDE")]
+    [InlineData("Codex")]
+    [InlineData("MIMO")]
+    [InlineData("OpenCode")]
+    public void Parse_CaseInsensitiveClientNames_Succeeds(string name)
+    {
+        var result = InstallCliParser.Parse(new[] { name });
+
+        Assert.True(result.Valid);
+        Assert.NotNull(result.Client);
+    }
+
+    [Fact]
+    public void Parse_UnknownClient_ReturnsInvalid()
+    {
+        var result = InstallCliParser.Parse(new[] { "unknown-client" });
+
+        Assert.False(result.Valid);
+        Assert.Contains("Unsupported MCP client", result.ParseError);
+    }
+
+    [Fact]
+    public void Parse_MissingClient_ReturnsInvalid()
+    {
+        var result = InstallCliParser.Parse(System.Array.Empty<string>());
+
+        Assert.False(result.Valid);
+        Assert.Contains("No MCP client specified", result.ParseError);
+    }
+
+    [Fact]
+    public void Parse_DefaultServerName_IsTiaPortal()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex" });
+
+        Assert.True(result.Valid);
+        Assert.Equal("tia-portal", result.ServerName);
+    }
+
+    [Fact]
+    public void Parse_CustomServerName_SetsValue()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex", "--name", "my-server" });
+
+        Assert.True(result.Valid);
+        Assert.Equal("my-server", result.ServerName);
+    }
+
+    [Fact]
+    public void Parse_CustomServerNameWithEquals_SetsValue()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex", "--name=my-server" });
+
+        Assert.True(result.Valid);
+        Assert.Equal("my-server", result.ServerName);
+    }
+
+    [Fact]
+    public void Parse_DefaultAccessMode_IsReadOnly()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex" });
+
+        Assert.True(result.Valid);
+        Assert.Equal("read-only", result.AccessMode);
+    }
+
+    [Fact]
+    public void Parse_ExplicitReadWrite_SetsAccessMode()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex", "--access-mode", "read-write" });
+
+        Assert.True(result.Valid);
+        Assert.Equal("read-write", result.AccessMode);
+    }
+
+    [Fact]
+    public void Parse_InvalidAccessMode_ReturnsInvalid()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex", "--access-mode", "invalid" });
+
+        Assert.False(result.Valid);
+        Assert.Contains("Invalid access mode", result.ParseError);
+    }
+
+    [Fact]
+    public void Parse_TiaProject_SetsValue()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex", "--tia-project", @"C:\Projects\Line.ap21" });
+
+        Assert.True(result.Valid);
+        Assert.Equal(@"C:\Projects\Line.ap21", result.TiaProject);
+    }
+
+    [Fact]
+    public void Parse_ServerPath_SetsValue()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex", "--server-path", @"C:\tools\tia-mcp.exe" });
+
+        Assert.True(result.Valid);
+        Assert.Equal(@"C:\tools\tia-mcp.exe", result.ServerPath);
+    }
+
+    [Fact]
+    public void Parse_DryRun_SetsFlag()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex", "--dry-run" });
+
+        Assert.True(result.Valid);
+        Assert.True(result.DryRun);
+    }
+
+    [Fact]
+    public void Parse_Json_SetsFlag()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex", "--json" });
+
+        Assert.True(result.Valid);
+        Assert.True(result.Json);
+    }
+
+    [Fact]
+    public void Parse_Help_SetsFlag()
+    {
+        var result = InstallCliParser.Parse(new[] { "--help" });
+
+        Assert.True(result.Valid);
+        Assert.True(result.Help);
+    }
+
+    [Fact]
+    public void Parse_UnknownOption_ReturnsInvalid()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex", "--unknown" });
+
+        Assert.False(result.Valid);
+        Assert.Contains("Unknown install argument", result.ParseError);
+    }
+
+    [Fact]
+    public void Parse_NameMissingValue_ReturnsInvalid()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex", "--name" });
+
+        Assert.False(result.Valid);
+        Assert.Contains("--name requires a value", result.ParseError);
+    }
+
+    [Fact]
+    public void Parse_AccessModeMissingValue_ReturnsInvalid()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex", "--access-mode" });
+
+        Assert.False(result.Valid);
+        Assert.Contains("--access-mode requires a value", result.ParseError);
+    }
+
+    [Fact]
+    public void Parse_TiaProjectMissingValue_ReturnsInvalid()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex", "--tia-project" });
+
+        Assert.False(result.Valid);
+        Assert.Contains("--tia-project requires a value", result.ParseError);
+    }
+
+    [Fact]
+    public void Parse_ServerPathMissingValue_ReturnsInvalid()
+    {
+        var result = InstallCliParser.Parse(new[] { "codex", "--server-path" });
+
+        Assert.False(result.Valid);
+        Assert.Contains("--server-path requires a value", result.ParseError);
+    }
+
+    [Fact]
+    public void Parse_MiMoCodeWithJson_ReturnsInvalidWithExit8()
+    {
+        var result = InstallCliParser.Parse(new[] { "mimo", "--json" });
+
+        Assert.False(result.Valid);
+        Assert.Contains("does not support --json", result.ParseError);
+    }
+
+    [Fact]
+    public void Parse_AllOptionsCombined_Succeeds()
+    {
+        var result = InstallCliParser.Parse(new[]
+        {
+            "codex",
+            "--name", "my-tia",
+            "--access-mode", "read-write",
+            "--tia-project", @"C:\Projects\Line.ap21",
+            "--server-path", @"C:\tools\tia-mcp.exe",
+            "--dry-run",
+            "--json"
+        });
+
+        Assert.True(result.Valid);
+        Assert.Equal(ClientKind.Codex, result.Client);
+        Assert.Equal("my-tia", result.ServerName);
+        Assert.Equal("read-write", result.AccessMode);
+        Assert.Equal(@"C:\Projects\Line.ap21", result.TiaProject);
+        Assert.Equal(@"C:\tools\tia-mcp.exe", result.ServerPath);
+        Assert.True(result.DryRun);
+        Assert.True(result.Json);
+    }
+}

--- a/TiaMcpServer.Tests/Cli/InstallCommandTests.cs
+++ b/TiaMcpServer.Tests/Cli/InstallCommandTests.cs
@@ -1,0 +1,358 @@
+using TiaMcpServer.Cli.Install;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Cli;
+
+public class InstallCommandTests
+{
+    private sealed class FakeProcessRunner : INativeProcessRunner
+    {
+        public List<NativeCommand> ExecutedCommands { get; } = new();
+        public Queue<NativeCommandResult> Results { get; } = new();
+
+        public Task<NativeCommandResult> RunAsync(NativeCommand command, CancellationToken cancellationToken)
+        {
+            ExecutedCommands.Add(command);
+            if (Results.Count > 0)
+            {
+                return Task.FromResult(Results.Dequeue());
+            }
+
+            return Task.FromResult(new NativeCommandResult(0, string.Empty, string.Empty));
+        }
+    }
+
+    private static string? FakeResolveServerExe(string? path) => path ?? @"C:\tools\tia-mcp.exe";
+    private static string? FakeFindClientExe(string exe) => $@"C:\tools\{exe}.exe";
+
+    [Fact]
+    public async Task RunAsync_Help_ReturnsZeroAndPrintsUsage()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "--help" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Usage: tia-mcp install", output.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_HelpJson_ReturnsZeroAndJsonUsage()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "--help", "--json" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"usage\"", output.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_MissingClient_ReturnsExitCode2()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await InstallCommand.RunAsync(
+            System.Array.Empty<string>(), runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        Assert.Equal(2, exitCode);
+        Assert.Contains("No MCP client specified", error.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_UnsupportedClient_ReturnsExitCode3()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "unknown-client" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        Assert.Equal(3, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_ServerExeNotFound_ReturnsExitCode5()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+        string? NullResolver(string? _) => null;
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "codex" }, runner, output, error, NullResolver, FakeFindClientExe);
+
+        Assert.Equal(5, exitCode);
+        Assert.Contains("tia-mcp executable not found", error.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_ClientNotFound_ReturnsExitCode4()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+        string? NullFinder(string _) => null;
+
+        // Need to make DetectAsync fail: override with a runner that returns failure for where.exe
+        runner.Results.Enqueue(new NativeCommandResult(1, string.Empty, "not found"));
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "codex" }, runner, output, error, FakeResolveServerExe, NullFinder);
+
+        Assert.Equal(4, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_MiMoCodeWithJson_ReturnsExitCode8()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // where.exe succeeds for mimo detection
+        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\mimo.exe", string.Empty));
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "mimo", "--json" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        Assert.Equal(8, exitCode);
+        Assert.Contains("does not support --json", output.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_DryRun_ReturnsZeroAndPrintsCommand()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // where.exe succeeds for codex detection
+        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "codex", "--dry-run" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("[dry-run]", output.ToString());
+        Assert.Contains("codex", output.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_DryRunJson_ReturnsZeroAndJsonDryRun()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // where.exe succeeds for codex detection
+        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "codex", "--dry-run", "--json" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"dryRun\":true", output.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_InstallSuccess_ReturnsZero()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // where.exe succeeds for codex detection
+        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
+        // Install succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
+        // Verification succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, "{}", string.Empty));
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "codex" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Successfully registered", output.ToString());
+        Assert.Contains("Verification: passed", output.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_InstallSuccess_ExecutesCorrectCommand()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // where.exe succeeds for codex detection
+        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
+        // Install succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
+        // Verification succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, "{}", string.Empty));
+
+        await InstallCommand.RunAsync(
+            new[] { "codex", "--name", "my-tia", "--access-mode", "read-write" },
+            runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        // First command is where.exe, second is the install, third is verification
+        Assert.Equal(3, runner.ExecutedCommands.Count);
+        Assert.Equal("codex", runner.ExecutedCommands[1].Executable);
+        Assert.Contains("mcp", runner.ExecutedCommands[1].Arguments);
+        Assert.Contains("add", runner.ExecutedCommands[1].Arguments);
+        Assert.Contains("my-tia", runner.ExecutedCommands[1].Arguments);
+    }
+
+    [Fact]
+    public async Task RunAsync_InstallFailed_ReturnsExitCode6()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // where.exe succeeds for codex detection
+        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
+        // Install fails
+        runner.Results.Enqueue(new NativeCommandResult(1, string.Empty, "Installation failed"));
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "codex" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        Assert.Equal(6, exitCode);
+        Assert.Contains("Install command failed", error.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_VerificationFailed_ReturnsExitCode7()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // where.exe succeeds for codex detection
+        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
+        // Install succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
+        // Verification fails
+        runner.Results.Enqueue(new NativeCommandResult(1, string.Empty, "Verification error"));
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "codex" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        Assert.Equal(7, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_JsonSuccess_OutputsJson()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // where.exe succeeds for codex detection
+        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
+        // Install succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
+        // Verification succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, "{}", string.Empty));
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "codex", "--json" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        Assert.Equal(0, exitCode);
+        var jsonOutput = output.ToString();
+        Assert.Contains("\"success\":true", jsonOutput);
+        Assert.Contains("\"client\":\"Codex\"", jsonOutput);
+        Assert.Contains("\"serverName\":\"tia-portal\"", jsonOutput);
+        Assert.Contains("\"accessMode\":\"read-only\"", jsonOutput);
+    }
+
+    [Fact]
+    public async Task RunAsync_JsonFailure_OutputsJsonError()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+        string? NullResolver(string? _) => null;
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "codex", "--json" }, runner, output, error, NullResolver, FakeFindClientExe);
+
+        Assert.Equal(5, exitCode);
+        Assert.Contains("\"success\":false", output.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_WithTiaProject_IncludesProjectInCommand()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // where.exe succeeds for codex detection
+        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
+        // Install succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
+        // Verification succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, "{}", string.Empty));
+
+        await InstallCommand.RunAsync(
+            new[] { "codex", "--tia-project", @"C:\Projects\Line.ap21" },
+            runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        var installCmd = runner.ExecutedCommands[1];
+        Assert.Contains("--project", installCmd.Arguments);
+        Assert.Contains(@"C:\Projects\Line.ap21", installCmd.Arguments);
+    }
+
+    [Fact]
+    public async Task RunAsync_ClaudeCode_UsesCorrectExecutable()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // where.exe succeeds for claude detection
+        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\claude.exe", string.Empty));
+        // Install succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
+        // Verification succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, "{}", string.Empty));
+
+        await InstallCommand.RunAsync(
+            new[] { "claude" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        Assert.Equal("claude", runner.ExecutedCommands[1].Executable);
+        Assert.Contains("--scope", runner.ExecutedCommands[1].Arguments);
+        Assert.Contains("user", runner.ExecutedCommands[1].Arguments);
+    }
+
+    [Fact]
+    public async Task RunAsync_OpenCode_UsesCorrectExecutable()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // where.exe succeeds for opencode detection
+        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\opencode.exe", string.Empty));
+        // Install succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
+        // Verification succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, "{}", string.Empty));
+
+        await InstallCommand.RunAsync(
+            new[] { "opencode" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+
+        Assert.Equal("opencode", runner.ExecutedCommands[1].Executable);
+    }
+}

--- a/TiaMcpServer.Tests/Cli/NativeProcessRunnerTests.cs
+++ b/TiaMcpServer.Tests/Cli/NativeProcessRunnerTests.cs
@@ -1,0 +1,99 @@
+using TiaMcpServer.Cli.Install;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Cli;
+
+public class NativeProcessRunnerTests
+{
+    [Fact]
+    public async Task RunAsync_ExitCodeZero_ReturnsZero()
+    {
+        var runner = new NativeProcessRunner();
+        var cmd = new NativeCommand("cmd.exe", new[] { "/c", "exit 0" }, false);
+
+        var result = await runner.RunAsync(cmd, CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_ExitCodeNonzero_ReturnsNonzero()
+    {
+        var runner = new NativeProcessRunner();
+        var cmd = new NativeCommand("cmd.exe", new[] { "/c", "exit 42" }, false);
+
+        var result = await runner.RunAsync(cmd, CancellationToken.None);
+
+        Assert.Equal(42, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_CapturesStdout()
+    {
+        var runner = new NativeProcessRunner();
+        var cmd = new NativeCommand("cmd.exe", new[] { "/c", "echo hello" }, false);
+
+        var result = await runner.RunAsync(cmd, CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("hello", result.Stdout);
+    }
+
+    [Fact]
+    public async Task RunAsync_CapturesStderr()
+    {
+        var runner = new NativeProcessRunner();
+        var cmd = new NativeCommand("cmd.exe", new[] { "/c", "echo error>&2" }, false);
+
+        var result = await runner.RunAsync(cmd, CancellationToken.None);
+
+        Assert.Contains("error", result.Stderr);
+    }
+
+    [Fact]
+    public async Task RunAsync_InvalidExecutable_ReturnsNegativeExitCode()
+    {
+        var runner = new NativeProcessRunner();
+        var cmd = new NativeCommand("nonexistent_command_xyz.exe", System.Array.Empty<string>(), false);
+
+        var result = await runner.RunAsync(cmd, CancellationToken.None);
+
+        Assert.Equal(-1, result.ExitCode);
+        Assert.NotEmpty(result.Stderr);
+    }
+
+    [Fact]
+    public async Task RunAsync_Cancellation_ReturnsCancelledResult()
+    {
+        var runner = new NativeProcessRunner();
+        var cmd = new NativeCommand("cmd.exe", new[] { "/c", "ping 127.0.0.1 -n 30" }, false);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        var result = await runner.RunAsync(cmd, cts.Token);
+
+        // Cancellation may result in exit code -1 (OperationCanceledException) or
+        // a nonzero exit code if the process was killed after the token fired.
+        Assert.Contains("cancel", result.Stderr, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RunAsync_Interactive_HasInteractiveFlag()
+    {
+        var runner = new NativeProcessRunner();
+        var cmd = new NativeCommand("cmd.exe", new[] { "/c", "echo test" }, true);
+
+        Assert.True(cmd.Interactive);
+    }
+
+    [Fact]
+    public async Task RunAsync_NonInteractive_CapturesOutput()
+    {
+        var runner = new NativeProcessRunner();
+        var cmd = new NativeCommand("cmd.exe", new[] { "/c", "echo captured" }, false);
+
+        var result = await runner.RunAsync(cmd, CancellationToken.None);
+
+        Assert.Contains("captured", result.Stdout);
+        Assert.False(cmd.Interactive);
+    }
+}

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -37,6 +37,7 @@
     <Compile Include="..\TiaMcpServer\Diagnostics\Checks\*.cs"
       Link="Host\Diagnostics\Checks\%(Filename)%(Extension)" />
     <Compile Include="..\TiaMcpServer\Cli\*.cs" Link="Host\Cli\%(Filename)%(Extension)" />
+    <Compile Include="..\TiaMcpServer\Cli\Install\*.cs" Link="Host\Cli\Install\%(Filename)%(Extension)" />
     <Compile Include="..\TiaMcpServer\Safety\OperationAccessPolicy.cs"
       Link="Host\OperationAccessPolicy.cs" />
     <Compile Include="..\TiaMcpServer\Worker\PersistentWorkerTransport.cs"

--- a/TiaMcpServer/Cli/Install/ClaudeCodeInstaller.cs
+++ b/TiaMcpServer/Cli/Install/ClaudeCodeInstaller.cs
@@ -1,0 +1,42 @@
+namespace TiaMcpServer.Cli.Install;
+
+internal sealed class ClaudeCodeInstaller : IMcpClientInstaller
+{
+    public ClientKind Client => ClientKind.ClaudeCode;
+
+    public async Task<ClientDetectionResult> DetectAsync(INativeProcessRunner runner, CancellationToken cancellationToken)
+    {
+        var result = await runner.RunAsync(
+            new NativeCommand("where.exe", new[] { "claude" }, false),
+            cancellationToken);
+
+        if (result.ExitCode == 0 && !string.IsNullOrWhiteSpace(result.Stdout))
+        {
+            var path = result.Stdout.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)[0];
+            return new ClientDetectionResult(true, path, null);
+        }
+
+        return new ClientDetectionResult(false, null, "Claude Code CLI not found. Install it from https://docs.anthropic.com/en/docs/claude-code");
+    }
+
+    public NativeCommand BuildInstallCommand(InstallOptions options, McpLaunchSpec spec)
+    {
+        var args = new List<string> { "mcp", "add", "--scope", "user", spec.ServerName, "--" };
+        args.Add(spec.ExecutablePath);
+        args.Add("--access-mode");
+        args.Add(options.AccessMode);
+
+        if (!string.IsNullOrWhiteSpace(options.TiaProject))
+        {
+            args.Add("--project");
+            args.Add(options.TiaProject);
+        }
+
+        return new NativeCommand("claude", args, false);
+    }
+
+    public NativeCommand? BuildVerificationCommand(InstallOptions options, McpLaunchSpec spec)
+    {
+        return new NativeCommand("claude", new[] { "mcp", "get", spec.ServerName }, false);
+    }
+}

--- a/TiaMcpServer/Cli/Install/ClientAliasResolver.cs
+++ b/TiaMcpServer/Cli/Install/ClientAliasResolver.cs
@@ -1,0 +1,38 @@
+namespace TiaMcpServer.Cli.Install;
+
+public static class ClientAliasResolver
+{
+    public static ClientKind? MapToClientKind(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var normalized = value.Trim();
+
+        if (string.Equals(normalized, "claude-code", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(normalized, "claude", StringComparison.OrdinalIgnoreCase))
+        {
+            return ClientKind.ClaudeCode;
+        }
+
+        if (string.Equals(normalized, "codex", StringComparison.OrdinalIgnoreCase))
+        {
+            return ClientKind.Codex;
+        }
+
+        if (string.Equals(normalized, "opencode", StringComparison.OrdinalIgnoreCase))
+        {
+            return ClientKind.OpenCode;
+        }
+
+        if (string.Equals(normalized, "mimocode", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(normalized, "mimo", StringComparison.OrdinalIgnoreCase))
+        {
+            return ClientKind.MiMoCode;
+        }
+
+        return null;
+    }
+}

--- a/TiaMcpServer/Cli/Install/ClientDetectionResult.cs
+++ b/TiaMcpServer/Cli/Install/ClientDetectionResult.cs
@@ -1,0 +1,3 @@
+namespace TiaMcpServer.Cli.Install;
+
+internal sealed record ClientDetectionResult(bool Found, string? ExecutablePath, string? Error);

--- a/TiaMcpServer/Cli/Install/ClientInstallerRegistry.cs
+++ b/TiaMcpServer/Cli/Install/ClientInstallerRegistry.cs
@@ -1,0 +1,22 @@
+namespace TiaMcpServer.Cli.Install;
+
+internal static class ClientInstallerRegistry
+{
+    private static readonly Dictionary<ClientKind, IMcpClientInstaller> Installers = new()
+    {
+        { ClientKind.ClaudeCode, new ClaudeCodeInstaller() },
+        { ClientKind.Codex, new CodexInstaller() },
+        { ClientKind.OpenCode, new OpenCodeInstaller() },
+        { ClientKind.MiMoCode, new MiMoCodeInstaller() }
+    };
+
+    public static IMcpClientInstaller GetInstaller(ClientKind client)
+    {
+        if (Installers.TryGetValue(client, out var installer))
+        {
+            return installer;
+        }
+
+        throw new ArgumentException($"No installer registered for client: {client}", nameof(client));
+    }
+}

--- a/TiaMcpServer/Cli/Install/ClientKind.cs
+++ b/TiaMcpServer/Cli/Install/ClientKind.cs
@@ -1,0 +1,9 @@
+namespace TiaMcpServer.Cli.Install;
+
+public enum ClientKind
+{
+    ClaudeCode,
+    Codex,
+    OpenCode,
+    MiMoCode
+}

--- a/TiaMcpServer/Cli/Install/CodexInstaller.cs
+++ b/TiaMcpServer/Cli/Install/CodexInstaller.cs
@@ -1,0 +1,42 @@
+namespace TiaMcpServer.Cli.Install;
+
+internal sealed class CodexInstaller : IMcpClientInstaller
+{
+    public ClientKind Client => ClientKind.Codex;
+
+    public async Task<ClientDetectionResult> DetectAsync(INativeProcessRunner runner, CancellationToken cancellationToken)
+    {
+        var result = await runner.RunAsync(
+            new NativeCommand("where.exe", new[] { "codex" }, false),
+            cancellationToken);
+
+        if (result.ExitCode == 0 && !string.IsNullOrWhiteSpace(result.Stdout))
+        {
+            var path = result.Stdout.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)[0];
+            return new ClientDetectionResult(true, path, null);
+        }
+
+        return new ClientDetectionResult(false, null, "Codex CLI not found. Install it from https://github.com/openai/codex");
+    }
+
+    public NativeCommand BuildInstallCommand(InstallOptions options, McpLaunchSpec spec)
+    {
+        var args = new List<string> { "mcp", "add", spec.ServerName, "--" };
+        args.Add(spec.ExecutablePath);
+        args.Add("--access-mode");
+        args.Add(options.AccessMode);
+
+        if (!string.IsNullOrWhiteSpace(options.TiaProject))
+        {
+            args.Add("--project");
+            args.Add(options.TiaProject);
+        }
+
+        return new NativeCommand("codex", args, false);
+    }
+
+    public NativeCommand? BuildVerificationCommand(InstallOptions options, McpLaunchSpec spec)
+    {
+        return new NativeCommand("codex", new[] { "mcp", "get", spec.ServerName, "--json" }, false);
+    }
+}

--- a/TiaMcpServer/Cli/Install/ExecutableResolver.cs
+++ b/TiaMcpServer/Cli/Install/ExecutableResolver.cs
@@ -1,0 +1,91 @@
+using System.Diagnostics;
+
+namespace TiaMcpServer.Cli.Install;
+
+internal static class ExecutableResolver
+{
+    public static string? ResolveServerExecutable(string? serverPath)
+    {
+        // 1. Explicit --server-path
+        if (!string.IsNullOrWhiteSpace(serverPath))
+        {
+            if (File.Exists(serverPath))
+            {
+                return Path.GetFullPath(serverPath);
+            }
+
+            return null;
+        }
+
+        // 2. where.exe tia-mcp
+        var whereResult = RunWhere("tia-mcp");
+        if (whereResult is not null)
+        {
+            return whereResult;
+        }
+
+        // 3. %USERPROFILE%\.dotnet\tools\tia-mcp.exe
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrEmpty(userProfile))
+        {
+            var dotnetToolPath = Path.Combine(userProfile, ".dotnet", "tools", "tia-mcp.exe");
+            if (File.Exists(dotnetToolPath))
+            {
+                return dotnetToolPath;
+            }
+        }
+
+        // 4. Environment.ProcessPath (if tia-mcp)
+        var processPath = Environment.ProcessPath;
+        if (!string.IsNullOrEmpty(processPath) &&
+            Path.GetFileNameWithoutExtension(processPath).Equals("tia-mcp", StringComparison.OrdinalIgnoreCase) &&
+            File.Exists(processPath))
+        {
+            return processPath;
+        }
+
+        return null;
+    }
+
+    public static string? FindClientExecutable(string clientExe)
+    {
+        return RunWhere(clientExe);
+    }
+
+    private static string? RunWhere(string executable)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "where.exe",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                UseShellExecute = false
+            };
+            psi.ArgumentList.Add(executable);
+
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                return null;
+            }
+
+            process.WaitForExit(5000);
+            var stdout = process.StandardOutput.ReadToEnd().Trim();
+            if (process.ExitCode == 0 && !string.IsNullOrEmpty(stdout))
+            {
+                // where.exe may return multiple lines; take the first
+                var firstLine = stdout.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)[0];
+                return firstLine;
+            }
+
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/TiaMcpServer/Cli/Install/IMcpClientInstaller.cs
+++ b/TiaMcpServer/Cli/Install/IMcpClientInstaller.cs
@@ -1,0 +1,12 @@
+namespace TiaMcpServer.Cli.Install;
+
+internal interface IMcpClientInstaller
+{
+    ClientKind Client { get; }
+
+    Task<ClientDetectionResult> DetectAsync(INativeProcessRunner runner, CancellationToken cancellationToken);
+
+    NativeCommand BuildInstallCommand(InstallOptions options, McpLaunchSpec spec);
+
+    NativeCommand? BuildVerificationCommand(InstallOptions options, McpLaunchSpec spec);
+}

--- a/TiaMcpServer/Cli/Install/INativeProcessRunner.cs
+++ b/TiaMcpServer/Cli/Install/INativeProcessRunner.cs
@@ -1,0 +1,6 @@
+namespace TiaMcpServer.Cli.Install;
+
+internal interface INativeProcessRunner
+{
+    Task<NativeCommandResult> RunAsync(NativeCommand command, CancellationToken cancellationToken);
+}

--- a/TiaMcpServer/Cli/Install/InstallCliParser.cs
+++ b/TiaMcpServer/Cli/Install/InstallCliParser.cs
@@ -1,0 +1,211 @@
+namespace TiaMcpServer.Cli.Install;
+
+public static class InstallCliParser
+{
+    private const string NameFlag = "--name";
+    private const string NamePrefix = "--name=";
+    private const string AccessModeFlag = "--access-mode";
+    private const string AccessModePrefix = "--access-mode=";
+    private const string TiaProjectFlag = "--tia-project";
+    private const string TiaProjectPrefix = "--tia-project=";
+    private const string ServerPathFlag = "--server-path";
+    private const string ServerPathPrefix = "--server-path=";
+    private const string DryRunFlag = "--dry-run";
+    private const string JsonFlag = "--json";
+    private const string HelpFlag = "--help";
+
+    public static InstallOptions Parse(string[] args)
+    {
+        bool dryRun = false;
+        bool json = false;
+        bool help = false;
+        string? serverName = null;
+        string? accessMode = null;
+        string? tiaProject = null;
+        string? serverPath = null;
+        ClientKind? client = null;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+
+            if (string.Equals(arg, HelpFlag, StringComparison.OrdinalIgnoreCase))
+            {
+                help = true;
+                continue;
+            }
+
+            if (string.Equals(arg, DryRunFlag, StringComparison.OrdinalIgnoreCase))
+            {
+                dryRun = true;
+                continue;
+            }
+
+            if (string.Equals(arg, JsonFlag, StringComparison.OrdinalIgnoreCase))
+            {
+                json = true;
+                continue;
+            }
+
+            if (string.Equals(arg, NameFlag, StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 >= args.Length ||
+                    string.IsNullOrWhiteSpace(args[i + 1]) ||
+                    args[i + 1].StartsWith("--", StringComparison.Ordinal))
+                {
+                    return Invalid("--name requires a value.", json);
+                }
+
+                serverName = args[++i];
+                continue;
+            }
+
+            if (arg.StartsWith(NamePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                serverName = arg.Substring(NamePrefix.Length);
+                if (string.IsNullOrWhiteSpace(serverName))
+                {
+                    return Invalid("--name requires a value.", json);
+                }
+
+                continue;
+            }
+
+            if (string.Equals(arg, AccessModeFlag, StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 >= args.Length ||
+                    string.IsNullOrWhiteSpace(args[i + 1]) ||
+                    args[i + 1].StartsWith("--", StringComparison.Ordinal))
+                {
+                    return Invalid("--access-mode requires a value. Valid values: 'read-only', 'read-write'.", json);
+                }
+
+                accessMode = args[++i];
+                continue;
+            }
+
+            if (arg.StartsWith(AccessModePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                accessMode = arg.Substring(AccessModePrefix.Length);
+                if (string.IsNullOrWhiteSpace(accessMode))
+                {
+                    return Invalid("--access-mode requires a value. Valid values: 'read-only', 'read-write'.", json);
+                }
+
+                continue;
+            }
+
+            if (string.Equals(arg, TiaProjectFlag, StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 >= args.Length ||
+                    string.IsNullOrWhiteSpace(args[i + 1]) ||
+                    args[i + 1].StartsWith("--", StringComparison.Ordinal))
+                {
+                    return Invalid("--tia-project requires a value.", json);
+                }
+
+                tiaProject = args[++i];
+                continue;
+            }
+
+            if (arg.StartsWith(TiaProjectPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                tiaProject = arg.Substring(TiaProjectPrefix.Length);
+                if (string.IsNullOrWhiteSpace(tiaProject))
+                {
+                    return Invalid("--tia-project requires a value.", json);
+                }
+
+                continue;
+            }
+
+            if (string.Equals(arg, ServerPathFlag, StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 >= args.Length ||
+                    string.IsNullOrWhiteSpace(args[i + 1]) ||
+                    args[i + 1].StartsWith("--", StringComparison.Ordinal))
+                {
+                    return Invalid("--server-path requires a value.", json);
+                }
+
+                serverPath = args[++i];
+                continue;
+            }
+
+            if (arg.StartsWith(ServerPathPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                serverPath = arg.Substring(ServerPathPrefix.Length);
+                if (string.IsNullOrWhiteSpace(serverPath))
+                {
+                    return Invalid("--server-path requires a value.", json);
+                }
+
+                continue;
+            }
+
+            // Positional argument: client name
+            if (!arg.StartsWith("--", StringComparison.Ordinal) && client is null)
+            {
+                var resolved = ClientAliasResolver.MapToClientKind(arg);
+                if (resolved is null)
+                {
+                    return Invalid($"Unsupported MCP client: '{arg}'.", json);
+                }
+
+                client = resolved;
+                continue;
+            }
+
+            return Invalid($"Unknown install argument: '{arg}'.", json);
+        }
+
+        if (help)
+        {
+            return new InstallOptions(true, client, serverName ?? "tia-portal", accessMode ?? "read-only", tiaProject, serverPath, dryRun, json, help, null);
+        }
+
+        if (client is null)
+        {
+            return Invalid("No MCP client specified. Usage: tia-mcp install <client>", json);
+        }
+
+        // Validate access mode if provided
+        if (accessMode is not null &&
+            !string.Equals(accessMode, "read-only", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(accessMode, "read-write", StringComparison.OrdinalIgnoreCase))
+        {
+            return Invalid($"Invalid access mode '{accessMode}'. Valid values: 'read-only', 'read-write'.", json);
+        }
+
+        // Validate MiMoCode + --json is not supported
+        if (client == ClientKind.MiMoCode && json)
+        {
+            return new InstallOptions(
+                false,
+                client,
+                serverName ?? "tia-portal",
+                accessMode ?? "read-only",
+                tiaProject,
+                serverPath,
+                dryRun,
+                json,
+                help,
+                "MiMoCode installation uses interactive mode and does not support --json output.");
+        }
+
+        return new InstallOptions(
+            true,
+            client,
+            serverName ?? "tia-portal",
+            accessMode ?? "read-only",
+            tiaProject,
+            serverPath,
+            dryRun,
+            json,
+            help,
+            null);
+    }
+
+    private static InstallOptions Invalid(string error, bool json)
+        => new(false, null, "tia-portal", "read-only", null, null, false, json, false, error);
+}

--- a/TiaMcpServer/Cli/Install/InstallCommand.cs
+++ b/TiaMcpServer/Cli/Install/InstallCommand.cs
@@ -1,0 +1,283 @@
+using System.Text.Json;
+
+namespace TiaMcpServer.Cli.Install;
+
+public static class InstallCommand
+{
+    private const string UsageText = """
+        Usage: tia-mcp install <client> [options]
+
+        Register the TIA Portal MCP server with a supported MCP client.
+
+        Supported clients:
+          claude-code, claude    Claude Code (Anthropic)
+          codex                  Codex (OpenAI)
+          opencode               OpenCode
+          mimocode, mimo         MiMoCode (Xiaomi)
+
+        Options:
+          --name <name>          Server registration name (default: tia-portal).
+          --access-mode <mode>   Access mode: read-only, read-write (default: read-only).
+          --tia-project <path>   Bind to a specific TIA Portal project.
+          --server-path <path>   Explicit path to the tia-mcp executable.
+          --dry-run              Print the install command without executing.
+          --json                 Emit JSON output (not supported with mimocode).
+          --help                 Show this help message and exit.
+
+        Exit codes:
+          0  Success.
+          1  General failure.
+          2  Invalid arguments.
+          3  Unsupported client.
+          4  Client executable not found.
+          5  tia-mcp executable not found.
+          6  Native command failed.
+          7  Verification failed.
+          8  Unsupported option combination.
+        """;
+
+    public static Task<int> RunAsync(string[] args)
+        => RunAsync(args, new NativeProcessRunner(), Console.Out, Console.Error);
+
+    internal static Task<int> RunAsync(string[] args, INativeProcessRunner runner, TextWriter output, TextWriter error)
+        => RunAsync(args, runner, output, error, ExecutableResolver.ResolveServerExecutable, ExecutableResolver.FindClientExecutable);
+
+    internal static async Task<int> RunAsync(
+        string[] args,
+        INativeProcessRunner runner,
+        TextWriter output,
+        TextWriter error,
+        Func<string?, string?> resolveServerExe,
+        Func<string, string?> findClientExe)
+    {
+        var options = InstallCliParser.Parse(args);
+
+        // Handle --help
+        if (options.Help)
+        {
+            output.WriteLine(options.Json
+                ? JsonSerializer.Serialize(new { usage = UsageText })
+                : UsageText);
+            return 0;
+        }
+
+        // Handle parse errors
+        if (!options.Valid)
+        {
+            if (options.Json)
+            {
+                output.WriteLine(JsonSerializer.Serialize(new
+                {
+                    success = false,
+                    error = options.ParseError
+                }));
+            }
+            else
+            {
+                error.WriteLine($"error: {options.ParseError}");
+                error.WriteLine(UsageText);
+            }
+
+            // Exit code 8 for unsupported combo, 3 for unsupported client, 2 for other parse errors
+            if (options.ParseError?.Contains("does not support --json") == true ||
+                options.ParseError?.Contains("does not support") == true)
+            {
+                return 8;
+            }
+
+            if (options.ParseError?.Contains("Unsupported MCP client") == true)
+            {
+                return 3;
+            }
+
+            return 2;
+        }
+
+        var client = options.Client!.Value;
+        var installer = ClientInstallerRegistry.GetInstaller(client);
+
+        // Resolve tia-mcp executable
+        var serverExePath = resolveServerExe(options.ServerPath);
+        if (serverExePath is null)
+        {
+            var msg = "tia-mcp executable not found. Install it with: dotnet tool install -g TiaMcpServer";
+            if (options.Json)
+            {
+                output.WriteLine(JsonSerializer.Serialize(new { success = false, client = client.ToString(), error = msg }));
+            }
+            else
+            {
+                error.WriteLine($"error: {msg}");
+            }
+
+            return 5;
+        }
+
+        // Build MCP launch arguments
+        var launchArgs = new List<string> { "--access-mode", options.AccessMode };
+        if (!string.IsNullOrWhiteSpace(options.TiaProject))
+        {
+            launchArgs.Add("--project");
+            launchArgs.Add(options.TiaProject);
+        }
+
+        var spec = new McpLaunchSpec(options.ServerName, serverExePath, launchArgs);
+
+        // Detect client executable
+        var detection = await installer.DetectAsync(runner, CancellationToken.None);
+        if (!detection.Found)
+        {
+            if (options.Json)
+            {
+                output.WriteLine(JsonSerializer.Serialize(new
+                {
+                    success = false,
+                    client = client.ToString(),
+                    error = detection.Error
+                }));
+            }
+            else
+            {
+                error.WriteLine($"error: {detection.Error}");
+            }
+
+            return 4;
+        }
+
+        // For MiMoCode with --json, reject
+        if (client == ClientKind.MiMoCode && options.Json)
+        {
+            var msg = "MiMoCode installation uses interactive mode and does not support --json output.";
+            output.WriteLine(JsonSerializer.Serialize(new { success = false, client = client.ToString(), error = msg }));
+            return 8;
+        }
+
+        // Build install command
+        var installCommand = installer.BuildInstallCommand(options, spec);
+
+        // Dry-run: print command and exit
+        if (options.DryRun)
+        {
+            if (options.Json)
+            {
+                output.WriteLine(JsonSerializer.Serialize(new
+                {
+                    dryRun = true,
+                    client = client.ToString(),
+                    executable = installCommand.Executable,
+                    arguments = installCommand.Arguments,
+                    interactive = installCommand.Interactive
+                }));
+            }
+            else
+            {
+                output.WriteLine($"[dry-run] Would execute: {installCommand.Executable} {string.Join(" ", installCommand.Arguments)}");
+            }
+
+            return 0;
+        }
+
+        // Execute install command
+        var installResult = await runner.RunAsync(installCommand, CancellationToken.None);
+
+        if (installResult.ExitCode != 0)
+        {
+            if (options.Json)
+            {
+                output.WriteLine(JsonSerializer.Serialize(new
+                {
+                    success = false,
+                    client = client.ToString(),
+                    serverName = spec.ServerName,
+                    accessMode = options.AccessMode,
+                    serverPath = spec.ExecutablePath,
+                    interactive = installCommand.Interactive,
+                    installCommand = FormatCommand(installCommand),
+                    installExitCode = installResult.ExitCode,
+                    error = string.IsNullOrWhiteSpace(installResult.Stderr) ? installResult.Stdout : installResult.Stderr
+                }));
+            }
+            else
+            {
+                error.WriteLine($"error: Install command failed (exit code {installResult.ExitCode})");
+                if (!string.IsNullOrWhiteSpace(installResult.Stderr))
+                {
+                    error.WriteLine(installResult.Stderr);
+                }
+
+                if (!string.IsNullOrWhiteSpace(installResult.Stdout))
+                {
+                    error.WriteLine(installResult.Stdout);
+                }
+            }
+
+            return 6;
+        }
+
+        // Run verification
+        int? verificationExitCode = null;
+        string? verificationStdout = null;
+        string? verificationStderr = null;
+
+        var verifyCommand = installer.BuildVerificationCommand(options, spec);
+        if (verifyCommand is not null)
+        {
+            var verifyResult = await runner.RunAsync(verifyCommand, CancellationToken.None);
+            verificationExitCode = verifyResult.ExitCode;
+            verificationStdout = verifyResult.Stdout;
+            verificationStderr = verifyResult.Stderr;
+        }
+
+        // Output success
+        if (options.Json)
+        {
+            output.WriteLine(JsonSerializer.Serialize(new
+            {
+                success = true,
+                client = client.ToString(),
+                serverName = spec.ServerName,
+                accessMode = options.AccessMode,
+                serverPath = spec.ExecutablePath,
+                interactive = installCommand.Interactive,
+                installCommand = FormatCommand(installCommand),
+                installExitCode = installResult.ExitCode,
+                verificationExitCode = verificationExitCode
+            }));
+        }
+        else
+        {
+            output.WriteLine($"Successfully registered '{spec.ServerName}' with {FormatClientName(client)}.");
+            output.WriteLine($"  Server path: {spec.ExecutablePath}");
+            output.WriteLine($"  Access mode: {options.AccessMode}");
+            if (!string.IsNullOrWhiteSpace(options.TiaProject))
+            {
+                output.WriteLine($"  TIA project: {options.TiaProject}");
+            }
+
+            if (verificationExitCode is not null)
+            {
+                output.WriteLine(verificationExitCode == 0
+                    ? "  Verification: passed"
+                    : $"  Verification: failed (exit code {verificationExitCode})");
+            }
+        }
+
+        return verificationExitCode is > 0 ? 7 : 0;
+    }
+
+    private static string[] FormatCommand(NativeCommand command)
+    {
+        var result = new List<string> { command.Executable };
+        result.AddRange(command.Arguments);
+        return result.ToArray();
+    }
+
+    private static string FormatClientName(ClientKind client) => client switch
+    {
+        ClientKind.ClaudeCode => "Claude Code",
+        ClientKind.Codex => "Codex",
+        ClientKind.OpenCode => "OpenCode",
+        ClientKind.MiMoCode => "MiMoCode",
+        _ => client.ToString()
+    };
+}

--- a/TiaMcpServer/Cli/Install/InstallOptions.cs
+++ b/TiaMcpServer/Cli/Install/InstallOptions.cs
@@ -1,0 +1,13 @@
+namespace TiaMcpServer.Cli.Install;
+
+public sealed record InstallOptions(
+    bool Valid,
+    ClientKind? Client,
+    string ServerName,
+    string AccessMode,
+    string? TiaProject,
+    string? ServerPath,
+    bool DryRun,
+    bool Json,
+    bool Help,
+    string? ParseError);

--- a/TiaMcpServer/Cli/Install/InstallResult.cs
+++ b/TiaMcpServer/Cli/Install/InstallResult.cs
@@ -1,0 +1,10 @@
+namespace TiaMcpServer.Cli.Install;
+
+internal sealed record InstallResult(
+    bool Success,
+    int ExitCode,
+    string? Stdout,
+    string? Stderr,
+    int? VerificationExitCode,
+    string? VerificationStdout,
+    string? VerificationStderr);

--- a/TiaMcpServer/Cli/Install/McpLaunchSpec.cs
+++ b/TiaMcpServer/Cli/Install/McpLaunchSpec.cs
@@ -1,0 +1,6 @@
+namespace TiaMcpServer.Cli.Install;
+
+internal sealed record McpLaunchSpec(
+    string ServerName,
+    string ExecutablePath,
+    IReadOnlyList<string> Arguments);

--- a/TiaMcpServer/Cli/Install/MiMoCodeInstaller.cs
+++ b/TiaMcpServer/Cli/Install/MiMoCodeInstaller.cs
@@ -1,0 +1,33 @@
+namespace TiaMcpServer.Cli.Install;
+
+internal sealed class MiMoCodeInstaller : IMcpClientInstaller
+{
+    public ClientKind Client => ClientKind.MiMoCode;
+
+    public async Task<ClientDetectionResult> DetectAsync(INativeProcessRunner runner, CancellationToken cancellationToken)
+    {
+        var result = await runner.RunAsync(
+            new NativeCommand("where.exe", new[] { "mimo" }, false),
+            cancellationToken);
+
+        if (result.ExitCode == 0 && !string.IsNullOrWhiteSpace(result.Stdout))
+        {
+            var path = result.Stdout.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)[0];
+            return new ClientDetectionResult(true, path, null);
+        }
+
+        return new ClientDetectionResult(false, null, "MiMoCode CLI not found. Install it from https://github.com/Xiaomi/mimocode");
+    }
+
+    public NativeCommand BuildInstallCommand(InstallOptions options, McpLaunchSpec spec)
+    {
+        // MiMoCode uses interactive mode; the user enters values manually
+        var args = new List<string> { "mcp", "add" };
+        return new NativeCommand("mimo", args, true);
+    }
+
+    public NativeCommand? BuildVerificationCommand(InstallOptions options, McpLaunchSpec spec)
+    {
+        return new NativeCommand("mimo", new[] { "mcp", "list" }, false);
+    }
+}

--- a/TiaMcpServer/Cli/Install/NativeCommand.cs
+++ b/TiaMcpServer/Cli/Install/NativeCommand.cs
@@ -1,0 +1,6 @@
+namespace TiaMcpServer.Cli.Install;
+
+internal sealed record NativeCommand(
+    string Executable,
+    IReadOnlyList<string> Arguments,
+    bool Interactive);

--- a/TiaMcpServer/Cli/Install/NativeCommandResult.cs
+++ b/TiaMcpServer/Cli/Install/NativeCommandResult.cs
@@ -1,0 +1,6 @@
+namespace TiaMcpServer.Cli.Install;
+
+internal sealed record NativeCommandResult(
+    int ExitCode,
+    string Stdout,
+    string Stderr);

--- a/TiaMcpServer/Cli/Install/NativeProcessRunner.cs
+++ b/TiaMcpServer/Cli/Install/NativeProcessRunner.cs
@@ -1,0 +1,58 @@
+using System.Diagnostics;
+
+namespace TiaMcpServer.Cli.Install;
+
+internal sealed class NativeProcessRunner : INativeProcessRunner
+{
+    public async Task<NativeCommandResult> RunAsync(NativeCommand command, CancellationToken cancellationToken)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = command.Executable,
+            UseShellExecute = false,
+            CreateNoWindow = !command.Interactive,
+            RedirectStandardOutput = !command.Interactive,
+            RedirectStandardError = !command.Interactive,
+            RedirectStandardInput = !command.Interactive
+        };
+
+        foreach (var arg in command.Arguments)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        try
+        {
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                return new NativeCommandResult(-1, string.Empty, "Failed to start process.");
+            }
+
+            if (command.Interactive)
+            {
+                // Interactive mode: wait for exit without capturing streams
+                await process.WaitForExitAsync(cancellationToken);
+                return new NativeCommandResult(process.ExitCode, string.Empty, string.Empty);
+            }
+
+            // Non-interactive: capture output
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+            await process.WaitForExitAsync(cancellationToken);
+
+            var stdout = await stdoutTask;
+            var stderr = await stderrTask;
+
+            return new NativeCommandResult(process.ExitCode, stdout, stderr);
+        }
+        catch (OperationCanceledException)
+        {
+            return new NativeCommandResult(-1, string.Empty, "Operation was cancelled.");
+        }
+        catch (Exception ex)
+        {
+            return new NativeCommandResult(-1, string.Empty, ex.Message);
+        }
+    }
+}

--- a/TiaMcpServer/Cli/Install/OpenCodeInstaller.cs
+++ b/TiaMcpServer/Cli/Install/OpenCodeInstaller.cs
@@ -1,0 +1,42 @@
+namespace TiaMcpServer.Cli.Install;
+
+internal sealed class OpenCodeInstaller : IMcpClientInstaller
+{
+    public ClientKind Client => ClientKind.OpenCode;
+
+    public async Task<ClientDetectionResult> DetectAsync(INativeProcessRunner runner, CancellationToken cancellationToken)
+    {
+        var result = await runner.RunAsync(
+            new NativeCommand("where.exe", new[] { "opencode" }, false),
+            cancellationToken);
+
+        if (result.ExitCode == 0 && !string.IsNullOrWhiteSpace(result.Stdout))
+        {
+            var path = result.Stdout.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)[0];
+            return new ClientDetectionResult(true, path, null);
+        }
+
+        return new ClientDetectionResult(false, null, "OpenCode CLI not found. Install it from https://github.com/opencode-ai/opencode");
+    }
+
+    public NativeCommand BuildInstallCommand(InstallOptions options, McpLaunchSpec spec)
+    {
+        var args = new List<string> { "mcp", "add", spec.ServerName, "--" };
+        args.Add(spec.ExecutablePath);
+        args.Add("--access-mode");
+        args.Add(options.AccessMode);
+
+        if (!string.IsNullOrWhiteSpace(options.TiaProject))
+        {
+            args.Add("--project");
+            args.Add(options.TiaProject);
+        }
+
+        return new NativeCommand("opencode", args, false);
+    }
+
+    public NativeCommand? BuildVerificationCommand(InstallOptions options, McpLaunchSpec spec)
+    {
+        return new NativeCommand("opencode", new[] { "mcp", "list" }, false);
+    }
+}

--- a/TiaMcpServer/Program.cs
+++ b/TiaMcpServer/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 using TiaMcpServer.Batch;
 using TiaMcpServer.Cli;
+using TiaMcpServer.Cli.Install;
 using TiaMcpServer.Contracts;
 using TiaMcpServer.Safety;
 using TiaMcpServer.Tools;
@@ -15,6 +16,11 @@ namespace TiaMcpServer
     {
         private static async Task<int> Main(string[] args)
         {
+            if (args.Length > 0 && string.Equals(args[0], "install", StringComparison.OrdinalIgnoreCase))
+            {
+                return await InstallCommand.RunAsync(args[1..]);
+            }
+
             if (args.Length > 0 && string.Equals(args[0], "doctor", StringComparison.OrdinalIgnoreCase))
             {
                 return await DoctorCommand.RunAsync(args[1..]);


### PR DESCRIPTION
## Summary
- Implements `tia-mcp install <client>` command that registers the TIA Portal MCP server with 4 supported agentic coding tools (Claude Code, Codex, OpenCode, MiMoCode) by invoking each client's official MCP CLI
- Strictly avoids any direct configuration file editing - all installation is done via native client CLIs
- 80+ tests covering parser, command construction, process runner, executable resolution, alias resolution, and integration

## Key Features
- CLI dispatch in Program.Main before access-mode parsing
- ClientAliasResolver handles aliases (claude->ClaudeCode, mimo->MiMoCode)
- ExecutableResolver finds tia-mcp via --server-path, where.exe, or .NET global tool path
- NativeProcessRunner uses ProcessStartInfo.ArgumentList (no shell strings)
- 4 client adapters (ClaudeCode, Codex, OpenCode, MiMoCode) each implementing IMcpClientInstaller
- Dry-run mode prints commands without execution
- JSON output mode for machine-readable results
- MiMoCode interactive mode shows values for manual entry
- Verification commands run after successful installation
- Exit codes 0-8 for different error conditions

## Files Changed
**Modified:**
- TiaMcpServer/Program.cs (added install dispatch before doctor check)
- TiaMcpServer.Tests/TiaMcpServer.Tests.csproj (added Cli/Install/*.cs wildcard)
- README.md (added 'Register with an MCP client' section)

**Created (19 source files):**
- TiaMcpServer/Cli/Install/ (full directory)

**Created (6 test files):**
- TiaMcpServer.Tests/Cli/ (full directory)
