### PR TITLE
Separate project reads and compile checks from batch tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,24 +16,26 @@ The current implementation covers project discovery and lifecycle operations, PL
 
 ## Tools
 
-The server currently exposes 10 tools.
+The server currently exposes 12 tools in read-write mode and 3 tools in read-only mode.
 
 ### Batch operations
 
-- `execute_read_batch` - run up to 50 read operations in one call. Each item carries an `operationId`, an `operation` name (e.g. `get_block_content`, `list_tag_tables`), and that operation's parameters. Reads run independently, so a failing item does not stop the others. Bound large reads with `depth`/`startPath` (`browse_project_tree`) and `maxResults` (`search_equipment_catalog` defaults to 50, and `read_cross_references`); oversized batch responses are truncated or omitted server-side with explicit markers.
+- `execute_read_batch` - run up to 50 read operations in one call. Each item carries an `operationId`, an `operation` name (e.g. `get_block_content`, `list_tag_tables`), and that operation's parameters. Reads run independently, so a failing item does not stop the others. Bound `search_equipment_catalog` and `read_cross_references` with `maxResults`; oversized batch responses are truncated or omitted server-side with explicit markers.
 - `preview_write_batch` / `apply_write_batch` - preview up to 50 write operations and receive one batch-level `safetyToken` bound to the exact ordered operation list and the combined current state, then apply them. Apply runs sequentially, stops on the first failure, and marks later items `skipped` (no transaction or rollback). Requires `confirm=true` and the `safetyToken`. Batches cover data writes (block, tag table, tag, user constant, network device); project-lifecycle operations stay single-tool only.
 
 The batch tools are the only path for data operations. Each `operation` name (e.g. `get_block_content`, `list_tag_tables`, `create_tag`, `update_block_logic`, `add_network_device`) carries that operation's parameters as one item; a single operation is just a one-item batch.
 
 Every operation result may carry a `warnings` array — non-fatal degradation notes captured from the TIA Openness worker (e.g. members skipped while reading a protected device). A populated `warnings` array means the payload may be partial. `read_hardware_config` additionally reports unreadable members in a payload-level `messages` array; device/module name and type-identifier fields omit values that could not be read instead of returning `0`/empty-string placeholders (a few secondary name fields still fall back to an empty string, with the failure noted in `messages`).
 
-Available read operations (for `execute_read_batch`): `browse_project_tree`, `get_block_content`, `list_tag_tables`, `read_hardware_config`, `read_cross_references`, `search_equipment_catalog`, `compile_check`, `get_project_status`.
+Available read operations for `execute_read_batch`: `read_hardware_config`, `search_equipment_catalog`, `read_cross_references`, `get_block_content`, `list_tag_tables`, and `get_type_content`.
 
 Available write operations (for `preview_write_batch` / `apply_write_batch`): `update_block_logic`, `create_block` / `delete_block`, `create_block_group` / `delete_block_group`, `create_tag_table` / `delete_tag_table`, `create_tag` / `update_tag` / `delete_tag`, `create_user_constant` / `update_user_constant` / `delete_user_constant`, `add_network_device`, `configure_network_device`, `start_plc` / `stop_plc`.
 
 ### Project tools
 
-- `get_project_status` - read active project metadata.
+- `get_project_status` — read active project metadata without opening or switching projects.
+- `browse_project_tree` — browse a bounded project subtree with optional `depth` and `startPath`.
+- `compile_check` — compile a PLC or selected block and return compiler messages; available only in read-write mode.
 - `open_project` / `create_project` / `save_project` / `save_project_as` / `archive_project` / `close_project` - project lifecycle writes. These stay single-tool only (not batchable) and are self-previewing: call the tool WITHOUT `safetyToken` to get a preview plus a single-use token, then call it again with `confirm=true` and the token to apply.
 
 ## Write safety
