### PR TITLE
fix(install): resolve MCP client executables correctly on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,22 +27,6 @@ jobs:
             - name: Run scoped coverage
               run: dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-build --configuration Release --collect:"XPlat Code Coverage" --settings TiaMcpServer.Tests/coverage.runsettings --results-directory TestResults
 
-            - name: Report uncovered install lines
-              shell: pwsh
-              run: |
-                  $report = @(Get-ChildItem -Path TestResults -Recurse -Filter coverage.cobertura.xml)[0]
-                  [xml]$coverage = Get-Content $report.FullName
-                  $targets = @("ExecutableResolver.cs", "InstallCommand.cs")
-                  foreach ($class in $coverage.coverage.packages.package.classes.class) {
-                      $fileName = [System.IO.Path]::GetFileName([string]$class.filename)
-                      if ($targets -contains $fileName) {
-                          $missed = @($class.lines.line | Where-Object { [int]$_.hits -eq 0 } | ForEach-Object { [string]$_.number })
-                          $partial = @($class.lines.line | Where-Object { $_.'condition-coverage' -and $_.'condition-coverage' -notlike '100%*' } | ForEach-Object { "$($_.number) [$($_.'condition-coverage')]" })
-                          Write-Host "$fileName uncovered lines: $($missed -join ', ')"
-                          Write-Host "$fileName partial branches: $($partial -join ', ')"
-                      }
-                  }
-
             - name: Enforce coverage threshold
               shell: pwsh
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,9 @@ jobs:
                       $fileName = [System.IO.Path]::GetFileName([string]$class.filename)
                       if ($targets -contains $fileName) {
                           $missed = @($class.lines.line | Where-Object { [int]$_.hits -eq 0 } | ForEach-Object { [string]$_.number })
+                          $partial = @($class.lines.line | Where-Object { $_.'condition-coverage' -and $_.'condition-coverage' -notlike '100%*' } | ForEach-Object { "$($_.number) [$($_.'condition-coverage')]" })
                           Write-Host "$fileName uncovered lines: $($missed -join ', ')"
+                          Write-Host "$fileName partial branches: $($partial -join ', ')"
                       }
                   }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,20 @@ jobs:
             - name: Run scoped coverage
               run: dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-build --configuration Release --collect:"XPlat Code Coverage" --settings TiaMcpServer.Tests/coverage.runsettings --results-directory TestResults
 
+            - name: Report uncovered install lines
+              shell: pwsh
+              run: |
+                  $report = @(Get-ChildItem -Path TestResults -Recurse -Filter coverage.cobertura.xml)[0]
+                  [xml]$coverage = Get-Content $report.FullName
+                  $targets = @("ExecutableResolver.cs", "InstallCommand.cs")
+                  foreach ($class in $coverage.coverage.packages.package.classes.class) {
+                      $fileName = [System.IO.Path]::GetFileName([string]$class.filename)
+                      if ($targets -contains $fileName) {
+                          $missed = @($class.lines.line | Where-Object { [int]$_.hits -eq 0 } | ForEach-Object { [string]$_.number })
+                          Write-Host "$fileName uncovered lines: $($missed -join ', ')"
+                      }
+                  }
+
             - name: Enforce coverage threshold
               shell: pwsh
               run: |

--- a/TiaMcpServer.Tests/Cli/ClientInstallerTests.cs
+++ b/TiaMcpServer.Tests/Cli/ClientInstallerTests.cs
@@ -22,6 +22,9 @@ public class ClientInstallerTests
         return new InstallOptions(true, ClientKind.Codex, "tia-portal", accessMode, project, serverPath, dryRun, json, false, null);
     }
 
+    private static ExecutableResolutionResult DefaultResolve(string exe)
+        => new(true, exe, $@"C:\tools\{exe}.exe", ExecutableKind.Native, null);
+
     [Fact]
     public void ClaudeCode_ReadOnly_BuildsCorrectCommand()
     {
@@ -29,7 +32,7 @@ public class ClientInstallerTests
         var spec = CreateSpec();
         var options = CreateOptions();
 
-        var cmd = installer.BuildInstallCommand(options, spec);
+        var cmd = installer.BuildInstallCommand(options, spec, DefaultResolve);
 
         Assert.Equal("claude", cmd.Executable);
         Assert.False(cmd.Interactive);
@@ -43,7 +46,7 @@ public class ClientInstallerTests
         var spec = CreateSpec();
         var options = CreateOptions("read-write");
 
-        var cmd = installer.BuildInstallCommand(options, spec);
+        var cmd = installer.BuildInstallCommand(options, spec, DefaultResolve);
 
         Assert.Equal("claude", cmd.Executable);
         Assert.Contains("--access-mode", cmd.Arguments);
@@ -57,7 +60,7 @@ public class ClientInstallerTests
         var spec = CreateSpec("my-tia-server");
         var options = CreateOptions();
 
-        var cmd = installer.BuildInstallCommand(options, spec);
+        var cmd = installer.BuildInstallCommand(options, spec, DefaultResolve);
 
         Assert.Contains("my-tia-server", cmd.Arguments);
     }
@@ -69,7 +72,7 @@ public class ClientInstallerTests
         var spec = CreateSpec(project: @"C:\Projects\Line.ap21");
         var options = CreateOptions(project: @"C:\Projects\Line.ap21");
 
-        var cmd = installer.BuildInstallCommand(options, spec);
+        var cmd = installer.BuildInstallCommand(options, spec, DefaultResolve);
 
         Assert.Contains("--project", cmd.Arguments);
         Assert.Contains(@"C:\Projects\Line.ap21", cmd.Arguments);
@@ -96,7 +99,7 @@ public class ClientInstallerTests
         var spec = CreateSpec();
         var options = CreateOptions();
 
-        var cmd = installer.BuildInstallCommand(options, spec);
+        var cmd = installer.BuildInstallCommand(options, spec, DefaultResolve);
 
         Assert.Equal("codex", cmd.Executable);
         Assert.False(cmd.Interactive);
@@ -110,7 +113,7 @@ public class ClientInstallerTests
         var spec = CreateSpec();
         var options = CreateOptions("read-write");
 
-        var cmd = installer.BuildInstallCommand(options, spec);
+        var cmd = installer.BuildInstallCommand(options, spec, DefaultResolve);
 
         Assert.Equal("codex", cmd.Executable);
         Assert.Contains("read-write", cmd.Arguments);
@@ -123,7 +126,7 @@ public class ClientInstallerTests
         var spec = CreateSpec(project: @"C:\Projects\Line.ap21");
         var options = CreateOptions(project: @"C:\Projects\Line.ap21");
 
-        var cmd = installer.BuildInstallCommand(options, spec);
+        var cmd = installer.BuildInstallCommand(options, spec, DefaultResolve);
 
         Assert.Contains("--project", cmd.Arguments);
         Assert.Contains(@"C:\Projects\Line.ap21", cmd.Arguments);
@@ -150,7 +153,7 @@ public class ClientInstallerTests
         var spec = CreateSpec();
         var options = CreateOptions();
 
-        var cmd = installer.BuildInstallCommand(options, spec);
+        var cmd = installer.BuildInstallCommand(options, spec, DefaultResolve);
 
         Assert.Equal("opencode", cmd.Executable);
         Assert.False(cmd.Interactive);
@@ -164,7 +167,7 @@ public class ClientInstallerTests
         var spec = CreateSpec(project: @"C:\Projects\Line.ap21");
         var options = CreateOptions(project: @"C:\Projects\Line.ap21");
 
-        var cmd = installer.BuildInstallCommand(options, spec);
+        var cmd = installer.BuildInstallCommand(options, spec, DefaultResolve);
 
         Assert.Contains("--project", cmd.Arguments);
         Assert.Contains(@"C:\Projects\Line.ap21", cmd.Arguments);
@@ -191,7 +194,10 @@ public class ClientInstallerTests
         var spec = CreateSpec();
         var options = CreateOptions();
 
-        var cmd = installer.BuildInstallCommand(options, spec);
+        ExecutableResolutionResult FakeResolve(string exe)
+            => new(true, exe, $@"C:\tools\{exe}.exe", ExecutableKind.Native, null);
+
+        var cmd = installer.BuildInstallCommand(options, spec, FakeResolve);
 
         Assert.Equal("mimo", cmd.Executable);
         Assert.True(cmd.Interactive);
@@ -219,7 +225,7 @@ public class ClientInstallerTests
         var spec = new McpLaunchSpec("tia-portal", @"C:\Program Files\Tools\tia-mcp.exe", new[] { "--access-mode", "read-only" });
         var options = CreateOptions();
 
-        var cmd = installer.BuildInstallCommand(options, spec);
+        var cmd = installer.BuildInstallCommand(options, spec, DefaultResolve);
 
         Assert.Contains(@"C:\Program Files\Tools\tia-mcp.exe", cmd.Arguments);
     }
@@ -232,7 +238,7 @@ public class ClientInstallerTests
         var spec = CreateSpec(project: projectPath);
         var options = CreateOptions(project: projectPath);
 
-        var cmd = installer.BuildInstallCommand(options, spec);
+        var cmd = installer.BuildInstallCommand(options, spec, DefaultResolve);
 
         Assert.Contains(projectPath, cmd.Arguments);
     }
