### PR TITLE
fix: align doctor package runtime assets

### DIFF
--- a/TiaMcpServer.Tests/Diagnostics/DoctorPackageVerificationScriptTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/DoctorPackageVerificationScriptTests.cs
@@ -1,0 +1,159 @@
+using System.Diagnostics;
+using System.IO.Compression;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Diagnostics;
+
+public class DoctorPackageVerificationScriptTests
+{
+    [Fact]
+    public void BuiltWorkerPayload_PassesPackageVerification()
+    {
+        var workerOutput = FindBuiltWorkerOutput();
+        var packagePath = CreatePackage(workerOutput);
+
+        try
+        {
+            var result = RunVerifier(packagePath);
+
+            Assert.True(
+                result.ExitCode == 0,
+                $"Package verifier failed.{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}{result.StandardError}");
+        }
+        finally
+        {
+            File.Delete(packagePath);
+        }
+    }
+
+    [Fact]
+    public void WorkerPayloadWithoutValueTuple_FailsPackageVerification()
+    {
+        var workerOutput = FindBuiltWorkerOutput();
+        var packagePath = CreatePackage(workerOutput, excludedFile: "System.ValueTuple.dll");
+
+        try
+        {
+            var result = RunVerifier(packagePath);
+            var output = result.StandardOutput + Environment.NewLine + result.StandardError;
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.Contains("System.ValueTuple.dll", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(packagePath);
+        }
+    }
+
+    [Fact]
+    public void WorkerPayloadWithUnexpectedPipelineAssembly_FailsPackageVerification()
+    {
+        var workerOutput = FindBuiltWorkerOutput();
+        var packagePath = CreatePackage(
+            workerOutput,
+            additionalEntry: "System.IO.Pipelines.dll");
+
+        try
+        {
+            var result = RunVerifier(packagePath);
+            var output = result.StandardOutput + Environment.NewLine + result.StandardError;
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.Contains("System.IO.Pipelines.dll", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(packagePath);
+        }
+    }
+
+    private static string CreatePackage(
+        string workerOutput,
+        string? excludedFile = null,
+        string? additionalEntry = null)
+    {
+        var packagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"doctor-package-{Guid.NewGuid():N}.nupkg");
+
+        using var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create);
+        foreach (var builtFile in Directory.EnumerateFiles(workerOutput, "*", SearchOption.TopDirectoryOnly))
+        {
+            if (string.Equals(Path.GetFileName(builtFile), excludedFile, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var entryName = "tools/net8.0/any/openness-worker/" + Path.GetFileName(builtFile);
+            archive.CreateEntryFromFile(builtFile, entryName);
+        }
+
+        if (additionalEntry is not null)
+        {
+            archive.CreateEntry("tools/net8.0/any/openness-worker/" + additionalEntry);
+        }
+
+        return packagePath;
+    }
+
+    private static string FindBuiltWorkerOutput()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var configuration = new DirectoryInfo(AppContext.BaseDirectory).Parent?.Name;
+        Assert.False(string.IsNullOrEmpty(configuration), "Test build configuration could not be determined.");
+
+        var outputDir = Path.Combine(
+            repositoryRoot,
+            "TiaMcpServer.OpennessWorker",
+            "bin",
+            configuration!,
+            "net48");
+        Assert.True(
+            File.Exists(Path.Combine(outputDir, "TiaMcpServer.OpennessWorker.exe")),
+            $"No built net48 output found under {outputDir}. Build TiaMcpServer.OpennessWorker before running this test.");
+        return outputDir;
+    }
+
+    private static ScriptResult RunVerifier(string packagePath)
+    {
+        var scriptPath = Path.Combine(GetRepositoryRoot(), "scripts", "verify-doctor-package.ps1");
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-File");
+        startInfo.ArgumentList.Add(scriptPath);
+        startInfo.ArgumentList.Add("-PackagePath");
+        startInfo.ArgumentList.Add(packagePath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start pwsh process.");
+        var standardOutput = process.StandardOutput.ReadToEnd();
+        var standardError = process.StandardError.ReadToEnd();
+        if (!process.WaitForExit(30_000))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException("Package verifier did not exit within 30 seconds.");
+        }
+
+        return new ScriptResult(process.ExitCode, standardOutput, standardError);
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        return Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            ".."));
+    }
+
+    private sealed record ScriptResult(int ExitCode, string StandardOutput, string StandardError);
+}

