### PR TITLE
fix: keep S7-300/400 block reads working when document export is rejected

### DIFF
--- a/TiaMcpServer.OpennessWorker/Openness/BlockDocumentPackagePolicy.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/BlockDocumentPackagePolicy.cs
@@ -1,0 +1,104 @@
+using System;
+
+namespace TiaMcpServer.OpennessWorker.Openness;
+
+/// <summary>The outcome of asking what a failed s7dcl document-package export means.</summary>
+internal sealed class BlockDocumentPackageOutcome
+{
+    private BlockDocumentPackageOutcome(bool isFatal, string message)
+    {
+        IsFatal = isFatal;
+        Message = message;
+    }
+
+    /// <summary>True when no document survived and the bundle would be empty.</summary>
+    public bool IsFatal { get; }
+
+    /// <summary>Error text when <see cref="IsFatal"/>; warning text otherwise. Never empty.</summary>
+    public string Message { get; }
+
+    public static BlockDocumentPackageOutcome Fatal(string message)
+        => new BlockDocumentPackageOutcome(true, message);
+
+    public static BlockDocumentPackageOutcome Degraded(string message)
+        => new BlockDocumentPackageOutcome(false, message);
+}
+
+/// <summary>
+/// Decides whether a failed s7dcl document-package export should fail the whole read.
+///
+/// <para>
+/// The bundle carries two kinds of document. The Simatic ML XML is authoritative: it is what
+/// update_block_logic consumes. The s7dcl package is human-readable rung text and is read-only
+/// context. Treating a missing supplementary document as fatal loses the authoritative one too,
+/// which is the defect this type exists to end — S7-300/S7-400 CPUs never support document
+/// export, so every block on those CPUs was unreadable even though its XML exported cleanly.
+/// </para>
+/// <para>
+/// The rule is therefore the bundle's own invariant rather than a CPU-family list: a bundle is
+/// unusable only when it would contain no documents at all. Keying off the surviving document
+/// avoids matching Siemens message text or maintaining a hard-coded device-family table, both of
+/// which would rot.
+/// </para>
+/// <para>
+/// Siemens-free by construction so the test project can link and cover it: the caller reduces the
+/// live export result to a bool and a detail string.
+/// </para>
+/// </summary>
+internal static class BlockDocumentPackagePolicy
+{
+    /// <summary>Keeps a Siemens exception message from dominating the warning list.</summary>
+    internal const int MaxDetailLength = 300;
+
+    public static BlockDocumentPackageOutcome Decide(
+        bool hasPrimaryXmlDocument,
+        string displayPath,
+        string failureDetail)
+    {
+        var detail = Summarize(failureDetail);
+
+        if (!hasPrimaryXmlDocument)
+        {
+            return BlockDocumentPackageOutcome.Fatal(
+                $"No document could be exported for '{displayPath}'. The Simatic ML XML export did "
+                + $"not succeed and the s7dcl document package failed: {detail}");
+        }
+
+        return BlockDocumentPackageOutcome.Degraded(
+            $"Human-readable rung text (s7dcl) is unavailable for '{displayPath}': {detail} The "
+            + "Simatic ML XML document was exported, so this payload is complete for reading and "
+            + "for update_block_logic. CPUs of the S7-300/S7-400 series never support this "
+            + "document package.");
+    }
+
+    /// <summary>
+    /// Reduces a Siemens message to one bounded single-line clause. Newlines are collapsed because
+    /// the worker splits captured stderr on newlines, so a multi-line warning would arrive as
+    /// several unrelated-looking warnings.
+    /// </summary>
+    private static string Summarize(string failureDetail)
+    {
+        if (string.IsNullOrWhiteSpace(failureDetail))
+        {
+            return "TIA Portal reported no detail.";
+        }
+
+        var collapsed = failureDetail
+            .Replace("\r\n", " ")
+            .Replace('\r', ' ')
+            .Replace('\n', ' ')
+            .Trim();
+
+        while (collapsed.Contains("  "))
+        {
+            collapsed = collapsed.Replace("  ", " ");
+        }
+
+        if (collapsed.Length > MaxDetailLength)
+        {
+            collapsed = collapsed.Substring(0, MaxDetailLength - 1) + "…";
+        }
+
+        return collapsed.EndsWith(".", StringComparison.Ordinal) ? collapsed : collapsed + ".";
+    }
+}