@@ -170,10 +172,11 @@ Configuration precedence: CLI argument > environment variable > default (read-wr
 
 The mode is resolved once at startup and cannot be changed during the process lifetime. There is no MCP tool that changes the access mode at runtime.
 
-In read-only mode, the server exposes only two MCP tools:
+In read-only mode, the server exposes exactly three MCP tools:
 
-- `get_project_status` - read active project metadata.
-- `execute_read_batch` - run read operations in a batch (including `browse_project_tree`, `read_hardware_config`, `read_cross_references`, `search_equipment_catalog`, `get_block_content`, `list_tag_tables`, `get_project_status`).
+- `get_project_status` — read active project metadata without opening or switching projects.
+- `browse_project_tree` — browse a bounded project subtree with optional `depth` and `startPath`.
+- `execute_read_batch` — run the six retained non-project read operations in a batch.
 
 The following operations are **not available** in read-only mode:
 
@@ -294,21 +297,33 @@ npx -y @modelcontextprotocol/inspector dotnet .\TiaMcpServer\bin\Debug\net8.0\Ti
 In the Inspector UI:
 
 - Open the Tools tab.
-- Click `List Tools` and verify the 10 tools appear.
-- Start with reads: call `execute_read_batch` with an `operations` array (each item has an `operationId`, an `operation` name such as `browse_project_tree` / `list_tag_tables` / `read_hardware_config` / `read_cross_references` / `compile_check`, and that operation's parameters).
+- Click `List Tools` and verify the 12 tools appear in read-write mode.
+- Start with the standalone `get_project_status` and `browse_project_tree` tools.
+- In read-write mode, call standalone `compile_check` for PLC or block compilation.
+- Then call `execute_read_batch` with an `operations` array whose items use retained operations such as `list_tag_tables`, `read_hardware_config`, `read_cross_references`, or `get_block_content`.
 - Use a `search_equipment_catalog` read item before hardware insertion so you can copy an exact `typeIdentifier`.
 - Use a `get_block_content` read item on a block path returned by `browse_project_tree`.
 - Use `get_project_status` before lifecycle changes.
 - Avoid writes unless the project is disposable or backed up. Writes go through `preview_write_batch`, then `apply_write_batch` with `confirm=true` and the returned batch `safetyToken`.
 
-Recommended read smoke-test for `execute_read_batch` (independent items; a failing item does not stop the others):
+For a bounded tree read, call standalone `browse_project_tree` with inputs such as:
+
+```json
+{ "projectPath": null, "depth": 2, "startPath": "PLC_1" }
+```
+
+In read-write mode, call standalone `compile_check` with inputs such as:
+
+```json
+{ "projectPath": null, "plcName": "PLC_1", "blockPath": "PLC_1/Blocks/Main" }
+```
+
+Then use this read smoke-test for `execute_read_batch` (independent items; a failing item does not stop the others):
 
 ```json
 {
   "operations": [
-    { "operationId": "tree", "operation": "browse_project_tree" },
     { "operationId": "hw", "operation": "read_hardware_config" },
-    { "operationId": "compile", "operation": "compile_check" },
     { "operationId": "xref", "operation": "read_cross_references", "filter": "ObjectsWithReferences", "plcName": "PLC_1" },
     { "operationId": "catalog", "operation": "search_equipment_catalog", "query": "1516" }
   ]
@@ -320,7 +335,7 @@ Large projects can return large JSON from cross-reference diagnostics; narrow ea
 ```json
 {
   "operations": [
-    { "operationId": "tree", "operation": "browse_project_tree", "projectPath": "C:\\Projects\\Sandbox\\Line.ap21" }
+    { "operationId": "hardware", "operation": "read_hardware_config", "projectPath": "C:\\Projects\\Sandbox\\Line.ap21" }
   ]
 }
 ```

--- a/TiaMcpServer.Tests/BatchOperationCatalogTests.cs
+++ b/TiaMcpServer.Tests/BatchOperationCatalogTests.cs
@@ -19,7 +19,7 @@ public class BatchOperationCatalogTests
     {
         var operations = new List<BatchOperationRequest>
         {
-            Op("a", "browse_project_tree"),
+            Op("a", "read_hardware_config"),
             Op("b", "get_block_content", r => r.BlockPath = "PLC_1/Main"),
             Op("c", "search_equipment_catalog", r => r.Query = "CPU"),
         };
@@ -52,7 +52,7 @@ public class BatchOperationCatalogTests
         var operations = new List<BatchOperationRequest>();
         for (var i = 0; i < BatchOperationCatalog.MaxBatchSize + 1; i++)
         {
-            operations.Add(Op($"id{i}", "browse_project_tree"));
+            operations.Add(Op($"id{i}", "read_hardware_config"));
         }
 
         var result = BatchOperationCatalog.ValidateReadBatch(operations);
@@ -85,7 +85,7 @@ public class BatchOperationCatalogTests
     public void ValidateReadBatch_RejectsDuplicateOperationId()
     {
         var result = BatchOperationCatalog.ValidateReadBatch(
-            new[] { Op("dup", "browse_project_tree"), Op("dup", "read_hardware_config") });
+            new[] { Op("dup", "read_hardware_config"), Op("dup", "list_tag_tables") });
 
         Assert.False(result.IsValid);
         Assert.Contains("dup", result.Error);
@@ -94,7 +94,7 @@ public class BatchOperationCatalogTests
     [Fact]
     public void ValidateReadBatch_RejectsMissingOperationId()
     {
-        var result = BatchOperationCatalog.ValidateReadBatch(new[] { Op("", "browse_project_tree") });
+        var result = BatchOperationCatalog.ValidateReadBatch(new[] { Op("", "read_hardware_config") });
 
         Assert.False(result.IsValid);
         Assert.Contains("operationId", result.Error);
@@ -220,8 +220,10 @@ public class BatchOperationCatalogTests
 
         Assert.False(result.IsValid);
         Assert.Contains("Valid read operations", result.Error);
-        Assert.Contains("browse_project_tree", result.Error);
-        Assert.Contains("get_block_content", result.Error);
+        Assert.Contains("get_type_content", result.Error);
+        Assert.DoesNotContain("get_project_status", result.Error);
+        Assert.DoesNotContain("browse_project_tree", result.Error);
+        Assert.DoesNotContain("compile_check", result.Error);
     }
 
     [Fact]
@@ -254,35 +256,17 @@ public class BatchOperationCatalogTests
     }
 
     [Fact]
-    public void Validate_RejectsDepthAndStartPathOnNonTreeOperations()
-    {
-        var operations = new[]
-        {
-            new BatchOperationRequest { OperationId = "a", Operation = "list_tag_tables", Depth = 2 },
-            new BatchOperationRequest { OperationId = "b", Operation = "get_project_status", StartPath = "PLC_1" },
-        };
-
-        var result = BatchOperationCatalog.ValidateReadBatch(operations);
-
-        Assert.False(result.IsValid);
-        Assert.Contains("'depth' is not valid for list_tag_tables", result.Error);
-        Assert.Contains("'startPath' is not valid for get_project_status", result.Error);
-        Assert.Contains("operationId 'a'", result.Error);
-        Assert.Contains("operationId 'b'", result.Error);
-    }
-
-    [Fact]
     public void Validate_RejectsMaxResultsOnUnsupportedOperations()
     {
         var operations = new[]
         {
-            new BatchOperationRequest { OperationId = "a", Operation = "browse_project_tree", MaxResults = 10 },
+            new BatchOperationRequest { OperationId = "a", Operation = "list_tag_tables", MaxResults = 10 },
         };
 
         var result = BatchOperationCatalog.ValidateReadBatch(operations);
 
         Assert.False(result.IsValid);
-        Assert.Contains("'maxResults' is not valid for browse_project_tree", result.Error);
+        Assert.Contains("'maxResults' is not valid for list_tag_tables", result.Error);
     }
 
     [Fact]
@@ -290,14 +274,12 @@ public class BatchOperationCatalogTests
     {
         var operations = new[]
         {
-            new BatchOperationRequest { OperationId = "a", Operation = "browse_project_tree", Depth = 0 },
-            new BatchOperationRequest { OperationId = "b", Operation = "search_equipment_catalog", Query = "cpu", MaxResults = 0 },
+            new BatchOperationRequest { OperationId = "a", Operation = "search_equipment_catalog", Query = "cpu", MaxResults = 0 },
         };
 
         var result = BatchOperationCatalog.ValidateReadBatch(operations);
 
         Assert.False(result.IsValid);
-        Assert.Contains("'depth' must be 1 or greater", result.Error);
         Assert.Contains("'maxResults' must be 1 or greater", result.Error);
     }
 
@@ -306,9 +288,8 @@ public class BatchOperationCatalogTests
     {
         var operations = new[]
         {
-            new BatchOperationRequest { OperationId = "a", Operation = "browse_project_tree", Depth = 2, StartPath = "PLC_1/Blocks" },
-            new BatchOperationRequest { OperationId = "b", Operation = "search_equipment_catalog", Query = "cpu", MaxResults = 10 },
-            new BatchOperationRequest { OperationId = "c", Operation = "read_cross_references", MaxResults = 100 },
+            new BatchOperationRequest { OperationId = "a", Operation = "search_equipment_catalog", Query = "cpu", MaxResults = 10 },
+            new BatchOperationRequest { OperationId = "b", Operation = "read_cross_references", MaxResults = 100 },
         };
 
         var result = BatchOperationCatalog.ValidateReadBatch(operations);
@@ -319,8 +300,8 @@ public class BatchOperationCatalogTests
     [Fact]
     public void All_ExposesEverySpec()
     {
-        // 9 reads + 18 writes.
-        Assert.Equal(27, BatchOperationCatalog.All.Count);
+        // 6 reads + 18 writes.
+        Assert.Equal(24, BatchOperationCatalog.All.Count);
     }
 
     [Fact]
@@ -329,14 +310,11 @@ public class BatchOperationCatalogTests
         var none = Array.Empty<string>();
         var expected = new Dictionary<string, (BatchOperationCategory Category, IReadOnlyList<string> Required, IReadOnlyList<string> Optional)>
         {
-            ["browse_project_tree"] = (BatchOperationCategory.Read, none, new[] { "depth", "startPath" }),
             ["read_hardware_config"] = (BatchOperationCategory.Read, none, none),
             ["search_equipment_catalog"] = (BatchOperationCategory.Read, new[] { "query" }, new[] { "maxResults" }),
             ["read_cross_references"] = (BatchOperationCategory.Read, none, new[] { "plcName", "filter", "maxResults" }),
             ["get_block_content"] = (BatchOperationCategory.Read, new[] { "blockPath" }, new[] { "format" }),
             ["list_tag_tables"] = (BatchOperationCategory.Read, none, new[] { "plcName" }),
-            ["compile_check"] = (BatchOperationCategory.Read, none, new[] { "blockPath", "plcName" }),
-            ["get_project_status"] = (BatchOperationCategory.Read, none, none),
             ["get_type_content"] = (BatchOperationCategory.Read, new[] { "typePath" }, new[] { "format" }),
             ["update_block_logic"] = (BatchOperationCategory.Write, new[] { "blockPath", "yamlContent" }, new[] { "format" }),
             ["create_tag_table"] = (BatchOperationCategory.Write, new[] { "tableName" }, new[] { "plcName", "folderPath" }),
@@ -521,36 +499,12 @@ public class BatchOperationCatalogTests
             new BatchOperationRequest
             {
                 OperationId = "a",
-                Operation = "get_project_status",
+                Operation = "read_hardware_config",
                 ProjectPath = "C:\\p.ap21"
             }
         });
 
         Assert.True(result.IsValid);
-    }
-
-    [Fact]
-    public void DepthOnANonTreeOperation_IsStillRejected()
-    {
-        var result = BatchOperationCatalog.ValidateReadBatch(new[]
-        {
-            new BatchOperationRequest { OperationId = "a", Operation = "read_hardware_config", Depth = 2 }
-        });
-
-        Assert.False(result.IsValid);
-        Assert.Contains("depth", result.Error);
-    }
-
-    [Fact]
-    public void DepthBelowOne_IsStillRejected()
-    {
-        var result = BatchOperationCatalog.ValidateReadBatch(new[]
-        {
-            new BatchOperationRequest { OperationId = "a", Operation = "browse_project_tree", Depth = 0 }
-        });
-
-        Assert.False(result.IsValid);
-        Assert.Contains("1 or greater", result.Error);
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/BatchOperationCatalogTests.cs
+++ b/TiaMcpServer.Tests/BatchOperationCatalogTests.cs
@@ -571,6 +571,19 @@ public class BatchOperationCatalogTests
         Assert.True(result.IsValid, result.Error);
     }
 
+    [Theory]
+    [InlineData("get_project_status")]
+    [InlineData("browse_project_tree")]
+    [InlineData("compile_check")]
+    public void ValidateReadBatch_RejectsStandaloneProjectOperations(string operation)
+    {
+        var result = BatchOperationCatalog.ValidateReadBatch(new[] { Op("a", operation) });
+
+        Assert.False(result.IsValid);
+        Assert.Contains($"Unknown operation '{operation}'", result.Error);
+        Assert.DoesNotContain(operation, BatchOperationCatalog.ReadOperationNames);
+    }
+
     private static BatchOperationRequest FullyPopulated(string id, string operation)
     {
         Assert.True(BatchOperationCatalog.TryGetSpec(operation, out var spec));

--- a/TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs
+++ b/TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs
@@ -34,14 +34,30 @@ public class BatchOperationRequestJsonTests
     }
 
     [Fact]
-    public void Deserializes_BoundingFields()
+    public void DeserializesRetainedMaxResultsField()
     {
-        var json = """{"operationId":"a","operation":"browse_project_tree","depth":3,"startPath":"PLC_1/Blocks","maxResults":25}""";
+        var json = """{"operationId":"a","operation":"search_equipment_catalog","query":"CPU","maxResults":25}""";
 
         var request = JsonSerializer.Deserialize<BatchOperationRequest>(json, WebOptions)!;
 
-        Assert.Equal(3, request.Depth);
-        Assert.Equal("PLC_1/Blocks", request.StartPath);
         Assert.Equal(25, request.MaxResults);
+    }
+
+    [Theory]
+    [InlineData("""{"operationId":"a","operation":"read_hardware_config","depth":3}""", "depth")]
+    [InlineData("""{"operationId":"a","operation":"read_hardware_config","startPath":"PLC_1/Blocks"}""", "startPath")]
+    public void RemovedProjectTreeFields_AreRejected(string json, string field)
+    {
+        var exception = Assert.Throws<JsonException>(
+            () => JsonSerializer.Deserialize<BatchOperationRequest>(json, WebOptions));
+
+        Assert.Contains(field, exception.Message);
+    }
+
+    [Fact]
+    public void BatchRequestType_DoesNotExposeProjectTreeFields()
+    {
+        Assert.Null(typeof(BatchOperationRequest).GetProperty("Depth"));
+        Assert.Null(typeof(BatchOperationRequest).GetProperty("StartPath"));
     }
 }

--- a/TiaMcpServer.Tests/BatchPayloadBudgetTests.cs
+++ b/TiaMcpServer.Tests/BatchPayloadBudgetTests.cs
@@ -210,4 +210,15 @@ public class BatchPayloadBudgetTests
         Assert.Contains("\"failed\":3", response);
         Assert.True(response.Length <= 3_000);
     }
+
+    [Fact]
+    public void BatchMarkers_DoNotRecommendStandaloneProjectFields()
+    {
+        var text = BatchPayloadBudget.TruncationTrailer(BatchPayloadBudget.MaxItemChars)
+            + BatchPayloadBudget.OmissionMarker(BatchPayloadBudget.MaxBatchChars);
+        var normalized = text.ToLowerInvariant();
+
+        Assert.DoesNotContain("startpath", normalized);
+        Assert.DoesNotContain("depth", normalized);
+    }
 }

--- a/TiaMcpServer.Tests/BatchToolMetadataTests.cs
+++ b/TiaMcpServer.Tests/BatchToolMetadataTests.cs
@@ -117,7 +117,7 @@ public class BatchToolMetadataTests
     {
         var description = PropertyDescription(nameof(BatchOperationRequest.PlcName));
         Assert.Contains("list_tag_tables", description);
-        Assert.Contains("compile_check", description);
+        Assert.DoesNotContain("compile_check", description);
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/BatchToolMetadataTests.cs
+++ b/TiaMcpServer.Tests/BatchToolMetadataTests.cs
@@ -93,12 +93,12 @@ public class BatchToolMetadataTests
     }
 
     [Fact]
-    public void BlockPathDescription_CoversAllBlockOperationsAndCompileCheck()
+    public void BlockPathDescription_CoversBatchBlockOperations()
     {
         var description = PropertyDescription(nameof(BatchOperationRequest.BlockPath));
         Assert.Contains("create_block", description);
         Assert.Contains("delete_block", description);
-        Assert.Contains("compile_check", description);
+        Assert.DoesNotContain("compile_check", description);
     }
 
     [Fact]
@@ -118,6 +118,40 @@ public class BatchToolMetadataTests
         var description = PropertyDescription(nameof(BatchOperationRequest.PlcName));
         Assert.Contains("list_tag_tables", description);
         Assert.Contains("compile_check", description);
+    }
+
+    [Fact]
+    public void ExecuteReadBatchDescriptions_OmitStandaloneProjectOperations()
+    {
+        foreach (var toolType in new[] { typeof(BatchTools), typeof(ReadBatchTools) })
+        {
+            var description = MethodDescription(toolType, "ExecuteReadBatch");
+            foreach (var retained in BatchOperationCatalog.ReadOperationNames)
+            {
+                Assert.Contains(retained, description);
+            }
+
+            Assert.DoesNotContain("get_project_status", description);
+            Assert.DoesNotContain("browse_project_tree", description);
+            Assert.DoesNotContain("compile_check", description);
+        }
+    }
+
+    [Fact]
+    public void BatchRequestDescriptions_OmitStandaloneProjectOperations()
+    {
+        foreach (var propertyName in new[]
+        {
+            nameof(BatchOperationRequest.Operation),
+            nameof(BatchOperationRequest.BlockPath),
+            nameof(BatchOperationRequest.PlcName)
+        })
+        {
+            var description = PropertyDescription(propertyName);
+            Assert.DoesNotContain("get_project_status", description);
+            Assert.DoesNotContain("browse_project_tree", description);
+            Assert.DoesNotContain("compile_check", description);
+        }
     }
 
     [Theory]
@@ -140,5 +174,14 @@ public class BatchToolMetadataTests
         var description = property!.GetCustomAttribute<DescriptionAttribute>();
         Assert.NotNull(description);
         Assert.False(string.IsNullOrWhiteSpace(description!.Description));
+    }
+
+    private static string MethodDescription(Type toolType, string methodName)
+    {
+        var method = toolType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(method);
+        var description = method!.GetCustomAttribute<DescriptionAttribute>();
+        Assert.NotNull(description);
+        return description!.Description;
     }
 }

--- a/TiaMcpServer.Tests/McpToolSchemaTests.cs
+++ b/TiaMcpServer.Tests/McpToolSchemaTests.cs
@@ -165,4 +165,17 @@ public class McpToolSchemaTests
 
         public bool IsService(Type serviceType) => _services.ContainsKey(serviceType);
     }
+
+    [Fact]
+    public void BrowseProjectTree_SchemaExposesOnlyModelInputs()
+    {
+        var properties = SchemaPropertyNames(
+            typeof(ProjectReadTools),
+            nameof(ProjectReadTools.BrowseProjectTree));
+
+        Assert.Equal(
+            new[] { "depth", "projectPath", "startPath" },
+            properties.OrderBy(name => name).ToArray());
+        Assert.DoesNotContain("workerClient", properties);
+    }
 }

--- a/TiaMcpServer.Tests/McpToolSchemaTests.cs
+++ b/TiaMcpServer.Tests/McpToolSchemaTests.cs
@@ -100,10 +100,17 @@ public class McpToolSchemaTests
             .Select(m => m.GetCustomAttribute<McpServerToolAttribute>())
             .Where(a => a is not null)
             .Select(a => a!.Name)
+            .OrderBy(name => name)
             .ToArray();
-        Assert.Equal(12, toolNames.Length);
-        Assert.Equal(12, toolNames.Distinct().Count());
-        Assert.DoesNotContain("probe_project_status_for_lifecycle", toolNames);
+
+        Assert.Equal(
+            new[]
+            {
+                "apply_write_batch", "archive_project", "browse_project_tree", "close_project",
+                "compile_check", "create_project", "execute_read_batch", "get_project_status",
+                "open_project", "preview_write_batch", "save_project", "save_project_as"
+            },
+            toolNames);
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/McpToolSchemaTests.cs
+++ b/TiaMcpServer.Tests/McpToolSchemaTests.cs
@@ -84,12 +84,12 @@ public class McpToolSchemaTests
     /// ProjectLifecycleTools lives in - which, for TiaMcpServer.Tests, is the test assembly
     /// itself, since the host's tool source files are compiled directly into it (see
     /// TiaMcpServer.Tests.csproj's Compile Include entries). Counts every method on those types
-    /// carrying [McpServerTool] and asserts the exact approved surface: 10 tools total, and the
+    /// carrying [McpServerTool] and asserts the exact approved surface: 12 tools total, and the
     /// internal lifecycle probe (probe_project_status_for_lifecycle, never [McpServerTool]-decorated)
     /// absent.
     /// </summary>
     [Fact]
-    public void McpToolSurface_ExposesExactlyTenApprovedTools()
+    public void McpToolSurface_ExposesExactlyTwelveApprovedTools()
     {
         var toolTypes = typeof(ProjectLifecycleTools).Assembly
             .GetTypes()
@@ -101,9 +101,8 @@ public class McpToolSchemaTests
             .Where(a => a is not null)
             .Select(a => a!.Name)
             .ToArray();
-
-        Assert.Equal(10, toolNames.Length);
-        Assert.Equal(10, toolNames.Distinct().Count());
+        Assert.Equal(12, toolNames.Length);
+        Assert.Equal(12, toolNames.Distinct().Count());
         Assert.DoesNotContain("probe_project_status_for_lifecycle", toolNames);
     }
 
@@ -177,5 +176,20 @@ public class McpToolSchemaTests
             new[] { "depth", "projectPath", "startPath" },
             properties.OrderBy(name => name).ToArray());
         Assert.DoesNotContain("workerClient", properties);
+    }
+
+    [Fact]
+    public void CompileCheck_SchemaExposesOnlyModelInputs()
+    {
+        var properties = SchemaPropertyNames(
+            typeof(ProjectEngineeringTools),
+            nameof(ProjectEngineeringTools.CompileCheck));
+
+        Assert.Equal(
+            new[] { "blockPath", "plcName", "projectPath" },
+            properties.OrderBy(name => name).ToArray());
+        Assert.DoesNotContain("workerClient", properties);
+        Assert.DoesNotContain("confirm", properties);
+        Assert.DoesNotContain("safetyToken", properties);
     }
 }

--- a/TiaMcpServer.Tests/ProjectStandaloneToolTests.cs
+++ b/TiaMcpServer.Tests/ProjectStandaloneToolTests.cs
@@ -74,4 +74,38 @@ public class ProjectStandaloneToolTests
             root.GetProperty("failureCategory").GetString());
         Assert.Contains("depth", root.GetProperty("error").GetString());
     }
+
+    [Fact]
+    public void CompileCheck_HasEngineeringMcpMetadata()
+    {
+        var method = typeof(ProjectEngineeringTools).GetMethod(
+            nameof(ProjectEngineeringTools.CompileCheck),
+            BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        var attribute = method!.GetCustomAttribute<McpServerToolAttribute>();
+        Assert.NotNull(attribute);
+        Assert.Equal("compile_check", attribute!.Name);
+        Assert.False(attribute.ReadOnly);
+        Assert.False(attribute.Destructive);
+        Assert.False(attribute.OpenWorld);
+    }
+
+    [Fact]
+    public async Task CompileCheck_ForwardsEveryArgument()
+    {
+        using var client = CreateClient(FakeWorkerLocator.Locate());
+
+        var response = await ProjectEngineeringTools.CompileCheck(
+            client,
+            projectPath: "echo",
+            plcName: "PLC_1",
+            blockPath: "PLC_1/Blocks/Main");
+        var request = WorkerRequestFromEnvelope(response);
+
+        Assert.Equal("compile_check", request.GetProperty("method").GetString());
+        Assert.Equal("echo", request.GetProperty("projectPath").GetString());
+        Assert.Equal("PLC_1", request.GetProperty("plcName").GetString());
+        Assert.Equal("PLC_1/Blocks/Main", request.GetProperty("blockPath").GetString());
+    }
 }

--- a/TiaMcpServer.Tests/ProjectStandaloneToolTests.cs
+++ b/TiaMcpServer.Tests/ProjectStandaloneToolTests.cs
@@ -1,0 +1,77 @@
+using System.Reflection;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Tools;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+public class ProjectStandaloneToolTests
+{
+    private static OpennessWorkerClient CreateClient(string workerPath)
+        => new(
+            new ProjectSessionBinding(null),
+            logger: null,
+            workerExecutablePath: workerPath);
+
+    private static JsonElement WorkerRequestFromEnvelope(string response)
+    {
+        using var envelope = JsonDocument.Parse(response);
+        var payload = envelope.RootElement.GetProperty("payload").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(payload));
+        using var request = JsonDocument.Parse(payload!);
+        return request.RootElement.Clone();
+    }
+
+    [Fact]
+    public void BrowseProjectTree_HasReadOnlyMcpMetadata()
+    {
+        var method = typeof(ProjectReadTools).GetMethod(
+            nameof(ProjectReadTools.BrowseProjectTree),
+            BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        var attribute = method!.GetCustomAttribute<McpServerToolAttribute>();
+        Assert.NotNull(attribute);
+        Assert.Equal("browse_project_tree", attribute!.Name);
+        Assert.True(attribute.ReadOnly);
+        Assert.False(attribute.Destructive);
+        Assert.False(attribute.OpenWorld);
+    }
+
+    [Fact]
+    public async Task BrowseProjectTree_ForwardsEveryArgument()
+    {
+        using var client = CreateClient(FakeWorkerLocator.Locate());
+
+        var response = await ProjectReadTools.BrowseProjectTree(
+            client,
+            projectPath: "echo",
+            depth: 2,
+            startPath: "PLC_1/Blocks");
+        var request = WorkerRequestFromEnvelope(response);
+
+        Assert.Equal("browse_project_tree", request.GetProperty("method").GetString());
+        Assert.Equal("echo", request.GetProperty("projectPath").GetString());
+        Assert.Equal(2, request.GetProperty("depth").GetInt32());
+        Assert.Equal("PLC_1/Blocks", request.GetProperty("startPath").GetString());
+    }
+
+    [Fact]
+    public async Task BrowseProjectTree_InvalidDepthFailsBeforeWorkerAccess()
+    {
+        using var client = CreateClient("missing-worker.exe");
+
+        var response = await ProjectReadTools.BrowseProjectTree(client, depth: 0);
+
+        using var document = JsonDocument.Parse(response);
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("success").GetBoolean());
+        Assert.Equal(
+            WorkerFailureCategories.ValidationError,
+            root.GetProperty("failureCategory").GetString());
+        Assert.Contains("depth", root.GetProperty("error").GetString());
+    }
+}

--- a/TiaMcpServer.Tests/ProjectStandaloneToolTests.cs
+++ b/TiaMcpServer.Tests/ProjectStandaloneToolTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Text.Json;
 using ModelContextProtocol.Server;
+using TiaMcpServer.Batch;
 using TiaMcpServer.Contracts;
 using TiaMcpServer.Tools;
 using TiaMcpServer.Worker;
@@ -23,6 +24,12 @@ public class ProjectStandaloneToolTests
         Assert.False(string.IsNullOrWhiteSpace(payload));
         using var request = JsonDocument.Parse(payload!);
         return request.RootElement.Clone();
+    }
+
+    private static string PayloadFromEnvelope(string response)
+    {
+        using var envelope = JsonDocument.Parse(response);
+        return envelope.RootElement.GetProperty("payload").GetString()!;
     }
 
     [Fact]
@@ -76,6 +83,22 @@ public class ProjectStandaloneToolTests
     }
 
     [Fact]
+    public async Task BrowseProjectTree_OversizedSuccess_IsCappedAtMaxItemChars()
+    {
+        using var client = CreateClient(FakeWorkerLocator.Locate());
+
+        var response = await ProjectReadTools.BrowseProjectTree(
+            client,
+            projectPath: "echo",
+            startPath: new string('x', BatchPayloadBudget.MaxItemChars + 100));
+        var payload = PayloadFromEnvelope(response);
+
+        Assert.Equal(BatchPayloadBudget.MaxItemChars, payload.Length);
+        Assert.Contains("[TRUNCATED", payload);
+        Assert.Contains("depth or a more specific startPath", payload);
+    }
+
+    [Fact]
     public void CompileCheck_HasEngineeringMcpMetadata()
     {
         var method = typeof(ProjectEngineeringTools).GetMethod(
@@ -107,5 +130,21 @@ public class ProjectStandaloneToolTests
         Assert.Equal("echo", request.GetProperty("projectPath").GetString());
         Assert.Equal("PLC_1", request.GetProperty("plcName").GetString());
         Assert.Equal("PLC_1/Blocks/Main", request.GetProperty("blockPath").GetString());
+    }
+
+    [Fact]
+    public async Task CompileCheck_OversizedSuccess_IsCappedAtMaxItemChars()
+    {
+        using var client = CreateClient(FakeWorkerLocator.Locate());
+
+        var response = await ProjectEngineeringTools.CompileCheck(
+            client,
+            projectPath: "echo",
+            blockPath: new string('x', BatchPayloadBudget.MaxItemChars + 100));
+        var payload = PayloadFromEnvelope(response);
+
+        Assert.Equal(BatchPayloadBudget.MaxItemChars, payload.Length);
+        Assert.Contains("[TRUNCATED", payload);
+        Assert.Contains("plcName or blockPath", payload);
     }
 }

--- a/TiaMcpServer.Tests/ReadOnlyModeTests.cs
+++ b/TiaMcpServer.Tests/ReadOnlyModeTests.cs
@@ -467,7 +467,7 @@ public class ReadOnlyModeTests
         var ops = new[]
         {
             new BatchOperationRequest { OperationId = "a", Operation = "update_block_logic", BlockPath = "Main", YamlContent = "x" },
-            new BatchOperationRequest { OperationId = "b", Operation = "compile_check" },
+            new BatchOperationRequest { OperationId = "b", Operation = "read_hardware_config" },
         };
         var errors = BatchOperationCatalog.ValidateAccessMode(ops, McpAccessMode.ReadWrite);
         Assert.Empty(errors);
@@ -487,25 +487,12 @@ public class ReadOnlyModeTests
     }
 
     [Fact]
-    public void ValidateAccessMode_ReadOnly_DeniesCompileCheck()
-    {
-        var ops = new[]
-        {
-            new BatchOperationRequest { OperationId = "a", Operation = "compile_check" },
-        };
-        var errors = BatchOperationCatalog.ValidateAccessMode(ops, McpAccessMode.ReadOnly);
-        Assert.Single(errors);
-        Assert.Contains("compile_check", errors[0]);
-    }
-
-    [Fact]
     public void ValidateAccessMode_ReadOnly_AllowsReadOperations()
     {
         var ops = new[]
         {
-            new BatchOperationRequest { OperationId = "a", Operation = "get_project_status" },
-            new BatchOperationRequest { OperationId = "b", Operation = "browse_project_tree" },
-            new BatchOperationRequest { OperationId = "c", Operation = "get_block_content", BlockPath = "Main" },
+            new BatchOperationRequest { OperationId = "a", Operation = "read_hardware_config" },
+            new BatchOperationRequest { OperationId = "b", Operation = "get_block_content", BlockPath = "Main" },
         };
         var errors = BatchOperationCatalog.ValidateAccessMode(ops, McpAccessMode.ReadOnly);
         Assert.Empty(errors);
@@ -516,7 +503,7 @@ public class ReadOnlyModeTests
     {
         var ops = new[]
         {
-            new BatchOperationRequest { OperationId = "a", Operation = "get_project_status" },
+            new BatchOperationRequest { OperationId = "a", Operation = "read_hardware_config" },
             new BatchOperationRequest { OperationId = "b", Operation = "update_block_logic", BlockPath = "Main", YamlContent = "x" },
         };
         var errors = BatchOperationCatalog.ValidateAccessMode(ops, McpAccessMode.ReadOnly);
@@ -554,10 +541,17 @@ public class ReadOnlyModeTests
             .Select(method => method.GetCustomAttribute<McpServerToolAttribute>())
             .Where(attribute => attribute is not null)
             .Select(attribute => attribute!.Name)
+            .OrderBy(name => name)
             .ToArray();
 
-        Assert.Equal(12, toolNames.Length);
-        Assert.Equal(12, toolNames.Distinct().Count());
+        Assert.Equal(
+            new[]
+            {
+                "apply_write_batch", "archive_project", "browse_project_tree", "close_project",
+                "compile_check", "create_project", "execute_read_batch", "get_project_status",
+                "open_project", "preview_write_batch", "save_project", "save_project_as"
+            },
+            toolNames);
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/ReadOnlyModeTests.cs
+++ b/TiaMcpServer.Tests/ReadOnlyModeTests.cs
@@ -529,21 +529,35 @@ public class ReadOnlyModeTests
     #region Tool Discovery Tests
 
     [Fact]
-    public void ReadWriteMode_HasAllTenTools()
+    public void ReadOnlyMode_HasExactlyThreeTools()
     {
-        // In read-write mode, all 10 tools should be discoverable via assembly scanning.
-        var toolTypes = typeof(ProjectLifecycleTools).Assembly
-            .GetTypes()
-            .Where(t => t.GetCustomAttribute<McpServerToolTypeAttribute>() is not null);
-
-        var toolNames = toolTypes
-            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance))
-            .Select(m => m.GetCustomAttribute<McpServerToolAttribute>())
-            .Where(a => a is not null)
-            .Select(a => a!.Name)
+        var toolNames = new[] { typeof(ProjectReadTools), typeof(ReadBatchTools) }
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => method.GetCustomAttribute<McpServerToolAttribute>())
+            .Where(attribute => attribute is not null)
+            .Select(attribute => attribute!.Name)
+            .OrderBy(name => name)
             .ToArray();
 
-        Assert.Equal(10, toolNames.Length);
+        Assert.Equal(
+            new[] { "browse_project_tree", "execute_read_batch", "get_project_status" },
+            toolNames);
+    }
+
+    [Fact]
+    public void ReadWriteMode_HasExactlyTwelveDistinctTools()
+    {
+        var toolNames = typeof(ProjectLifecycleTools).Assembly
+            .GetTypes()
+            .Where(type => type.GetCustomAttribute<McpServerToolTypeAttribute>() is not null)
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => method.GetCustomAttribute<McpServerToolAttribute>())
+            .Where(attribute => attribute is not null)
+            .Select(attribute => attribute!.Name)
+            .ToArray();
+
+        Assert.Equal(12, toolNames.Length);
+        Assert.Equal(12, toolNames.Distinct().Count());
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/StandaloneToolResultFormatterTests.cs
+++ b/TiaMcpServer.Tests/StandaloneToolResultFormatterTests.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Tools;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+public class StandaloneToolResultFormatterTests
+{
+    [Fact]
+    public void OversizedSuccess_IsCappedWithHintAndKeepsWarnings()
+    {
+        var result = WorkerCallResult.Ok(
+            new string('x', BatchPayloadBudget.MaxItemChars + 100),
+            new[] { "keep this warning" });
+
+        var text = StandaloneToolResultFormatter.Format(
+            result,
+            "Narrow with depth or startPath.");
+
+        using var document = JsonDocument.Parse(text);
+        var root = document.RootElement;
+        var payload = root.GetProperty("payload").GetString()!;
+
+        Assert.True(root.GetProperty("success").GetBoolean());
+        Assert.Equal(BatchPayloadBudget.MaxItemChars, payload.Length);
+        Assert.Contains("[TRUNCATED", payload);
+        Assert.Contains("depth or startPath", payload);
+        Assert.Equal(
+            "keep this warning",
+            root.GetProperty("warnings")[0].GetString());
+    }
+
+    [Fact]
+    public void Failure_IsNotRewrittenOrTruncated()
+    {
+        var result = WorkerCallResult.Fail(
+            WorkerFailureCategories.ValidationError,
+            "invalid input",
+            new[] { "keep this warning" });
+
+        var text = StandaloneToolResultFormatter.Format(result, "unused hint");
+
+        using var document = JsonDocument.Parse(text);
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("success").GetBoolean());
+        Assert.Equal(string.Empty, root.GetProperty("payload").GetString());
+        Assert.Equal(
+            WorkerFailureCategories.ValidationError,
+            root.GetProperty("failureCategory").GetString());
+        Assert.Equal("invalid input", root.GetProperty("error").GetString());
+        Assert.Equal(
+            "keep this warning",
+            root.GetProperty("warnings")[0].GetString());
+    }
+}

--- a/TiaMcpServer.Tests/StandaloneToolResultFormatterTests.cs
+++ b/TiaMcpServer.Tests/StandaloneToolResultFormatterTests.cs
@@ -55,4 +55,21 @@ public class StandaloneToolResultFormatterTests
             "keep this warning",
             root.GetProperty("warnings")[0].GetString());
     }
+
+    [Fact]
+    public void OversizedSuccess_WithOversizedHint_RemainsCapped()
+    {
+        var result = WorkerCallResult.Ok(
+            new string('x', BatchPayloadBudget.MaxItemChars + 100));
+
+        var text = StandaloneToolResultFormatter.Format(
+            result,
+            new string('h', BatchPayloadBudget.MaxItemChars * 2));
+
+        using var document = JsonDocument.Parse(text);
+        var payload = document.RootElement.GetProperty("payload").GetString()!;
+
+        Assert.Equal(BatchPayloadBudget.MaxItemChars, payload.Length);
+        Assert.Contains("[TRUNCATED", payload);
+    }
 }

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -51,6 +51,8 @@
       Link="Host\ProjectLifecycleTools.cs" />
     <Compile Include="..\TiaMcpServer\Tools\ProjectReadTools.cs"
       Link="Host\ProjectReadTools.cs" />
+    <Compile Include="..\TiaMcpServer\Tools\ProjectEngineeringTools.cs"
+      Link="Host\ProjectEngineeringTools.cs" />
     <Compile Include="..\TiaMcpServer\Tools\StandaloneToolResultFormatter.cs"
       Link="Host\StandaloneToolResultFormatter.cs" />
     <Compile Include="..\TiaMcpServer\Tools\ProjectWriteTools.cs"

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -51,6 +51,8 @@
       Link="Host\ProjectLifecycleTools.cs" />
     <Compile Include="..\TiaMcpServer\Tools\ProjectReadTools.cs"
       Link="Host\ProjectReadTools.cs" />
+    <Compile Include="..\TiaMcpServer\Tools\StandaloneToolResultFormatter.cs"
+      Link="Host\StandaloneToolResultFormatter.cs" />
     <Compile Include="..\TiaMcpServer\Tools\ProjectWriteTools.cs"
       Link="Host\ProjectWriteTools.cs" />
     <Compile Include="..\TiaMcpServer\Batch\BatchOperationRequest.cs"

--- a/TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs
+++ b/TiaMcpServer.Tests/WriteToolSafetyTokenTests.cs
@@ -26,9 +26,9 @@ public class WriteToolSafetyTokenTests
     }
 
     [Fact]
-    public void LifecycleSurfaceIsExactlySevenTools()
+    public void ProjectReadAndLifecycleSurfaceIsExactlyEightTools()
     {
-        // Tools have been split into ProjectReadTools (1 tool) and ProjectWriteTools (6 tools).
+        // ProjectReadTools exposes two reads; ProjectWriteTools exposes six lifecycle writes.
         var readToolNames = typeof(ProjectReadTools)
             .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance)
             .Select(m => m.GetCustomAttribute<McpServerToolAttribute>()?.Name)
@@ -46,7 +46,7 @@ public class WriteToolSafetyTokenTests
         Assert.Equal(
             new[]
             {
-                "archive_project", "close_project", "create_project", "get_project_status",
+                "archive_project", "browse_project_tree", "close_project", "create_project", "get_project_status",
                 "open_project", "save_project", "save_project_as"
             },
             allToolNames);

--- a/TiaMcpServer/Batch/BatchOperationCatalog.cs
+++ b/TiaMcpServer/Batch/BatchOperationCatalog.cs
@@ -284,9 +284,9 @@ public static class BatchOperationCatalog
             new BatchOperationSpec("read_hardware_config", BatchOperationCategory.Read, None, None),
             new BatchOperationSpec("search_equipment_catalog", BatchOperationCategory.Read, new[] { "query" }, new[] { "maxResults" }),
             new BatchOperationSpec("read_cross_references", BatchOperationCategory.Read, None, new[] { "plcName", "filter", "maxResults" }),
-            new BatchOperationSpec("get_block_content", BatchOperationCategory.Read, new[] { "blockPath" }, new[] { "format", "withDependencies" }),
+            new BatchOperationSpec("get_block_content", BatchOperationCategory.Read, new[] { "blockPath" }, new[] { "format" }),
             new BatchOperationSpec("list_tag_tables", BatchOperationCategory.Read, None, new[] { "plcName" }),
-            new BatchOperationSpec("get_type_content", BatchOperationCategory.Read, new[] { "typePath" }, new[] { "format", "withDependencies" }),
+            new BatchOperationSpec("get_type_content", BatchOperationCategory.Read, new[] { "typePath" }, new[] { "format" }),
 
             // Data writes
             new BatchOperationSpec("update_block_logic", BatchOperationCategory.Write, new[] { "blockPath", "yamlContent" }, new[] { "format" }),

--- a/TiaMcpServer/Batch/BatchOperationCatalog.cs
+++ b/TiaMcpServer/Batch/BatchOperationCatalog.cs
@@ -267,11 +267,6 @@ public static class BatchOperationCatalog
 
     private static IEnumerable<string> ValidateBounds(BatchOperationRequest op)
     {
-        if (op.Depth is < 1)
-        {
-            yield return "'depth' must be 1 or greater.";
-        }
-
         if (op.MaxResults is < 1)
         {
             yield return "'maxResults' must be 1 or greater.";
@@ -286,15 +281,12 @@ public static class BatchOperationCatalog
         var specs = new[]
         {
             // Reads
-            new BatchOperationSpec("browse_project_tree", BatchOperationCategory.Read, None, new[] { "depth", "startPath" }),
             new BatchOperationSpec("read_hardware_config", BatchOperationCategory.Read, None, None),
             new BatchOperationSpec("search_equipment_catalog", BatchOperationCategory.Read, new[] { "query" }, new[] { "maxResults" }),
             new BatchOperationSpec("read_cross_references", BatchOperationCategory.Read, None, new[] { "plcName", "filter", "maxResults" }),
-            new BatchOperationSpec("get_block_content", BatchOperationCategory.Read, new[] { "blockPath" }, new[] { "format" }),
+            new BatchOperationSpec("get_block_content", BatchOperationCategory.Read, new[] { "blockPath" }, new[] { "format", "withDependencies" }),
             new BatchOperationSpec("list_tag_tables", BatchOperationCategory.Read, None, new[] { "plcName" }),
-            new BatchOperationSpec("compile_check", BatchOperationCategory.Read, None, new[] { "blockPath", "plcName" }),
-            new BatchOperationSpec("get_project_status", BatchOperationCategory.Read, None, None),
-            new BatchOperationSpec("get_type_content", BatchOperationCategory.Read, new[] { "typePath" }, new[] { "format" }),
+            new BatchOperationSpec("get_type_content", BatchOperationCategory.Read, new[] { "typePath" }, new[] { "format", "withDependencies" }),
 
             // Data writes
             new BatchOperationSpec("update_block_logic", BatchOperationCategory.Write, new[] { "blockPath", "yamlContent" }, new[] { "format" }),

--- a/TiaMcpServer/Batch/BatchOperationRequest.cs
+++ b/TiaMcpServer/Batch/BatchOperationRequest.cs
@@ -18,7 +18,7 @@ public sealed class BatchOperationRequest
     [Description("Client-supplied unique identifier for this item within the batch; the result is keyed by it.")]
     public string OperationId { get; set; } = string.Empty;
 
-    [Description("The operation to run for this item. Read operations: browse_project_tree, read_hardware_config, read_cross_references, search_equipment_catalog, get_block_content, list_tag_tables, compile_check, get_project_status, get_type_content. "
+    [Description("The operation to run for this item. Read operations: read_hardware_config, read_cross_references, search_equipment_catalog, get_block_content, list_tag_tables, get_type_content. "
         + "Write operations: update_block_logic, create_block, delete_block, create_block_group, delete_block_group, create_tag_table, delete_tag_table, create_tag, update_tag, delete_tag, create_user_constant, update_user_constant, delete_user_constant, add_network_device, configure_network_device, start_plc, stop_plc, update_type_content. "
         + "Use reads only in execute_read_batch and writes only in preview_write_batch/apply_write_batch.")]
     public string Operation { get; set; } = string.Empty;

--- a/TiaMcpServer/Batch/BatchOperationRequest.cs
+++ b/TiaMcpServer/Batch/BatchOperationRequest.cs
@@ -26,23 +26,17 @@ public sealed class BatchOperationRequest
     [Description("Optional absolute project path (.ap21). When omitted, the active project is used; all write items in one batch must share the same project path.")]
     public string? ProjectPath { get; set; }
 
-    [Description("PLC block path, e.g. PLC_1/Main or PLC_1/Blocks/Folder/Block. Required by get_block_content, update_block_logic, create_block, delete_block, create_block_group, delete_block_group. Optional for compile_check to compile only that block.")]
+    [Description("PLC block path, e.g. PLC_1/Main or PLC_1/Blocks/Folder/Block. Required by get_block_content, update_block_logic, create_block, delete_block, create_block_group, and delete_block_group.")]
     public string? BlockPath { get; set; }
 
     [Description("SIMATIC SD document content for the block. Required by update_block_logic.")]
     public string? YamlContent { get; set; }
 
-    [Description("Optional PLC software name to scope the operation. Honored by list_tag_tables, read_cross_references, compile_check, start_plc, stop_plc, and the tag, tag-table, and user-constant operations.")]
+    [Description("Optional PLC software name to scope the operation. Honored by list_tag_tables, read_cross_references, start_plc, stop_plc, and the tag, tag-table, and user-constant operations.")]
     public string? PlcName { get; set; }
 
     [Description("Hardware catalog search query. Required by search_equipment_catalog.")]
     public string? Query { get; set; }
-
-    [Description("Optional maximum tree depth for browse_project_tree; 1 returns only top-level nodes and marks pruned nodes with a ChildrenOmitted count. Combine with startPath to narrow large projects.")]
-    public int? Depth { get; set; }
-
-    [Description("Optional subtree root for browse_project_tree, matching a node's Path detail exactly (case-insensitive), e.g. PLC_1/Blocks. Errors if no node matches.")]
-    public string? StartPath { get; set; }
 
     [Description("Optional result cap. Valid for search_equipment_catalog (default 50 when omitted) and read_cross_references (unlimited when omitted; a truncation message is added when the cap is hit).")]
     public int? MaxResults { get; set; }

--- a/TiaMcpServer/Batch/BatchPayloadBudget.cs
+++ b/TiaMcpServer/Batch/BatchPayloadBudget.cs
@@ -220,12 +220,12 @@ public static class BatchPayloadBudget
     public static string TruncationTrailer(int maxItemChars)
     {
         var fullTrailer = $"\n[TRUNCATED — this item's payload exceeded {maxItemChars} characters. "
-            + "Narrow the read (plcName, filter, startPath, depth, maxResults) or split the batch.]";
+            + "Narrow the read (plcName, filter, maxResults) or split the batch.]";
         return LimitMarker(fullTrailer, maxItemChars, $"[TRUNCATED: exceeded {maxItemChars} chars]");
     }
 
     public static string OmissionMarker(int maxBatchChars)
         => $"[OMITTED — the combined batch response exceeded {maxBatchChars} characters. "
             + "Re-run this operationId in its own execute_read_batch call, narrowed with "
-            + "plcName/filter/startPath/depth/maxResults.]";
+            + "plcName/filter/maxResults.]";
 }

--- a/TiaMcpServer/Batch/BatchTools.cs
+++ b/TiaMcpServer/Batch/BatchTools.cs
@@ -19,9 +19,9 @@ public static class BatchTools
     private const string PreviewToolName = "preview_write_batch";
     private const string ApplyToolName = "apply_write_batch";
 
-    [Description("Run up to 50 read operations in one call. Each item is { operationId (unique), operation, ...that operation's parameters }; projectPath is optional on every item. Reads run independently, so a failing item does not stop the others. "
-        + "Valid operations (parentheses list required fields): browse_project_tree, read_hardware_config, read_cross_references, search_equipment_catalog (query), get_block_content (blockPath), list_tag_tables, compile_check, get_project_status, get_type_content (typePath). "
-        + "Large projects: bound payloads with depth/startPath (browse_project_tree) and maxResults (search_equipment_catalog, read_cross_references); oversized responses are truncated server-side with an explicit marker.")]
+    [Description("Run up to 50 non-project read operations in one call. Each item is { operationId (unique), operation, ...that operation's parameters }; projectPath is optional on every item. Reads run independently, so a failing item does not stop the others. "
+    + "Valid operations (parentheses list required fields): read_hardware_config, search_equipment_catalog (query), read_cross_references, get_block_content (blockPath), list_tag_tables, get_type_content (typePath). "
+    + "Large reads: bound search_equipment_catalog and read_cross_references with maxResults; oversized responses are truncated or omitted server-side with explicit markers.")]
     public static async Task<string> ExecuteReadBatch(
         OpennessWorkerClient workerClient,
         [Description("Ordered list of read operations. Each: { operationId, operation, ...operation parameters }.")] BatchOperationRequest[] operations)

--- a/TiaMcpServer/Batch/BatchWorkerInvoker.cs
+++ b/TiaMcpServer/Batch/BatchWorkerInvoker.cs
@@ -54,14 +54,11 @@ public static class BatchWorkerInvoker
     public static Task<WorkerCallResult> InvokeAsync(OpennessWorkerClient client, BatchOperationRequest op) => op.Operation switch
     {
         // Reads
-        "browse_project_tree" => client.BrowseProjectTreeAsync(op.ProjectPath, op.Depth, op.StartPath),
         "read_hardware_config" => client.ReadHardwareConfigAsync(op.ProjectPath),
         "search_equipment_catalog" => client.SearchEquipmentCatalogAsync(op.Query!, op.ProjectPath, op.MaxResults),
         "read_cross_references" => client.ReadCrossReferencesAsync(op.ProjectPath, op.PlcName, op.Filter, op.MaxResults),
         "get_block_content" => InvokeGetBlockContent(client, op),
         "list_tag_tables" => client.ListTagTablesAsync(op.PlcName, op.ProjectPath),
-        "compile_check" => client.CompileCheckAsync(op.BlockPath, op.PlcName, op.ProjectPath),
-        "get_project_status" => client.GetProjectStatusAsync(op.ProjectPath),
         "get_type_content" => InvokeGetTypeContent(client, op),
 
         // Data writes

--- a/TiaMcpServer/Batch/ReadBatchTools.cs
+++ b/TiaMcpServer/Batch/ReadBatchTools.cs
@@ -12,9 +12,9 @@ namespace TiaMcpServer.Batch;
 public class ReadBatchTools
 {
     [McpServerTool(Name = "execute_read_batch", ReadOnly = true, Destructive = false, OpenWorld = false)]
-    [Description("Run up to 50 read operations in one call. Each item is { operationId (unique), operation, ...that operation's parameters }; projectPath is optional on every item. Reads run independently, so a failing item does not stop the others. "
-        + "Valid operations (parentheses list required fields): browse_project_tree, read_hardware_config, read_cross_references, search_equipment_catalog (query), get_block_content (blockPath), list_tag_tables, get_project_status, and compile_check (read-write mode only). "
-        + "Large projects: bound payloads with depth/startPath (browse_project_tree) and maxResults (search_equipment_catalog, read_cross_references); oversized responses are truncated server-side with an explicit marker.")]
+    [Description("Run up to 50 non-project read operations in one call. Each item is { operationId (unique), operation, ...that operation's parameters }; projectPath is optional on every item. Reads run independently, so a failing item does not stop the others. "
+    + "Valid operations (parentheses list required fields): read_hardware_config, search_equipment_catalog (query), read_cross_references, get_block_content (blockPath), list_tag_tables, get_type_content (typePath). "
+    + "Large reads: bound search_equipment_catalog and read_cross_references with maxResults; oversized responses are truncated or omitted server-side with explicit markers.")]
     public static async Task<string> ExecuteReadBatch(
         OpennessWorkerClient workerClient,
         [Description("Ordered list of read operations. Each: { operationId, operation, ...operation parameters }.")] BatchOperationRequest[] operations)

--- a/TiaMcpServer/Program.cs
+++ b/TiaMcpServer/Program.cs
@@ -64,7 +64,8 @@ namespace TiaMcpServer
 
             if (accessMode == McpAccessMode.ReadWrite)
             {
-                mcp.WithTools<ProjectWriteTools>()
+                mcp.WithTools<ProjectEngineeringTools>()
+                   .WithTools<ProjectWriteTools>()
                    .WithTools<WriteBatchTools>();
             }
 

--- a/TiaMcpServer/Tools/ProjectEngineeringTools.cs
+++ b/TiaMcpServer/Tools/ProjectEngineeringTools.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Tools;
+
+/// <summary>Project engineering actions exposed only in read-write mode.</summary>
+[McpServerToolType]
+public class ProjectEngineeringTools
+{
+    [McpServerTool(Name = "compile_check", ReadOnly = false, Destructive = false, OpenWorld = false)]
+    [Description("Compile a PLC or selected block scope and return compiler messages. Available only in read-write mode.")]
+    public static async Task<string> CompileCheck(
+        OpennessWorkerClient workerClient,
+        [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null,
+        [Description("Optional PLC software name to compile.")] string? plcName = null,
+        [Description("Optional PLC block path to compile only that block.")] string? blockPath = null)
+    {
+        var result = await workerClient
+            .CompileCheckAsync(blockPath, plcName, projectPath)
+            .ConfigureAwait(false);
+        return StandaloneToolResultFormatter.Format(
+            result,
+            "Narrow the compile with plcName or blockPath.");
+    }
+}

--- a/TiaMcpServer/Tools/ProjectReadTools.cs
+++ b/TiaMcpServer/Tools/ProjectReadTools.cs
@@ -1,12 +1,11 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
+using TiaMcpServer.Contracts;
 using TiaMcpServer.Worker;
 
 namespace TiaMcpServer.Tools;
 
-/// <summary>
-/// Read-only project tools. Exposed in both read-only and read-write modes.
-/// </summary>
+/// <summary>Read-only project tools exposed in both access modes.</summary>
 [McpServerToolType]
 public class ProjectReadTools
 {
@@ -16,4 +15,29 @@ public class ProjectReadTools
         OpennessWorkerClient workerClient,
         [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null)
         => (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToEnvelopeText();
+
+    [McpServerTool(Name = "browse_project_tree", ReadOnly = true, Destructive = false, OpenWorld = false)]
+    [Description("Browse the active TIA Portal project hierarchy. Use depth and startPath to bound large projects.")]
+    public static async Task<string> BrowseProjectTree(
+        OpennessWorkerClient workerClient,
+        [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null,
+        [Description("Optional maximum tree depth. Must be 1 or greater; 1 returns only top-level nodes.")] int? depth = null,
+        [Description("Optional subtree root matching a node Path exactly, case-insensitively, e.g. PLC_1/Blocks.")] string? startPath = null)
+    {
+        if (depth is < 1)
+        {
+            return StandaloneToolResultFormatter.Format(
+                WorkerCallResult.Fail(
+                    WorkerFailureCategories.ValidationError,
+                    "'depth' must be 1 or greater."),
+                "Use a valid depth or omit it.");
+        }
+
+        var result = await workerClient
+            .BrowseProjectTreeAsync(projectPath, depth, startPath)
+            .ConfigureAwait(false);
+        return StandaloneToolResultFormatter.Format(
+            result,
+            "Narrow the read with a smaller depth or a more specific startPath.");
+    }
 }

--- a/TiaMcpServer/Tools/StandaloneToolResultFormatter.cs
+++ b/TiaMcpServer/Tools/StandaloneToolResultFormatter.cs
@@ -9,8 +9,16 @@ internal static class StandaloneToolResultFormatter
     {
         if (result.Success && result.Payload.Length > BatchPayloadBudget.MaxItemChars)
         {
-            var trailer = $"\n[TRUNCATED — payload exceeded "
-                + $"{BatchPayloadBudget.MaxItemChars} characters. {narrowingHint}]";
+            var trailerPrefix = $"\n[TRUNCATED — payload exceeded "
+                + $"{BatchPayloadBudget.MaxItemChars} characters. ";
+            const string trailerSuffix = "]";
+            var maxHintLength = Math.Max(
+                0,
+                BatchPayloadBudget.MaxItemChars - trailerPrefix.Length - trailerSuffix.Length);
+            var boundedHint = narrowingHint.Substring(
+                0,
+                Math.Min(narrowingHint.Length, maxHintLength));
+            var trailer = trailerPrefix + boundedHint + trailerSuffix;
             var retainedLength = Math.Max(
                 0,
                 BatchPayloadBudget.MaxItemChars - trailer.Length);

--- a/TiaMcpServer/Tools/StandaloneToolResultFormatter.cs
+++ b/TiaMcpServer/Tools/StandaloneToolResultFormatter.cs
@@ -1,0 +1,26 @@
+using TiaMcpServer.Batch;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Tools;
+
+internal static class StandaloneToolResultFormatter
+{
+    public static string Format(WorkerCallResult result, string narrowingHint)
+    {
+        if (result.Success && result.Payload.Length > BatchPayloadBudget.MaxItemChars)
+        {
+            var trailer = $"\n[TRUNCATED — payload exceeded "
+                + $"{BatchPayloadBudget.MaxItemChars} characters. {narrowingHint}]";
+            var retainedLength = Math.Max(
+                0,
+                BatchPayloadBudget.MaxItemChars - trailer.Length);
+
+            result = result with
+            {
+                Payload = result.Payload.Substring(0, retainedLength) + trailer
+            };
+        }
+
+        return result.ToEnvelopeText();
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,7 +53,7 @@ falling back to another mode.
 
 ### Read-write mode
 
-Read-write mode preserves the complete tool surface and the existing
+Read-write mode exposes the complete 12-tool surface and preserves the existing
 preview-then-apply safety-token model.
 
 ### Read-only mode
@@ -75,6 +75,7 @@ Tool registration is explicit and mode-dependent. The host always registers:
 
 It registers the following only in read-write mode:
 
+- `ProjectEngineeringTools`
 - `ProjectWriteTools`
 - `WriteBatchTools`
 
@@ -87,26 +88,23 @@ part of the active tool surface.
 | Tool | Purpose |
 |---|---|
 | `get_project_status` | Return status and metadata for the project already open in TIA Portal. |
+| `browse_project_tree` | Return a bounded project subtree using optional `depth` and `startPath`. |
 | `execute_read_batch` | Execute up to 50 validated observation operations. |
 
 The read batch supports:
 
-- `browse_project_tree`
 - `read_hardware_config`
 - `search_equipment_catalog`
 - `read_cross_references`
 - `get_block_content`
 - `list_tag_tables`
-- `get_project_status`
-
-`compile_check` remains part of the read-batch catalog for read-write mode, but
-it is denied in read-only mode because the Siemens compilation API may modify
-internal project state.
+- `get_type_content`
 
 ### Additional read-write tools
 
 | Tool | Purpose |
 |---|---|
+| `compile_check` | Compile a PLC or selected block and return compiler messages. This engineering tool is read-write-only and does not use a safety token. |
 | `open_project` | Open and bind a project. |
 | `create_project` | Create and bind a project. |
 | `save_project` | Save the active project. |
@@ -199,9 +197,9 @@ remaining items from running.
 Write batches execute sequentially and stop on the first failure. Already
 completed writes are not rolled back.
 
-Access-mode validation runs before a read batch starts. This is why a
-`compile_check` item is rejected as a whole-batch validation error in read-only
-mode rather than being sent to the worker.
+`compile_check` is absent from read-only tool discovery. The underlying access
+policy also rejects internal compile requests in read-only mode before they are
+sent to the worker.
 
 ## 8. Write safety
 

--- a/docs/SupportedOperations/DEVICES_OPERATIONS_SUMMARY.md
+++ b/docs/SupportedOperations/DEVICES_OPERATIONS_SUMMARY.md
@@ -8,7 +8,7 @@
 | `execute_read_batch` | `search_equipment_catalog` | Requires `query`; accepts bounded `maxResults`; returns catalog type identifiers for candidate devices. |
 | `preview_write_batch` → `apply_write_batch` | `add_network_device` | Requires an exact catalog `typeIdentifier` and `deviceName`; accepts optional `deviceItemName`. |
 | `preview_write_batch` → `apply_write_batch` | `configure_network_device` | Requires `deviceName`; accepts `ipAddress`, `subnetMask`, `pnDeviceName`, `subnetName`, and `ioSystemName`. |
-| `execute_read_batch` | `browse_project_tree` | Locates devices and other project objects; accepts optional `depth` and `startPath`. |
+| `browse_project_tree` | `browse_project_tree` | Locates devices and other project objects; accepts optional `projectPath`, `depth`, and `startPath`. |
 
 `add_network_device` and `configure_network_device` are data writes. Preview the complete ordered sequence and apply it with the returned token. The catalog identifier and device name are validated before the worker performs the change.
 

--- a/docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md
+++ b/docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md
@@ -2,16 +2,16 @@
 
 ## Supported read operations
 
-| Operation | Inputs | Behavior |
-|---|---|---|
-| `browse_project_tree` | Optional `depth`, `startPath` | Locates PLC software, blocks, groups, types, and other project objects. |
-| `get_block_content` | Required `blockPath`; optional `format` | Reads an existing block as XML/SimaticML or an eligible external source. See [IMPORT_EXPORT_OPTIONS_SUMMARY.md](IMPORT_EXPORT_OPTIONS_SUMMARY.md). |
-| `get_type_content` | Required `typePath`; optional `format` | Reads an existing PLC type as `.udt` source or XML/SimaticML. |
-| `list_tag_tables` | Optional `plcName` | Lists PLC tag tables and the exposed tag and constant information. |
-| `read_cross_references` | Optional `plcName`, `filter`, `maxResults` | Reads cross-references. Filters are `AllObjects`, `ObjectsWithReferences`, `ObjectsWithoutReferences`, and `UnusedObjects`. |
-| `compile_check` | Optional `plcName`, `blockPath` | Compiles the PLC or selected block scope and returns compiler messages. |
+| Entry point | Operation | Inputs | Behavior |
+|---|---|---|---|
+| `browse_project_tree` | `browse_project_tree` | Optional `projectPath`, `depth`, `startPath` | Locates PLC software, blocks, groups, types, and other project objects. |
+| `execute_read_batch` | `get_block_content` | Required `blockPath`; optional `format` | Reads an existing block as XML/SimaticML or an eligible external source. See [IMPORT_EXPORT_OPTIONS_SUMMARY.md](IMPORT_EXPORT_OPTIONS_SUMMARY.md). |
+| `execute_read_batch` | `get_type_content` | Required `typePath`; optional `format` | Reads an existing PLC type as `.udt` source or XML/SimaticML. |
+| `execute_read_batch` | `list_tag_tables` | Optional `plcName` | Lists PLC tag tables and the exposed tag and constant information. |
+| `execute_read_batch` | `read_cross_references` | Optional `plcName`, `filter`, `maxResults` | Reads cross-references. Filters are `AllObjects`, `ObjectsWithReferences`, `ObjectsWithoutReferences`, and `UnusedObjects`. |
+| `compile_check` | `compile_check` | Optional `projectPath`, `plcName`, `blockPath` | Compiles the PLC or selected block scope and returns compiler messages. |
 
-`compile_check` is classified as a read operation for batch and safety purposes, but it performs a compile action in TIA Portal.
+Tree browsing and compilation are standalone tools. `compile_check` is a read-write-mode engineering operation and does not use a safety token.
 
 ## Supported write operations
 

--- a/docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md
+++ b/docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md
@@ -5,11 +5,10 @@
 | Entry point | Operation | Inputs and behavior |
 |---|---|---|
 | `get_project_status` | `get_project_status` | Optional `projectPath`; reads status and metadata without opening or switching projects. |
-| `execute_read_batch` | `get_project_status` | The same status read inside a read batch. |
-| `execute_read_batch` | `browse_project_tree` | Optional `depth` and `startPath`; returns bounded project-tree data. |
-| `execute_read_batch` | `compile_check` | Optional `plcName` and `blockPath`; compiles the selected scope and returns compiler messages. |
+| `browse_project_tree` | `browse_project_tree` | Optional `projectPath`, `depth`, and `startPath`; returns bounded project-tree data. |
+| `compile_check` | `compile_check` | Optional `projectPath`, `plcName`, and `blockPath`; compiles the selected scope and returns compiler messages. Available only in read-write mode. |
 
-`compile_check` is a read-batch operation for safety classification, although compiling is an engineering action in TIA Portal.
+`compile_check` is a standalone engineering operation. It is not marked read-only, does not use a safety token, and is exposed only in read-write mode.
 
 ## Lifecycle operations
 

--- a/docs/SupportedOperations/README.md
+++ b/docs/SupportedOperations/README.md
@@ -22,7 +22,9 @@ Every batch item contains an `operationId`, an `operation` name, and the fields 
 
 `execute_read_batch` supports:
 
-`browse_project_tree`, `read_hardware_config`, `search_equipment_catalog`, `read_cross_references`, `get_block_content`, `list_tag_tables`, `compile_check`, `get_project_status`, and `get_type_content`.
+`read_hardware_config`, `search_equipment_catalog`, `read_cross_references`, `get_block_content`, `list_tag_tables`, and `get_type_content`.
+
+Project status, project-tree browsing, and compilation are separate tools: `get_project_status`, `browse_project_tree`, and `compile_check`. The first two are available in both access modes; `compile_check` is available only in read-write mode.
 
 #### Write operations
 
@@ -43,7 +45,7 @@ The server also provides six single-purpose lifecycle tools:
 | `archive_project` | Archives a project to the requested location. |
 | `close_project` | Closes the active project and clears the session binding. |
 
-`get_project_status` is both a standalone read tool and a read-batch operation. It reads project metadata without opening or switching projects.
+`get_project_status`, `browse_project_tree`, and `compile_check` are standalone project tools rather than batch operations.
 
 ## Write safety
 

--- a/docs/superpowers/plans/2026-07-31-standalone-project-tools.md
+++ b/docs/superpowers/plans/2026-07-31-standalone-project-tools.md
@@ -1,0 +1,1050 @@
+# Standalone Project Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose `get_project_status`, `browse_project_tree`, and `compile_check` as standalone project tools and remove all three from `execute_read_batch` without changing worker protocol or TIA Openness behavior.
+
+**Architecture:** Keep the existing `OpennessWorkerClient` and .NET Framework worker methods unchanged. Add thin standalone host-tool adapters, conditionally register the engineering-only compile tool, preserve the existing 60,000-character per-result cap, and narrow the generic read-batch catalog and schema to six non-project operations.
+
+**Tech Stack:** C#/.NET 8 host and tests, ModelContextProtocol 1.2.0, xUnit 2.9.0, FakeWorker newline-delimited JSON integration tests, PowerShell 7 verification, .NET Framework 4.8 Openness worker unchanged.
+
+## Global Constraints
+
+- Work on the existing `codex/project-lifecycle-separation` branch; do not create a worktree or switch branches.
+- Follow TDD for every behavior change: add the focused test, run it and observe RED, then edit production code.
+- Immediate breaking removal: no aliases, deprecation period, warnings, or migration-specific errors for removed batch operations.
+- `compile_check` remains unavailable in read-only mode and does not gain the lifecycle preview/apply safety-token flow.
+- Keep project binding, timeout/crash handling, warning propagation, worker request method names, and worker handlers unchanged.
+- Keep successful standalone tree and compile payloads capped at exactly `BatchPayloadBudget.MaxItemChars` (60,000 characters).
+- Do not edit `TiaMcpServer.OpennessWorker/` or `TiaMcpServer.Contracts/WorkerRequest.cs`.
+- Do not run live TIA Portal operations; this host-surface refactor is verified with unit tests, FakeWorker integration tests, the stub build, and coverage.
+- Serialize solution builds with `-m:1` and use `/p:UseTiaPortalReferenceStubs=true`.
+- Do not commit unless the user explicitly authorizes commits during execution. Each task's commit step is conditional on that authorization.
+
+---
+
+## File Structure
+
+### Create
+
+- `TiaMcpServer/Tools/StandaloneToolResultFormatter.cs` — cap successful standalone payloads and serialize the existing structured envelope.
+- `TiaMcpServer/Tools/ProjectEngineeringTools.cs` — read-write-mode-only `compile_check` MCP adapter.
+- `TiaMcpServer.Tests/StandaloneToolResultFormatterTests.cs` — payload cap and failure/warning preservation tests.
+- `TiaMcpServer.Tests/ProjectStandaloneToolTests.cs` — standalone tool metadata, validation, and FakeWorker forwarding tests.
+
+### Modify
+
+- `TiaMcpServer/Tools/ProjectReadTools.cs` — add standalone `browse_project_tree`.
+- `TiaMcpServer/Program.cs` — register `ProjectEngineeringTools` only in read-write mode.
+- `TiaMcpServer.Tests/TiaMcpServer.Tests.csproj` — link the two new host source files into the test project.
+- `TiaMcpServer.Tests/McpToolSchemaTests.cs` — pin standalone model-facing schemas and the 12-tool surface.
+- `TiaMcpServer.Tests/ReadOnlyModeTests.cs` — pin the 3-tool read-only and 12-tool read-write surfaces.
+- `TiaMcpServer/Batch/BatchOperationRequest.cs` — remove tree-only batch fields and project-operation description claims.
+- `TiaMcpServer/Batch/BatchOperationCatalog.cs` — remove three project reads and depth validation.
+- `TiaMcpServer/Batch/BatchWorkerInvoker.cs` — remove the three read-dispatch arms only.
+- `TiaMcpServer/Batch/ReadBatchTools.cs` — publish the exact six-operation generic read list.
+- `TiaMcpServer/Batch/BatchTools.cs` — keep the backward-compatible wrapper description aligned.
+- `TiaMcpServer/Batch/BatchPayloadBudget.cs` — remove standalone-only narrowing hints from batch markers.
+- `TiaMcpServer.Tests/BatchOperationCatalogTests.cs` — pin immediate removal and the reduced field contract.
+- `TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs` — reject removed batch fields.
+- `TiaMcpServer.Tests/BatchToolMetadataTests.cs` — pin both batch descriptions and DTO descriptions.
+- `TiaMcpServer.Tests/BatchPayloadBudgetTests.cs` — pin generic-batch narrowing guidance.
+- `README.md`, `docs/ARCHITECTURE.md`, and affected `docs/SupportedOperations/*.md` — document the 12-tool standalone project surface.
+
+---
+
+### Task 1: Bound standalone result envelopes
+
+**Files:**
+
+- Create: `TiaMcpServer/Tools/StandaloneToolResultFormatter.cs`
+- Create: `TiaMcpServer.Tests/StandaloneToolResultFormatterTests.cs`
+- Modify: `TiaMcpServer.Tests/TiaMcpServer.Tests.csproj` (host `Tools` compile links)
+
+**Interfaces:**
+
+- Consumes: `WorkerCallResult`, `WorkerCallResult.ToEnvelopeText()`, and `BatchPayloadBudget.MaxItemChars`.
+- Produces: `StandaloneToolResultFormatter.Format(WorkerCallResult result, string narrowingHint) : string`.
+- Contract: cap only successful `Payload`; never alter failure category, error, warnings, or success state.
+
+- [ ] **Step 1: Write the failing formatter tests**
+
+Create `TiaMcpServer.Tests/StandaloneToolResultFormatterTests.cs`:
+
+```csharp
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Tools;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+public class StandaloneToolResultFormatterTests
+{
+    [Fact]
+    public void OversizedSuccess_IsCappedWithHintAndKeepsWarnings()
+    {
+        var result = WorkerCallResult.Ok(
+            new string('x', BatchPayloadBudget.MaxItemChars + 100),
+            new[] { "keep this warning" });
+
+        var text = StandaloneToolResultFormatter.Format(
+            result,
+            "Narrow with depth or startPath.");
+
+        using var document = JsonDocument.Parse(text);
+        var root = document.RootElement;
+        var payload = root.GetProperty("payload").GetString()!;
+
+        Assert.True(root.GetProperty("success").GetBoolean());
+        Assert.Equal(BatchPayloadBudget.MaxItemChars, payload.Length);
+        Assert.Contains("[TRUNCATED", payload);
+        Assert.Contains("depth or startPath", payload);
+        Assert.Equal(
+            "keep this warning",
+            root.GetProperty("warnings")[0].GetString());
+    }
+
+    [Fact]
+    public void Failure_IsNotRewrittenOrTruncated()
+    {
+        var result = WorkerCallResult.Fail(
+            WorkerFailureCategories.ValidationError,
+            "invalid input",
+            new[] { "keep this warning" });
+
+        var text = StandaloneToolResultFormatter.Format(result, "unused hint");
+
+        using var document = JsonDocument.Parse(text);
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("success").GetBoolean());
+        Assert.Equal(string.Empty, root.GetProperty("payload").GetString());
+        Assert.Equal(
+            WorkerFailureCategories.ValidationError,
+            root.GetProperty("failureCategory").GetString());
+        Assert.Equal("invalid input", root.GetProperty("error").GetString());
+        Assert.Equal(
+            "keep this warning",
+            root.GetProperty("warnings")[0].GetString());
+    }
+}
+```
+
+- [ ] **Step 2: Run the formatter tests and observe RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore --filter "FullyQualifiedName~StandaloneToolResultFormatterTests"
+```
+
+Expected: build/test failure because `StandaloneToolResultFormatter` does not exist.
+
+- [ ] **Step 3: Implement the minimal formatter**
+
+Create `TiaMcpServer/Tools/StandaloneToolResultFormatter.cs`:
+
+```csharp
+using TiaMcpServer.Batch;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Tools;
+
+internal static class StandaloneToolResultFormatter
+{
+    public static string Format(WorkerCallResult result, string narrowingHint)
+    {
+        if (result.Success && result.Payload.Length > BatchPayloadBudget.MaxItemChars)
+        {
+            var fullTrailer = $"\n[TRUNCATED — payload exceeded "
+                + $"{BatchPayloadBudget.MaxItemChars} characters. {narrowingHint}]";
+            var trailer = fullTrailer.Length <= BatchPayloadBudget.MaxItemChars
+                ? fullTrailer
+                : fullTrailer.Substring(0, BatchPayloadBudget.MaxItemChars);
+            var retainedLength = Math.Max(
+                0,
+                BatchPayloadBudget.MaxItemChars - trailer.Length);
+
+            result = result with
+            {
+                Payload = result.Payload.Substring(0, retainedLength) + trailer
+            };
+        }
+
+        return result.ToEnvelopeText();
+    }
+}
+```
+
+Add this compile link beside `ProjectReadTools.cs` in `TiaMcpServer.Tests/TiaMcpServer.Tests.csproj`:
+
+```xml
+    <Compile Include="..\TiaMcpServer\Tools\StandaloneToolResultFormatter.cs"
+      Link="Host\StandaloneToolResultFormatter.cs" />
+```
+
+- [ ] **Step 4: Run the formatter tests and observe GREEN**
+
+Run the command from Step 2.
+
+Expected: both `StandaloneToolResultFormatterTests` pass.
+
+- [ ] **Step 5: Commit only if commits were explicitly authorized**
+
+If authorized:
+
+```powershell
+git add TiaMcpServer/Tools/StandaloneToolResultFormatter.cs TiaMcpServer.Tests/StandaloneToolResultFormatterTests.cs TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+git commit -m "refactor: bound standalone tool results"
+```
+
+Otherwise leave the verified changes uncommitted and continue.
+
+---
+
+### Task 2: Expose `browse_project_tree` as a standalone read tool
+
+**Files:**
+
+- Create: `TiaMcpServer.Tests/ProjectStandaloneToolTests.cs`
+- Modify: `TiaMcpServer/Tools/ProjectReadTools.cs:10-19`
+- Modify: `TiaMcpServer.Tests/McpToolSchemaTests.cs` (standalone read schema tests)
+
+**Interfaces:**
+
+- Consumes: `OpennessWorkerClient.BrowseProjectTreeAsync(string? projectPath, int? depth, string? startPath)` and `StandaloneToolResultFormatter.Format`.
+- Produces: `ProjectReadTools.BrowseProjectTree(OpennessWorkerClient workerClient, string? projectPath = null, int? depth = null, string? startPath = null) : Task<string>`.
+- Validation: `depth < 1` returns `WorkerFailureCategories.ValidationError` without worker access.
+
+- [ ] **Step 1: Write failing metadata, validation, forwarding, and schema tests**
+
+Create `TiaMcpServer.Tests/ProjectStandaloneToolTests.cs`:
+
+```csharp
+using System.Reflection;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Tools;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+public class ProjectStandaloneToolTests
+{
+    private static OpennessWorkerClient CreateClient(string workerPath)
+        => new(
+            new ProjectSessionBinding(null),
+            logger: null,
+            workerExecutablePath: workerPath);
+
+    private static JsonElement WorkerRequestFromEnvelope(string response)
+    {
+        using var envelope = JsonDocument.Parse(response);
+        var payload = envelope.RootElement.GetProperty("payload").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(payload));
+        using var request = JsonDocument.Parse(payload!);
+        return request.RootElement.Clone();
+    }
+
+    [Fact]
+    public void BrowseProjectTree_HasReadOnlyMcpMetadata()
+    {
+        var method = typeof(ProjectReadTools).GetMethod(
+            nameof(ProjectReadTools.BrowseProjectTree),
+            BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        var attribute = method!.GetCustomAttribute<McpServerToolAttribute>();
+        Assert.NotNull(attribute);
+        Assert.Equal("browse_project_tree", attribute!.Name);
+        Assert.True(attribute.ReadOnly);
+        Assert.False(attribute.Destructive);
+        Assert.False(attribute.OpenWorld);
+    }
+
+    [Fact]
+    public async Task BrowseProjectTree_ForwardsEveryArgument()
+    {
+        using var client = CreateClient(FakeWorkerLocator.Locate());
+
+        var response = await ProjectReadTools.BrowseProjectTree(
+            client,
+            projectPath: "echo",
+            depth: 2,
+            startPath: "PLC_1/Blocks");
+        var request = WorkerRequestFromEnvelope(response);
+
+        Assert.Equal("browse_project_tree", request.GetProperty("method").GetString());
+        Assert.Equal("echo", request.GetProperty("projectPath").GetString());
+        Assert.Equal(2, request.GetProperty("depth").GetInt32());
+        Assert.Equal("PLC_1/Blocks", request.GetProperty("startPath").GetString());
+    }
+
+    [Fact]
+    public async Task BrowseProjectTree_InvalidDepthFailsBeforeWorkerAccess()
+    {
+        using var client = CreateClient("missing-worker.exe");
+
+        var response = await ProjectReadTools.BrowseProjectTree(client, depth: 0);
+
+        using var document = JsonDocument.Parse(response);
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("success").GetBoolean());
+        Assert.Equal(
+            WorkerFailureCategories.ValidationError,
+            root.GetProperty("failureCategory").GetString());
+        Assert.Contains("depth", root.GetProperty("error").GetString());
+    }
+}
+```
+
+Add this test to `McpToolSchemaTests.cs`:
+
+```csharp
+    [Fact]
+    public void BrowseProjectTree_SchemaExposesOnlyModelInputs()
+    {
+        var properties = SchemaPropertyNames(
+            typeof(ProjectReadTools),
+            nameof(ProjectReadTools.BrowseProjectTree));
+
+        Assert.Equal(
+            new[] { "depth", "projectPath", "startPath" },
+            properties.OrderBy(name => name).ToArray());
+        Assert.DoesNotContain("workerClient", properties);
+    }
+```
+
+- [ ] **Step 2: Run the focused tests and observe RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore --filter "FullyQualifiedName~ProjectStandaloneToolTests|FullyQualifiedName~BrowseProjectTree_SchemaExposesOnlyModelInputs"
+```
+
+Expected: compilation failure because `ProjectReadTools.BrowseProjectTree` does not exist.
+
+- [ ] **Step 3: Add the standalone method**
+
+Replace `TiaMcpServer/Tools/ProjectReadTools.cs` with:
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Tools;
+
+/// <summary>Read-only project tools exposed in both access modes.</summary>
+[McpServerToolType]
+public class ProjectReadTools
+{
+    [McpServerTool(Name = "get_project_status", ReadOnly = true, Destructive = false, OpenWorld = false)]
+    [Description("Get status and metadata for the active TIA Portal project.")]
+    public static async Task<string> GetProjectStatus(
+        OpennessWorkerClient workerClient,
+        [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null)
+        => (await workerClient.GetProjectStatusAsync(projectPath).ConfigureAwait(false)).ToEnvelopeText();
+
+    [McpServerTool(Name = "browse_project_tree", ReadOnly = true, Destructive = false, OpenWorld = false)]
+    [Description("Browse the active TIA Portal project hierarchy. Use depth and startPath to bound large projects.")]
+    public static async Task<string> BrowseProjectTree(
+        OpennessWorkerClient workerClient,
+        [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null,
+        [Description("Optional maximum tree depth. Must be 1 or greater; 1 returns only top-level nodes.")] int? depth = null,
+        [Description("Optional subtree root matching a node Path exactly, case-insensitively, e.g. PLC_1/Blocks.")] string? startPath = null)
+    {
+        if (depth is < 1)
+        {
+            return StandaloneToolResultFormatter.Format(
+                WorkerCallResult.Fail(
+                    WorkerFailureCategories.ValidationError,
+                    "'depth' must be 1 or greater."),
+                "Use a valid depth or omit it.");
+        }
+
+        var result = await workerClient
+            .BrowseProjectTreeAsync(projectPath, depth, startPath)
+            .ConfigureAwait(false);
+        return StandaloneToolResultFormatter.Format(
+            result,
+            "Narrow the read with a smaller depth or a more specific startPath.");
+    }
+}
+```
+
+- [ ] **Step 4: Run the focused tests and observe GREEN**
+
+Run the command from Step 2.
+
+Expected: metadata, forwarding, validation, and schema tests pass.
+
+- [ ] **Step 5: Commit only if commits were explicitly authorized**
+
+If authorized:
+
+```powershell
+git add TiaMcpServer/Tools/ProjectReadTools.cs TiaMcpServer.Tests/ProjectStandaloneToolTests.cs TiaMcpServer.Tests/McpToolSchemaTests.cs
+git commit -m "feat: expose project tree as standalone tool"
+```
+
+Otherwise leave the verified changes uncommitted and continue.
+
+---
+
+### Task 3: Expose `compile_check` only in read-write mode
+
+**Files:**
+
+- Create: `TiaMcpServer/Tools/ProjectEngineeringTools.cs`
+- Modify: `TiaMcpServer/Program.cs:55-68`
+- Modify: `TiaMcpServer.Tests/TiaMcpServer.Tests.csproj` (host `Tools` compile links)
+- Modify: `TiaMcpServer.Tests/ProjectStandaloneToolTests.cs`
+- Modify: `TiaMcpServer.Tests/McpToolSchemaTests.cs`
+- Modify: `TiaMcpServer.Tests/ReadOnlyModeTests.cs:531-601`
+
+**Interfaces:**
+
+- Consumes: `OpennessWorkerClient.CompileCheckAsync(string? blockPath, string? plcName, string? projectPath)` and `StandaloneToolResultFormatter.Format`.
+- Produces: `ProjectEngineeringTools.CompileCheck(OpennessWorkerClient workerClient, string? projectPath = null, string? plcName = null, string? blockPath = null) : Task<string>`.
+- Registration: `ProjectEngineeringTools` appears only inside the `McpAccessMode.ReadWrite` branch in `Program.Main`.
+
+- [ ] **Step 1: Write the failing engineering-tool tests**
+
+Append to `ProjectStandaloneToolTests.cs`:
+
+```csharp
+    [Fact]
+    public void CompileCheck_HasEngineeringMcpMetadata()
+    {
+        var method = typeof(ProjectEngineeringTools).GetMethod(
+            nameof(ProjectEngineeringTools.CompileCheck),
+            BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        var attribute = method!.GetCustomAttribute<McpServerToolAttribute>();
+        Assert.NotNull(attribute);
+        Assert.Equal("compile_check", attribute!.Name);
+        Assert.False(attribute.ReadOnly);
+        Assert.False(attribute.Destructive);
+        Assert.False(attribute.OpenWorld);
+    }
+
+    [Fact]
+    public async Task CompileCheck_ForwardsEveryArgument()
+    {
+        using var client = CreateClient(FakeWorkerLocator.Locate());
+
+        var response = await ProjectEngineeringTools.CompileCheck(
+            client,
+            projectPath: "echo",
+            plcName: "PLC_1",
+            blockPath: "PLC_1/Blocks/Main");
+        var request = WorkerRequestFromEnvelope(response);
+
+        Assert.Equal("compile_check", request.GetProperty("method").GetString());
+        Assert.Equal("echo", request.GetProperty("projectPath").GetString());
+        Assert.Equal("PLC_1", request.GetProperty("plcName").GetString());
+        Assert.Equal("PLC_1/Blocks/Main", request.GetProperty("blockPath").GetString());
+    }
+```
+
+Add to `McpToolSchemaTests.cs`:
+
+```csharp
+    [Fact]
+    public void CompileCheck_SchemaExposesOnlyModelInputs()
+    {
+        var properties = SchemaPropertyNames(
+            typeof(ProjectEngineeringTools),
+            nameof(ProjectEngineeringTools.CompileCheck));
+
+        Assert.Equal(
+            new[] { "blockPath", "plcName", "projectPath" },
+            properties.OrderBy(name => name).ToArray());
+        Assert.DoesNotContain("workerClient", properties);
+        Assert.DoesNotContain("confirm", properties);
+        Assert.DoesNotContain("safetyToken", properties);
+    }
+```
+
+Replace `ReadWriteMode_HasAllTenTools` in `ReadOnlyModeTests.cs` with these two tests:
+
+```csharp
+    [Fact]
+    public void ReadOnlyMode_HasExactlyThreeTools()
+    {
+        var toolNames = new[] { typeof(ProjectReadTools), typeof(ReadBatchTools) }
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => method.GetCustomAttribute<McpServerToolAttribute>())
+            .Where(attribute => attribute is not null)
+            .Select(attribute => attribute!.Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(
+            new[] { "browse_project_tree", "execute_read_batch", "get_project_status" },
+            toolNames);
+    }
+
+    [Fact]
+    public void ReadWriteMode_HasExactlyTwelveDistinctTools()
+    {
+        var toolNames = typeof(ProjectLifecycleTools).Assembly
+            .GetTypes()
+            .Where(type => type.GetCustomAttribute<McpServerToolTypeAttribute>() is not null)
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => method.GetCustomAttribute<McpServerToolAttribute>())
+            .Where(attribute => attribute is not null)
+            .Select(attribute => attribute!.Name)
+            .ToArray();
+
+        Assert.Equal(12, toolNames.Length);
+        Assert.Equal(12, toolNames.Distinct().Count());
+    }
+```
+
+Replace `McpToolSurface_ExposesExactlyTenApprovedTools` in `McpToolSchemaTests.cs` with:
+
+```csharp
+    [Fact]
+    public void McpToolSurface_ExposesExactlyTwelveApprovedTools()
+    {
+        var toolTypes = typeof(ProjectLifecycleTools).Assembly
+            .GetTypes()
+            .Where(type => type.GetCustomAttribute<McpServerToolTypeAttribute>() is not null);
+
+        var toolNames = toolTypes
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => method.GetCustomAttribute<McpServerToolAttribute>())
+            .Where(attribute => attribute is not null)
+            .Select(attribute => attribute!.Name)
+            .ToArray();
+
+        Assert.Equal(12, toolNames.Length);
+        Assert.Equal(12, toolNames.Distinct().Count());
+        Assert.Contains("browse_project_tree", toolNames);
+        Assert.Contains("compile_check", toolNames);
+        Assert.DoesNotContain("probe_project_status_for_lifecycle", toolNames);
+    }
+```
+
+Update the adjacent XML comment from 10 to 12 tools.
+
+- [ ] **Step 2: Run the focused tests and observe RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore --filter "FullyQualifiedName~ProjectStandaloneToolTests|FullyQualifiedName~McpToolSchemaTests|FullyQualifiedName~ReadOnlyMode_HasExactly|FullyQualifiedName~ReadWriteMode_HasExactly"
+```
+
+Expected: compilation failure because `ProjectEngineeringTools` does not exist, plus the tool-count assertion remains at the old surface until production changes land.
+
+- [ ] **Step 3: Implement and conditionally register the engineering tool**
+
+Create `TiaMcpServer/Tools/ProjectEngineeringTools.cs`:
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Tools;
+
+/// <summary>Project engineering actions exposed only in read-write mode.</summary>
+[McpServerToolType]
+public class ProjectEngineeringTools
+{
+    [McpServerTool(Name = "compile_check", ReadOnly = false, Destructive = false, OpenWorld = false)]
+    [Description("Compile a PLC or selected block scope and return compiler messages. Available only in read-write mode.")]
+    public static async Task<string> CompileCheck(
+        OpennessWorkerClient workerClient,
+        [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null,
+        [Description("Optional PLC software name to compile.")] string? plcName = null,
+        [Description("Optional PLC block path to compile only that block.")] string? blockPath = null)
+    {
+        var result = await workerClient
+            .CompileCheckAsync(blockPath, plcName, projectPath)
+            .ConfigureAwait(false);
+        return StandaloneToolResultFormatter.Format(
+            result,
+            "Narrow the compile with plcName or blockPath.");
+    }
+}
+```
+
+Add to the read-write registration block in `TiaMcpServer/Program.cs`:
+
+```csharp
+            if (accessMode == McpAccessMode.ReadWrite)
+            {
+                mcp.WithTools<ProjectEngineeringTools>()
+                   .WithTools<ProjectWriteTools>()
+                   .WithTools<WriteBatchTools>();
+            }
+```
+
+Add the test-project compile link beside `ProjectReadTools.cs`:
+
+```xml
+    <Compile Include="..\TiaMcpServer\Tools\ProjectEngineeringTools.cs"
+      Link="Host\ProjectEngineeringTools.cs" />
+```
+
+Keep the existing `OperationAccessPolicy` and `OpennessWorkerClient_ReadOnly_DeniesCompileCheck` tests unchanged; they remain the defense-in-depth layer.
+
+- [ ] **Step 4: Run the focused tests and observe GREEN**
+
+Run the command from Step 2.
+
+Expected: standalone compile metadata, forwarding, schema, 3-tool read-only surface, and 12-tool full surface all pass.
+
+- [ ] **Step 5: Commit only if commits were explicitly authorized**
+
+If authorized:
+
+```powershell
+git add TiaMcpServer/Tools/ProjectEngineeringTools.cs TiaMcpServer/Program.cs TiaMcpServer.Tests/TiaMcpServer.Tests.csproj TiaMcpServer.Tests/ProjectStandaloneToolTests.cs TiaMcpServer.Tests/McpToolSchemaTests.cs TiaMcpServer.Tests/ReadOnlyModeTests.cs
+git commit -m "feat: expose compile check as standalone tool"
+```
+
+Otherwise leave the verified changes uncommitted and continue.
+
+---
+
+### Task 4: Remove project operations and tree fields from `execute_read_batch`
+
+**Files:**
+
+- Modify: `TiaMcpServer/Batch/BatchOperationRequest.cs:15-48`
+- Modify: `TiaMcpServer/Batch/BatchOperationCatalog.cs` (`ValidateBounds`, `BuildSpecs`)
+- Modify: `TiaMcpServer/Batch/BatchWorkerInvoker.cs:50-90`
+- Modify: `TiaMcpServer/Batch/ReadBatchTools.cs:14-43`
+- Modify: `TiaMcpServer/Batch/BatchTools.cs:22-40`
+- Modify: `TiaMcpServer/Batch/BatchPayloadBudget.cs:220-229`
+- Modify: `TiaMcpServer.Tests/BatchOperationCatalogTests.cs`
+- Modify: `TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs`
+- Modify: `TiaMcpServer.Tests/BatchToolMetadataTests.cs`
+- Modify: `TiaMcpServer.Tests/BatchPayloadBudgetTests.cs`
+
+**Interfaces:**
+
+- `BatchOperationCatalog.ReadOperationNames` becomes exactly: `read_hardware_config`, `search_equipment_catalog`, `read_cross_references`, `get_block_content`, `list_tag_tables`, `get_type_content`.
+- `BatchOperationRequest` removes `Depth` and `StartPath` from its MCP/JSON schema.
+- Removed operation names receive the existing generic unknown-operation batch error.
+- Keep `BatchWorkerInvoker.ReadCurrentStateAsync` calls to `GetProjectStatusAsync` for `start_plc`/`stop_plc`; remove only the three read arms in `InvokeAsync`.
+
+- [ ] **Step 1: Add focused failing removal tests without changing production**
+
+Add to `BatchOperationCatalogTests.cs`:
+
+```csharp
+    [Theory]
+    [InlineData("get_project_status")]
+    [InlineData("browse_project_tree")]
+    [InlineData("compile_check")]
+    public void ValidateReadBatch_RejectsStandaloneProjectOperations(string operation)
+    {
+        var result = BatchOperationCatalog.ValidateReadBatch(new[] { Op("a", operation) });
+
+        Assert.False(result.IsValid);
+        Assert.Contains($"Unknown operation '{operation}'", result.Error);
+        Assert.DoesNotContain(operation, BatchOperationCatalog.ReadOperationNames);
+    }
+```
+
+Add to `BatchOperationRequestJsonTests.cs`:
+
+```csharp
+    [Theory]
+    [InlineData("""{"operationId":"a","operation":"read_hardware_config","depth":3}""", "depth")]
+    [InlineData("""{"operationId":"a","operation":"read_hardware_config","startPath":"PLC_1/Blocks"}""", "startPath")]
+    public void RemovedProjectTreeFields_AreRejected(string json, string field)
+    {
+        var exception = Assert.Throws<JsonException>(
+            () => JsonSerializer.Deserialize<BatchOperationRequest>(json, WebOptions));
+
+        Assert.Contains(field, exception.Message);
+    }
+
+    [Fact]
+    public void BatchRequestType_DoesNotExposeProjectTreeFields()
+    {
+        Assert.Null(typeof(BatchOperationRequest).GetProperty("Depth"));
+        Assert.Null(typeof(BatchOperationRequest).GetProperty("StartPath"));
+    }
+```
+
+Add an overload to `BatchToolMetadataTests.cs`:
+
+```csharp
+    private static string MethodDescription(Type toolType, string methodName)
+    {
+        var method = toolType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(method);
+        var description = method!.GetCustomAttribute<DescriptionAttribute>();
+        Assert.NotNull(description);
+        return description!.Description;
+    }
+```
+
+Keep the existing helper as:
+
+```csharp
+    private static string MethodDescription(string methodName)
+        => MethodDescription(typeof(BatchTools), methodName);
+```
+
+Then add:
+
+```csharp
+    [Fact]
+    public void ExecuteReadBatchDescriptions_OmitStandaloneProjectOperations()
+    {
+        foreach (var toolType in new[] { typeof(BatchTools), typeof(ReadBatchTools) })
+        {
+            var description = MethodDescription(toolType, "ExecuteReadBatch");
+            foreach (var retained in BatchOperationCatalog.ReadOperationNames)
+            {
+                Assert.Contains(retained, description);
+            }
+
+            Assert.DoesNotContain("get_project_status", description);
+            Assert.DoesNotContain("browse_project_tree", description);
+            Assert.DoesNotContain("compile_check", description);
+        }
+    }
+
+    [Fact]
+    public void BatchRequestDescriptions_OmitStandaloneProjectOperations()
+    {
+        foreach (var propertyName in new[]
+        {
+            nameof(BatchOperationRequest.Operation),
+            nameof(BatchOperationRequest.BlockPath),
+            nameof(BatchOperationRequest.PlcName)
+        })
+        {
+            var description = PropertyDescription(propertyName);
+            Assert.DoesNotContain("get_project_status", description);
+            Assert.DoesNotContain("browse_project_tree", description);
+            Assert.DoesNotContain("compile_check", description);
+        }
+    }
+```
+
+Add to `BatchPayloadBudgetTests.cs`:
+
+```csharp
+    [Fact]
+    public void BatchMarkers_DoNotRecommendStandaloneProjectFields()
+    {
+        var text = BatchPayloadBudget.TruncationTrailer(BatchPayloadBudget.MaxItemChars)
+            + BatchPayloadBudget.OmissionMarker(BatchPayloadBudget.MaxBatchChars);
+        var normalized = text.ToLowerInvariant();
+
+        Assert.DoesNotContain("startpath", normalized);
+        Assert.DoesNotContain("depth", normalized);
+    }
+```
+
+- [ ] **Step 2: Run the new tests and observe RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore --filter "FullyQualifiedName~ValidateReadBatch_RejectsStandaloneProjectOperations|FullyQualifiedName~RemovedProjectTreeFields_AreRejected|FullyQualifiedName~BatchRequestType_DoesNotExposeProjectTreeFields|FullyQualifiedName~ExecuteReadBatchDescriptions_OmitStandaloneProjectOperations|FullyQualifiedName~BatchRequestDescriptions_OmitStandaloneProjectOperations|FullyQualifiedName~BatchMarkers_DoNotRecommendStandaloneProjectFields"
+```
+
+Expected: assertions fail because the catalog, DTO, metadata, and markers still expose the old batch surface.
+
+- [ ] **Step 3: Narrow the production batch contract**
+
+In `BatchOperationRequest.cs`:
+
+1. Replace the read-operation portion of `Operation`'s description with:
+
+```csharp
+"Read operations: read_hardware_config, read_cross_references, search_equipment_catalog, get_block_content, list_tag_tables, get_type_content. "
+```
+
+2. Remove `compile_check` from the `BlockPath` and `PlcName` descriptions.
+3. Delete the `Depth` and `StartPath` properties and their descriptions.
+
+In `BatchOperationCatalog.BuildSpecs`, make the read section exactly:
+
+```csharp
+            // Reads
+            new BatchOperationSpec("read_hardware_config", BatchOperationCategory.Read, None, None),
+            new BatchOperationSpec("search_equipment_catalog", BatchOperationCategory.Read, new[] { "query" }, new[] { "maxResults" }),
+            new BatchOperationSpec("read_cross_references", BatchOperationCategory.Read, None, new[] { "plcName", "filter", "maxResults" }),
+            new BatchOperationSpec("get_block_content", BatchOperationCategory.Read, new[] { "blockPath" }, new[] { "format" }),
+            new BatchOperationSpec("list_tag_tables", BatchOperationCategory.Read, None, new[] { "plcName" }),
+            new BatchOperationSpec("get_type_content", BatchOperationCategory.Read, new[] { "typePath" }, new[] { "format" }),
+```
+
+Remove the depth branch from `ValidateBounds`, leaving:
+
+```csharp
+    private static IEnumerable<string> ValidateBounds(BatchOperationRequest op)
+    {
+        if (op.MaxResults is < 1)
+        {
+            yield return "'maxResults' must be 1 or greater.";
+        }
+    }
+```
+
+In `BatchWorkerInvoker.InvokeAsync`, make the read arms exactly:
+
+```csharp
+        // Reads
+        "read_hardware_config" => client.ReadHardwareConfigAsync(op.ProjectPath),
+        "search_equipment_catalog" => client.SearchEquipmentCatalogAsync(op.Query!, op.ProjectPath, op.MaxResults),
+        "read_cross_references" => client.ReadCrossReferencesAsync(op.ProjectPath, op.PlcName, op.Filter, op.MaxResults),
+        "get_block_content" => InvokeGetBlockContent(client, op),
+        "list_tag_tables" => client.ListTagTablesAsync(op.PlcName, op.ProjectPath),
+        "get_type_content" => InvokeGetTypeContent(client, op),
+```
+
+Do not remove this write-snapshot arm from `ReadCurrentStateAsync`:
+
+```csharp
+        "start_plc" or "stop_plc"
+            => client.GetProjectStatusAsync(op.ProjectPath),
+```
+
+Use the same description text on `ReadBatchTools.ExecuteReadBatch` and `BatchTools.ExecuteReadBatch`:
+
+```csharp
+[Description("Run up to 50 non-project read operations in one call. Each item is { operationId (unique), operation, ...that operation's parameters }; projectPath is optional on every item. Reads run independently, so a failing item does not stop the others. "
+    + "Valid operations (parentheses list required fields): read_hardware_config, search_equipment_catalog (query), read_cross_references, get_block_content (blockPath), list_tag_tables, get_type_content (typePath). "
+    + "Large reads: bound search_equipment_catalog and read_cross_references with maxResults; oversized responses are truncated or omitted server-side with explicit markers.")]
+```
+
+In `BatchPayloadBudget.TruncationTrailer` and `OmissionMarker`, replace the narrowing lists with only `plcName`, `filter`, and `maxResults`.
+
+- [ ] **Step 4: Update existing tests to the reduced contract**
+
+In `BatchOperationCatalogTests.cs`:
+
+- Replace `browse_project_tree` fixtures used only as a valid read with `read_hardware_config`.
+- Remove `Validate_RejectsDepthAndStartPathOnNonTreeOperations`.
+- Change `Validate_RejectsOutOfRangeBounds` to cover only `MaxResults = 0`.
+- Change `Validate_AcceptsBoundsOnTheirOperations` to cover `maxResults` on `search_equipment_catalog` and `read_cross_references` only.
+- Remove `browse_project_tree`, `compile_check`, and `get_project_status` from the expected dictionary in `All_MatchesTheAuthoritativeOperationFieldContract`.
+- Update `ValidateReadBatch_UnknownOperationErrorListsValidReadOperations` to assert a retained name such as `get_type_content` and to assert all three removed names are absent.
+
+In `BatchOperationRequestJsonTests.cs`, replace `Deserializes_BoundingFields` with:
+
+```csharp
+    [Fact]
+    public void DeserializesRetainedMaxResultsField()
+    {
+        var json = """{"operationId":"a","operation":"search_equipment_catalog","query":"CPU","maxResults":25}""";
+
+        var request = JsonSerializer.Deserialize<BatchOperationRequest>(json, WebOptions)!;
+
+        Assert.Equal(25, request.MaxResults);
+    }
+```
+
+In `BatchToolMetadataTests.cs`:
+
+- Rename `BlockPathDescription_CoversAllBlockOperationsAndCompileCheck` to `BlockPathDescription_CoversBatchBlockOperations` and replace the `compile_check` inclusion assertion with `Assert.DoesNotContain("compile_check", description)`.
+- Keep `PlcNameDescription_NamesTheOperationsThatHonorIt`, but replace its compile inclusion assertion with `Assert.DoesNotContain("compile_check", description)`.
+
+- [ ] **Step 5: Run the complete batch-focused suite and observe GREEN**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore --filter "FullyQualifiedName~BatchOperationCatalogTests|FullyQualifiedName~BatchOperationRequestJsonTests|FullyQualifiedName~BatchToolMetadataTests|FullyQualifiedName~BatchPayloadBudgetTests|FullyQualifiedName~BatchToolsTests|FullyQualifiedName~BatchFieldForwardingTests"
+```
+
+Expected: all selected tests pass; the valid read-operation list contains exactly six names.
+
+- [ ] **Step 6: Commit only if commits were explicitly authorized**
+
+If authorized:
+
+```powershell
+git add TiaMcpServer/Batch/BatchOperationRequest.cs TiaMcpServer/Batch/BatchOperationCatalog.cs TiaMcpServer/Batch/BatchWorkerInvoker.cs TiaMcpServer/Batch/ReadBatchTools.cs TiaMcpServer/Batch/BatchTools.cs TiaMcpServer/Batch/BatchPayloadBudget.cs TiaMcpServer.Tests/BatchOperationCatalogTests.cs TiaMcpServer.Tests/BatchOperationRequestJsonTests.cs TiaMcpServer.Tests/BatchToolMetadataTests.cs TiaMcpServer.Tests/BatchPayloadBudgetTests.cs
+git commit -m "refactor: remove project reads from batch"
+```
+
+Otherwise leave the verified changes uncommitted and continue.
+
+---
+
+### Task 5: Align current documentation and run full verification
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/SupportedOperations/README.md`
+- Modify: `docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md`
+- Modify: `docs/SupportedOperations/DEVICES_OPERATIONS_SUMMARY.md`
+- Modify: `docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md`
+- Verify unchanged context: `docs/SupportedOperations/HMI_OPERATIONS_SUMMARY.md`, `docs/SupportedOperations/TESTSUITE_OPERATIONS_SUMMARY.md`, `docs/SupportedOperations/NETWORK_OPERATIONS_SUMMARY.md`
+- Verify: `docs/superpowers/specs/2026-07-31-standalone-project-tools-design.md`
+
+**Interfaces:**
+
+- Public read-write surface: 12 tools.
+- Standalone project tools: `get_project_status`, `browse_project_tree`, `compile_check`.
+- Generic `execute_read_batch` operations: the exact six-name catalog from Task 4.
+- Evidence boundary: unit/FakeWorker/stub-build verification only; no fresh live TIA claim.
+
+- [ ] **Step 1: Update the top-level public surface and examples**
+
+In `README.md`:
+
+- Change every current tool-count claim from 10 to 12.
+- List these standalone tools separately:
+
+```markdown
+- `get_project_status` — read active project metadata without opening or switching projects.
+- `browse_project_tree` — browse a bounded project subtree with optional `depth` and `startPath`.
+- `compile_check` — compile a PLC or selected block and return compiler messages; available only in read-write mode.
+```
+
+- Replace every current `execute_read_batch` operation list with:
+
+```markdown
+Available read operations for `execute_read_batch`: `read_hardware_config`, `search_equipment_catalog`, `read_cross_references`, `get_block_content`, `list_tag_tables`, and `get_type_content`.
+```
+
+- Replace batch examples containing tree/status/compile items with separate standalone calls followed by a batch containing only retained operations.
+- Remove `depth`/`startPath` from generic batch payload-narrowing guidance; retain them on standalone `browse_project_tree` guidance.
+
+In `docs/ARCHITECTURE.md`:
+
+- Add standalone rows for `browse_project_tree` and `compile_check` beside `get_project_status`.
+- Mark `compile_check` read-write-only and non-tokenized.
+- Replace the read-batch catalog with the exact six retained operations.
+- Update the full public-tool count to 12 and remove the statement that compile remains in the read batch.
+
+- [ ] **Step 2: Update supported-operation summaries**
+
+In `docs/SupportedOperations/README.md`, use:
+
+```markdown
+`execute_read_batch` supports:
+
+`read_hardware_config`, `search_equipment_catalog`, `read_cross_references`, `get_block_content`, `list_tag_tables`, and `get_type_content`.
+
+Project status, project-tree browsing, and compilation are separate tools: `get_project_status`, `browse_project_tree`, and `compile_check`. The first two are available in both access modes; `compile_check` is available only in read-write mode.
+```
+
+In `docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md`, make the read table:
+
+```markdown
+| Entry point | Operation | Inputs and behavior |
+|---|---|---|
+| `get_project_status` | `get_project_status` | Optional `projectPath`; reads status and metadata without opening or switching projects. |
+| `browse_project_tree` | `browse_project_tree` | Optional `projectPath`, `depth`, and `startPath`; returns bounded project-tree data. |
+| `compile_check` | `compile_check` | Optional `projectPath`, `plcName`, and `blockPath`; compiles the selected scope and returns compiler messages. Available only in read-write mode. |
+```
+
+Replace the old batch-classification sentence with:
+
+```markdown
+`compile_check` is a standalone engineering operation. It is not marked read-only, does not use a safety token, and is exposed only in read-write mode.
+```
+
+In `docs/SupportedOperations/DEVICES_OPERATIONS_SUMMARY.md`, change the `browse_project_tree` entry point from `execute_read_batch` to the standalone `browse_project_tree` tool.
+
+In `docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md`, state that tree browsing and compilation are standalone tools and remove the old read-batch/safety classification.
+
+Read the HMI, TestSuite, and network summaries named above; change only wording that still implies `compile_check` or `browse_project_tree` is a batch operation. Do not broaden their capability claims.
+
+- [ ] **Step 3: Run bounded documentation-contract checks**
+
+Run:
+
+```powershell
+$currentDocs = @(
+    'README.md',
+    'docs/ARCHITECTURE.md',
+    'docs/SupportedOperations/README.md',
+    'docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md',
+    'docs/SupportedOperations/DEVICES_OPERATIONS_SUMMARY.md',
+    'docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md'
+)
+$violations = Select-String -Path $currentDocs -Pattern 'execute_read_batch' |
+    Where-Object { $_.Line -match 'get_project_status|browse_project_tree|compile_check' }
+if ($violations) { $violations | ForEach-Object { Write-Error $_.Line }; throw 'Project operations remain documented as batch operations.' }
+rg -n "12 tools|browse_project_tree|compile_check|get_project_status" README.md docs/ARCHITECTURE.md docs/SupportedOperations
+```
+
+Expected: no violation error; the search output shows all three standalone tool names in current public documentation and the 12-tool claim in `README.md`.
+
+Run the existing documentation-sensitive tests:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore --filter "FullyQualifiedName~CiWorkflowTests|FullyQualifiedName~McpToolSchemaTests|FullyQualifiedName~BatchToolMetadataTests"
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 4: Run the serialized Release stub build**
+
+Run:
+
+```powershell
+dotnet build TiaMcpServer.sln -m:1 --no-restore --configuration Release /p:UseTiaPortalReferenceStubs=true
+```
+
+Expected: build succeeds with zero errors. This proves compilation against the reference stubs, not live TIA behavior.
+
+- [ ] **Step 5: Run the full suite with scoped coverage and enforce 80%**
+
+Run in PowerShell 7:
+
+```powershell
+$coverageRun = Join-Path 'TestResults' ('standalone-project-tools-' + [DateTimeOffset]::UtcNow.ToString('yyyyMMddHHmmss'))
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-build --configuration Release --collect:"XPlat Code Coverage" --settings TiaMcpServer.Tests/coverage.runsettings --results-directory $coverageRun
+$reports = @(Get-ChildItem -Path $coverageRun -Recurse -Filter coverage.cobertura.xml)
+if ($reports.Count -ne 1) { throw "Expected exactly one Cobertura report; found $($reports.Count)." }
+./scripts/verify-coverage-threshold.ps1 -CoveragePath $reports[0].FullName -MinimumLineRate 0.80
+```
+
+Expected: all tests pass and the script reports a line rate of at least `0.80`.
+
+- [ ] **Step 6: Review the complete diff and whitespace**
+
+Run:
+
+```powershell
+git diff --check
+git status --short
+git diff --stat
+```
+
+Review the complete diff and confirm:
+
+- no `TiaMcpServer.OpennessWorker/` or worker request-contract file changed;
+- no project operation remains in `BatchOperationCatalog.ReadOperationNames`;
+- `start_plc`/`stop_plc` current-state reads still use `GetProjectStatusAsync`;
+- no live-TIA evidence claim was added;
+- only the approved spec, plan, implementation, tests, and current public documentation changed.
+
+- [ ] **Step 7: Commit only if commits were explicitly authorized**
+
+If authorized:
+
+```powershell
+git add README.md docs/ARCHITECTURE.md docs/SupportedOperations/README.md docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md docs/SupportedOperations/DEVICES_OPERATIONS_SUMMARY.md docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md docs/SupportedOperations/HMI_OPERATIONS_SUMMARY.md docs/SupportedOperations/TESTSUITE_OPERATIONS_SUMMARY.md docs/SupportedOperations/NETWORK_OPERATIONS_SUMMARY.md docs/superpowers/specs/2026-07-31-standalone-project-tools-design.md docs/superpowers/plans/2026-07-31-standalone-project-tools.md
+git commit -m "docs: document standalone project tools"
+```
+
+If earlier tasks were also intentionally left uncommitted, stage and commit their verified files only under the user's explicit commit authorization. Otherwise leave the completed branch uncommitted for user review.

--- a/docs/superpowers/specs/2026-07-31-standalone-project-tools-design.md
+++ b/docs/superpowers/specs/2026-07-31-standalone-project-tools-design.md
@@ -1,0 +1,204 @@
+# Standalone Project Tools Design
+
+**Date:** 2026-07-31
+**Status:** Approved in design review
+
+## Objective
+
+Separate project-level reads from the generic `execute_read_batch` surface. The MCP server will expose project status, project-tree browsing, and compilation checks as standalone tools, while the read batch remains focused on PLC, hardware, catalog, cross-reference, tag-table, block, and type data.
+
+This is an immediate public API break. The removed batch operations will not have aliases, deprecation warnings, or migration-specific error handling.
+
+## Current State
+
+The public project surface currently mixes two shapes:
+
+- `get_project_status` is already a standalone tool but is duplicated in `execute_read_batch`.
+- `browse_project_tree` and `compile_check` exist only as `execute_read_batch` operations.
+- The six project lifecycle writes (`open_project`, `create_project`, `save_project`, `save_project_as`, `archive_project`, and `close_project`) are already standalone self-previewing tools.
+
+All three project reads already have dedicated `OpennessWorkerClient` methods and worker dispatch methods. The refactor therefore changes the .NET 8 host surface only; it does not change the host/worker protocol or Siemens Openness implementation.
+
+## Public Tool Surface
+
+### Project reads
+
+`ProjectReadTools` is registered in both read-only and read-write modes and exposes:
+
+1. `get_project_status(projectPath?)`
+   - Reads status and metadata without opening, switching, or binding a project.
+   - Retains `ReadOnly=true`, `Destructive=false`, and `OpenWorld=false` metadata.
+
+2. `browse_project_tree(projectPath?, depth?, startPath?)`
+   - Reads the bounded project hierarchy through the existing `BrowseProjectTreeAsync` client method.
+   - Retains `ReadOnly=true`, `Destructive=false`, and `OpenWorld=false` metadata.
+   - Rejects `depth < 1` as `validation_error` before worker access.
+
+### Project engineering
+
+A new `ProjectEngineeringTools` MCP tool type is registered only in read-write mode and exposes:
+
+1. `compile_check(projectPath?, plcName?, blockPath?)`
+   - Invokes the existing Siemens compilation path and returns compiler messages.
+   - Uses `ReadOnly=false`, `Destructive=false`, and `OpenWorld=false` metadata because compilation is an engineering action, not a pure read.
+   - Does not use the preview/apply safety-token flow. This preserves the current `compile_check` safety behavior; the refactor only changes its entry point.
+
+The underlying `OperationAccessPolicy` continues to deny `compile_check` in read-only mode as defense in depth, even though the tool is not registered there.
+
+### Project lifecycle writes
+
+The six lifecycle-write tools and their safety-token behavior remain unchanged.
+
+### Tool counts
+
+- Read-only mode: 3 tools (`get_project_status`, `browse_project_tree`, and `execute_read_batch`).
+- Read-write mode: 12 tools (the 3 read-only tools, `compile_check`, 6 lifecycle-write tools, and 2 write-batch tools).
+
+## Generic Read-Batch Surface
+
+`execute_read_batch` retains exactly these six operations:
+
+1. `read_hardware_config`
+2. `search_equipment_catalog`
+3. `read_cross_references`
+4. `get_block_content`
+5. `list_tag_tables`
+6. `get_type_content`
+
+The following operations are removed from `BatchOperationCatalog` and `BatchWorkerInvoker`:
+
+- `get_project_status`
+- `browse_project_tree`
+- `compile_check`
+
+Submitting any removed name to `execute_read_batch` produces the existing generic unknown-operation validation response, including the current valid read-operation list. Validation fails before any worker call.
+
+Both registered and backward-compatible `execute_read_batch` descriptions must list exactly the six remaining operations and must not mention the removed operations as valid batch items.
+
+## Batch Schema Cleanup
+
+The flat `BatchOperationRequest` DTO no longer needs the project-tree-only properties:
+
+- `Depth`
+- `StartPath`
+
+They are removed from the batch schema and become direct parameters of the standalone `browse_project_tree` tool. The corresponding JSON-schema and request-serialization tests are updated.
+
+`BlockPath`, `PlcName`, and `ProjectPath` remain in `BatchOperationRequest` because retained batch operations still use them. Their descriptions must no longer claim `compile_check` as a batch consumer.
+
+Batch payload-truncation and omission guidance must also stop recommending `depth` or `startPath`, since those inputs will no longer exist on `execute_read_batch`.
+
+## Data Flow
+
+The standalone tools are thin host adapters:
+
+```text
+MCP tool
+  -> existing OpennessWorkerClient method
+  -> existing newline-delimited JSON worker request
+  -> existing .NET Framework Openness worker handler
+  -> WorkerCallResult structured envelope
+```
+
+The mappings are:
+
+- `get_project_status` -> `GetProjectStatusAsync`
+- `browse_project_tree` -> `BrowseProjectTreeAsync`
+- `compile_check` -> `CompileCheckAsync`
+
+No worker method strings, request contract properties, Openness handlers, session-binding rules, or timeout/crash behavior change.
+
+## Response Budget
+
+Today, `browse_project_tree` and `compile_check` inherit the read batch's 60,000-character per-item payload cap. Moving them to standalone tools must not make their successful responses unbounded.
+
+A focused standalone read-result budget helper will:
+
+- leave failures, failure categories, resolved-path behavior, and warnings unchanged;
+- leave successful payloads at or below 60,000 characters;
+- append an explicit truncation marker when a payload exceeds the cap;
+- provide tool-specific narrowing guidance:
+  - `browse_project_tree`: use `depth` and `startPath`;
+  - `compile_check`: use `plcName` and `blockPath`.
+
+The final result is serialized through the existing `WorkerCallResult.ToEnvelopeText()` structured envelope.
+
+## Validation and Error Handling
+
+- `browse_project_tree(depth < 1)` returns a categorized `validation_error` without invoking the worker.
+- Worker validation failures, binding conflicts, timeouts, crashes, and warnings keep their existing `WorkerCallResult` categories and text.
+- `compile_check` is absent from read-only tool registration and remains blocked by `OperationAccessPolicy` if invoked internally in read-only mode.
+- Removed batch operations return the existing batch-level unknown-operation error before execution begins.
+- A failure in one retained read-batch item continues not to stop other valid items.
+
+## Testing Strategy
+
+Implementation follows TDD. Each production change begins with a focused failing test.
+
+### Standalone tool tests
+
+- `ProjectReadTools` exposes `get_project_status` and `browse_project_tree` with the expected MCP metadata and parameters.
+- `ProjectEngineeringTools` exposes only `compile_check` with engineering-action metadata.
+- Tool methods forward every parameter to the existing `OpennessWorkerClient` method.
+- `browse_project_tree` rejects invalid depth before worker access.
+- Successful oversized tree and compile payloads are truncated with the correct hint.
+- Structured failures and warnings survive standalone formatting unchanged.
+
+### Access-mode and schema tests
+
+- Read-only mode exposes exactly 3 tools.
+- Read-write mode exposes exactly 12 tools.
+- `compile_check` is not registered in read-only mode.
+- The underlying client policy still rejects `compile_check` in read-only mode.
+- Injected services do not appear in the public standalone tool schemas.
+- `depth` and `startPath` no longer appear in the batch request schema.
+
+### Batch-removal tests
+
+- The catalog contains exactly the six retained read operations.
+- `get_project_status`, `browse_project_tree`, and `compile_check` are rejected as unknown read-batch operations.
+- Both `execute_read_batch` descriptions include every retained operation and none of the removed names.
+- `BatchWorkerInvoker` no longer contains dispatch arms for the removed operations.
+- Existing batch field-forwarding, independent-failure, and payload-budget invariants continue to pass for retained operations.
+
+### Verification
+
+Run:
+
+1. Focused tests during each red/green cycle.
+2. Serialized stub build with `-m:1` and `UseTiaPortalReferenceStubs=true`.
+3. Full `TiaMcpServer.Tests` suite.
+4. The repository's scoped 80% coverage threshold through `scripts/verify-coverage-threshold.ps1`.
+5. Documentation link/name/scope checks.
+
+No live TIA Portal test is required because the worker protocol and Openness implementation do not change. Static and FakeWorker verification will be reported separately from runtime TIA evidence.
+
+## Documentation Changes
+
+Update all current public-surface descriptions, including:
+
+- `README.md`
+- `docs/ARCHITECTURE.md`
+- `docs/SupportedOperations/README.md`
+- `docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md`
+- any other current `docs/SupportedOperations/` page that lists the affected entry points
+
+Documentation must:
+
+- state that the server exposes 12 tools in read-write mode;
+- list `get_project_status`, `browse_project_tree`, and `compile_check` as standalone tools;
+- classify `compile_check` as a read-write-mode engineering operation;
+- list exactly the six retained `execute_read_batch` operations;
+- replace batch-based project-tree and compilation examples with standalone calls;
+- remove batch narrowing guidance that mentions `depth` or `startPath`;
+- preserve the distinction between static verification and live TIA behavior.
+
+## Non-Goals
+
+- No aliases or deprecation period for removed batch operations.
+- No dedicated project-read batch.
+- No batching of lifecycle writes.
+- No changes to safety-token behavior.
+- No new project operations.
+- No worker protocol or Siemens Openness changes.
+- No live TIA Portal execution as part of this host-surface refactor.


### PR DESCRIPTION
## Summary

- expose `get_project_status`, `browse_project_tree`, and `compile_check` as standalone project tools
- restrict `execute_read_batch` to the exact six retained read operations
- bound standalone tool output to 60,000 characters, including oversized narrowing hints
- pin the 12-tool read-write surface and access-mode behavior in tests
- update the public README, architecture, and supported-operation documentation

## Why

Project status, tree browsing, and compilation have distinct parameters, access rules, and payload characteristics. Keeping them in the generic read-batch surface left stale DTO metadata, ambiguous documentation, and incomplete result-size guarantees.

The corrective review also found an accidental `withDependencies` catalog option, stale batch-operation tests, an outdated public-tool count, and a payload-cap edge case when the narrowing hint itself was oversized.

## Impact

- `get_project_status` and `browse_project_tree` are available in read-only and read-write modes.
- `compile_check` is standalone, non-tokenized, and available only in read-write mode.
- `execute_read_batch` now exposes only `read_hardware_config`, `search_equipment_catalog`, `read_cross_references`, `get_block_content`, `list_tag_tables`, and `get_type_content`.
- Existing PLC start/stop state reads continue to use `GetProjectStatusAsync`.

## Validation

- Release reference-stub build: passed with 0 warnings and 0 errors
- Full Release test suite: 851 passed, 0 failed
- Scoped line coverage: 89.37% (minimum 80%)
- Documentation contract checks: passed
- `git diff --check`: passed
- No changes to `TiaMcpServer.OpennessWorker/` or `TiaMcpServer.Contracts/WorkerRequest.cs`
- No live TIA Portal operation was run; runtime acceptance remains separate