--- a/TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/OpennessWorkerCheckTests.cs
@@ -12,7 +12,6 @@ public class OpennessWorkerCheckTests
         "TiaMcpServer.Contracts.dll",
         "Microsoft.Bcl.AsyncInterfaces.dll",
         "System.Buffers.dll",
-        "System.IO.Pipelines.dll",
         "System.Memory.dll",
         "System.Numerics.Vectors.dll",
         "System.Runtime.CompilerServices.Unsafe.dll",
@@ -111,27 +110,14 @@ public class OpennessWorkerCheckTests
     [Fact]
     public void RequiredCompanionFiles_CoverWorkerRuntimeAssets()
     {
-        var repositoryRoot = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory,
-            "..", "..", "..", ".."));
-        var binRoot = Path.Combine(repositoryRoot, "TiaMcpServer.OpennessWorker", "bin");
-
         // NuGet's project.assets.json restore-graph shape (bare TFM vs.
         // RID-qualified targets, or something else entirely) varies across SDK
         // versions and OS, so it isn't a stable source of truth here. The build
         // output directory is: it's the exact set of files CopyOpennessWorker
         // copies into openness-worker/, so compare against that instead.
-        var outputDir = Directory.Exists(binRoot)
-            ? Directory.EnumerateDirectories(binRoot)
-                .Select(configDir => Path.Combine(configDir, "net48"))
-                .FirstOrDefault(dir => File.Exists(Path.Combine(dir, "TiaMcpServer.OpennessWorker.exe")))
-            : null;
+        var outputDir = FindBuiltWorkerOutput();
 
-        Assert.False(
-            string.IsNullOrEmpty(outputDir),
-            $"No built net48 output found under {binRoot}. Build TiaMcpServer.OpennessWorker before running this test.");
-
-        var builtDlls = Directory.EnumerateFiles(outputDir!, "*.dll", SearchOption.TopDirectoryOnly)
+        var builtDlls = Directory.EnumerateFiles(outputDir, "*.dll", SearchOption.TopDirectoryOnly)
             .Select(Path.GetFileName)
             .Where(name => !name!.StartsWith("Siemens.Engineering", StringComparison.OrdinalIgnoreCase))
             .ToList();