@@ -273,5 +279,204 @@ public class ClientInstallerTests
     {
         var installer = new MiMoCodeInstaller();
         Assert.Equal(ClientKind.MiMoCode, installer.Client);
+    }
+
+    // --- Adapter integration: DetectAsync uses resolver ---
+
+    [Fact]
+    public async Task ClaudeCode_DetectAsync_WithCmdResolver_ReturnsCmdKind()
+    {
+        var installer = new ClaudeCodeInstaller();
+        ExecutableResolutionResult CmdResolver(string exe)
+            => new(true, exe, @"C:\npm\claude.cmd", ExecutableKind.CommandScript, null);
+
+        var result = await installer.DetectAsync(CmdResolver, CancellationToken.None);
+
+        Assert.True(result.Found);
+        Assert.Equal(@"C:\npm\claude.cmd", result.ExecutablePath);
+        Assert.Equal(ExecutableKind.CommandScript, result.Kind);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public async Task Codex_DetectAsync_WithExeResolver_ReturnsNativeKind()
+    {
+        var installer = new CodexInstaller();
+        ExecutableResolutionResult ExeResolver(string exe)
+            => new(true, exe, @"C:\tools\codex.exe", ExecutableKind.Native, null);
+
+        var result = await installer.DetectAsync(ExeResolver, CancellationToken.None);
+
+        Assert.True(result.Found);
+        Assert.Equal(@"C:\tools\codex.exe", result.ExecutablePath);
+        Assert.Equal(ExecutableKind.Native, result.Kind);
+    }
+
+    [Fact]
+    public async Task OpenCode_DetectAsync_WithCmdResolver_ReturnsCmdKind()
+    {
+        var installer = new OpenCodeInstaller();
+        ExecutableResolutionResult CmdResolver(string exe)
+            => new(true, exe, @"C:\npm\opencode.cmd", ExecutableKind.CommandScript, null);
+
+        var result = await installer.DetectAsync(CmdResolver, CancellationToken.None);
+
+        Assert.True(result.Found);
+        Assert.Equal(ExecutableKind.CommandScript, result.Kind);
+    }
+
+    [Fact]
+    public async Task MiMoCode_DetectAsync_WithCmdResolver_ReturnsCmdKind()
+    {
+        var installer = new MiMoCodeInstaller();
+        ExecutableResolutionResult CmdResolver(string exe)
+            => new(true, exe, @"C:\npm\mimo.cmd", ExecutableKind.CommandScript, null);
+
+        var result = await installer.DetectAsync(CmdResolver, CancellationToken.None);
+
+        Assert.True(result.Found);
+        Assert.Equal(ExecutableKind.CommandScript, result.Kind);
+    }
+
+    [Fact]
+    public async Task ClaudeCode_DetectAsync_WithNotFoundResolver_ReturnsNotFound()
+    {
+        var installer = new ClaudeCodeInstaller();
+        ExecutableResolutionResult NotFoundResolver(string exe)
+            => new(false, exe, null, ExecutableKind.Native, "not found");
+
+        var result = await installer.DetectAsync(NotFoundResolver, CancellationToken.None);
+
+        Assert.False(result.Found);
+        Assert.NotNull(result.Error);
+        Assert.Contains("Claude Code was not found", result.Error);
+    }
+
+    [Fact]
+    public async Task Codex_DetectAsync_WithNotFoundResolver_ReturnsNotFound()
+    {
+        var installer = new CodexInstaller();
+        ExecutableResolutionResult NotFoundResolver(string exe)
+            => new(false, exe, null, ExecutableKind.Native, "not found");
+
+        var result = await installer.DetectAsync(NotFoundResolver, CancellationToken.None);
+
+        Assert.False(result.Found);
+        Assert.Contains("Codex", result.Error);
+    }
+
+    [Fact]
+    public async Task OpenCode_DetectAsync_WithNotFoundResolver_ReturnsNotFound()
+    {
+        var installer = new OpenCodeInstaller();
+        ExecutableResolutionResult NotFoundResolver(string exe)
+            => new(false, exe, null, ExecutableKind.Native, "not found");
+
+        var result = await installer.DetectAsync(NotFoundResolver, CancellationToken.None);
+
+        Assert.False(result.Found);
+        Assert.Contains("OpenCode", result.Error);
+    }
+
+    [Fact]
+    public async Task MiMoCode_DetectAsync_WithNotFoundResolver_ReturnsNotFound()
+    {
+        var installer = new MiMoCodeInstaller();
+        ExecutableResolutionResult NotFoundResolver(string exe)
+            => new(false, exe, null, ExecutableKind.Native, "not found");
+
+        var result = await installer.DetectAsync(NotFoundResolver, CancellationToken.None);
+
+        Assert.False(result.Found);
+        Assert.Contains("MiMoCode", result.Error);
+    }
+
+    // --- Adapter integration: BuildInstallCommand uses runner with resolved path ---
+
+    [Fact]
+    public async Task ClaudeCode_CmdShim_RunnerUsesComspec()
+    {
+        var installer = new ClaudeCodeInstaller();
+        var spec = CreateSpec();
+        var options = CreateOptions();
+
+        ExecutableResolutionResult CmdResolver(string exe)
+            => new(true, exe, @"C:\npm\claude.cmd", ExecutableKind.CommandScript, null);
+
+        var detection = await installer.DetectAsync(CmdResolver, CancellationToken.None);
+        var cmd = installer.BuildInstallCommand(options, spec, DefaultResolve);
+        cmd = cmd with { ResolvedPath = detection.ExecutablePath, Kind = detection.Kind };
+
+        var (fileName, args) = NativeProcessRunner.BuildProcessArgs(cmd);
+
+        var comspec = Environment.GetEnvironmentVariable("COMSPEC")
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "cmd.exe");
+        Assert.Equal(comspec, fileName);
+        Assert.Equal("/d", args[0]);
+        Assert.Equal("/s", args[1]);
+        Assert.Equal("/c", args[2]);
+        Assert.Equal(@"C:\npm\claude.cmd", args[3]);
+    }
+
+    [Fact]
+    public async Task Codex_Exe_RunnerUsesResolvedPath()
+    {
+        var installer = new CodexInstaller();
+        var spec = CreateSpec();
+        var options = CreateOptions();
+
+        ExecutableResolutionResult ExeResolver(string exe)
+            => new(true, exe, @"C:\tools\codex.exe", ExecutableKind.Native, null);
+
+        var detection = await installer.DetectAsync(ExeResolver, CancellationToken.None);
+        var cmd = installer.BuildInstallCommand(options, spec, DefaultResolve);
+        cmd = cmd with { ResolvedPath = detection.ExecutablePath, Kind = detection.Kind };
+
+        var (fileName, args) = NativeProcessRunner.BuildProcessArgs(cmd);
+
+        Assert.Equal(@"C:\tools\codex.exe", fileName);
+    }
+
+    // --- Regression test: .cmd shim does not cause file-not-found ---
+
+    [Fact]
+    public async Task ClaudeCode_CmdShim_DoesNotFailWithFileNotFound()
+    {
+        // This test reproduces the original bug:
+        // Given: command = "claude", where.exe returns a .cmd path
+        // When: tia-mcp install claude-code
+        // Then: the process runner uses cmd.exe, not the bare "claude" command
+
+        var installer = new ClaudeCodeInstaller();
+        var spec = CreateSpec();
+        var options = CreateOptions();
+
+        ExecutableResolutionResult CmdResolver(string exe)
+            => new(true, exe, @"C:\Users\allan\AppData\Roaming\npm\claude.cmd",
+                   ExecutableKind.CommandScript, null);
+
+        var detection = await installer.DetectAsync(CmdResolver, CancellationToken.None);
+        Assert.True(detection.Found);
+        Assert.Equal(ExecutableKind.CommandScript, detection.Kind);
+
+        var cmd = installer.BuildInstallCommand(options, spec, DefaultResolve);
+        cmd = cmd with { ResolvedPath = detection.ExecutablePath, Kind = detection.Kind };
+
+        var (fileName, args) = NativeProcessRunner.BuildProcessArgs(cmd);
+
+        // Must use cmd.exe, not "claude" directly
+        var comspec = Environment.GetEnvironmentVariable("COMSPEC")
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "cmd.exe");
+        Assert.Equal(comspec, fileName);
+
+        // Script path must be after /c
+        Assert.Equal("/d", args[0]);
+        Assert.Equal("/s", args[1]);
+        Assert.Equal("/c", args[2]);
+        Assert.Equal(@"C:\Users\allan\AppData\Roaming\npm\claude.cmd", args[3]);
+
+        // MCP args follow
+        Assert.Equal("mcp", args[4]);
+        Assert.Equal("add", args[5]);
     }
 }