--- a/TiaMcpServer.OpennessWorker/Openness/BlockExporter.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/BlockExporter.cs
@@ -82,6 +82,7 @@ public static partial class BlockExporter
         try
         {
             var documents = new List<BlockImportDocument>();
+            var xmlExported = false;
 
             // Simatic ML XML (FlgNet) — the authoritative document for update_block_logic.
             // Export() requires a consistent block. When it fails we emit no XML document at
@@ -96,6 +97,7 @@ public static partial class BlockExporter
                     xmlName,
                     xmlName,
                     BlockXmlSanitizer.RemoveDocumentInfo(File.ReadAllText(xmlPath))));
+                xmlExported = true;
             }
             catch (Exception)
             {
@@ -103,17 +105,40 @@ public static partial class BlockExporter
                 // error when it finds no Simatic ML document in the bundle.
             }
 
-            // s7dcl documents package (human-readable rung text) — read-only context.
-            DocumentExportResult result = target.Block!.ExportAsDocuments(
-                new DirectoryInfo(tempDir), target.DocumentName);
-
-            if (result.State != DocumentResultState.Success)
-                throw new InvalidOperationException($"Export failed with state: {result.State}");
-
-            foreach (FileInfo file in result.ExportedDocuments)
+            // s7dcl documents package (human-readable rung text) — read-only context, and
+            // therefore not worth discarding the authoritative XML above for. S7-300/S7-400 CPUs
+            // reject document export outright, which used to fail the entire read for every block
+            // on those CPUs even when the XML had exported cleanly.
+            try
             {
-                documents.Add(new BlockImportDocument(
-                    file.Name, file.Name, File.ReadAllText(file.FullName)));
+                DocumentExportResult result = target.Block!.ExportAsDocuments(
+                    new DirectoryInfo(tempDir), target.DocumentName);
+
+                if (result.State != DocumentResultState.Success)
+                {
+                    throw new InvalidOperationException(
+                        $"TIA Portal returned document export state '{result.State}'.");
+                }
+
+                foreach (FileInfo file in result.ExportedDocuments)
+                {
+                    documents.Add(new BlockImportDocument(
+                        file.Name, file.Name, File.ReadAllText(file.FullName)));
+                }
+            }
+            catch (Exception exception)
+            {
+                var outcome = BlockDocumentPackagePolicy.Decide(
+                    xmlExported, address.ToDisplayPath(), exception.Message);
+
+                if (outcome.IsFatal)
+                {
+                    throw new WorkerOperationException(
+                        WorkerFailureCategories.WorkerOperationFailed, outcome.Message);
+                }
+
+                // Captured into the response's Warnings by HandleLineWithCapturedStderr.
+                Console.Error.WriteLine(outcome.Message);
             }
 
             return BlockBundleFormat.Compose(documents);