@@ -150,6 +136,46 @@ public class OpennessWorkerCheckTests
         Assert.DoesNotContain(
             OpennessWorkerCheck.RequiredCompanionFiles,
             file => file.EndsWith("runtimeconfig.json", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void BuiltWorkerOutput_PassesDoctorCompanionCheck()
+    {
+        var outputDir = FindBuiltWorkerOutput();
+
+        var baseDir = Path.Combine(Path.GetTempPath(), "doctor-test-" + Guid.NewGuid().ToString("N"));
+        var workerDir = Path.Combine(baseDir, "openness-worker");
+        var appInfo = new FakeApplicationInfoService { BaseDirectory = baseDir };
+        var fileSystem = new FakeFileSystemService();
+
+        foreach (var builtFile in Directory.EnumerateFiles(outputDir, "*", SearchOption.TopDirectoryOnly))
+        {
+            fileSystem.AddFile(Path.Combine(workerDir, Path.GetFileName(builtFile)));
+        }
+
+        var result = new OpennessWorkerCheck(appInfo, fileSystem).Run();
+
+        Assert.Equal(DiagnosticStatus.Passed, result.Status);
+    }
+
+    private static string FindBuiltWorkerOutput()
+    {
+        var repositoryRoot = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", ".."));
+        var configuration = new DirectoryInfo(AppContext.BaseDirectory).Parent?.Name;
+        Assert.False(string.IsNullOrEmpty(configuration), "Test build configuration could not be determined.");
+
+        var outputDir = Path.Combine(
+            repositoryRoot,
+            "TiaMcpServer.OpennessWorker",
+            "bin",
+            configuration!,
+            "net48");
+        Assert.True(
+            File.Exists(Path.Combine(outputDir, "TiaMcpServer.OpennessWorker.exe")),
+            $"No built net48 output found under {outputDir}. Build TiaMcpServer.OpennessWorker before running this test.");
+        return outputDir;
     }
 
     [Fact]

--- a/TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs
+++ b/TiaMcpServer/Diagnostics/Checks/OpennessWorkerCheck.cs
@@ -10,7 +10,6 @@ public sealed class OpennessWorkerCheck : IDiagnosticCheck
         "TiaMcpServer.Contracts.dll",
         "Microsoft.Bcl.AsyncInterfaces.dll",
         "System.Buffers.dll",
-        "System.IO.Pipelines.dll",
         "System.Memory.dll",
         "System.Numerics.Vectors.dll",
         "System.Runtime.CompilerServices.Unsafe.dll",

--- a/scripts/verify-doctor-package.ps1
+++ b/scripts/verify-doctor-package.ps1
@@ -50,14 +50,20 @@ $requiredFiles = @(
     'TiaMcpServer.Contracts.dll',
     'Microsoft.Bcl.AsyncInterfaces.dll',
     'System.Buffers.dll',
-    'System.IO.Pipelines.dll',
     'System.Memory.dll',
     'System.Numerics.Vectors.dll',
     'System.Runtime.CompilerServices.Unsafe.dll',
     'System.Text.Encodings.Web.dll',
     'System.Text.Json.dll',
-    'System.Threading.Tasks.Extensions.dll'
+    'System.Threading.Tasks.Extensions.dll',
+    'System.ValueTuple.dll'
 )
+
+$requiredFileNames = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+foreach ($requiredFile in $requiredFiles) {
+    [void] $requiredFileNames.Add($requiredFile)
+}
 
 foreach ($requiredFile in $requiredFiles) {
     $expectedEntry = $canonicalPrefix + $requiredFile
@@ -81,6 +87,18 @@ $siemensAssemblies = @($entries | Where-Object {
 })
 if ($siemensAssemblies.Count -gt 0) {
     throw "NuGet package must not include Siemens Openness assemblies: $($siemensAssemblies -join ', ')."
+}
+
+$unexpectedWorkerAssemblies = @($canonicalEntries | Where-Object {
+    if (-not $_.EndsWith('.dll', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $false
+    }
+
+    $fileName = [System.IO.Path]::GetFileName($_)
+    return -not $requiredFileNames.Contains($fileName)
+})
+if ($unexpectedWorkerAssemblies.Count -gt 0) {
+    throw "NuGet package contains unexpected worker assemblies: $($unexpectedWorkerAssemblies -join ', ')."
 }
 
 Write-Host "Verified ${resolvedPackage}: one canonical worker subtree, $($requiredFiles.Count) required files, no worker runtimeconfig, no Siemens DLLs."


### PR DESCRIPTION
## Summary

- align the doctor companion list with the worker's current net48 runtime closure
- require `System.ValueTuple.dll` and remove the obsolete `System.IO.Pipelines.dll` requirement
- reject unexpected worker assemblies in the NuGet package verifier
- add behavioral regression coverage for the doctor check and package verifier

## Root cause

The worker's `System.Text.Json` dependency was aligned from 10.0.4 to 8.0.5. The restored net48 runtime closure changed accordingly, but the doctor and release package verifier retained the old Pipelines requirement. Fresh GitHub release builds therefore omitted Pipelines correctly and failed the stale verification contract.

## Impact

Release packages built from the current dependency graph now pass verification, while incomplete packages and packages containing stale worker DLLs fail closed.

## Validation

- `dotnet build TiaMcpServer.sln -c Release --no-restore -m:1 --disable-build-servers /p:UseTiaPortalReferenceStubs=true` — 0 warnings, 0 errors
- `dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Release --no-build --no-restore -m:1 --disable-build-servers` — 2,264 passed
- clean package build plus `scripts/verify-doctor-package.ps1` — passed; ValueTuple present and Pipelines absent