--- a/TiaMcpServer.Tests/Cli/EnvironmentFallbackCoverageTests.cs
+++ b/TiaMcpServer.Tests/Cli/EnvironmentFallbackCoverageTests.cs
@@ -1,0 +1,141 @@
+using System.Reflection;
+using TiaMcpServer.Cli.Install;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Cli;
+
+[CollectionDefinition("Process environment", DisableParallelization = true)]
+public sealed class ProcessEnvironmentCollection
+{
+}
+
+[Collection("Process environment")]
+public sealed class EnvironmentFallbackCoverageTests
+{
+    private sealed class FakeProcessRunner : INativeProcessRunner
+    {
+        public Task<NativeCommandResult> RunAsync(
+            NativeCommand command,
+            CancellationToken cancellationToken)
+            => Task.FromResult(new NativeCommandResult(0, string.Empty, string.Empty));
+    }
+
+    private static string? ResolveServerExecutable(string? path)
+        => path ?? @"C:\tools\tia-mcp.exe";
+
+    private static ExecutableResolutionResult ResolveCommandClient(string executable)
+        => new(
+            true,
+            executable,
+            $@"C:\npm\{executable}.cmd",
+            ExecutableKind.CommandScript,
+            null);
+
+    [Fact]
+    public void BuildProcessArgs_CommandScriptWithoutComspec_UsesSystemCmd()
+    {
+        var originalComspec = Environment.GetEnvironmentVariable("COMSPEC");
+        try
+        {
+            Environment.SetEnvironmentVariable("COMSPEC", null);
+            var command = new NativeCommand(
+                "claude",
+                new[] { "mcp", "add" },
+                false,
+                @"C:\npm\claude.cmd",
+                ExecutableKind.CommandScript);
+
+            var (fileName, arguments) = NativeProcessRunner.BuildProcessArgs(command);
+
+            Assert.Equal(
+                Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.System),
+                    "cmd.exe"),
+                fileName);
+            Assert.Equal("/c", arguments[2]);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("COMSPEC", originalComspec);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_DryRunWithoutComspec_UsesSystemCmdFallback()
+    {
+        var originalComspec = Environment.GetEnvironmentVariable("COMSPEC");
+        try
+        {
+            Environment.SetEnvironmentVariable("COMSPEC", null);
+            var output = new StringWriter();
+            var error = new StringWriter();
+
+            var exitCode = await InstallCommand.RunAsync(
+                new[] { "codex", "--dry-run" },
+                new FakeProcessRunner(),
+                output,
+                error,
+                ResolveServerExecutable,
+                ResolveCommandClient);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("cmd.exe /d /s /c", output.ToString());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("COMSPEC", originalComspec);
+        }
+    }
+
+    [Fact]
+    public void FormatCommand_WithoutResolvedPath_UsesExecutableName()
+    {
+        var method = typeof(InstallCommand).GetMethod(
+            "FormatCommand",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var command = new NativeCommand(
+            "codex",
+            new[] { "mcp", "list" },
+            false,
+            null,
+            ExecutableKind.Native);
+
+        var formatted = (string[])method.Invoke(null, new object[] { command })!;
+
+        Assert.Equal("codex", formatted[0]);
+        Assert.Equal("mcp", formatted[1]);
+        Assert.Equal("list", formatted[2]);
+    }
+
+    [Fact]
+    public void ResolveInstallExecutable_FullResolvedPathMatch_ReusesDetection()
+    {
+        var method = typeof(InstallCommand).GetMethod(
+            "ResolveInstallExecutable",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var detection = new ClientDetectionResult(
+            true,
+            @"C:\tools\codex.exe",
+            ExecutableKind.Native,
+            null);
+        ExecutableResolutionResult UnexpectedResolver(string executable)
+            => throw new InvalidOperationException(
+                $"Resolver should not be called for '{executable}'.");
+
+        var result = (ExecutableResolutionResult)method.Invoke(
+            null,
+            new object[]
+            {
+                @"C:\tools\codex.exe",
+                detection,
+                (Func<string, ExecutableResolutionResult>)UnexpectedResolver
+            })!;
+
+        Assert.Equal(detection.ExecutablePath, result.ResolvedPath);
+        Assert.Equal(detection.Kind, result.Kind);
+    }
+}

--- a/TiaMcpServer.Tests/Cli/ExecutableResolutionCoverageTests.cs
+++ b/TiaMcpServer.Tests/Cli/ExecutableResolutionCoverageTests.cs
@@ -1,0 +1,381 @@
+using System.Reflection;
+using TiaMcpServer.Cli.Install;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Cli;
+
+public sealed class ExecutableResolutionCoverageTests
+{
+    private sealed class FakeProcessRunner : INativeProcessRunner
+    {
+        public List<NativeCommand> ExecutedCommands { get; } = new();
+        public Queue<NativeCommandResult> Results { get; } = new();
+
+        public Task<NativeCommandResult> RunAsync(
+            NativeCommand command,
+            CancellationToken cancellationToken)
+        {
+            ExecutedCommands.Add(command);
+            return Task.FromResult(
+                Results.Count > 0
+                    ? Results.Dequeue()
+                    : new NativeCommandResult(0, string.Empty, string.Empty));
+        }
+    }
+
+    private static string? ResolveServerExecutable(string? path)
+        => path ?? @"C:\tools\tia-mcp.exe";
+
+    private static ExecutableResolutionResult ResolveNativeClient(string executable)
+        => new(
+            true,
+            executable,
+            $@"C:\tools\{executable}.exe",
+            ExecutableKind.Native,
+            null);
+
+    private static ExecutableResolutionResult ResolveBatchClient(string executable)
+        => new(
+            true,
+            executable,
+            $@"C:\npm\{executable}.bat",
+            ExecutableKind.BatchScript,
+            null);
+
+    [Theory]
+    [InlineData(".exe", ExecutableKind.Native)]
+    [InlineData(".cmd", ExecutableKind.CommandScript)]
+    [InlineData(".bat", ExecutableKind.BatchScript)]
+    public void ResolveClientExecutable_AbsolutePathWithoutExtension_ResolvesFile(
+        string extension,
+        ExecutableKind expectedKind)
+    {
+        var tempDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "tia_mcp_absolute_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+
+        var commandPath = Path.Combine(tempDirectory, "client");
+        var executablePath = commandPath + extension;
+        File.WriteAllText(executablePath, string.Empty);
+
+        try
+        {
+            var result = ExecutableResolver.ResolveClientExecutable(commandPath);
+
+            Assert.True(result.Found);
+            Assert.Equal(Path.GetFullPath(executablePath), result.ResolvedPath);
+            Assert.Equal(expectedKind, result.Kind);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(".exe", ExecutableKind.Native)]
+    [InlineData(".cmd", ExecutableKind.CommandScript)]
+    [InlineData(".bat", ExecutableKind.BatchScript)]
+    public void ResolveClientExecutable_CommonProgramsDirectory_ResolvesFile(
+        string extension,
+        ExecutableKind expectedKind)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var localAppData = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData);
+        var programsDirectory = Path.Combine(localAppData, "Programs");
+        Directory.CreateDirectory(programsDirectory);
+
+        var command = "tia_mcp_common_" + Guid.NewGuid().ToString("N");
+        var executablePath = Path.Combine(programsDirectory, command + extension);
+        File.WriteAllText(executablePath, string.Empty);
+
+        try
+        {
+            var result = ExecutableResolver.ResolveClientExecutable(command);
+
+            Assert.True(result.Found);
+            Assert.Equal(executablePath, result.ResolvedPath);
+            Assert.Equal(expectedKind, result.Kind);
+        }
+        finally
+        {
+            File.Delete(executablePath);
+        }
+    }
+
+    [Fact]
+    public void ResolveClientExecutable_CommonProgramsDirectory_ResolvesBareFile()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var localAppData = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData);
+        var programsDirectory = Path.Combine(localAppData, "Programs");
+        Directory.CreateDirectory(programsDirectory);
+
+        var command = "tia_mcp_bare_" + Guid.NewGuid().ToString("N");
+        var executablePath = Path.Combine(programsDirectory, command);
+        File.WriteAllText(executablePath, string.Empty);
+
+        try
+        {
+            var result = ExecutableResolver.ResolveClientExecutable(command);
+
+            Assert.True(result.Found);
+            Assert.Equal(executablePath, result.ResolvedPath);
+            Assert.Equal(ExecutableKind.Native, result.Kind);
+        }
+        finally
+        {
+            File.Delete(executablePath);
+        }
+    }
+
+    [Theory]
+    [InlineData(@"C:\tools\client.exe", 0)]
+    [InlineData(@"C:\tools\client.cmd", 1)]
+    [InlineData(@"C:\tools\client.bat", 2)]
+    [InlineData(@"C:\tools\client", 3)]
+    public void ExtensionPriority_OrdersSupportedExecutableKinds(
+        string path,
+        int expectedPriority)
+    {
+        var method = typeof(ExecutableResolver).GetMethod(
+            "ExtensionPriority",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        var priority = (int)method.Invoke(null, new object[] { path })!;
+        Assert.Equal(expectedPriority, priority);
+    }
+
+    [Fact]
+    public async Task RunAsync_ParseErrorWithJson_EmitsStructuredError()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "--json", "unsupported-client" },
+            runner,
+            output,
+            error,
+            ResolveServerExecutable,
+            ResolveNativeClient);
+
+        Assert.Equal(3, exitCode);
+        Assert.Contains("\"success\":false", output.ToString());
+        Assert.Contains("Unsupported MCP client", output.ToString());
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_MiMoDryRun_PrintsInteractiveGuideWithoutExecuting()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "mimo", "--dry-run" },
+            runner,
+            output,
+            error,
+            ResolveServerExecutable,
+            ResolveNativeClient);
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(runner.ExecutedCommands);
+        Assert.Contains("Interactive mode: follow the prompts below.", output.ToString());
+        Assert.Contains("Server name:     tia-portal", output.ToString());
+        Assert.Contains("Transport type:  stdio", output.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_InstallFailureWithOnlyStdout_WritesStdout()
+    {
+        var runner = new FakeProcessRunner();
+        runner.Results.Enqueue(new NativeCommandResult(1, "failure on stdout", string.Empty));
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "codex" },
+            runner,
+            output,
+            error,
+            ResolveServerExecutable,
+            ResolveNativeClient);
+
+        Assert.Equal(6, exitCode);
+        Assert.Contains("failure on stdout", error.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_InstallFailureJsonWithOnlyStdout_UsesStdoutAsError()
+    {
+        var runner = new FakeProcessRunner();
+        runner.Results.Enqueue(new NativeCommandResult(1, "failure on stdout", "   "));
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "codex", "--json" },
+            runner,
+            output,
+            error,
+            ResolveServerExecutable,
+            ResolveNativeClient);
+
+        Assert.Equal(6, exitCode);
+        Assert.Contains("\"error\":\"failure on stdout\"", output.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_DryRunJsonWithBatchShim_ReportsActualExecution()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "codex", "--dry-run", "--json" },
+            runner,
+            output,
+            error,
+            ResolveServerExecutable,
+            ResolveBatchClient);
+
+        var json = output.ToString();
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"clientExecutableKind\":\"batch_script\"", json);
+        Assert.Contains("codex.bat", json);
+        Assert.Contains("\"/c\"", json);
+    }
+
+    [Fact]
+    public async Task RunAsync_OpenCodeDryRunJson_ReportsClientCommand()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "opencode", "--dry-run", "--json" },
+            runner,
+            output,
+            error,
+            ResolveServerExecutable,
+            ResolveNativeClient);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"clientCommand\":\"opencode\"", output.ToString());
+    }
+
+    [Fact]
+    public void ResolveInstallExecutable_DifferentCommand_UsesResolver()
+    {
+        var method = typeof(InstallCommand).GetMethod(
+            "ResolveInstallExecutable",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var detection = new ClientDetectionResult(
+            true,
+            @"C:\tools\mimo.exe",
+            ExecutableKind.Native,
+            null);
+        string? resolvedCommand = null;
+        ExecutableResolutionResult Resolver(string executable)
+        {
+            resolvedCommand = executable;
+            return new ExecutableResolutionResult(
+                true,
+                executable,
+                @"C:\npm\claude.cmd",
+                ExecutableKind.CommandScript,
+                null);
+        }
+
+        var result = (ExecutableResolutionResult)method.Invoke(
+            null,
+            new object[]
+            {
+                "claude",
+                detection,
+                (Func<string, ExecutableResolutionResult>)Resolver
+            })!;
+
+        Assert.Equal("claude", resolvedCommand);
+        Assert.Equal(@"C:\npm\claude.cmd", result.ResolvedPath);
+        Assert.Equal(ExecutableKind.CommandScript, result.Kind);
+    }
+
+    [Fact]
+    public void PrintInteractiveGuide_UnsupportedClient_PrintsFallback()
+    {
+        var method = typeof(InstallCommand).GetMethod(
+            "PrintInteractiveGuide",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var output = new StringWriter();
+        var spec = new McpLaunchSpec(
+            "tia-portal",
+            @"C:\tools\tia-mcp.exe",
+            new[] { "--access-mode", "read-only" });
+        var options = new InstallOptions(
+            true,
+            ClientKind.Codex,
+            "tia-portal",
+            "read-only",
+            null,
+            null,
+            false,
+            false,
+            false,
+            null);
+
+        method.Invoke(null, new object[] { output, ClientKind.Codex, spec, options });
+
+        Assert.Contains("no guide available for Codex", output.ToString());
+    }
+
+    [Fact]
+    public void GetClientCommand_FormatsMiMoAndUnknownValues()
+    {
+        var method = typeof(InstallCommand).GetMethod(
+            "GetClientCommand",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        Assert.Equal("mimo", method.Invoke(null, new object[] { ClientKind.MiMoCode }));
+        Assert.Equal("12345", method.Invoke(null, new object[] { (ClientKind)12345 }));
+    }
+
+    [Fact]
+    public void FormatKind_FormatsBatchAndUnknownValues()
+    {
+        var method = typeof(InstallCommand).GetMethod(
+            "FormatKind",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        Assert.Equal(
+            "batch_script",
+            method.Invoke(null, new object[] { ExecutableKind.BatchScript }));
+        Assert.Equal(
+            "12345",
+            method.Invoke(null, new object[] { (ExecutableKind)12345 }));
+    }
+}

--- a/TiaMcpServer.Tests/Cli/ExecutableResolverTests.cs
+++ b/TiaMcpServer.Tests/Cli/ExecutableResolverTests.cs
@@ -5,6 +5,8 @@ namespace TiaMcpServer.Tests.Cli;
 
 public class ExecutableResolverTests
 {
+    // --- Server executable resolution ---
+
     [Fact]
     public void ResolveServerExecutable_ExplicitPath_ReturnsPath()
     {
@@ -34,19 +36,10 @@ public class ExecutableResolverTests
     public void ResolveServerExecutable_NullOrEmpty_FallsThroughResolution()
     {
         // This test verifies that null input doesn't throw and falls through to other resolution methods.
-        // The actual result depends on whether tia-mcp is installed on the test machine.
         var result = ExecutableResolver.ResolveServerExecutable(null);
 
         // We can't assert a specific value since it depends on the environment,
         // but it should not throw.
-    }
-
-    [Fact]
-    public void FindClientExecutable_NonexistentClient_ReturnsNull()
-    {
-        var result = ExecutableResolver.FindClientExecutable("nonexistent_client_xyz");
-
-        Assert.Null(result);
     }
 
     [Fact]
@@ -68,5 +61,194 @@ public class ExecutableResolverTests
             File.Delete(tempFile);
             Directory.Delete(tempDir);
         }
+    }
+
+    // --- Client executable resolution ---
+
+    [Fact]
+    public void ResolveClientExecutable_NonexistentCommand_ReturnsNotFound()
+    {
+        var result = ExecutableResolver.ResolveClientExecutable("nonexistent_command_xyz_12345");
+
+        Assert.False(result.Found);
+        Assert.Null(result.ResolvedPath);
+        Assert.Contains("not found", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResolveClientExecutable_EmptyCommand_ReturnsNotFound()
+    {
+        var result = ExecutableResolver.ResolveClientExecutable("");
+
+        Assert.False(result.Found);
+        Assert.Contains("empty", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResolveClientExecutable_WhitespaceCommand_ReturnsNotFound()
+    {
+        var result = ExecutableResolver.ResolveClientExecutable("   ");
+
+        Assert.False(result.Found);
+    }
+
+    [Fact]
+    public void ResolveClientExecutable_AbsolutePathExistingFile_ReturnsFullPath()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var result = ExecutableResolver.ResolveClientExecutable(tempFile);
+
+            Assert.True(result.Found);
+            Assert.Equal(Path.GetFullPath(tempFile), result.ResolvedPath);
+            Assert.Equal(ExecutableKind.Native, result.Kind);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ResolveClientExecutable_AbsolutePathNonexistent_ReturnsNotFound()
+    {
+        var result = ExecutableResolver.ResolveClientExecutable(@"C:\nonexistent\path\client.exe");
+
+        Assert.False(result.Found);
+        Assert.Contains("does not exist", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResolveClientExecutable_AbsolutePathWithSpaces_IsResolved()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "test dir with spaces " + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        var tempFile = Path.Combine(tempDir, "myclient.exe");
+        File.WriteAllText(tempFile, "");
+        try
+        {
+            var result = ExecutableResolver.ResolveClientExecutable(tempFile);
+
+            Assert.True(result.Found);
+            Assert.Equal(Path.GetFullPath(tempFile), result.ResolvedPath);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+            Directory.Delete(tempDir);
+        }
+    }
+
+    [Fact]
+    public void ResolveClientExecutable_WhereExeFindsExe_ReturnsNativeKind()
+    {
+        // cmd.exe should always be findable via where.exe
+        var result = ExecutableResolver.ResolveClientExecutable("cmd");
+
+        Assert.True(result.Found);
+        Assert.NotNull(result.ResolvedPath);
+        Assert.EndsWith(".exe", result.ResolvedPath, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(ExecutableKind.Native, result.Kind);
+    }
+
+    [Fact]
+    public void ResolveClientExecutable_KnownCommand_WhereExeFindsIt()
+    {
+        // where.exe should find itself
+        var result = ExecutableResolver.ResolveClientExecutable("where");
+
+        Assert.True(result.Found);
+        Assert.NotNull(result.ResolvedPath);
+        Assert.Contains("where", result.ResolvedPath, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResolveClientExecutable_ResultCommand_PreservesOriginalName()
+    {
+        var result = ExecutableResolver.ResolveClientExecutable("cmd");
+
+        Assert.Equal("cmd", result.Command);
+    }
+
+    [Fact]
+    public void ResolveClientExecutable_UnicodePath_IsHandled()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "test_unicode_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        var tempFile = Path.Combine(tempDir, "client.exe");
+        File.WriteAllText(tempFile, "");
+        try
+        {
+            var result = ExecutableResolver.ResolveClientExecutable(tempFile);
+
+            Assert.True(result.Found);
+            Assert.Equal(Path.GetFullPath(tempFile), result.ResolvedPath);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+            Directory.Delete(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task ResolveClientExecutable_Cancellation_DoesNotThrow()
+    {
+        // ResolveClientExecutable is synchronous and doesn't take a CancellationToken,
+        // but the DetectAsync path does. Verify it doesn't throw.
+        var resolver = new ClaudeCodeInstaller();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Should not throw even with cancelled token
+        var result = await resolver.DetectAsync(
+            ExecutableResolver.ResolveClientExecutable, cts.Token);
+
+        // Result depends on environment, but should not throw
+        Assert.NotNull(result);
+    }
+
+    // --- FindClientExecutable legacy method ---
+
+    [Fact]
+    public void FindClientExecutable_NonexistentClient_ReturnsNull()
+    {
+        var result = ExecutableResolver.FindClientExecutable("nonexistent_client_xyz");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void FindClientExecutable_KnownCommand_ReturnsPath()
+    {
+        var result = ExecutableResolver.FindClientExecutable("cmd");
+
+        Assert.NotNull(result);
+    }
+
+    // --- ClassifyExtension ---
+
+    [Theory]
+    [InlineData(@"C:\path\tool.exe", ExecutableKind.Native)]
+    [InlineData(@"C:\path\tool.cmd", ExecutableKind.CommandScript)]
+    [InlineData(@"C:\path\tool.bat", ExecutableKind.BatchScript)]
+    [InlineData(@"C:\path\tool", ExecutableKind.Native)]
+    public void ClassifyExtension_ReturnsCorrectKind(string path, ExecutableKind expected)
+    {
+        var result = ExecutableResolver.ClassifyExtension(path);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(@"C:\path\TOOL.CMD", ExecutableKind.CommandScript)]
+    [InlineData(@"C:\path\TOOL.BAT", ExecutableKind.BatchScript)]
+    [InlineData(@"C:\path\TOOL.EXE", ExecutableKind.Native)]
+    public void ClassifyExtension_CaseInsensitive(string path, ExecutableKind expected)
+    {
+        var result = ExecutableResolver.ClassifyExtension(path);
+
+        Assert.Equal(expected, result);
     }
 }

--- a/TiaMcpServer.Tests/Cli/FinalInstallCoverageTests.cs
+++ b/TiaMcpServer.Tests/Cli/FinalInstallCoverageTests.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics;
+using TiaMcpServer.Cli.Install;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Cli;
+
+public sealed class FinalInstallCoverageTests
+{
+    private sealed class FakeProcessRunner : INativeProcessRunner
+    {
+        public Task<NativeCommandResult> RunAsync(
+            NativeCommand command,
+            CancellationToken cancellationToken)
+            => Task.FromResult(new NativeCommandResult(0, string.Empty, string.Empty));
+    }
+
+    private static string? ResolveServerExecutable(string? path)
+        => path ?? @"C:\tools\tia-mcp.exe";
+
+    private static ExecutableResolutionResult ResolveCommandScript(string executable)
+        => new(
+            true,
+            executable,
+            $@"C:\npm\{executable}.cmd",
+            ExecutableKind.CommandScript,
+            null);
+
+    [Fact]
+    public void RunWhereAll_ProcessStartFailure_ReturnsEmptyResult()
+    {
+        Process? ThrowingStarter(ProcessStartInfo _)
+            => throw new InvalidOperationException("process start failed");
+
+        var results = ExecutableResolver.RunWhereAll(
+            "client",
+            ThrowingStarter);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task RunAsync_DryRunJsonWithCommandShim_FormatsCommandScriptKind()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "codex", "--dry-run", "--json" },
+            new FakeProcessRunner(),
+            output,
+            error,
+            ResolveServerExecutable,
+            ResolveCommandScript);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains(
+            "\"clientExecutableKind\":\"command_script\"",
+            output.ToString());
+    }
+}

--- a/TiaMcpServer.Tests/Cli/InstallCliParserTests.cs
+++ b/TiaMcpServer.Tests/Cli/InstallCliParserTests.cs
@@ -196,7 +196,7 @@ public class InstallCliParserTests
     }
 
     [Fact]
-    public void Parse_MiMoCodeWithJson_ReturnsInvalidWithExit8()
+    public void Parse_MiMoCodeWithJson_ReturnsInvalid()
     {
         var result = InstallCliParser.Parse(new[] { "mimo", "--json" });
 

--- a/TiaMcpServer.Tests/Cli/InstallCommandEntryPointCoverageTests.cs
+++ b/TiaMcpServer.Tests/Cli/InstallCommandEntryPointCoverageTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using TiaMcpServer.Cli.Install;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Cli;
+
+public sealed class InstallCommandEntryPointCoverageTests
+{
+    private sealed class FakeProcessRunner : INativeProcessRunner
+    {
+        public Task<NativeCommandResult> RunAsync(
+            NativeCommand command,
+            CancellationToken cancellationToken)
+            => Task.FromResult(new NativeCommandResult(0, string.Empty, string.Empty));
+    }
+
+    [Fact]
+    public async Task RunAsync_InjectedRunnerEntryPoint_HandlesHelp()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "--help" },
+            new FakeProcessRunner(),
+            output,
+            error);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Usage: tia-mcp install", output.ToString());
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public void FormatClientName_UnknownValue_UsesEnumText()
+    {
+        var method = typeof(InstallCommand).GetMethod(
+            "FormatClientName",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var formatted = method.Invoke(null, new object[] { (ClientKind)12345 });
+
+        Assert.Equal("12345", formatted);
+    }
+}

--- a/TiaMcpServer.Tests/Cli/InstallCommandTests.cs
+++ b/TiaMcpServer.Tests/Cli/InstallCommandTests.cs
@@ -23,7 +23,15 @@ public class InstallCommandTests
     }
 
     private static string? FakeResolveServerExe(string? path) => path ?? @"C:\tools\tia-mcp.exe";
-    private static string? FakeFindClientExe(string exe) => $@"C:\tools\{exe}.exe";
+
+    private static ExecutableResolutionResult FakeResolveClientExe(string exe)
+        => new(true, exe, $@"C:\tools\{exe}.exe", ExecutableKind.Native, null);
+
+    private static ExecutableResolutionResult FakeResolveClientExeAsCmd(string exe)
+        => new(true, exe, $@"C:\Users\user\AppData\Roaming\npm\{exe}.cmd", ExecutableKind.CommandScript, null);
+
+    private static ExecutableResolutionResult NotFoundClientExe(string exe)
+        => new(false, exe, null, ExecutableKind.Native, $"The executable '{exe}' was not found.");
 
     [Fact]
     public async Task RunAsync_Help_ReturnsZeroAndPrintsUsage()
@@ -33,7 +41,7 @@ public class InstallCommandTests
         var error = new StringWriter();
 
         var exitCode = await InstallCommand.RunAsync(
-            new[] { "--help" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            new[] { "--help" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
         Assert.Equal(0, exitCode);
         Assert.Contains("Usage: tia-mcp install", output.ToString());
@@ -47,7 +55,7 @@ public class InstallCommandTests
         var error = new StringWriter();
 
         var exitCode = await InstallCommand.RunAsync(
-            new[] { "--help", "--json" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            new[] { "--help", "--json" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
         Assert.Equal(0, exitCode);
         Assert.Contains("\"usage\"", output.ToString());
@@ -61,7 +69,7 @@ public class InstallCommandTests
         var error = new StringWriter();
 
         var exitCode = await InstallCommand.RunAsync(
-            System.Array.Empty<string>(), runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            System.Array.Empty<string>(), runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
         Assert.Equal(2, exitCode);
         Assert.Contains("No MCP client specified", error.ToString());
@@ -75,7 +83,7 @@ public class InstallCommandTests
         var error = new StringWriter();
 
         var exitCode = await InstallCommand.RunAsync(
-            new[] { "unknown-client" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            new[] { "unknown-client" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
         Assert.Equal(3, exitCode);
     }
@@ -89,7 +97,7 @@ public class InstallCommandTests
         string? NullResolver(string? _) => null;
 
         var exitCode = await InstallCommand.RunAsync(
-            new[] { "codex" }, runner, output, error, NullResolver, FakeFindClientExe);
+            new[] { "codex" }, runner, output, error, NullResolver, FakeResolveClientExe);
 
         Assert.Equal(5, exitCode);
         Assert.Contains("tia-mcp executable not found", error.ToString());
@@ -101,15 +109,31 @@ public class InstallCommandTests
         var runner = new FakeProcessRunner();
         var output = new StringWriter();
         var error = new StringWriter();
-        string? NullFinder(string _) => null;
-
-        // Need to make DetectAsync fail: override with a runner that returns failure for where.exe
-        runner.Results.Enqueue(new NativeCommandResult(1, string.Empty, "not found"));
 
         var exitCode = await InstallCommand.RunAsync(
-            new[] { "codex" }, runner, output, error, FakeResolveServerExe, NullFinder);
+            new[] { "codex" }, runner, output, error, FakeResolveServerExe, NotFoundClientExe);
 
         Assert.Equal(4, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_MiMoCode_UsesInteractiveMode()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // Install succeeds (interactive)
+        runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
+        // Verification succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, "3 server(s)", string.Empty));
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "mimo" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("mimo", runner.ExecutedCommands[0].Executable);
+        Assert.True(runner.ExecutedCommands[0].Interactive);
     }
 
     [Fact]
@@ -119,11 +143,8 @@ public class InstallCommandTests
         var output = new StringWriter();
         var error = new StringWriter();
 
-        // where.exe succeeds for mimo detection
-        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\mimo.exe", string.Empty));
-
         var exitCode = await InstallCommand.RunAsync(
-            new[] { "mimo", "--json" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            new[] { "mimo", "--json" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
         Assert.Equal(8, exitCode);
         Assert.Contains("does not support --json", output.ToString());
@@ -136,14 +157,11 @@ public class InstallCommandTests
         var output = new StringWriter();
         var error = new StringWriter();
 
-        // where.exe succeeds for codex detection
-        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
-
         var exitCode = await InstallCommand.RunAsync(
-            new[] { "codex", "--dry-run" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            new[] { "codex", "--dry-run" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
         Assert.Equal(0, exitCode);
-        Assert.Contains("[dry-run]", output.ToString());
+        Assert.Contains("Dry run", output.ToString());
         Assert.Contains("codex", output.ToString());
     }
 
@@ -154,11 +172,8 @@ public class InstallCommandTests
         var output = new StringWriter();
         var error = new StringWriter();
 
-        // where.exe succeeds for codex detection
-        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
-
         var exitCode = await InstallCommand.RunAsync(
-            new[] { "codex", "--dry-run", "--json" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            new[] { "codex", "--dry-run", "--json" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
         Assert.Equal(0, exitCode);
         Assert.Contains("\"dryRun\":true", output.ToString());
@@ -171,15 +186,13 @@ public class InstallCommandTests
         var output = new StringWriter();
         var error = new StringWriter();
 
-        // where.exe succeeds for codex detection
-        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
         // Install succeeds
         runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
         // Verification succeeds
         runner.Results.Enqueue(new NativeCommandResult(0, "{}", string.Empty));
 
         var exitCode = await InstallCommand.RunAsync(
-            new[] { "codex" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            new[] { "codex" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
         Assert.Equal(0, exitCode);
         Assert.Contains("Successfully registered", output.ToString());
@@ -193,8 +206,6 @@ public class InstallCommandTests
         var output = new StringWriter();
         var error = new StringWriter();
 
-        // where.exe succeeds for codex detection
-        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
         // Install succeeds
         runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
         // Verification succeeds
@@ -202,14 +213,14 @@ public class InstallCommandTests
 
         await InstallCommand.RunAsync(
             new[] { "codex", "--name", "my-tia", "--access-mode", "read-write" },
-            runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
-        // First command is where.exe, second is the install, third is verification
-        Assert.Equal(3, runner.ExecutedCommands.Count);
-        Assert.Equal("codex", runner.ExecutedCommands[1].Executable);
-        Assert.Contains("mcp", runner.ExecutedCommands[1].Arguments);
-        Assert.Contains("add", runner.ExecutedCommands[1].Arguments);
-        Assert.Contains("my-tia", runner.ExecutedCommands[1].Arguments);
+        // First command is install, second is verification
+        Assert.Equal(2, runner.ExecutedCommands.Count);
+        Assert.Equal("codex", runner.ExecutedCommands[0].Executable);
+        Assert.Contains("mcp", runner.ExecutedCommands[0].Arguments);
+        Assert.Contains("add", runner.ExecutedCommands[0].Arguments);
+        Assert.Contains("my-tia", runner.ExecutedCommands[0].Arguments);
     }
 
     [Fact]
@@ -219,13 +230,11 @@ public class InstallCommandTests
         var output = new StringWriter();
         var error = new StringWriter();
 
-        // where.exe succeeds for codex detection
-        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
         // Install fails
         runner.Results.Enqueue(new NativeCommandResult(1, string.Empty, "Installation failed"));
 
         var exitCode = await InstallCommand.RunAsync(
-            new[] { "codex" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            new[] { "codex" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
         Assert.Equal(6, exitCode);
         Assert.Contains("Install command failed", error.ToString());
@@ -238,15 +247,13 @@ public class InstallCommandTests
         var output = new StringWriter();
         var error = new StringWriter();
 
-        // where.exe succeeds for codex detection
-        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
         // Install succeeds
         runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
         // Verification fails
         runner.Results.Enqueue(new NativeCommandResult(1, string.Empty, "Verification error"));
 
         var exitCode = await InstallCommand.RunAsync(
-            new[] { "codex" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            new[] { "codex" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
         Assert.Equal(7, exitCode);
     }
@@ -258,15 +265,13 @@ public class InstallCommandTests
         var output = new StringWriter();
         var error = new StringWriter();
 
-        // where.exe succeeds for codex detection
-        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
         // Install succeeds
         runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
         // Verification succeeds
         runner.Results.Enqueue(new NativeCommandResult(0, "{}", string.Empty));
 
         var exitCode = await InstallCommand.RunAsync(
-            new[] { "codex", "--json" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            new[] { "codex", "--json" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
         Assert.Equal(0, exitCode);
         var jsonOutput = output.ToString();
@@ -274,6 +279,8 @@ public class InstallCommandTests
         Assert.Contains("\"client\":\"Codex\"", jsonOutput);
         Assert.Contains("\"serverName\":\"tia-portal\"", jsonOutput);
         Assert.Contains("\"accessMode\":\"read-only\"", jsonOutput);
+        Assert.Contains("\"resolvedClientPath\"", jsonOutput);
+        Assert.Contains("\"clientExecutableKind\"", jsonOutput);
     }
 
     [Fact]
@@ -285,10 +292,11 @@ public class InstallCommandTests
         string? NullResolver(string? _) => null;
 
         var exitCode = await InstallCommand.RunAsync(
-            new[] { "codex", "--json" }, runner, output, error, NullResolver, FakeFindClientExe);
+            new[] { "codex", "--json" }, runner, output, error, NullResolver, FakeResolveClientExe);
 
         Assert.Equal(5, exitCode);
         Assert.Contains("\"success\":false", output.ToString());
+        Assert.Contains("\"tia_mcp_executable_not_found\"", output.ToString());
     }
 
     [Fact]
@@ -298,8 +306,6 @@ public class InstallCommandTests
         var output = new StringWriter();
         var error = new StringWriter();
 
-        // where.exe succeeds for codex detection
-        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\codex.exe", string.Empty));
         // Install succeeds
         runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
         // Verification succeeds
@@ -307,9 +313,9 @@ public class InstallCommandTests
 
         await InstallCommand.RunAsync(
             new[] { "codex", "--tia-project", @"C:\Projects\Line.ap21" },
-            runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
-        var installCmd = runner.ExecutedCommands[1];
+        var installCmd = runner.ExecutedCommands[0];
         Assert.Contains("--project", installCmd.Arguments);
         Assert.Contains(@"C:\Projects\Line.ap21", installCmd.Arguments);
     }
@@ -321,19 +327,17 @@ public class InstallCommandTests
         var output = new StringWriter();
         var error = new StringWriter();
 
-        // where.exe succeeds for claude detection
-        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\claude.exe", string.Empty));
         // Install succeeds
         runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
         // Verification succeeds
         runner.Results.Enqueue(new NativeCommandResult(0, "{}", string.Empty));
 
         await InstallCommand.RunAsync(
-            new[] { "claude" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            new[] { "claude" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
-        Assert.Equal("claude", runner.ExecutedCommands[1].Executable);
-        Assert.Contains("--scope", runner.ExecutedCommands[1].Arguments);
-        Assert.Contains("user", runner.ExecutedCommands[1].Arguments);
+        Assert.Equal("claude", runner.ExecutedCommands[0].Executable);
+        Assert.Contains("--scope", runner.ExecutedCommands[0].Arguments);
+        Assert.Contains("user", runner.ExecutedCommands[0].Arguments);
     }
 
     [Fact]
@@ -343,16 +347,86 @@ public class InstallCommandTests
         var output = new StringWriter();
         var error = new StringWriter();
 
-        // where.exe succeeds for opencode detection
-        runner.Results.Enqueue(new NativeCommandResult(0, @"C:\tools\opencode.exe", string.Empty));
         // Install succeeds
         runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
         // Verification succeeds
         runner.Results.Enqueue(new NativeCommandResult(0, "{}", string.Empty));
 
         await InstallCommand.RunAsync(
-            new[] { "opencode" }, runner, output, error, FakeResolveServerExe, FakeFindClientExe);
+            new[] { "opencode" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
 
-        Assert.Equal("opencode", runner.ExecutedCommands[1].Executable);
+        Assert.Equal("opencode", runner.ExecutedCommands[0].Executable);
+    }
+
+    [Fact]
+    public async Task RunAsync_CmdShim_PatchesResolvedPathAndKind()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // Install succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, string.Empty, string.Empty));
+        // Verification succeeds
+        runner.Results.Enqueue(new NativeCommandResult(0, "{}", string.Empty));
+
+        await InstallCommand.RunAsync(
+            new[] { "claude" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExeAsCmd);
+
+        var installCmd = runner.ExecutedCommands[0];
+        Assert.Equal(ExecutableKind.CommandScript, installCmd.Kind);
+        Assert.Equal(@"C:\Users\user\AppData\Roaming\npm\claude.cmd", installCmd.ResolvedPath);
+    }
+
+    [Fact]
+    public async Task RunAsync_ClientNotFound_JsonOutput_HasErrorCode()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "claude", "--json" }, runner, output, error, FakeResolveServerExe, NotFoundClientExe);
+
+        Assert.Equal(4, exitCode);
+        var jsonOutput = output.ToString();
+        Assert.Contains("\"client_not_found\"", jsonOutput);
+        Assert.Contains("\"success\":false", jsonOutput);
+    }
+
+    [Fact]
+    public async Task RunAsync_DryRun_CmdShim_ShowsExecutionMethod()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "claude", "--dry-run" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExeAsCmd);
+
+        Assert.Equal(0, exitCode);
+        var text = output.ToString();
+        Assert.Contains("Execution method:", text);
+        Assert.Contains("/d /s /c", text);
+        Assert.Contains("claude.cmd", text);
+    }
+
+    [Fact]
+    public async Task RunAsync_InstallFailed_Json_HasErrorCode()
+    {
+        var runner = new FakeProcessRunner();
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // Install fails
+        runner.Results.Enqueue(new NativeCommandResult(1, string.Empty, "Installation failed"));
+
+        var exitCode = await InstallCommand.RunAsync(
+            new[] { "codex", "--json" }, runner, output, error, FakeResolveServerExe, FakeResolveClientExe);
+
+        Assert.Equal(6, exitCode);
+        var jsonOutput = output.ToString();
+        Assert.Contains("\"client_command_failed\"", jsonOutput);
+        Assert.Contains("\"success\":false", jsonOutput);
     }
 }

--- a/TiaMcpServer.Tests/Cli/NativeProcessRunnerTests.cs
+++ b/TiaMcpServer.Tests/Cli/NativeProcessRunnerTests.cs
@@ -96,4 +96,213 @@ public class NativeProcessRunnerTests
         Assert.Contains("captured", result.Stdout);
         Assert.False(cmd.Interactive);
     }
+
+    // --- BuildProcessArgs tests ---
+
+    [Fact]
+    public void BuildProcessArgs_NativeExe_UsesResolvedPathDirectly()
+    {
+        var cmd = new NativeCommand("claude", new[] { "mcp", "add" }, false,
+            @"C:\tools\claude.exe", ExecutableKind.Native);
+
+        var (fileName, args) = NativeProcessRunner.BuildProcessArgs(cmd);
+
+        Assert.Equal(@"C:\tools\claude.exe", fileName);
+        Assert.Equal(new[] { "mcp", "add" }, args);
+    }
+
+    [Fact]
+    public void BuildProcessArgs_CmdScript_UsesComspec()
+    {
+        var cmd = new NativeCommand("claude", new[] { "mcp", "add" }, false,
+            @"C:\Users\user\AppData\Roaming\npm\claude.cmd", ExecutableKind.CommandScript);
+
+        var (fileName, args) = NativeProcessRunner.BuildProcessArgs(cmd);
+
+        var comspec = Environment.GetEnvironmentVariable("COMSPEC")
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "cmd.exe");
+        Assert.Equal(comspec, fileName);
+        Assert.Equal("/d", args[0]);
+        Assert.Equal("/s", args[1]);
+        Assert.Equal("/c", args[2]);
+        Assert.Equal(@"C:\Users\user\AppData\Roaming\npm\claude.cmd", args[3]);
+        Assert.Equal("mcp", args[4]);
+        Assert.Equal("add", args[5]);
+    }
+
+    [Fact]
+    public void BuildProcessArgs_BatchScript_UsesComspec()
+    {
+        var cmd = new NativeCommand("tool", new[] { "arg1" }, false,
+            @"C:\tools\tool.bat", ExecutableKind.BatchScript);
+
+        var (fileName, args) = NativeProcessRunner.BuildProcessArgs(cmd);
+
+        var comspec = Environment.GetEnvironmentVariable("COMSPEC")
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "cmd.exe");
+        Assert.Equal(comspec, fileName);
+        Assert.Equal("/d", args[0]);
+        Assert.Equal("/s", args[1]);
+        Assert.Equal("/c", args[2]);
+        Assert.Equal(@"C:\tools\tool.bat", args[3]);
+        Assert.Equal("arg1", args[4]);
+    }
+
+    [Fact]
+    public void BuildProcessArgs_NoResolvedPath_FallsBackToExecutable()
+    {
+        var cmd = new NativeCommand("cmd.exe", new[] { "/c", "echo test" }, false);
+
+        var (fileName, args) = NativeProcessRunner.BuildProcessArgs(cmd);
+
+        Assert.Equal("cmd.exe", fileName);
+        Assert.Equal(new[] { "/c", "echo test" }, args);
+    }
+
+    [Fact]
+    public void BuildProcessArgs_CmdScript_PutsMcpArgsAfterScript()
+    {
+        var mcpArgs = new[] { "mcp", "add", "--scope", "user", "tia-portal", "--",
+            @"C:\tools\tia-mcp.exe", "--access-mode", "read-only" };
+        var cmd = new NativeCommand("claude", mcpArgs, false,
+            @"C:\npm\claude.cmd", ExecutableKind.CommandScript);
+
+        var (fileName, args) = NativeProcessRunner.BuildProcessArgs(cmd);
+
+        // args[0..2] = /d /s /c
+        // args[3] = script path
+        // args[4..] = MCP arguments
+        Assert.Equal(@"C:\npm\claude.cmd", args[3]);
+        Assert.Equal("mcp", args[4]);
+        Assert.Equal("add", args[5]);
+        Assert.Equal("--scope", args[6]);
+        Assert.Equal("user", args[7]);
+        Assert.Equal("tia-portal", args[8]);
+        Assert.Equal("--", args[9]);
+        Assert.Equal(@"C:\tools\tia-mcp.exe", args[10]);
+        Assert.Equal("--access-mode", args[11]);
+        Assert.Equal("read-only", args[12]);
+    }
+
+    [Fact]
+    public void BuildProcessArgs_CmdScriptWithSpaces_PreservesPath()
+    {
+        var cmd = new NativeCommand("claude", new[] { "mcp", "add" }, false,
+            @"C:\Users\Allan Marum\AppData\Roaming\npm\claude.cmd", ExecutableKind.CommandScript);
+
+        var (fileName, args) = NativeProcessRunner.BuildProcessArgs(cmd);
+
+        // The script path is passed as a separate argument, not concatenated
+        Assert.Equal(@"C:\Users\Allan Marum\AppData\Roaming\npm\claude.cmd", args[3]);
+    }
+
+    [Fact]
+    public void BuildProcessArgs_Interactive_UsesSameLogic()
+    {
+        var cmd = new NativeCommand("mimo", new[] { "mcp", "add" }, true,
+            @"C:\npm\mimo.cmd", ExecutableKind.CommandScript);
+
+        var (fileName, args) = NativeProcessRunner.BuildProcessArgs(cmd);
+
+        var comspec = Environment.GetEnvironmentVariable("COMSPEC")
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "cmd.exe");
+        Assert.Equal(comspec, fileName);
+        Assert.Equal("/d", args[0]);
+        Assert.Equal("/s", args[1]);
+        Assert.Equal("/c", args[2]);
+        Assert.Equal(@"C:\npm\mimo.cmd", args[3]);
+    }
+
+    // --- .cmd execution end-to-end ---
+
+    [Fact]
+    public async Task RunAsync_CmdScript_ExecutesThroughComspec()
+    {
+        // Create a temporary .cmd file
+        var tempDir = Path.Combine(Path.GetTempPath(), "test_cmd_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        var cmdFile = Path.Combine(tempDir, "test.cmd");
+        File.WriteAllText(cmdFile, "@echo hello_from_cmd");
+
+        try
+        {
+            var runner = new NativeProcessRunner();
+            var cmd = new NativeCommand("test", System.Array.Empty<string>(), false,
+                cmdFile, ExecutableKind.CommandScript);
+
+            var result = await runner.RunAsync(cmd, CancellationToken.None);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("hello_from_cmd", result.Stdout);
+        }
+        finally
+        {
+            File.Delete(cmdFile);
+            Directory.Delete(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_BatchScript_ExecutesThroughComspec()
+    {
+        // Create a temporary .bat file
+        var tempDir = Path.Combine(Path.GetTempPath(), "test_bat_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        var batFile = Path.Combine(tempDir, "test.bat");
+        File.WriteAllText(batFile, "@echo hello_from_bat");
+
+        try
+        {
+            var runner = new NativeProcessRunner();
+            var cmd = new NativeCommand("test", System.Array.Empty<string>(), false,
+                batFile, ExecutableKind.BatchScript);
+
+            var result = await runner.RunAsync(cmd, CancellationToken.None);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("hello_from_bat", result.Stdout);
+        }
+        finally
+        {
+            File.Delete(batFile);
+            Directory.Delete(tempDir);
+        }
+    }
+
+    // --- ProcessStartInfo validation ---
+
+    [Fact]
+    public void BuildProcessArgs_Native_VerifyProcessStartInfo()
+    {
+        var cmd = new NativeCommand("claude", new[] { "mcp", "add" }, false,
+            @"C:\tools\claude.exe", ExecutableKind.Native);
+
+        var (fileName, args) = NativeProcessRunner.BuildProcessArgs(cmd);
+
+        // Verify the process would be started correctly
+        Assert.Equal(@"C:\tools\claude.exe", fileName);
+        Assert.DoesNotContain("/d", args);
+        Assert.DoesNotContain("/s", args);
+        Assert.DoesNotContain("/c", args);
+    }
+
+    [Fact]
+    public void BuildProcessArgs_Cmd_VerifyProcessStartInfo()
+    {
+        var cmd = new NativeCommand("claude", new[] { "mcp", "add" }, false,
+            @"C:\npm\claude.cmd", ExecutableKind.CommandScript);
+
+        var (fileName, args) = NativeProcessRunner.BuildProcessArgs(cmd);
+
+        var comspec = Environment.GetEnvironmentVariable("COMSPEC")
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "cmd.exe");
+        Assert.Equal(comspec, fileName);
+        Assert.Equal("/d", args[0]);
+        Assert.Equal("/s", args[1]);
+        Assert.Equal("/c", args[2]);
+        Assert.Equal(@"C:\npm\claude.cmd", args[3]);
+        // MCP args come after
+        Assert.Equal("mcp", args[4]);
+        Assert.Equal("add", args[5]);
+    }
 }

--- a/TiaMcpServer/Cli/Install/ClaudeCodeInstaller.cs
+++ b/TiaMcpServer/Cli/Install/ClaudeCodeInstaller.cs
@@ -4,22 +4,22 @@ internal sealed class ClaudeCodeInstaller : IMcpClientInstaller
 {
     public ClientKind Client => ClientKind.ClaudeCode;
 
-    public async Task<ClientDetectionResult> DetectAsync(INativeProcessRunner runner, CancellationToken cancellationToken)
+    public Task<ClientDetectionResult> DetectAsync(
+        Func<string, ExecutableResolutionResult> resolveClientExe,
+        CancellationToken cancellationToken)
     {
-        var result = await runner.RunAsync(
-            new NativeCommand("where.exe", new[] { "claude" }, false),
-            cancellationToken);
-
-        if (result.ExitCode == 0 && !string.IsNullOrWhiteSpace(result.Stdout))
-        {
-            var path = result.Stdout.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)[0];
-            return new ClientDetectionResult(true, path, null);
-        }
-
-        return new ClientDetectionResult(false, null, "Claude Code CLI not found. Install it from https://docs.anthropic.com/en/docs/claude-code");
+        var result = resolveClientExe("claude");
+        return Task.FromResult(new ClientDetectionResult(
+            result.Found,
+            result.ResolvedPath,
+            result.Kind,
+            result.Found ? null : "Claude Code was not found.\n\nExpected command:\n  claude\n\nVerify the installation with:\n  claude --version\n\nAfter installing Claude Code, run:\n  tia-mcp install claude-code"));
     }
 
-    public NativeCommand BuildInstallCommand(InstallOptions options, McpLaunchSpec spec)
+    public NativeCommand BuildInstallCommand(
+        InstallOptions options,
+        McpLaunchSpec spec,
+        Func<string, ExecutableResolutionResult> resolveClientExe)
     {
         var args = new List<string> { "mcp", "add", "--scope", "user", spec.ServerName, "--" };
         args.Add(spec.ExecutablePath);

--- a/TiaMcpServer/Cli/Install/CodexInstaller.cs
+++ b/TiaMcpServer/Cli/Install/CodexInstaller.cs
@@ -4,22 +4,22 @@ internal sealed class CodexInstaller : IMcpClientInstaller
 {
     public ClientKind Client => ClientKind.Codex;
 
-    public async Task<ClientDetectionResult> DetectAsync(INativeProcessRunner runner, CancellationToken cancellationToken)
+    public Task<ClientDetectionResult> DetectAsync(
+        Func<string, ExecutableResolutionResult> resolveClientExe,
+        CancellationToken cancellationToken)
     {
-        var result = await runner.RunAsync(
-            new NativeCommand("where.exe", new[] { "codex" }, false),
-            cancellationToken);
-
-        if (result.ExitCode == 0 && !string.IsNullOrWhiteSpace(result.Stdout))
-        {
-            var path = result.Stdout.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)[0];
-            return new ClientDetectionResult(true, path, null);
-        }
-
-        return new ClientDetectionResult(false, null, "Codex CLI not found. Install it from https://github.com/openai/codex");
+        var result = resolveClientExe("codex");
+        return Task.FromResult(new ClientDetectionResult(
+            result.Found,
+            result.ResolvedPath,
+            result.Kind,
+            result.Found ? null : "Codex CLI was not found.\n\nExpected command:\n  codex\n\nVerify the installation with:\n  codex --version\n\nAfter installing Codex, run:\n  tia-mcp install codex"));
     }
 
-    public NativeCommand BuildInstallCommand(InstallOptions options, McpLaunchSpec spec)
+    public NativeCommand BuildInstallCommand(
+        InstallOptions options,
+        McpLaunchSpec spec,
+        Func<string, ExecutableResolutionResult> resolveClientExe)
     {
         var args = new List<string> { "mcp", "add", spec.ServerName, "--" };
         args.Add(spec.ExecutablePath);

--- a/TiaMcpServer/Cli/Install/ExecutableKind.cs
+++ b/TiaMcpServer/Cli/Install/ExecutableKind.cs
@@ -1,0 +1,8 @@
+namespace TiaMcpServer.Cli.Install;
+
+public enum ExecutableKind
+{
+    Native,
+    CommandScript,
+    BatchScript
+}

--- a/TiaMcpServer/Cli/Install/ExecutableResolutionResult.cs
+++ b/TiaMcpServer/Cli/Install/ExecutableResolutionResult.cs
@@ -1,7 +1,8 @@
 namespace TiaMcpServer.Cli.Install;
 
-internal sealed record ClientDetectionResult(
+internal sealed record ExecutableResolutionResult(
     bool Found,
-    string? ExecutablePath,
+    string Command,
+    string? ResolvedPath,
     ExecutableKind Kind,
     string? Error);

--- a/TiaMcpServer/Cli/Install/ExecutableResolver.cs
+++ b/TiaMcpServer/Cli/Install/ExecutableResolver.cs
@@ -128,17 +128,10 @@ internal static class ExecutableResolver
             var lines = RunWhereAll(candidate);
             if (lines.Count == 0) continue;
 
-            // Filter to existing files and pick by priority
-            var existing = lines
-                .Where(File.Exists)
+            // where.exe returns existing paths; pick the preferred executable kind.
+            var best = lines
                 .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
-
-            if (existing.Count == 0) continue;
-
-            // Sort by extension priority: .exe > .cmd > .bat > no extension
-            var best = existing
-                .OrderBy(f => ExtensionPriority(f))
+                .OrderBy(ExtensionPriority)
                 .First();
 
             return new ExecutableResolutionResult(true, command, best,
@@ -277,33 +270,16 @@ internal static class ExecutableResolver
             };
             psi.ArgumentList.Add(executable);
 
-            using var process = Process.Start(psi);
-            if (process is null)
-            {
-                return results;
-            }
-
+            using var process = Process.Start(psi)!;
             process.WaitForExit(5000);
             if (process.ExitCode != 0)
             {
                 return results;
             }
 
-            var stdout = process.StandardOutput.ReadToEnd();
-            if (string.IsNullOrWhiteSpace(stdout))
-            {
-                return results;
-            }
-
-            var lines = stdout.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-            foreach (var line in lines)
-            {
-                var trimmed = line.Trim();
-                if (!string.IsNullOrEmpty(trimmed))
-                {
-                    results.Add(trimmed);
-                }
-            }
+            results.AddRange(process.StandardOutput.ReadToEnd().Split(
+                new[] { '\r', '\n' },
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
         }
         catch
         {

--- a/TiaMcpServer/Cli/Install/ExecutableResolver.cs
+++ b/TiaMcpServer/Cli/Install/ExecutableResolver.cs
@@ -256,6 +256,11 @@ internal static class ExecutableResolver
     }
 
     private static List<string> RunWhereAll(string executable)
+        => RunWhereAll(executable, Process.Start);
+
+    internal static List<string> RunWhereAll(
+        string executable,
+        Func<ProcessStartInfo, Process?> startProcess)
     {
         var results = new List<string>();
         try
@@ -270,7 +275,7 @@ internal static class ExecutableResolver
             };
             psi.ArgumentList.Add(executable);
 
-            using var process = Process.Start(psi)!;
+            using var process = startProcess(psi)!;
             process.WaitForExit(5000);
             if (process.ExitCode != 0)
             {

--- a/TiaMcpServer/Cli/Install/ExecutableResolver.cs
+++ b/TiaMcpServer/Cli/Install/ExecutableResolver.cs
@@ -4,6 +4,8 @@ namespace TiaMcpServer.Cli.Install;
 
 internal static class ExecutableResolver
 {
+    private static readonly string[] WindowsExtensions = { ".exe", ".cmd", ".bat" };
+
     public static string? ResolveServerExecutable(string? serverPath)
     {
         // 1. Explicit --server-path
@@ -47,9 +49,180 @@ internal static class ExecutableResolver
         return null;
     }
 
+    public static ExecutableResolutionResult ResolveClientExecutable(string command)
+    {
+        if (string.IsNullOrWhiteSpace(command))
+        {
+            return new ExecutableResolutionResult(false, command, null, ExecutableKind.Native,
+                "Command is empty.");
+        }
+
+        // 1. Absolute path
+        if (Path.IsPathRooted(command))
+        {
+            return ResolveAbsolute(command);
+        }
+
+        // 2. where.exe with extensions
+        var whereResult = ResolveViaWhere(command);
+        if (whereResult is not null)
+        {
+            return whereResult;
+        }
+
+        // 3. Common directories
+        var commonResult = ResolveFromCommonDirectories(command);
+        if (commonResult is not null)
+        {
+            return commonResult;
+        }
+
+        // 4. Not found
+        return new ExecutableResolutionResult(false, command, null, ExecutableKind.Native,
+            $"The executable '{command}' was not found.");
+    }
+
+    /// <summary>
+    /// Legacy method for backward compatibility. Returns only the path or null.
+    /// </summary>
     public static string? FindClientExecutable(string clientExe)
     {
-        return RunWhere(clientExe);
+        var result = ResolveClientExecutable(clientExe);
+        return result.Found ? result.ResolvedPath : null;
+    }
+
+    private static ExecutableResolutionResult ResolveAbsolute(string path)
+    {
+        if (File.Exists(path))
+        {
+            var kind = ClassifyExtension(path);
+            return new ExecutableResolutionResult(true, path, Path.GetFullPath(path), kind, null);
+        }
+
+        // Try adding extensions
+        foreach (var ext in WindowsExtensions)
+        {
+            var withExt = path + ext;
+            if (File.Exists(withExt))
+            {
+                return new ExecutableResolutionResult(true, path, Path.GetFullPath(withExt),
+                    ClassifyExtension(withExt), null);
+            }
+        }
+
+        return new ExecutableResolutionResult(false, path, null, ExecutableKind.Native,
+            $"The path '{path}' does not exist.");
+    }
+
+    private static ExecutableResolutionResult? ResolveViaWhere(string command)
+    {
+        // Try where.exe with the bare command first, then with each extension
+        var candidates = new List<string> { command };
+        foreach (var ext in WindowsExtensions)
+        {
+            candidates.Add(command + ext);
+        }
+
+        foreach (var candidate in candidates)
+        {
+            var lines = RunWhereAll(candidate);
+            if (lines.Count == 0) continue;
+
+            // Filter to existing files and pick by priority
+            var existing = lines
+                .Where(File.Exists)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (existing.Count == 0) continue;
+
+            // Sort by extension priority: .exe > .cmd > .bat > no extension
+            var best = existing
+                .OrderBy(f => ExtensionPriority(f))
+                .First();
+
+            return new ExecutableResolutionResult(true, command, best,
+                ClassifyExtension(best), null);
+        }
+
+        return null;
+    }
+
+    private static ExecutableResolutionResult? ResolveFromCommonDirectories(string command)
+    {
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+        var searchDirs = new List<string>();
+
+        if (!string.IsNullOrEmpty(userProfile))
+        {
+            searchDirs.Add(Path.Combine(userProfile, ".local", "bin"));
+            searchDirs.Add(Path.Combine(userProfile, ".dotnet", "tools"));
+        }
+
+        if (!string.IsNullOrEmpty(appData))
+        {
+            searchDirs.Add(Path.Combine(appData, "npm"));
+        }
+
+        if (!string.IsNullOrEmpty(localAppData))
+        {
+            searchDirs.Add(Path.Combine(localAppData, "Programs"));
+        }
+
+        foreach (var dir in searchDirs)
+        {
+            if (!Directory.Exists(dir)) continue;
+
+            // Try with each extension, then bare
+            foreach (var ext in WindowsExtensions)
+            {
+                var candidate = Path.Combine(dir, command + ext);
+                if (File.Exists(candidate))
+                {
+                    return new ExecutableResolutionResult(true, command, candidate,
+                        ClassifyExtension(candidate), null);
+                }
+            }
+
+            // Try bare name
+            var bare = Path.Combine(dir, command);
+            if (File.Exists(bare))
+            {
+                return new ExecutableResolutionResult(true, command, bare,
+                    ClassifyExtension(bare), null);
+            }
+        }
+
+        return null;
+    }
+
+    internal static ExecutableKind ClassifyExtension(string path)
+    {
+        var ext = Path.GetExtension(path);
+        if (string.Equals(ext, ".cmd", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(ext, ".bat", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Equals(ext, ".cmd", StringComparison.OrdinalIgnoreCase)
+                ? ExecutableKind.CommandScript
+                : ExecutableKind.BatchScript;
+        }
+
+        return ExecutableKind.Native;
+    }
+
+    private static int ExtensionPriority(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        return ext switch
+        {
+            ".exe" => 0,
+            ".cmd" => 1,
+            ".bat" => 2,
+            _ => 3
+        };
     }
 
     private static string? RunWhere(string executable)
@@ -87,5 +260,56 @@ internal static class ExecutableResolver
         {
             return null;
         }
+    }
+
+    private static List<string> RunWhereAll(string executable)
+    {
+        var results = new List<string>();
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "where.exe",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                UseShellExecute = false
+            };
+            psi.ArgumentList.Add(executable);
+
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                return results;
+            }
+
+            process.WaitForExit(5000);
+            if (process.ExitCode != 0)
+            {
+                return results;
+            }
+
+            var stdout = process.StandardOutput.ReadToEnd();
+            if (string.IsNullOrWhiteSpace(stdout))
+            {
+                return results;
+            }
+
+            var lines = stdout.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var line in lines)
+            {
+                var trimmed = line.Trim();
+                if (!string.IsNullOrEmpty(trimmed))
+                {
+                    results.Add(trimmed);
+                }
+            }
+        }
+        catch
+        {
+            // where.exe not available or failed
+        }
+
+        return results;
     }
 }

--- a/TiaMcpServer/Cli/Install/IMcpClientInstaller.cs
+++ b/TiaMcpServer/Cli/Install/IMcpClientInstaller.cs
@@ -4,9 +4,14 @@ internal interface IMcpClientInstaller
 {
     ClientKind Client { get; }
 
-    Task<ClientDetectionResult> DetectAsync(INativeProcessRunner runner, CancellationToken cancellationToken);
+    Task<ClientDetectionResult> DetectAsync(
+        Func<string, ExecutableResolutionResult> resolveClientExe,
+        CancellationToken cancellationToken);
 
-    NativeCommand BuildInstallCommand(InstallOptions options, McpLaunchSpec spec);
+    NativeCommand BuildInstallCommand(
+        InstallOptions options,
+        McpLaunchSpec spec,
+        Func<string, ExecutableResolutionResult> resolveClientExe);
 
     NativeCommand? BuildVerificationCommand(InstallOptions options, McpLaunchSpec spec);
 }

--- a/TiaMcpServer/Cli/Install/InstallCommand.cs
+++ b/TiaMcpServer/Cli/Install/InstallCommand.cs
@@ -21,7 +21,7 @@ public static class InstallCommand
           --tia-project <path>   Bind to a specific TIA Portal project.
           --server-path <path>   Explicit path to the tia-mcp executable.
           --dry-run              Print the install command without executing.
-          --json                 Emit JSON output (not supported with mimocode).
+          --json                 Emit JSON output.
           --help                 Show this help message and exit.
 
         Exit codes:
@@ -40,7 +40,7 @@ public static class InstallCommand
         => RunAsync(args, new NativeProcessRunner(), Console.Out, Console.Error);
 
     internal static Task<int> RunAsync(string[] args, INativeProcessRunner runner, TextWriter output, TextWriter error)
-        => RunAsync(args, runner, output, error, ExecutableResolver.ResolveServerExecutable, ExecutableResolver.FindClientExecutable);
+        => RunAsync(args, runner, output, error, ExecutableResolver.ResolveServerExecutable, ExecutableResolver.ResolveClientExecutable);
 
     internal static async Task<int> RunAsync(
         string[] args,
@@ -48,7 +48,7 @@ public static class InstallCommand
         TextWriter output,
         TextWriter error,
         Func<string?, string?> resolveServerExe,
-        Func<string, string?> findClientExe)
+        Func<string, ExecutableResolutionResult> resolveClientExe)
     {
         var options = InstallCliParser.Parse(args);
 
@@ -103,7 +103,13 @@ public static class InstallCommand
             var msg = "tia-mcp executable not found. Install it with: dotnet tool install -g TiaMcpServer";
             if (options.Json)
             {
-                output.WriteLine(JsonSerializer.Serialize(new { success = false, client = client.ToString(), error = msg }));
+                output.WriteLine(JsonSerializer.Serialize(new
+                {
+                    success = false,
+                    client = client.ToString(),
+                    errorCode = "tia_mcp_executable_not_found",
+                    message = msg
+                }));
             }
             else
             {
@@ -123,8 +129,8 @@ public static class InstallCommand
 
         var spec = new McpLaunchSpec(options.ServerName, serverExePath, launchArgs);
 
-        // Detect client executable
-        var detection = await installer.DetectAsync(runner, CancellationToken.None);
+        // Detect and resolve client executable
+        var detection = await installer.DetectAsync(resolveClientExe, CancellationToken.None);
         if (!detection.Found)
         {
             if (options.Json)
@@ -133,12 +139,14 @@ public static class InstallCommand
                 {
                     success = false,
                     client = client.ToString(),
-                    error = detection.Error
+                    clientCommand = GetClientCommand(client),
+                    errorCode = "client_not_found",
+                    message = detection.Error
                 }));
             }
             else
             {
-                error.WriteLine($"error: {detection.Error}");
+                error.WriteLine(detection.Error);
             }
 
             return 4;
@@ -152,8 +160,26 @@ public static class InstallCommand
             return 8;
         }
 
-        // Build install command
-        var installCommand = installer.BuildInstallCommand(options, spec);
+        // Build install command and resolve its executable
+        var installCommand = installer.BuildInstallCommand(options, spec, resolveClientExe);
+        var installExeResolution = ResolveInstallExecutable(
+            installCommand.Executable, detection, resolveClientExe);
+        installCommand = installCommand with
+        {
+            ResolvedPath = installExeResolution.ResolvedPath,
+            Kind = installExeResolution.Kind
+        };
+
+        // Build verification command and patch with detected executable
+        var verifyCommand = installer.BuildVerificationCommand(options, spec);
+        if (verifyCommand is not null)
+        {
+            verifyCommand = verifyCommand with
+            {
+                ResolvedPath = detection.ExecutablePath,
+                Kind = detection.Kind
+            };
+        }
 
         // Dry-run: print command and exit
         if (options.DryRun)
@@ -164,17 +190,53 @@ public static class InstallCommand
                 {
                     dryRun = true,
                     client = client.ToString(),
-                    executable = installCommand.Executable,
-                    arguments = installCommand.Arguments,
+                    clientCommand = GetClientCommand(client),
+                    resolvedClientPath = detection.ExecutablePath,
+                    clientExecutableKind = FormatKind(detection.Kind),
+                    serverPath = spec.ExecutablePath,
+                    nativeCommand = FormatCommand(installCommand),
                     interactive = installCommand.Interactive
                 }));
             }
             else
             {
-                output.WriteLine($"[dry-run] Would execute: {installCommand.Executable} {string.Join(" ", installCommand.Arguments)}");
+                output.WriteLine("Dry run: no changes will be made.");
+                output.WriteLine();
+                output.WriteLine($"Client: {FormatClientName(client)}");
+                output.WriteLine($"Client executable:");
+                output.WriteLine($"  {detection.ExecutablePath}");
+
+                if (installCommand.Kind != ExecutableKind.Native)
+                {
+                    var cmdExe = Environment.GetEnvironmentVariable("COMSPEC")
+                        ?? Path.Combine(
+                            Environment.GetFolderPath(Environment.SpecialFolder.System),
+                            "cmd.exe");
+                    output.WriteLine();
+                    output.WriteLine("Execution method:");
+                    output.WriteLine($"  {Path.GetFileName(cmdExe)} /d /s /c");
+                }
+
+                output.WriteLine();
+                output.WriteLine("Native command:");
+                output.WriteLine($"  {string.Join(" ", FormatCommand(installCommand))}");
+
+                // Print interactive guide for MiMoCode
+                if (installCommand.Interactive)
+                {
+                    output.WriteLine();
+                    PrintInteractiveGuide(output, client, spec, options);
+                }
             }
 
             return 0;
+        }
+
+        // Print interactive guide before launching interactive commands
+        if (installCommand.Interactive)
+        {
+            PrintInteractiveGuide(output, client, spec, options);
+            output.WriteLine();
         }
 
         // Execute install command
@@ -188,6 +250,10 @@ public static class InstallCommand
                 {
                     success = false,
                     client = client.ToString(),
+                    clientCommand = GetClientCommand(client),
+                    resolvedClientPath = detection.ExecutablePath,
+                    clientExecutableKind = FormatKind(detection.Kind),
+                    errorCode = "client_command_failed",
                     serverName = spec.ServerName,
                     accessMode = options.AccessMode,
                     serverPath = spec.ExecutablePath,
@@ -200,6 +266,7 @@ public static class InstallCommand
             else
             {
                 error.WriteLine($"error: Install command failed (exit code {installResult.ExitCode})");
+
                 if (!string.IsNullOrWhiteSpace(installResult.Stderr))
                 {
                     error.WriteLine(installResult.Stderr);
@@ -219,7 +286,6 @@ public static class InstallCommand
         string? verificationStdout = null;
         string? verificationStderr = null;
 
-        var verifyCommand = installer.BuildVerificationCommand(options, spec);
         if (verifyCommand is not null)
         {
             var verifyResult = await runner.RunAsync(verifyCommand, CancellationToken.None);
@@ -235,6 +301,9 @@ public static class InstallCommand
             {
                 success = true,
                 client = client.ToString(),
+                clientCommand = GetClientCommand(client),
+                resolvedClientPath = detection.ExecutablePath,
+                clientExecutableKind = FormatKind(detection.Kind),
                 serverName = spec.ServerName,
                 accessMode = options.AccessMode,
                 serverPath = spec.ExecutablePath,
@@ -267,9 +336,70 @@ public static class InstallCommand
 
     private static string[] FormatCommand(NativeCommand command)
     {
-        var result = new List<string> { command.Executable };
+        var result = new List<string>();
+
+        // Show what will actually be executed
+        if (command.Kind == ExecutableKind.CommandScript || command.Kind == ExecutableKind.BatchScript)
+        {
+            var cmdExe = Environment.GetEnvironmentVariable("COMSPEC")
+                ?? Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.System),
+                    "cmd.exe");
+            result.Add(Path.GetFileName(cmdExe));
+            result.Add("/d");
+            result.Add("/s");
+            result.Add("/c");
+        }
+
+        result.Add(command.ResolvedPath ?? command.Executable);
         result.AddRange(command.Arguments);
         return result.ToArray();
+    }
+
+    private static ExecutableResolutionResult ResolveInstallExecutable(
+        string installExeName,
+        ClientDetectionResult detection,
+        Func<string, ExecutableResolutionResult> resolveClientExe)
+    {
+        // If the install command uses the same executable as detected, reuse the detection result
+        if (string.Equals(installExeName, detection.ExecutablePath, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(installExeName, Path.GetFileNameWithoutExtension(detection.ExecutablePath), StringComparison.OrdinalIgnoreCase))
+        {
+            return new ExecutableResolutionResult(
+                detection.Found,
+                installExeName,
+                detection.ExecutablePath,
+                detection.Kind,
+                detection.Error);
+        }
+
+        // Different executable (e.g. MiMoCode uses 'claude' for install but detects 'mimo')
+        return resolveClientExe(installExeName);
+    }
+
+    private static void PrintInteractiveGuide(
+        TextWriter output,
+        ClientKind client,
+        McpLaunchSpec spec,
+        InstallOptions options)
+    {
+        output.WriteLine("Interactive mode: follow the prompts below.");
+        output.WriteLine();
+        output.WriteLine("When prompted, enter the following values:");
+        output.WriteLine();
+
+        switch (client)
+        {
+            case ClientKind.MiMoCode:
+                output.WriteLine($"  Server name:     {spec.ServerName}");
+                output.WriteLine($"  Server command:  {spec.ExecutablePath}");
+                output.WriteLine($"  Server args:     --access-mode {options.AccessMode}");
+                output.WriteLine($"  Transport type:  stdio");
+                break;
+            default:
+                output.WriteLine($"  (no guide available for {FormatClientName(client)})");
+                break;
+        }
     }
 
     private static string FormatClientName(ClientKind client) => client switch
@@ -279,5 +409,22 @@ public static class InstallCommand
         ClientKind.OpenCode => "OpenCode",
         ClientKind.MiMoCode => "MiMoCode",
         _ => client.ToString()
+    };
+
+    private static string GetClientCommand(ClientKind client) => client switch
+    {
+        ClientKind.ClaudeCode => "claude",
+        ClientKind.Codex => "codex",
+        ClientKind.OpenCode => "opencode",
+        ClientKind.MiMoCode => "mimo",
+        _ => client.ToString().ToLowerInvariant()
+    };
+
+    private static string FormatKind(ExecutableKind kind) => kind switch
+    {
+        ExecutableKind.Native => "native",
+        ExecutableKind.CommandScript => "command_script",
+        ExecutableKind.BatchScript => "batch_script",
+        _ => kind.ToString().ToLowerInvariant()
     };
 }

--- a/TiaMcpServer/Cli/Install/MiMoCodeInstaller.cs
+++ b/TiaMcpServer/Cli/Install/MiMoCodeInstaller.cs
@@ -4,24 +4,25 @@ internal sealed class MiMoCodeInstaller : IMcpClientInstaller
 {
     public ClientKind Client => ClientKind.MiMoCode;
 
-    public async Task<ClientDetectionResult> DetectAsync(INativeProcessRunner runner, CancellationToken cancellationToken)
+    public Task<ClientDetectionResult> DetectAsync(
+        Func<string, ExecutableResolutionResult> resolveClientExe,
+        CancellationToken cancellationToken)
     {
-        var result = await runner.RunAsync(
-            new NativeCommand("where.exe", new[] { "mimo" }, false),
-            cancellationToken);
-
-        if (result.ExitCode == 0 && !string.IsNullOrWhiteSpace(result.Stdout))
-        {
-            var path = result.Stdout.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)[0];
-            return new ClientDetectionResult(true, path, null);
-        }
-
-        return new ClientDetectionResult(false, null, "MiMoCode CLI not found. Install it from https://github.com/Xiaomi/mimocode");
+        var result = resolveClientExe("mimo");
+        return Task.FromResult(new ClientDetectionResult(
+            result.Found,
+            result.ResolvedPath,
+            result.Kind,
+            result.Found ? null : "MiMoCode CLI was not found.\n\nExpected command:\n  mimo\n\nVerify the installation with:\n  mimo --version\n\nAfter installing MiMoCode, run:\n  tia-mcp install mimocode"));
     }
 
-    public NativeCommand BuildInstallCommand(InstallOptions options, McpLaunchSpec spec)
+    public NativeCommand BuildInstallCommand(
+        InstallOptions options,
+        McpLaunchSpec spec,
+        Func<string, ExecutableResolutionResult> resolveClientExe)
     {
-        // MiMoCode uses interactive mode; the user enters values manually
+        // MiMoCode uses interactive mode; the user enters values manually.
+        // The install command prints a guide before launching.
         var args = new List<string> { "mcp", "add" };
         return new NativeCommand("mimo", args, true);
     }

--- a/TiaMcpServer/Cli/Install/NativeCommand.cs
+++ b/TiaMcpServer/Cli/Install/NativeCommand.cs
@@ -3,4 +3,6 @@ namespace TiaMcpServer.Cli.Install;
 internal sealed record NativeCommand(
     string Executable,
     IReadOnlyList<string> Arguments,
-    bool Interactive);
+    bool Interactive,
+    string? ResolvedPath = null,
+    ExecutableKind Kind = ExecutableKind.Native);

--- a/TiaMcpServer/Cli/Install/NativeProcessRunner.cs
+++ b/TiaMcpServer/Cli/Install/NativeProcessRunner.cs
@@ -6,9 +6,11 @@ internal sealed class NativeProcessRunner : INativeProcessRunner
 {
     public async Task<NativeCommandResult> RunAsync(NativeCommand command, CancellationToken cancellationToken)
     {
+        var (fileName, argumentList) = BuildProcessArgs(command);
+
         var psi = new ProcessStartInfo
         {
-            FileName = command.Executable,
+            FileName = fileName,
             UseShellExecute = false,
             CreateNoWindow = !command.Interactive,
             RedirectStandardOutput = !command.Interactive,
@@ -16,7 +18,7 @@ internal sealed class NativeProcessRunner : INativeProcessRunner
             RedirectStandardInput = !command.Interactive
         };
 
-        foreach (var arg in command.Arguments)
+        foreach (var arg in argumentList)
         {
             psi.ArgumentList.Add(arg);
         }
@@ -54,5 +56,26 @@ internal sealed class NativeProcessRunner : INativeProcessRunner
         {
             return new NativeCommandResult(-1, string.Empty, ex.Message);
         }
+    }
+
+    internal static (string FileName, IReadOnlyList<string> Arguments) BuildProcessArgs(NativeCommand command)
+    {
+        var resolvedPath = command.ResolvedPath ?? command.Executable;
+
+        if (command.Kind == ExecutableKind.CommandScript || command.Kind == ExecutableKind.BatchScript)
+        {
+            // .cmd and .bat must be executed through cmd.exe
+            var cmdExe = Environment.GetEnvironmentVariable("COMSPEC")
+                ?? Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.System),
+                    "cmd.exe");
+
+            var args = new List<string> { "/d", "/s", "/c", resolvedPath };
+            args.AddRange(command.Arguments);
+            return (cmdExe, args);
+        }
+
+        // Native .exe or bare command
+        return (resolvedPath, command.Arguments);
     }
 }

--- a/TiaMcpServer/Cli/Install/OpenCodeInstaller.cs
+++ b/TiaMcpServer/Cli/Install/OpenCodeInstaller.cs
@@ -4,22 +4,22 @@ internal sealed class OpenCodeInstaller : IMcpClientInstaller
 {
     public ClientKind Client => ClientKind.OpenCode;
 
-    public async Task<ClientDetectionResult> DetectAsync(INativeProcessRunner runner, CancellationToken cancellationToken)
+    public Task<ClientDetectionResult> DetectAsync(
+        Func<string, ExecutableResolutionResult> resolveClientExe,
+        CancellationToken cancellationToken)
     {
-        var result = await runner.RunAsync(
-            new NativeCommand("where.exe", new[] { "opencode" }, false),
-            cancellationToken);
-
-        if (result.ExitCode == 0 && !string.IsNullOrWhiteSpace(result.Stdout))
-        {
-            var path = result.Stdout.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)[0];
-            return new ClientDetectionResult(true, path, null);
-        }
-
-        return new ClientDetectionResult(false, null, "OpenCode CLI not found. Install it from https://github.com/opencode-ai/opencode");
+        var result = resolveClientExe("opencode");
+        return Task.FromResult(new ClientDetectionResult(
+            result.Found,
+            result.ResolvedPath,
+            result.Kind,
+            result.Found ? null : "OpenCode CLI was not found.\n\nExpected command:\n  opencode\n\nVerify the installation with:\n  opencode --version\n\nAfter installing OpenCode, run:\n  tia-mcp install opencode"));
     }
 
-    public NativeCommand BuildInstallCommand(InstallOptions options, McpLaunchSpec spec)
+    public NativeCommand BuildInstallCommand(
+        InstallOptions options,
+        McpLaunchSpec spec,
+        Func<string, ExecutableResolutionResult> resolveClientExe)
     {
         var args = new List<string> { "mcp", "add", spec.ServerName, "--" };
         args.Add(spec.ExecutablePath);


### PR DESCRIPTION
## Summary

Fixes `tia-mcp install` on Windows when an MCP client CLI is installed as an npm command shim (`.cmd` or `.bat`) rather than a native `.exe`.

Previously, the installer passed the bare client command directly to `ProcessStartInfo` with `UseShellExecute = false`. Windows cannot execute `.cmd` and `.bat` files that way, which caused installation commands such as `tia-mcp install claude-code` to fail with a file-not-found error even though the CLI was installed and available on `PATH`.

## What changed

- Added centralized MCP client executable resolution.
- Added executable classification for native binaries, `.cmd` scripts, and `.bat` scripts.
- Resolve client commands using:
  1. An explicit absolute path.
  2. `where.exe`, with `.exe`, `.cmd`, and `.bat` support.
  3. Common user installation directories such as `.local/bin`, `.dotnet/tools`, and the npm global bin directory.
- Prefer `.exe` over `.cmd`, then `.bat`, when multiple candidates are found.
- Execute native binaries directly.
- Execute `.cmd` and `.bat` files through `COMSPEC` using `cmd.exe /d /s /c`.
- Propagate the resolved path and executable type through client detection, installation, and verification.
- Improve human-readable dry-run output and structured JSON error details.
- Add an interactive setup guide before launching `mimo mcp add`.
- Apply the resolver consistently to Claude Code, Codex, OpenCode, and MiMoCode.

## Example

Before this change, an npm-installed client could fail with:

```text
error: Install command failed (exit code -1)
An error occurred trying to start process 'claude'...
The system cannot find the file specified.
```

After this change, a resolved shim such as `claude.cmd` is executed through `cmd.exe`, while native executables continue to run directly.

## Test coverage

Added and updated tests covering:

- Absolute executable paths.
- `.exe`, `.cmd`, and `.bat` resolution and prioritization.
- Common installation directory fallback.
- Native and command-script process execution.
- Paths containing spaces and Unicode characters.
- Missing-client and cancellation behavior.
- Client adapter integration for Claude Code, Codex, OpenCode, and MiMoCode.
- Regression coverage for the original `claude.cmd` file-not-found failure.
- Dry-run and JSON output behavior.

## Manual verification

```powershell
tia-mcp install claude-code --dry-run
tia-mcp install codex --dry-run
tia-mcp install opencode --dry-run
tia-mcp install mimocode --dry-run
```

The dry-run output now shows the resolved client path and the actual execution method without modifying the client configuration.