--- a/TiaMcpServer.Tests/Block/BlockDocumentPackagePolicyTests.cs
+++ b/TiaMcpServer.Tests/Block/BlockDocumentPackagePolicyTests.cs
@@ -1,0 +1,100 @@
+using TiaMcpServer.OpennessWorker.Openness;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Block;
+
+public class BlockDocumentPackagePolicyTests
+{
+    private const string S7300Detail =
+        "Error when calling method 'ExportAsDocuments' of type 'Siemens.Engineering.SW.Blocks.FC'.\r\n\r\n"
+        + "CPUs of the S7-300/S7-400 series do not support the document export or import of blocks "
+        + "or PLC data types.";
+
+    [Fact]
+    public void Surviving_xml_degrades_to_a_warning_rather_than_failing_the_read()
+    {
+        var outcome = BlockDocumentPackagePolicy.Decide(
+            hasPrimaryXmlDocument: true,
+            displayPath: "PLC_1/Blocks/10_Alarms/FC - Alarms",
+            failureDetail: S7300Detail);
+
+        Assert.False(outcome.IsFatal);
+        Assert.Contains("PLC_1/Blocks/10_Alarms/FC - Alarms", outcome.Message);
+    }
+
+    [Fact]
+    public void Degraded_message_says_the_payload_is_still_usable_for_writes()
+    {
+        var outcome = BlockDocumentPackagePolicy.Decide(
+            hasPrimaryXmlDocument: true,
+            displayPath: "PLC_1/Blocks/Main",
+            failureDetail: S7300Detail);
+
+        Assert.Contains("update_block_logic", outcome.Message);
+    }
+
+    [Fact]
+    public void No_surviving_document_is_fatal_because_the_bundle_would_be_empty()
+    {
+        var outcome = BlockDocumentPackagePolicy.Decide(
+            hasPrimaryXmlDocument: false,
+            displayPath: "PLC_1/Blocks/Main",
+            failureDetail: S7300Detail);
+
+        Assert.True(outcome.IsFatal);
+        Assert.Contains("PLC_1/Blocks/Main", outcome.Message);
+    }
+
+    [Fact]
+    public void Fatal_message_names_both_failed_exports_so_the_cause_is_not_ambiguous()
+    {
+        var outcome = BlockDocumentPackagePolicy.Decide(
+            hasPrimaryXmlDocument: false,
+            displayPath: "PLC_1/Blocks/Main",
+            failureDetail: "boom");
+
+        Assert.Contains("Simatic ML XML", outcome.Message);
+        Assert.Contains("s7dcl", outcome.Message);
+    }
+
+    [Fact]
+    public void Detail_is_collapsed_to_one_line_so_it_arrives_as_a_single_warning()
+    {
+        // The worker splits captured stderr on newlines; a multi-line detail would otherwise
+        // surface as several unrelated-looking warnings.
+        var outcome = BlockDocumentPackagePolicy.Decide(
+            hasPrimaryXmlDocument: true,
+            displayPath: "PLC_1/Blocks/Main",
+            failureDetail: S7300Detail);
+
+        Assert.DoesNotContain("\n", outcome.Message);
+        Assert.DoesNotContain("\r", outcome.Message);
+    }
+
+    [Fact]
+    public void Long_detail_is_bounded_so_one_warning_cannot_dominate_the_list()
+    {
+        var outcome = BlockDocumentPackagePolicy.Decide(
+            hasPrimaryXmlDocument: true,
+            displayPath: "PLC_1/Blocks/Main",
+            failureDetail: new string('x', 4000));
+
+        Assert.True(outcome.Message.Length < 1024);
+        Assert.Contains("…", outcome.Message);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void Missing_detail_still_produces_an_actionable_message(string? detail)
+    {
+        var outcome = BlockDocumentPackagePolicy.Decide(
+            hasPrimaryXmlDocument: true,
+            displayPath: "PLC_1/Blocks/Main",
+            failureDetail: detail!);
+
+        Assert.False(outcome.IsFatal);
+        Assert.Contains("no detail", outcome.Message);
+    }
+}

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -143,6 +143,8 @@
       Link="Linked\Openness\BlockXmlSanitizer.cs" />
     <Compile Include="..\TiaMcpServer.OpennessWorker\Openness\BlockBundleFormat.cs"
       Link="Linked\Openness\BlockBundleFormat.cs" />
+    <Compile Include="..\TiaMcpServer.OpennessWorker\Openness\BlockDocumentPackagePolicy.cs"
+      Link="Linked\Openness\BlockDocumentPackagePolicy.cs" />
     <None Include="Fixtures\get_block_content.ob-lad.bundle.txt"
       CopyToOutputDirectory="PreserveNewest" />
     <None Include="Fixtures\get_block_content.ob-lad.v2.bundle.txt"

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -11,6 +11,7 @@ installation that are surprising but expected.
 - No running TIA Portal instance: start TIA Portal V21 before calling tools that attach to the current project.
 - Access denied or attach failure: confirm the Windows user belongs to the `Siemens TIA Openness` user group, then sign out and back in.
 - `dotnet` selects the wrong SDK: install .NET SDK 8.0.4xx or update `global.json` to a locally installed .NET 8 SDK feature band.
+- `get_block_content` on an S7-300/S7-400 CPU returns a warning that the s7dcl rung text is unavailable: expected. Those CPU families do not support Siemens document export at all. The Simatic ML XML document is exported by a separate API and is present, so the payload is complete for reading and for `update_block_logic`; only the supplementary human-readable rung text is missing.
 
 ## Verified TIA Portal V21 behavior
 
@@ -24,6 +25,13 @@ uncertain worker outcome; inspect the current block instead.
 SCL `create_block` calls are verified: the generated SCL source contains a non-empty compile unit,
 the requested block resolves at its requested path, and `compile_check` confirms it compiles. The
 same guarded preview/token/apply flow applies to SCL and GlobalDB block creation.
+
+S7-300/S7-400 block reads are verified against a CPU 314C-2 PN/DP (`6ES7 314-6EH04-0AB0/V3.3`).
+`PlcBlock.ExportAsDocuments` is rejected outright by those CPU families, but `PlcBlock.Export`
+produces the authoritative Simatic ML XML for GlobalDB, InstanceDB, STL FC and LAD FC blocks on the
+same CPU. `get_block_content` therefore succeeds with `format=xml` and carries one warning naming
+the missing document package. `format=source` remains restricted to global data blocks and
+SCL-language FB/FC/OB.
 
 `save_project_as` with `rebind: false` is resolved: it is rejected up front with a
 `validation_error` response, before any preview, safety-token issuance, Siemens `SaveAs` call, or


### PR DESCRIPTION
## Problem

`get_block_content` fails for **every** block on an S7-300/S7-400 CPU:

```
Error: TIA Portal operation failed: Error when calling method 'ExportAsDocuments'
of type 'Siemens.Engineering.SW.Blocks.FC'.

CPUs of the S7-300/S7-400 series do not support the document export or import of
blocks or PLC data types.
```

The Siemens message is accurate, but it only describes one of the two exports the bundle performs.
`BlockExporter.Export` composes:

1. the **Simatic ML XML**, via `PlcBlock.Export` — authoritative, and what `update_block_logic`
   consumes;
2. the **s7dcl document package**, via `PlcBlock.ExportAsDocuments` — supplementary
   human-readable rung text, already commented in the code as "read-only context".

Only (2) is rejected by these CPU families. (1) succeeds on exactly the same blocks. But the
`ExportAsDocuments` call was unconditional and fatal, so a failure there discarded the
authoritative XML that had already exported cleanly a few lines above — and the whole read failed.

## Fix

Make the supplementary export non-fatal when the authoritative document survived. The read degrades
with a warning naming the missing package instead of failing.

It stays fatal when neither document exported, because the bundle would then be empty —
`BlockBundleFormat.Compose` rejects that case anyway.

The rule is keyed off **the surviving document**, not a Siemens message match or a hard-coded
device-family table; both of those would rot. That also means the change is not S7-300-specific: any
future CPU or block state that can produce XML but not the document package degrades the same way.

The decision itself lives in `BlockDocumentPackagePolicy`, Siemens-free by construction so the test
project can link and cover it — following the `SourceFormatEligibility` pattern. The warning reaches
the caller through `Console.Error`, which `HandleLineWithCapturedStderr` already folds into
`response.Warnings`, so no signature or contract changed.

## Verification

Per CONTRIBUTING, being explicit about what ran against what.

**Against a real TIA Portal V21 installation** — device `System:Device.S7300`, CPU 314C-2 PN/DP
(`6ES7 314-6EH04-0AB0/V3.3`), project created in V15 and upgraded to V21:

- Built with `/p:TiaPortalV21Dir=...` (real Siemens assemblies, not `ref/` stubs), attached the
  patched host + worker to the live project, and called `execute_read_batch` →
  `get_block_content` on the two blocks that previously failed hard:

  | Block | Language | Before | After |
  | --- | --- | --- | --- |
  | `FC - Alarms` | STL | `worker_operation_failed` | `IsError = False` + 1 warning |
  | `FC - AlarmsManagement` | LAD | `worker_operation_failed` | `IsError = False` + 1 warning |

  The warning arrives intact through the worker→host channel:

  ```
  TIA Openness worker warning: Human-readable rung text (s7dcl) is unavailable for
  'PLC_1/Blocks/10_Alarms/FC - AlarmsManagement': Error when calling method
  'ExportAsDocuments' … The Simatic ML XML document was exported, so this payload is
  complete for reading and for update_block_logic. …
  ```

- Separately, via direct Openness calls on the same CPU, confirming the XML is real content and not
  an empty shell: `PlcBlock.Export` succeeds for GlobalDB, InstanceDB, STL FC **and** LAD FC. The
  LAD block's XML is 45 KB containing 24 `Contact`/`Coil`/`RCoil` parts and 54 wires.
  `ExportAsDocuments` fails for all four.

  Reflection on V21 also confirms none of `Export`, `ExportAsDocuments` or `GenerateSource` carries
  `[Obsolete]` — `Export` is not a deprecated path being resurrected.

**Against stubs** — `dotnet build ... /p:UseTiaPortalReferenceStubs=true` clean, 0 warnings.
`dotnet test`: **2252 passed, 21 failed**. All 21 failures are `Win32Exception: cannot start process
'pwsh'` in the PowerShell-harness test classes (`CoverageThresholdScriptTests`,
`DoctorPackageVerificationScriptTests`, `NetworkIntrospectionLiveHarnessScriptTests`,
`NetworkSubnetLifecycle*ProbeContractTests`) — PowerShell 7 is not installed on this machine. They
fail identically before this change, and nothing block- or export-related fails.

One gap worth naming: my ad-hoc stdio harness captured the server's structured logs but came back
with an empty stdout payload, so I confirmed the **outcome** (`IsError = False` + warning) through
those logs rather than by re-reading the returned bundle bytes over MCP. The bundle's XML content is
covered by the direct-Openness check above.

## Notes

- 9 new unit tests in `BlockDocumentPackagePolicyTests`.
- `docs/guides/troubleshooting.md` gains the symptom under Troubleshooting and the verified S7-300
  behaviour under Verified TIA Portal V21 behavior.
- No contract, schema or tool-surface change. `format=source` eligibility is untouched.

## Possible follow-up (not in this PR)

`SourceFormatEligibility` refuses STL with the note that "TIA treats STL external sources as a
distinct file type (.awl) with no fixture and no live evidence behind it." I have that evidence now:
`GenerateSource` produced a valid `.awl` for an STL FC on this S7-300 — 1117 lines, network titles,
symbolic operands and inline comments intact, at 32 KB versus 413 KB for the same block's XML.

That is a separate design decision and touches a deliberate refusal, so I have deliberately kept it
out of this PR. Happy to open an issue or a spec for it if you would find it useful.

---

Authored by @WilliamTatendaJose with AI assistance (Claude). All findings above were executed and
verified against the live installation described; the reasoning and the code were reviewed by me
before submitting.
