### PR TITLE
Enhance project enumeration completeness

### DIFF
--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -332,6 +332,15 @@ while ((line = Console.In.ReadLine()) is not null)
                 ? Success(ToCamelCaseJson(IoMapMalformedHardwareConfig()))
                 : $$"""{"success":false,"error":"expected read_hardware_config, got '{{ReadMethod(line)}}'"}""");
             break;
+
+        case "project-enumeration-completeness":
+            Respond(ReadMethod(line) switch
+            {
+                "read_hardware_config" => Success(ToCamelCaseJson(ProjectCompletenessHardware())),
+                "browse_project_tree" => Success(ToCamelCaseJson(ProjectCompletenessTree())),
+                _ => $$"""{"success":false,"error":"unexpected project completeness method '{{ReadMethod(line)}}'"}"""
+            });
+            break;
         case "network-unresolvable-target":
             // A contract-valid, empty HardwareConfigInfo: no device can ever match a
             // configure_network_device target here, so a preview against this scenario proves
@@ -921,6 +930,78 @@ HardwareConfigInfo RoundTripHardwareConfig() => new()
             "PN/IE_2", "subnet-2", "Ethernet", "Ethernet",
             Array.Empty<IoSystemInfo>(),
             new[] { "PC_System_1.E2" }),
+    },
+};
+
+HardwareConfigInfo ProjectCompletenessHardware() => new()
+{
+    Devices = new List<DeviceInfo>
+    {
+        new() { Name = "Direct PLC", TypeIdentifier = "OrderNumber:CPU" },
+        new() { Name = "Grouped ET200", TypeIdentifier = "OrderNumber:ET200" },
+    },
+};
+
+List<ProjectTreeNode> ProjectCompletenessTree() => new()
+{
+    new()
+    {
+        Name = "Direct PLC",
+        NodeType = "Device",
+        Details = new Dictionary<string, string> { ["Path"] = "Direct PLC" },
+        Children = new List<ProjectTreeNode>(),
+    },
+    new()
+    {
+        Name = "Grouped ET200",
+        NodeType = "Device",
+        Details = new Dictionary<string, string> { ["Path"] = "Grouped ET200" },
+        Children = new List<ProjectTreeNode>
+        {
+            new()
+            {
+                Name = "PLC_Grouped",
+                NodeType = "PlcSoftware",
+                Details = new Dictionary<string, string> { ["Path"] = "Grouped ET200" },
+                Children = new List<ProjectTreeNode>
+                {
+                    new()
+                    {
+                        Name = "Blocks",
+                        NodeType = "BlockFolder",
+                        Details = new Dictionary<string, string> { ["Path"] = "PLC_Grouped/Blocks" },
+                        Children = new List<ProjectTreeNode>
+                        {
+                            new()
+                            {
+                                Name = "System blocks",
+                                NodeType = "SystemBlockFolder",
+                                Details = new Dictionary<string, string>
+                                {
+                                    ["Path"] = "PLC_Grouped/Blocks/System blocks"
+                                },
+                                Children = new List<ProjectTreeNode>
+                                {
+                                    new()
+                                    {
+                                        Name = "SafeFB",
+                                        NodeType = "FB",
+                                        Details = new Dictionary<string, string>
+                                        {
+                                            ["Path"] = "PLC_Grouped/Blocks/System blocks/SafeFB",
+                                            ["Number"] = "200",
+                                            ["ProgrammingLanguage"] = "F_LAD",
+                                            ["IsSystemBlock"] = "true",
+                                        },
+                                        Children = new List<ProjectTreeNode>(),
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
     },
 };
 

--- a/TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs
@@ -96,7 +96,7 @@ public static class HardwareConfigReader
         List<string> messages)
     {
         var candidates = new List<(Device Device, NetworkObjectDiscoveryEvidenceValue<string> NameEvidence)>();
-        foreach (Device device in project.Devices)
+        foreach (Device device in ProjectDeviceEnumerator.Enumerate(project))
         {
             var nameEvidence = ReadTypedIdentityString(() => device.Name, "Device name");
             candidates.Add((device, nameEvidence));

--- a/TiaMcpServer.OpennessWorker/Openness/ProjectDeviceEnumerator.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/ProjectDeviceEnumerator.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using Siemens.Engineering;
+using Siemens.Engineering.HW;
+
+namespace TiaMcpServer.OpennessWorker.Openness;
+
+internal static class ProjectDeviceEnumerator
+{
+    public static IEnumerable<Device> Enumerate(Project project)
+    {
+        foreach (Device device in project.Devices)
+        {
+            yield return device;
+        }
+
+        foreach (DeviceUserGroup group in project.DeviceGroups)
+        {
+            foreach (var device in Enumerate(group))
+            {
+                yield return device;
+            }
+        }
+    }
+
+    private static IEnumerable<Device> Enumerate(DeviceUserGroup group)
+    {
+        foreach (Device device in group.Devices)
+        {
+            yield return device;
+        }
+
+        foreach (DeviceUserGroup childGroup in group.Groups)
+        {
+            foreach (var device in Enumerate(childGroup))
+            {
+                yield return device;
+            }
+        }
+    }
+}

--- a/TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs
@@ -17,28 +17,33 @@ public class ProjectTreeWalker
     {
         var rootNodes = new List<ProjectTreeNode>();
 
-        foreach (Device device in project.Devices)
+        foreach (Device device in ProjectDeviceEnumerator.Enumerate(project))
         {
-            var children = new List<ProjectTreeNode>();
-
-            foreach (var plcSoftware in PlcSoftwareLocator.FindInDevice(device))
-            {
-                children.Add(WalkPlcSoftware(device.Name, plcSoftware));
-            }
-
-            rootNodes.Add(new ProjectTreeNode
-            {
-                Name = device.Name,
-                NodeType = "Device",
-                Details = new Dictionary<string, string>
-                {
-                    ["Path"] = device.Name
-                },
-                Children = children
-            });
+            rootNodes.Add(WalkDevice(device));
         }
 
         return rootNodes;
+    }
+
+    private static ProjectTreeNode WalkDevice(Device device)
+    {
+        var children = new List<ProjectTreeNode>();
+
+        foreach (var plcSoftware in PlcSoftwareLocator.FindInDevice(device))
+        {
+            children.Add(WalkPlcSoftware(device.Name, plcSoftware));
+        }
+
+        return new ProjectTreeNode
+        {
+            Name = device.Name,
+            NodeType = "Device",
+            Details = new Dictionary<string, string>
+            {
+                ["Path"] = device.Name
+            },
+            Children = children
+        };
     }
 
     private static ProjectTreeNode WalkPlcSoftware(string deviceName, PlcSoftware plcSoftware)

--- a/TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs
@@ -118,33 +118,7 @@ public class ProjectTreeWalker
         {
             try
             {
-                var details = new Dictionary<string, string>
-                {
-                    ["Path"] = CombinePath(path, block.Name),
-                    ["Number"] = block.Number.ToString(),
-                    ["ProgrammingLanguage"] = block.ProgrammingLanguage.ToString()
-                };
-
-                if (softwareUnitName is not null)
-                {
-                    details["SoftwareUnit"] = softwareUnitName;
-                }
-
-                children.Add(new ProjectTreeNode
-                {
-                    Name = block.Name,
-                    NodeType = block switch
-                    {
-                        OB => "OB",
-                        FB => "FB",
-                        FC => "FC",
-                        GlobalDB => "GlobalDB",
-                        InstanceDB => "InstanceDB",
-                        ArrayDB => "ArrayDB",
-                        _ => "Block"
-                    },
-                    Details = details
-                });
+                children.Add(BuildBlockNode(block, path, softwareUnitName, isSystemBlock: false));
             }
             catch (EngineeringException ex)
             {
@@ -164,10 +138,114 @@ public class ProjectTreeWalker
             }
         }
 
+        if (group is PlcBlockSystemGroup systemGroup)
+        {
+            foreach (PlcSystemBlockGroup childGroup in systemGroup.SystemBlockGroups)
+            {
+                try
+                {
+                    children.Add(WalkSystemBlockGroup(childGroup, CombinePath(path, childGroup.Name), softwareUnitName));
+                }
+                catch (EngineeringException ex)
+                {
+                    Console.Error.WriteLine(
+                        $"Skipping a system block group while walking block group '{group.Name}': {ex.Message}");
+                }
+            }
+        }
+
         return new ProjectTreeNode
         {
             Name = group.Name,
             NodeType = "BlockFolder",
+            Details = new Dictionary<string, string>
+            {
+                ["Path"] = path
+            },
+            Children = children
+        };
+    }
+
+    private static ProjectTreeNode BuildBlockNode(
+        PlcBlock block,
+        string path,
+        string? softwareUnitName,
+        bool isSystemBlock)
+    {
+        var details = new Dictionary<string, string>
+        {
+            ["Path"] = CombinePath(path, block.Name),
+            ["Number"] = block.Number.ToString(),
+            ["ProgrammingLanguage"] = block.ProgrammingLanguage.ToString()
+        };
+
+        if (softwareUnitName is not null)
+        {
+            details["SoftwareUnit"] = softwareUnitName;
+        }
+
+        if (isSystemBlock)
+        {
+            details["IsSystemBlock"] = "true";
+        }
+
+        return new ProjectTreeNode
+        {
+            Name = block.Name,
+            NodeType = block switch
+            {
+                OB => "OB",
+                FB => "FB",
+                FC => "FC",
+                GlobalDB => "GlobalDB",
+                InstanceDB => "InstanceDB",
+                ArrayDB => "ArrayDB",
+                _ => "Block"
+            },
+            Details = details
+        };
+    }
+
+    private static ProjectTreeNode WalkSystemBlockGroup(
+        PlcSystemBlockGroup group,
+        string path,
+        string? softwareUnitName)
+    {
+        var children = new List<ProjectTreeNode>();
+
+        foreach (PlcBlock block in group.Blocks)
+        {
+            try
+            {
+                children.Add(BuildBlockNode(block, path, softwareUnitName, isSystemBlock: true));
+            }
+            catch (EngineeringException ex)
+            {
+                Console.Error.WriteLine(
+                    $"Skipping a block while walking system block group '{group.Name}': {ex.Message}");
+            }
+        }
+
+        foreach (PlcSystemBlockGroup childGroup in group.Groups)
+        {
+            try
+            {
+                children.Add(WalkSystemBlockGroup(
+                    childGroup,
+                    CombinePath(path, childGroup.Name),
+                    softwareUnitName));
+            }
+            catch (EngineeringException ex)
+            {
+                Console.Error.WriteLine(
+                    $"Skipping a nested system block group while walking system block group '{group.Name}': {ex.Message}");
+            }
+        }
+
+        return new ProjectTreeNode
+        {
+            Name = group.Name,
+            NodeType = "SystemBlockFolder",
             Details = new Dictionary<string, string>
             {
                 ["Path"] = path

--- a/TiaMcpServer.Tests/Network/NetworkIoMapFakeWorkerTests.cs
+++ b/TiaMcpServer.Tests/Network/NetworkIoMapFakeWorkerTests.cs
@@ -18,6 +18,7 @@ namespace TiaMcpServer.Tests.Network;
 public class NetworkIoMapFakeWorkerTests
 {
     private const string Scenario = "network-io-map";
+    private const string ProjectCompletenessScenario = "project-enumeration-completeness";
 
     private static OpennessWorkerClient CreateClient(McpAccessMode mode = McpAccessMode.ReadWrite)
         => new(
@@ -42,6 +43,29 @@ public class NetworkIoMapFakeWorkerTests
         IncludeIoDetails = includeIoDetails,
         IncludeTagMatches = includeTagMatches,
     };
+
+    [Fact]
+    public async Task NetworkRead_ProjectCompletenessFixtureReturnsGroupedDeviceAsOrdinaryHardware()
+    {
+        using var client = CreateClient();
+
+        var result = await NetworkReadTools.NetworkRead(
+            client,
+            new[] { ReadHardware("complete", ProjectCompletenessScenario) });
+
+        Assert.False(result.IsError);
+        var operation = AssertOneCanonicalDocument(result)
+            .GetProperty("batch")
+            .GetProperty("operations")[0];
+        Assert.Equal("succeeded", operation.GetProperty("status").GetString());
+
+        var devices = operation.GetProperty("result").GetProperty("devices");
+        Assert.Equal(2, devices.GetArrayLength());
+        var grouped = devices.EnumerateArray().Single(
+            device => device.GetProperty("name").GetString() == "Grouped ET200");
+        Assert.False(grouped.TryGetProperty("group", out _));
+        Assert.False(grouped.TryGetProperty("deviceFolder", out _));
+    }
 
     [Fact]
     public async Task NetworkRead_IncludeIoDetailsReturnsStructuredAddressesChannelsAndTagMatches()

--- a/TiaMcpServer.Tests/Project/ProjectStandaloneToolTests.cs
+++ b/TiaMcpServer.Tests/Project/ProjectStandaloneToolTests.cs
@@ -80,6 +80,52 @@ public class ProjectStandaloneToolTests
     }
 
     [Fact]
+    public async Task BrowseProjectTree_ProjectCompletenessFixtureKeepsDevicesFlatAndMarksSystemBlocks()
+    {
+        using var client = CreateClient(FakeWorkerLocator.Locate());
+
+        var response = await ProjectReadTools.BrowseProjectTree(
+            client,
+            projectPath: "project-enumeration-completeness");
+        using var document = JsonDocument.Parse(PayloadFromEnvelope(response));
+        var nodes = document.RootElement
+            .EnumerateArray()
+            .SelectMany(Descendants)
+            .ToArray();
+
+        Assert.Contains(nodes, node =>
+            node.GetProperty("nodeType").GetString() == "Device"
+            && node.GetProperty("name").GetString() == "Grouped ET200");
+        Assert.DoesNotContain(nodes, node => node.GetProperty("nodeType").GetString() == "DeviceFolder");
+
+        var systemFolder = Assert.Single(nodes.Where(
+            node => node.GetProperty("nodeType").GetString() == "SystemBlockFolder"));
+        Assert.Equal("System blocks", systemFolder.GetProperty("name").GetString());
+
+        var systemBlock = Assert.Single(nodes.Where(
+            node => node.GetProperty("name").GetString() == "SafeFB"));
+        Assert.Equal("FB", systemBlock.GetProperty("nodeType").GetString());
+        Assert.Equal("true", systemBlock.GetProperty("details").GetProperty("IsSystemBlock").GetString());
+    }
+
+    private static IEnumerable<JsonElement> Descendants(JsonElement node)
+    {
+        yield return node;
+        if (!node.TryGetProperty("children", out var children))
+        {
+            yield break;
+        }
+
+        foreach (var child in children.EnumerateArray())
+        {
+            foreach (var descendant in Descendants(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+
+    [Fact]
     public async Task BrowseProjectTree_InvalidDepthFailsBeforeWorkerAccess()
     {
         using var client = CreateClient("missing-worker.exe");

--- a/TiaMcpServer.Tests/Project/ProjectTraversalSourceContractTests.cs
+++ b/TiaMcpServer.Tests/Project/ProjectTraversalSourceContractTests.cs
@@ -18,6 +18,15 @@ public class ProjectTraversalSourceContractTests
         Assert.Contains("foreach (Device device in group.Devices)", source, StringComparison.Ordinal);
         Assert.Contains("foreach (DeviceUserGroup childGroup in group.Groups)", source, StringComparison.Ordinal);
         Assert.Contains("foreach (var device in Enumerate(childGroup))", source, StringComparison.Ordinal);
+
+        Assert.True(
+            source.IndexOf("foreach (Device device in project.Devices)", StringComparison.Ordinal) <
+            source.IndexOf("foreach (DeviceUserGroup group in project.DeviceGroups)", StringComparison.Ordinal),
+            "Direct project devices must be enumerated before project device groups.");
+        Assert.True(
+            source.IndexOf("foreach (Device device in group.Devices)", StringComparison.Ordinal) <
+            source.IndexOf("foreach (DeviceUserGroup childGroup in group.Groups)", StringComparison.Ordinal),
+            "Direct group devices must be enumerated before child device groups.");
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/Project/ProjectTraversalSourceContractTests.cs
+++ b/TiaMcpServer.Tests/Project/ProjectTraversalSourceContractTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Project;
+
+public class ProjectTraversalSourceContractTests
+{
+    [Fact]
+    public void ProjectDeviceEnumerator_TraversesDirectAndNestedGroupsInOrder()
+    {
+        var source = ReadRepositorySource(
+            "TiaMcpServer.OpennessWorker", "Openness", "ProjectDeviceEnumerator.cs");
+
+        Assert.Contains("foreach (Device device in project.Devices)", source, StringComparison.Ordinal);
+        Assert.Contains("foreach (DeviceUserGroup group in project.DeviceGroups)", source, StringComparison.Ordinal);
+        Assert.Contains("foreach (Device device in group.Devices)", source, StringComparison.Ordinal);
+        Assert.Contains("foreach (DeviceUserGroup childGroup in group.Groups)", source, StringComparison.Ordinal);
+        Assert.Contains("foreach (var device in Enumerate(childGroup))", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HardwareAndTreeReaders_UseTheSameProjectDeviceEnumerator()
+    {
+        var hardware = ReadRepositorySource(
+            "TiaMcpServer.OpennessWorker", "Openness", "HardwareConfigReader.cs");
+        var tree = ReadRepositorySource(
+            "TiaMcpServer.OpennessWorker", "Openness", "ProjectTreeWalker.cs");
+
+        Assert.Contains("foreach (Device device in ProjectDeviceEnumerator.Enumerate(project))", hardware, StringComparison.Ordinal);
+        Assert.Contains("foreach (Device device in ProjectDeviceEnumerator.Enumerate(project))", tree, StringComparison.Ordinal);
+        Assert.DoesNotContain("foreach (Device device in project.Devices)", hardware, StringComparison.Ordinal);
+        Assert.DoesNotContain("foreach (Device device in project.Devices)", tree, StringComparison.Ordinal);
+        Assert.Contains("rootNodes.Add(WalkDevice(device));", tree, StringComparison.Ordinal);
+    }
+
+    private static string ReadRepositorySource(params string[] pathSegments)
+    {
+        var current = AppContext.BaseDirectory;
+        while (!string.IsNullOrEmpty(current))
+        {
+            var candidate = Path.Combine(new[] { current }.Concat(pathSegments).ToArray());
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate).Replace("\r\n", "\n");
+            }
+
+            current = Path.GetDirectoryName(current);
+        }
+
+        throw new FileNotFoundException(
+            $"Could not find repository file '{Path.Combine(pathSegments)}'.");
+    }
+}

--- a/TiaMcpServer.Tests/Project/ProjectTraversalSourceContractTests.cs
+++ b/TiaMcpServer.Tests/Project/ProjectTraversalSourceContractTests.cs
@@ -35,6 +35,33 @@ public class ProjectTraversalSourceContractTests
         Assert.Contains("rootNodes.Add(WalkDevice(device));", tree, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ProjectTreeWalker_TraversesEverySystemBlockGroupWithItsOwnTypedWalker()
+    {
+        var source = ReadRepositorySource(
+            "TiaMcpServer.OpennessWorker", "Openness", "ProjectTreeWalker.cs");
+
+        Assert.Contains("group is PlcBlockSystemGroup systemGroup", source, StringComparison.Ordinal);
+        Assert.Contains("foreach (PlcSystemBlockGroup childGroup in systemGroup.SystemBlockGroups)", source, StringComparison.Ordinal);
+        Assert.Contains("WalkSystemBlockGroup(childGroup", source, StringComparison.Ordinal);
+        Assert.Contains("foreach (PlcBlock block in group.Blocks)", source, StringComparison.Ordinal);
+        Assert.Contains("foreach (PlcSystemBlockGroup childGroup in group.Groups)", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProjectTreeWalker_MarksSystemMembershipWithoutChangingFunctionalBlockTypes()
+    {
+        var source = ReadRepositorySource(
+            "TiaMcpServer.OpennessWorker", "Openness", "ProjectTreeWalker.cs");
+
+        Assert.Contains("NodeType = \"SystemBlockFolder\"", source, StringComparison.Ordinal);
+        Assert.Contains("details[\"IsSystemBlock\"] = \"true\";", source, StringComparison.Ordinal);
+        Assert.Contains("BuildBlockNode(block, path, softwareUnitName, isSystemBlock: false)", source, StringComparison.Ordinal);
+        Assert.Contains("BuildBlockNode(block, path, softwareUnitName, isSystemBlock: true)", source, StringComparison.Ordinal);
+        Assert.Equal(1, source.Split("NodeType = block switch", StringSplitOptions.None).Length - 1);
+        Assert.DoesNotContain("HeaderAuthor", source, StringComparison.Ordinal);
+    }
+
     private static string ReadRepositorySource(params string[] pathSegments)
     {
         var current = AppContext.BaseDirectory;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,6 +110,12 @@ The read batch supports:
 - `list_network_objects`
 - `inspect_network_object`
 
+### Project enumeration completeness
+
+The net48 worker owns one ordered `ProjectDeviceEnumerator`: direct `Project.Devices` first, followed by a depth-first walk of `Project.DeviceGroups`. `HardwareConfigReader` and `ProjectTreeWalker` both consume it, preventing their definitions of a complete project from drifting. The public project tree deliberately flattens grouped devices into ordinary `Device` nodes.
+
+PLC user block groups and system block groups are different Openness types. `ProjectTreeWalker` therefore keeps separate recursive walkers and shares only block-node construction. `SystemBlockFolder` and `IsSystemBlock` encode system-hierarchy membership, not provenance. Hardware degradation uses `HardwareConfigInfo.Messages`; project-tree per-item failures retain the existing stderr-only best-effort boundary.
+
 ### Additional read-write tools
 
 | Tool | Purpose |

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,5 +46,6 @@ Agent-facing build and convention reference lives in [AGENTS.md](../AGENTS.md).
 acceptance reports produced while building features. It is historical process material, not
 current documentation — see its index for what is there and how to read it.
 
-Latest process entries: [PR #29 binding findings repair design](superpowers/specs/2026-08-28-pr29-binding-findings-repair-design.md)
-and [implementation plan](superpowers/plans/2026-08-28-pr29-binding-findings-repair.md).
+Latest process entries: [issue #31 project completeness and hardware pagination design](superpowers/specs/2026-08-28-issue-31-project-completeness-pagination-design.md),
+[PR #29 binding findings repair design](superpowers/specs/2026-08-28-pr29-binding-findings-repair-design.md),
+and its [implementation plan](superpowers/plans/2026-08-28-pr29-binding-findings-repair.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ Agent-facing build and convention reference lives in [AGENTS.md](../AGENTS.md).
 acceptance reports produced while building features. It is historical process material, not
 current documentation — see its index for what is there and how to read it.
 
-Latest process entries: [issue #31 project completeness and hardware pagination design](superpowers/specs/2026-08-28-issue-31-project-completeness-pagination-design.md),
+Latest process entries: [project completeness and hardware pagination design](superpowers/specs/2026-08-28-issue-31-project-completeness-pagination-design.md),
+its [PR 1 project enumeration completeness plan](superpowers/plans/2026-08-28-project-enumeration-completeness.md),
 [PR #29 binding findings repair design](superpowers/specs/2026-08-28-pr29-binding-findings-repair-design.md),
 and its [implementation plan](superpowers/plans/2026-08-28-pr29-binding-findings-repair.md).

--- a/docs/SupportedOperations/DEVICES_OPERATIONS_SUMMARY.md
+++ b/docs/SupportedOperations/DEVICES_OPERATIONS_SUMMARY.md
@@ -4,11 +4,11 @@
 
 | Entry point | Operation | Inputs and behavior |
 |---|---|---|
-| `execute_read_batch` | `read_hardware_config` | Reads devices, device items, network interfaces, nodes, subnets, and IO-system information represented by the hardware DTOs. Optional `deviceName` filter and opt-in structured I/O extraction (`includeIoDetails`, `includeTagMatches`) — see [NETWORK_OPERATIONS_SUMMARY.md](NETWORK_OPERATIONS_SUMMARY.md). |
+| `execute_read_batch` / `network_read` | `read_hardware_config` | Recursively discovers devices both at project root and in nested device groups, then reads device items, network interfaces, nodes, subnets, and IO systems. Optional `deviceName` filter and opt-in structured I/O extraction (`includeIoDetails`, `includeTagMatches`) — see [NETWORK_OPERATIONS_SUMMARY.md](NETWORK_OPERATIONS_SUMMARY.md). |
 | `execute_read_batch` | `search_equipment_catalog` | Requires `query`; accepts bounded `maxResults`; returns catalog type identifiers for candidate devices. |
 | `preview_write_batch` → `apply_write_batch` | `add_network_device` | Requires an exact catalog `typeIdentifier` and `deviceName`; accepts optional `deviceItemName`. |
 | `preview_write_batch` → `apply_write_batch` | `configure_network_device` | Requires `deviceName`; accepts `ipAddress`, `subnetMask`, `pnDeviceName`, `subnetName`, and `ioSystemName`. |
-| `browse_project_tree` | `browse_project_tree` | Locates devices and other project objects; accepts optional `projectPath`, `depth`, and `startPath`. |
+| `browse_project_tree` | `browse_project_tree` | Recursively discovers the same direct and grouped devices as flat `Device` nodes; accepts optional `projectPath`, `depth`, and `startPath`. |
 
 `add_network_device` and `configure_network_device` are data writes. Preview the complete ordered sequence and apply it with the returned token. The catalog identifier and device name are validated before the worker performs the change.
 
@@ -25,7 +25,7 @@ The hardware read path is an inspection surface. The write path is limited to ca
 
 The current surface does not provide:
 
-- Device groups, ungrouped-device management, or general device rename/delete.
+- Device-group creation, deletion, rename, or moving devices between groups. Existing grouped devices are discovered by read operations but group folders are not exposed as tree nodes.
 - Plug, move, copy, delete, or device-item/module-type changes.
 - Slot, subslot, and module manipulation beyond `add_network_device`.
 - Generic `GetAttributeInfos`, `GetAttributes`, or `SetAttributes` calls.

--- a/docs/SupportedOperations/NETWORK_OPERATIONS_SUMMARY.md
+++ b/docs/SupportedOperations/NETWORK_OPERATIONS_SUMMARY.md
@@ -23,7 +23,7 @@ The MCP provides a bounded device and network-identity surface:
 
 | Entry point | Operation | Inputs and behavior |
 |---|---|---|
-| `network_read` | `read_hardware_config` | Reads devices and their network DTOs: interfaces, nodes, subnets, and IO systems where present. Optional `deviceName` filter, optional `plcName` tag-matching selector, and opt-in structured I/O extraction (`includeIoDetails`, `includeTagMatches`) — see "Structured I/O map" below. |
+| `network_read` | `read_hardware_config` | Recursively discovers devices both at project root and in nested device groups, then reads their network DTOs: interfaces, nodes, subnets, and IO systems where present. Optional `deviceName` filter, optional `plcName` tag-matching selector, and opt-in structured I/O extraction (`includeIoDetails`, `includeTagMatches`) — see "Structured I/O map" below. |
 | `network_read` | `search_equipment_catalog` | Searches the hardware catalog for a device type before creation (`query`, optional `maxResults`). |
 | `network_read` | `list_network_objects` | Pages deterministic summaries for one or more `objectKinds`; accepts optional device-scoped filtering, `pageSize` 1-200, and an opaque continuation `cursor`. Complete identities include a selector that can be copied into inspection. |
 | `network_read` | `inspect_network_object` | Resolves one exact `target`, verifies its captured identity evidence, and returns modeled and generic attributes. Optional `attributeNames` is case-sensitive, duplicate-free, and limited to 200 names. |
@@ -216,9 +216,7 @@ A device item with I/O details carries:
 
 ### Payload size
 
-Detailed I/O output can be large. When a `read_hardware_config` result is omitted or truncated,
-the response guidance recommends narrowing with `deviceName`, disabling `includeIoDetails`/
-`includeTagMatches` where possible, or re-running the operation in its own `network_read` call.
+Recursive group traversal can make an unfiltered hardware result substantially larger than earlier versions because previously omitted devices are now present. The current unpaged contract still applies the 60,000-character per-result budget and may omit the whole operation with `reason: "resultExceededItemCharLimit"`. Until a paged request is explicitly available, use `deviceName`, disable optional detail flags where possible, and place the hardware read in its own `network_read` call. No device is silently skipped merely to fit the budget.
 
 ## The single-layer JSON contract
 
@@ -387,7 +385,7 @@ Every network operation decodes its worker payload against exactly one declared 
 
 | Operation | Result type | Notable shape |
 |---|---|---|
-| `read_hardware_config` | `HardwareConfigInfo` | `devices[]` (each with nested `items[]`, each item with `networkInterfaces[].nodes[]`), `subnets[]` (each with `ioSystems[]` and `connectedNodeNames[]`), a payload-level `messages[]` for unreadable members, and — only when requested — `items[].ioDetails` (addresses, channels, tag matches). |
+| `read_hardware_config` | `HardwareConfigInfo` | `devices[]` includes project-root and recursively grouped devices (each with nested `items[]`, each item with `networkInterfaces[].nodes[]`), `subnets[]` (each with `ioSystems[]` and `connectedNodeNames[]`), and a payload-level `messages[]` remains the hardware degradation channel; only when requested, `items[].ioDetails` contains addresses, channels, and tag matches. |
 | `search_equipment_catalog` | `CatalogEntryInfo[]` | `typeName`, `typeIdentifier`, optional `articleNumber`/`version`/`catalogPath`/`description`. |
 | `list_network_objects` | `NetworkObjectListInfo` | `items[]`, exact `totalCount`/`returnedCount`, and nullable `nextCursor`; each item preserves selector completeness and discovery diagnostics. |
 | `inspect_network_object` | `NetworkObjectInspectionInfo` | Verified `target`, typed `evidence`, independent per-attribute results, and non-fatal `messages[]`. |

--- a/docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md
+++ b/docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md
@@ -8,6 +8,10 @@
 | `browse_project_tree` | `browse_project_tree` | Optional `projectPath`, `depth`, and `startPath`; returns bounded project-tree data. |
 | `compile_check` | `compile_check` | Optional `projectPath`, `plcName`, and `blockPath`; compiles the selected scope and returns compiler messages. Available only in read-write mode. |
 
+`browse_project_tree` returns grouped and ungrouped devices with the same flat `Device` shape. PLC system-block groups use `nodeType: "SystemBlockFolder"`; contained blocks keep their functional block type and carry `details.IsSystemBlock: "true"`. That marker records TIA hierarchy membership only and is not an author, vendor, library, or provenance claim.
+
+The tree remains a bare array. Per-item Openness failures are best-effort worker stderr diagnostics rather than caller-visible warning objects; use `depth` and `startPath` to bound large trees.
+
 `compile_check` is a standalone engineering operation. It is not marked read-only, does not use a safety token, and is exposed only in read-write mode.
 
 ### `get_project_status` metadata surface

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -38,6 +38,7 @@ Task-level implementation plans derived from the specs above.
 
 | Date | Document |
 | --- | --- |
+| 2026-08-28 | [Project enumeration completeness](plans/2026-08-28-project-enumeration-completeness.md) |
 | 2026-08-28 | [PR #29 binding findings repair](plans/2026-08-28-pr29-binding-findings-repair.md) |
 | 2026-08-15 | [PR #27 review fixes](plans/2026-08-15-pr27-review-fixes.md) |
 | 2026-08-06 | [Network Phase 4 — subnet lifecycle](plans/2026-08-06-network-phase4-subnet-lifecycle.md) |

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -21,6 +21,7 @@ Design documents, written before implementation.
 
 | Date | Document |
 | --- | --- |
+| 2026-08-28 | [Issue #31 project completeness and hardware pagination](specs/2026-08-28-issue-31-project-completeness-pagination-design.md) |
 | 2026-08-28 | [PR #29 binding findings repair](specs/2026-08-28-pr29-binding-findings-repair-design.md) |
 | 2026-08-07 | [Documentation reorganization](specs/2026-08-07-docs-reorganization-design.md) |
 | 2026-08-06 | [Network Phase 4 — subnet lifecycle](specs/2026-08-06-network-phase4-subnet-lifecycle-design.md) |

--- a/docs/superpowers/plans/2026-08-28-project-enumeration-completeness.md
+++ b/docs/superpowers/plans/2026-08-28-project-enumeration-completeness.md
@@ -1,0 +1,845 @@
+# Project Enumeration Completeness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `read_hardware_config` and `browse_project_tree` discover devices in nested device groups, and make `browse_project_tree` return the complete PLC system-block hierarchy with explicit non-provenance semantics.
+
+**Architecture:** Add one net48 worker-local `ProjectDeviceEnumerator` consumed by both readers, then keep user-block and system-block recursion type-correct behind a shared block-node builder. Preserve the current public request contracts, flat device presentation, best-effort diagnostics, and unpaged result-budget behavior; validate public shapes through FakeWorker while reserving real Openness claims for a separately authorized read-only run.
+
+**Tech Stack:** C# 12 host/tests on .NET 8, C# worker on .NET Framework 4.8, Siemens TIA Portal V21 Openness APIs, xUnit, FakeWorker newline-delimited JSON IPC, PowerShell 7 for verification.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-issue-31-project-completeness-pagination-design.md` — this plan implements PR 1 only.
+
+## Global Constraints
+
+- Work only on `enhancement/project-enumeration-completeness`; pagination belongs to a later branch from updated `main`.
+- Do not add `pageSize`, `cursor`, pagination metadata, a new structured envelope, or automatic partial results.
+- `HardwareConfigReader` and `ProjectTreeWalker` must consume one shared ordered device enumerator.
+- Enumerate direct devices first, then recursively enumerate `DeviceUserGroup.Devices` and `DeviceUserGroup.Groups` in TIA collection order.
+- Grouped devices remain ordinary flat `Device` nodes; do not add `DeviceFolder` nodes.
+- System folders use `nodeType: "SystemBlockFolder"`; contained blocks retain `OB`, `FB`, `FC`, `GlobalDB`, `InstanceDB`, `ArrayDB`, or `Block` and add `details.IsSystemBlock: "true"`.
+- `IsSystemBlock` means hierarchy membership only. Do not infer Siemens, Safety, library, or author provenance and do not add `HeaderAuthor`.
+- Preserve current best-effort behavior: hardware warnings stay in `HardwareConfigInfo.Messages`; project-tree per-item `EngineeringException` failures stay on stderr; `browse_project_tree` remains a bare array.
+- Preserve the current unpaged 60,000-character per-result and 180,000-character batch-document behavior.
+- Static source-contract tests and FakeWorker fixtures are not live Openness evidence.
+- Do not run a live TIA project without separate authorization, and never mutate a project during this work.
+- Each future implementation commit requires explicit commit authorization under repository policy; the commit commands below define review boundaries, not present authorization.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `TiaMcpServer.OpennessWorker/Openness/ProjectDeviceEnumerator.cs` | Single ordered traversal of direct and recursively grouped devices. |
+| `TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs` | Select/filter devices from the shared traversal while preserving name evidence and messages. |
+| `TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs` | Render every enumerated device and separately recurse user and system block groups. |
+| `TiaMcpServer.Tests/Project/ProjectTraversalSourceContractTests.cs` | RED-capable source contracts for net48-only traversal patterns and shared-helper use. |
+| `TiaMcpServer.FakeWorker/Program.cs` | Typed fixture for complete hardware and project-tree public shapes. |
+| `TiaMcpServer.Tests/Network/NetworkIoMapFakeWorkerTests.cs` | Structured hardware result assertion for the grouped-device fixture. |
+| `TiaMcpServer.Tests/Project/ProjectStandaloneToolTests.cs` | Standalone tree assertion for flat grouped devices and system-block semantics. |
+| `docs/SupportedOperations/DEVICES_OPERATIONS_SUMMARY.md` | Device-facing completeness and scope boundary. |
+| `docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md` | Project-tree node semantics and diagnostics boundary. |
+| `docs/SupportedOperations/NETWORK_OPERATIONS_SUMMARY.md` | Complete hardware enumeration and the existing unpaged size limitation. |
+| `docs/ARCHITECTURE.md` | Shared device-enumeration seam and separate system-group walker. |
+
+---
+
+### Task 1: Share recursive device enumeration
+
+**Files:**
+- Create: `TiaMcpServer.OpennessWorker/Openness/ProjectDeviceEnumerator.cs`
+- Create: `TiaMcpServer.Tests/Project/ProjectTraversalSourceContractTests.cs`
+- Modify: `TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs:93-108`
+- Modify: `TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs:16-42`
+
+**Interfaces:**
+- Consumes: `Siemens.Engineering.Project.Devices`, `Project.DeviceGroups`, `DeviceUserGroup.Devices`, and `DeviceUserGroup.Groups`.
+- Produces: `internal static IEnumerable<Device> ProjectDeviceEnumerator.Enumerate(Project project)` in direct-then-depth-first group order.
+- Produces: `private static ProjectTreeNode ProjectTreeWalker.WalkDevice(Device device)` so direct and grouped devices have the same public shape.
+
+- [ ] **Step 1: Write the failing shared-traversal source contracts**
+
+Create `ProjectTraversalSourceContractTests.cs` with the repository-source helper and these tests:
+
+```csharp
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Project;
+
+public class ProjectTraversalSourceContractTests
+{
+    [Fact]
+    public void ProjectDeviceEnumerator_TraversesDirectAndNestedGroupsInOrder()
+    {
+        var source = ReadRepositorySource(
+            "TiaMcpServer.OpennessWorker", "Openness", "ProjectDeviceEnumerator.cs");
+
+        Assert.Contains("foreach (Device device in project.Devices)", source, StringComparison.Ordinal);
+        Assert.Contains("foreach (DeviceUserGroup group in project.DeviceGroups)", source, StringComparison.Ordinal);
+        Assert.Contains("foreach (Device device in group.Devices)", source, StringComparison.Ordinal);
+        Assert.Contains("foreach (DeviceUserGroup childGroup in group.Groups)", source, StringComparison.Ordinal);
+        Assert.Contains("foreach (var device in Enumerate(childGroup))", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HardwareAndTreeReaders_UseTheSameProjectDeviceEnumerator()
+    {
+        var hardware = ReadRepositorySource(
+            "TiaMcpServer.OpennessWorker", "Openness", "HardwareConfigReader.cs");
+        var tree = ReadRepositorySource(
+            "TiaMcpServer.OpennessWorker", "Openness", "ProjectTreeWalker.cs");
+
+        Assert.Contains("foreach (Device device in ProjectDeviceEnumerator.Enumerate(project))", hardware, StringComparison.Ordinal);
+        Assert.Contains("foreach (Device device in ProjectDeviceEnumerator.Enumerate(project))", tree, StringComparison.Ordinal);
+        Assert.DoesNotContain("foreach (Device device in project.Devices)", hardware, StringComparison.Ordinal);
+        Assert.DoesNotContain("foreach (Device device in project.Devices)", tree, StringComparison.Ordinal);
+        Assert.Contains("rootNodes.Add(WalkDevice(device));", tree, StringComparison.Ordinal);
+    }
+
+    private static string ReadRepositorySource(params string[] pathSegments)
+    {
+        var current = AppContext.BaseDirectory;
+        while (!string.IsNullOrEmpty(current))
+        {
+            var candidate = Path.Combine(new[] { current }.Concat(pathSegments).ToArray());
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate).Replace("\r\n", "\n");
+            }
+
+            current = Path.GetDirectoryName(current);
+        }
+
+        throw new FileNotFoundException(
+            $"Could not find repository file '{Path.Combine(pathSegments)}'.");
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused test and observe RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTraversalSourceContractTests"
+```
+
+Expected: FAIL because `ProjectDeviceEnumerator.cs` does not exist and both readers still loop over `project.Devices` directly. Record the failing assertion or `FileNotFoundException`; do not treat compilation or restore failure as the behavioral RED.
+
+- [ ] **Step 3: Add the minimal ordered enumerator**
+
+Create `ProjectDeviceEnumerator.cs`:
+
+```csharp
+using System.Collections.Generic;
+using Siemens.Engineering;
+using Siemens.Engineering.HW;
+
+namespace TiaMcpServer.OpennessWorker.Openness;
+
+internal static class ProjectDeviceEnumerator
+{
+    public static IEnumerable<Device> Enumerate(Project project)
+    {
+        foreach (Device device in project.Devices)
+        {
+            yield return device;
+        }
+
+        foreach (DeviceUserGroup group in project.DeviceGroups)
+        {
+            foreach (var device in Enumerate(group))
+            {
+                yield return device;
+            }
+        }
+    }
+
+    private static IEnumerable<Device> Enumerate(DeviceUserGroup group)
+    {
+        foreach (Device device in group.Devices)
+        {
+            yield return device;
+        }
+
+        foreach (DeviceUserGroup childGroup in group.Groups)
+        {
+            foreach (var device in Enumerate(childGroup))
+            {
+                yield return device;
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Make both readers consume the helper**
+
+In `HardwareConfigReader.SelectDevices`, replace only the enumeration source and retain the existing one-read name evidence:
+
+```csharp
+var candidates = new List<(Device Device, NetworkObjectDiscoveryEvidenceValue<string> NameEvidence)>();
+foreach (Device device in ProjectDeviceEnumerator.Enumerate(project))
+{
+    var nameEvidence = ReadTypedIdentityString(() => device.Name, "Device name");
+    candidates.Add((device, nameEvidence));
+}
+```
+
+In `ProjectTreeWalker.Walk`, route all devices through one node builder:
+
+```csharp
+public List<ProjectTreeNode> Walk(Project project)
+{
+    var rootNodes = new List<ProjectTreeNode>();
+
+    foreach (Device device in ProjectDeviceEnumerator.Enumerate(project))
+    {
+        rootNodes.Add(WalkDevice(device));
+    }
+
+    return rootNodes;
+}
+
+private static ProjectTreeNode WalkDevice(Device device)
+{
+    var children = new List<ProjectTreeNode>();
+
+    foreach (var plcSoftware in PlcSoftwareLocator.FindInDevice(device))
+    {
+        children.Add(WalkPlcSoftware(device.Name, plcSoftware));
+    }
+
+    return new ProjectTreeNode
+    {
+        Name = device.Name,
+        NodeType = "Device",
+        Details = new Dictionary<string, string>
+        {
+            ["Path"] = device.Name
+        },
+        Children = children
+    };
+}
+```
+
+Do not expose the containing group name and do not create a `DeviceFolder` node.
+
+- [ ] **Step 5: Run focused and regression tests and observe GREEN**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTraversalSourceContractTests|FullyQualifiedName~HardwareDeviceSelectionTests"
+```
+
+Expected: PASS. `HardwareDeviceSelectionTests.HardwareConfigReader_SelectDevices_ReadsNameOnceIntoEvidence` must continue proving that the helper change did not re-read device names.
+
+- [ ] **Step 6: Build the real worker shape against Siemens stubs**
+
+Run:
+
+```powershell
+dotnet build TiaMcpServer.sln -m:1 --no-restore --disable-build-servers /p:UseTiaPortalReferenceStubs=true
+```
+
+Expected: exit 0. This is the compile-time check for the exact `DeviceUserGroup` composition members; source-contract GREEN alone is insufficient.
+
+- [ ] **Step 7: Commit the task after explicit authorization**
+
+```powershell
+git add TiaMcpServer.OpennessWorker/Openness/ProjectDeviceEnumerator.cs TiaMcpServer.OpennessWorker/Openness/HardwareConfigReader.cs TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs TiaMcpServer.Tests/Project/ProjectTraversalSourceContractTests.cs
+git commit -m "feat: enumerate devices in nested groups"
+```
+
+---
+
+### Task 2: Traverse PLC system-block groups
+
+**Files:**
+- Modify: `TiaMcpServer.Tests/Project/ProjectTraversalSourceContractTests.cs`
+- Modify: `TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs:44-172`
+
+**Interfaces:**
+- Consumes: `PlcBlockSystemGroup.SystemBlockGroups`, `PlcSystemBlockGroup.Blocks`, and `PlcSystemBlockGroup.Groups`.
+- Produces: `WalkSystemBlockGroup(PlcSystemBlockGroup group, string path, string? softwareUnitName)`.
+- Produces: `BuildBlockNode(PlcBlock block, string path, string? softwareUnitName, bool isSystemBlock)`, the sole functional block-type mapping.
+
+- [ ] **Step 1: Add failing source contracts for the system hierarchy and marker semantics**
+
+Add these tests to `ProjectTraversalSourceContractTests`:
+
+```csharp
+[Fact]
+public void ProjectTreeWalker_TraversesEverySystemBlockGroupWithItsOwnTypedWalker()
+{
+    var source = ReadRepositorySource(
+        "TiaMcpServer.OpennessWorker", "Openness", "ProjectTreeWalker.cs");
+
+    Assert.Contains("group is PlcBlockSystemGroup systemGroup", source, StringComparison.Ordinal);
+    Assert.Contains("foreach (PlcSystemBlockGroup childGroup in systemGroup.SystemBlockGroups)", source, StringComparison.Ordinal);
+    Assert.Contains("WalkSystemBlockGroup(childGroup", source, StringComparison.Ordinal);
+    Assert.Contains("foreach (PlcBlock block in group.Blocks)", source, StringComparison.Ordinal);
+    Assert.Contains("foreach (PlcSystemBlockGroup childGroup in group.Groups)", source, StringComparison.Ordinal);
+}
+
+[Fact]
+public void ProjectTreeWalker_MarksSystemMembershipWithoutChangingFunctionalBlockTypes()
+{
+    var source = ReadRepositorySource(
+        "TiaMcpServer.OpennessWorker", "Openness", "ProjectTreeWalker.cs");
+
+    Assert.Contains("NodeType = \"SystemBlockFolder\"", source, StringComparison.Ordinal);
+    Assert.Contains("details[\"IsSystemBlock\"] = \"true\";", source, StringComparison.Ordinal);
+    Assert.Contains("BuildBlockNode(block, path, softwareUnitName, isSystemBlock: false)", source, StringComparison.Ordinal);
+    Assert.Contains("BuildBlockNode(block, path, softwareUnitName, isSystemBlock: true)", source, StringComparison.Ordinal);
+    Assert.Equal(1, source.Split("NodeType = block switch", StringSplitOptions.None).Length - 1);
+    Assert.DoesNotContain("HeaderAuthor", source, StringComparison.Ordinal);
+}
+```
+
+- [ ] **Step 2: Run the focused test and observe RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTraversalSourceContractTests"
+```
+
+Expected: FAIL on missing `PlcSystemBlockGroup` traversal, `SystemBlockFolder`, and `IsSystemBlock` evidence.
+
+- [ ] **Step 3: Extract the shared block-node builder**
+
+Replace the block-node construction inside `WalkBlockGroup` with:
+
+```csharp
+foreach (PlcBlock block in group.Blocks)
+{
+    try
+    {
+        children.Add(BuildBlockNode(block, path, softwareUnitName, isSystemBlock: false));
+    }
+    catch (EngineeringException ex)
+    {
+        Console.Error.WriteLine($"Skipping a block while walking block group '{group.Name}': {ex.Message}");
+    }
+}
+```
+
+Add one shared builder containing the existing functional node mapping:
+
+```csharp
+private static ProjectTreeNode BuildBlockNode(
+    PlcBlock block,
+    string path,
+    string? softwareUnitName,
+    bool isSystemBlock)
+{
+    var details = new Dictionary<string, string>
+    {
+        ["Path"] = CombinePath(path, block.Name),
+        ["Number"] = block.Number.ToString(),
+        ["ProgrammingLanguage"] = block.ProgrammingLanguage.ToString()
+    };
+
+    if (softwareUnitName is not null)
+    {
+        details["SoftwareUnit"] = softwareUnitName;
+    }
+
+    if (isSystemBlock)
+    {
+        details["IsSystemBlock"] = "true";
+    }
+
+    return new ProjectTreeNode
+    {
+        Name = block.Name,
+        NodeType = block switch
+        {
+            OB => "OB",
+            FB => "FB",
+            FC => "FC",
+            GlobalDB => "GlobalDB",
+            InstanceDB => "InstanceDB",
+            ArrayDB => "ArrayDB",
+            _ => "Block"
+        },
+        Details = details
+    };
+}
+```
+
+- [ ] **Step 4: Add type-correct system recursion with per-item degradation**
+
+After the existing `PlcBlockGroup.Groups` loop in `WalkBlockGroup`, add:
+
+```csharp
+if (group is PlcBlockSystemGroup systemGroup)
+{
+    foreach (PlcSystemBlockGroup childGroup in systemGroup.SystemBlockGroups)
+    {
+        try
+        {
+            children.Add(WalkSystemBlockGroup(
+                childGroup,
+                CombinePath(path, childGroup.Name),
+                softwareUnitName));
+        }
+        catch (EngineeringException ex)
+        {
+            Console.Error.WriteLine(
+                $"Skipping a system block group while walking block group '{group.Name}': {ex.Message}");
+        }
+    }
+}
+```
+
+Add the separate typed walker:
+
+```csharp
+private static ProjectTreeNode WalkSystemBlockGroup(
+    PlcSystemBlockGroup group,
+    string path,
+    string? softwareUnitName)
+{
+    var children = new List<ProjectTreeNode>();
+
+    foreach (PlcBlock block in group.Blocks)
+    {
+        try
+        {
+            children.Add(BuildBlockNode(block, path, softwareUnitName, isSystemBlock: true));
+        }
+        catch (EngineeringException ex)
+        {
+            Console.Error.WriteLine(
+                $"Skipping a block while walking system block group '{group.Name}': {ex.Message}");
+        }
+    }
+
+    foreach (PlcSystemBlockGroup childGroup in group.Groups)
+    {
+        try
+        {
+            children.Add(WalkSystemBlockGroup(
+                childGroup,
+                CombinePath(path, childGroup.Name),
+                softwareUnitName));
+        }
+        catch (EngineeringException ex)
+        {
+            Console.Error.WriteLine(
+                $"Skipping a nested system block group while walking system block group '{group.Name}': {ex.Message}");
+        }
+    }
+
+    return new ProjectTreeNode
+    {
+        Name = group.Name,
+        NodeType = "SystemBlockFolder",
+        Details = new Dictionary<string, string>
+        {
+            ["Path"] = path
+        },
+        Children = children
+    };
+}
+```
+
+- [ ] **Step 5: Run focused regressions and the stub build**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTraversalSourceContractTests|FullyQualifiedName~ProjectTreeFilterTests"
+dotnet build TiaMcpServer.sln -m:1 --no-restore --disable-build-servers /p:UseTiaPortalReferenceStubs=true
+```
+
+Expected: both commands exit 0. The unchanged pure `ProjectTreeFilterTests` prove the additive nodes still obey existing `depth` and `startPath` filtering after the worker returns the tree.
+
+- [ ] **Step 6: Commit the task after explicit authorization**
+
+```powershell
+git add TiaMcpServer.OpennessWorker/Openness/ProjectTreeWalker.cs TiaMcpServer.Tests/Project/ProjectTraversalSourceContractTests.cs
+git commit -m "feat: include system blocks in project tree"
+```
+
+---
+
+### Task 3: Prove the public shapes through FakeWorker
+
+**Files:**
+- Modify: `TiaMcpServer.FakeWorker/Program.cs`
+- Modify: `TiaMcpServer.Tests/Network/NetworkIoMapFakeWorkerTests.cs`
+- Modify: `TiaMcpServer.Tests/Project/ProjectStandaloneToolTests.cs`
+
+**Interfaces:**
+- Consumes: existing `Success`, `ToCamelCaseJson`, `NetworkReadTools.NetworkRead`, and `ProjectReadTools.BrowseProjectTree` paths.
+- Produces: FakeWorker scenario key `project-enumeration-completeness` for `read_hardware_config` and `browse_project_tree` only.
+- Produces: public evidence that grouped hardware is an ordinary `devices[]` member and grouped tree entries are flat `Device` nodes with nested `SystemBlockFolder` data.
+
+- [ ] **Step 1: Add the failing structured hardware assertion**
+
+In `NetworkIoMapFakeWorkerTests`, add a second scenario constant and test:
+
+```csharp
+private const string ProjectCompletenessScenario = "project-enumeration-completeness";
+
+[Fact]
+public async Task NetworkRead_ProjectCompletenessFixtureReturnsGroupedDeviceAsOrdinaryHardware()
+{
+    using var client = CreateClient();
+
+    var result = await NetworkReadTools.NetworkRead(
+        client,
+        new[] { ReadHardware("complete", ProjectCompletenessScenario) });
+
+    Assert.False(result.IsError);
+    var operation = AssertOneCanonicalDocument(result)
+        .GetProperty("batch")
+        .GetProperty("operations")[0];
+    Assert.Equal("succeeded", operation.GetProperty("status").GetString());
+
+    var devices = operation.GetProperty("result").GetProperty("devices");
+    Assert.Equal(2, devices.GetArrayLength());
+    var grouped = devices.EnumerateArray().Single(
+        device => device.GetProperty("name").GetString() == "Grouped ET200");
+    Assert.False(grouped.TryGetProperty("group", out _));
+    Assert.False(grouped.TryGetProperty("deviceFolder", out _));
+}
+```
+
+- [ ] **Step 2: Add the failing standalone project-tree assertion**
+
+In `ProjectStandaloneToolTests`, add:
+
+```csharp
+[Fact]
+public async Task BrowseProjectTree_ProjectCompletenessFixtureKeepsDevicesFlatAndMarksSystemBlocks()
+{
+    using var client = CreateClient(FakeWorkerLocator.Locate());
+
+    var response = await ProjectReadTools.BrowseProjectTree(
+        client,
+        projectPath: "project-enumeration-completeness");
+    using var document = JsonDocument.Parse(PayloadFromEnvelope(response));
+    var nodes = document.RootElement
+        .EnumerateArray()
+        .SelectMany(Descendants)
+        .ToArray();
+
+    Assert.Contains(nodes, node =>
+        node.GetProperty("nodeType").GetString() == "Device"
+        && node.GetProperty("name").GetString() == "Grouped ET200");
+    Assert.DoesNotContain(nodes, node => node.GetProperty("nodeType").GetString() == "DeviceFolder");
+
+    var systemFolder = Assert.Single(nodes.Where(
+        node => node.GetProperty("nodeType").GetString() == "SystemBlockFolder"));
+    Assert.Equal("System blocks", systemFolder.GetProperty("name").GetString());
+
+    var systemBlock = Assert.Single(nodes.Where(
+        node => node.GetProperty("name").GetString() == "SafeFB"));
+    Assert.Equal("FB", systemBlock.GetProperty("nodeType").GetString());
+    Assert.Equal("true", systemBlock.GetProperty("details").GetProperty("IsSystemBlock").GetString());
+}
+
+private static IEnumerable<JsonElement> Descendants(JsonElement node)
+{
+    yield return node;
+    if (!node.TryGetProperty("children", out var children))
+    {
+        yield break;
+    }
+
+    foreach (var child in children.EnumerateArray())
+    {
+        foreach (var descendant in Descendants(child))
+        {
+            yield return descendant;
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run both tests and observe RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "Name~ProjectCompletenessFixture"
+```
+
+Expected: FAIL because FakeWorker has no `project-enumeration-completeness` scenario. Confirm the failure is the unknown scenario/failed operation, not a test compilation problem.
+
+- [ ] **Step 4: Add one typed FakeWorker scenario for both reads**
+
+Add this switch arm near the other read fixtures:
+
+```csharp
+case "project-enumeration-completeness":
+    Respond(ReadMethod(line) switch
+    {
+        "read_hardware_config" => Success(ToCamelCaseJson(ProjectCompletenessHardware())),
+        "browse_project_tree" => Success(ToCamelCaseJson(ProjectCompletenessTree())),
+        _ => $$"""{"success":false,"error":"unexpected project completeness method '{{ReadMethod(line)}}'"}"""
+    });
+    break;
+```
+
+Add typed fixture builders with no folder/provenance member on hardware devices:
+
+```csharp
+static HardwareConfigInfo ProjectCompletenessHardware() => new()
+{
+    Devices = new List<DeviceInfo>
+    {
+        new() { Name = "Direct PLC", TypeIdentifier = "OrderNumber:CPU" },
+        new() { Name = "Grouped ET200", TypeIdentifier = "OrderNumber:ET200" },
+    },
+};
+
+static List<ProjectTreeNode> ProjectCompletenessTree() => new()
+{
+    new()
+    {
+        Name = "Direct PLC",
+        NodeType = "Device",
+        Details = new Dictionary<string, string> { ["Path"] = "Direct PLC" },
+    },
+    new()
+    {
+        Name = "Grouped ET200",
+        NodeType = "Device",
+        Details = new Dictionary<string, string> { ["Path"] = "Grouped ET200" },
+        Children = new List<ProjectTreeNode>
+        {
+            new()
+            {
+                Name = "PLC_Grouped",
+                NodeType = "PlcSoftware",
+                Details = new Dictionary<string, string> { ["Path"] = "Grouped ET200" },
+                Children = new List<ProjectTreeNode>
+                {
+                    new()
+                    {
+                        Name = "Blocks",
+                        NodeType = "BlockFolder",
+                        Details = new Dictionary<string, string> { ["Path"] = "PLC_Grouped/Blocks" },
+                        Children = new List<ProjectTreeNode>
+                        {
+                            new()
+                            {
+                                Name = "System blocks",
+                                NodeType = "SystemBlockFolder",
+                                Details = new Dictionary<string, string>
+                                {
+                                    ["Path"] = "PLC_Grouped/Blocks/System blocks"
+                                },
+                                Children = new List<ProjectTreeNode>
+                                {
+                                    new()
+                                    {
+                                        Name = "SafeFB",
+                                        NodeType = "FB",
+                                        Details = new Dictionary<string, string>
+                                        {
+                                            ["Path"] = "PLC_Grouped/Blocks/System blocks/SafeFB",
+                                            ["Number"] = "200",
+                                            ["ProgrammingLanguage"] = "F_LAD",
+                                            ["IsSystemBlock"] = "true",
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+};
+```
+
+- [ ] **Step 5: Run public-shape and regression tests and observe GREEN**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "Name~ProjectCompletenessFixture|FullyQualifiedName~ProjectStandaloneToolTests|FullyQualifiedName~NetworkIoMapFakeWorkerTests"
+```
+
+Expected: PASS. The test must inspect the canonical structured hardware result and the standalone tree payload, not merely the raw FakeWorker response literal.
+
+- [ ] **Step 6: Commit the task after explicit authorization**
+
+```powershell
+git add TiaMcpServer.FakeWorker/Program.cs TiaMcpServer.Tests/Network/NetworkIoMapFakeWorkerTests.cs TiaMcpServer.Tests/Project/ProjectStandaloneToolTests.cs
+git commit -m "test: cover complete project enumeration shapes"
+```
+
+---
+
+### Task 4: Document the complete traversal and current payload boundary
+
+**Files:**
+- Modify: `docs/SupportedOperations/DEVICES_OPERATIONS_SUMMARY.md:5-36`
+- Modify: `docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md:5-11`
+- Modify: `docs/SupportedOperations/NETWORK_OPERATIONS_SUMMARY.md:23-28,217-221,387-393`
+- Modify: `docs/ARCHITECTURE.md:90-112`
+
+**Interfaces:**
+- Consumes: the public shapes proved in Tasks 1-3.
+- Produces: current user-facing semantics without describing the later pagination contract.
+
+- [ ] **Step 1: Update the device and project operation summaries**
+
+In `DEVICES_OPERATIONS_SUMMARY.md`, make the two read rows state:
+
+```markdown
+| `execute_read_batch` / `network_read` | `read_hardware_config` | Recursively discovers devices both at project root and in nested device groups, then reads device items, network interfaces, nodes, subnets, and IO systems. Optional `deviceName` filter and opt-in structured I/O extraction (`includeIoDetails`, `includeTagMatches`) — see [NETWORK_OPERATIONS_SUMMARY.md](NETWORK_OPERATIONS_SUMMARY.md). |
+| `browse_project_tree` | `browse_project_tree` | Recursively discovers the same direct and grouped devices as flat `Device` nodes; accepts optional `projectPath`, `depth`, and `startPath`. |
+```
+
+Retain the non-goal for **managing** device groups, but disambiguate it from reads:
+
+```markdown
+- Device-group creation, deletion, rename, or moving devices between groups. Existing grouped devices are discovered by read operations but group folders are not exposed as tree nodes.
+```
+
+In `PROJECT_OPERATIONS_SUMMARY.md`, add immediately after the operation table:
+
+```markdown
+`browse_project_tree` returns grouped and ungrouped devices with the same flat `Device` shape. PLC system-block groups use `nodeType: "SystemBlockFolder"`; contained blocks keep their functional block type and carry `details.IsSystemBlock: "true"`. That marker records TIA hierarchy membership only and is not an author, vendor, library, or provenance claim.
+
+The tree remains a bare array. Per-item Openness failures are best-effort worker stderr diagnostics rather than caller-visible warning objects; use `depth` and `startPath` to bound large trees.
+```
+
+- [ ] **Step 2: Update the network operation payload guidance**
+
+In `NETWORK_OPERATIONS_SUMMARY.md`, describe grouped-device completeness in the operation row and add this payload-size guidance:
+
+```markdown
+Recursive group traversal can make an unfiltered hardware result substantially larger than earlier versions because previously omitted devices are now present. The current unpaged contract still applies the 60,000-character per-result budget and may omit the whole operation with `reason: "resultExceededItemCharLimit"`. Until a paged request is explicitly available, use `deviceName`, disable optional detail flags where possible, and place the hardware read in its own `network_read` call. No device is silently skipped merely to fit the budget.
+```
+
+Update the result-shape table to say that `devices[]` includes project-root and recursively grouped devices and that `messages[]` remains the hardware degradation channel.
+
+- [ ] **Step 3: Record the internal traversal seam in architecture**
+
+Add a focused subsection near the read-tool catalog in `ARCHITECTURE.md`:
+
+```markdown
+### Project enumeration completeness
+
+The net48 worker owns one ordered `ProjectDeviceEnumerator`: direct `Project.Devices` first, followed by a depth-first walk of `Project.DeviceGroups`. `HardwareConfigReader` and `ProjectTreeWalker` both consume it, preventing their definitions of a complete project from drifting. The public project tree deliberately flattens grouped devices into ordinary `Device` nodes.
+
+PLC user block groups and system block groups are different Openness types. `ProjectTreeWalker` therefore keeps separate recursive walkers and shares only block-node construction. `SystemBlockFolder` and `IsSystemBlock` encode system-hierarchy membership, not provenance. Hardware degradation uses `HardwareConfigInfo.Messages`; project-tree per-item failures retain the existing stderr-only best-effort boundary.
+```
+
+- [ ] **Step 4: Validate wording, links, and scope**
+
+Run:
+
+```powershell
+rg -n "ProjectDeviceEnumerator|SystemBlockFolder|IsSystemBlock|resultExceededItemCharLimit" docs/ARCHITECTURE.md docs/SupportedOperations
+git diff --check
+```
+
+Expected: the first command finds all four concepts and `git diff --check` exits 0. Read every modified paragraph once for the exact distinction between enumeration and device-group management.
+
+- [ ] **Step 5: Commit the task after explicit authorization**
+
+```powershell
+git add docs/ARCHITECTURE.md docs/SupportedOperations/DEVICES_OPERATIONS_SUMMARY.md docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md docs/SupportedOperations/NETWORK_OPERATIONS_SUMMARY.md
+git commit -m "docs: document complete project enumeration"
+```
+
+---
+
+### Task 5: Run full verification and prepare the live acceptance gate
+
+**Files:**
+- Verify only: all files changed by Tasks 1-4
+- Create only after an authorized live run: `docs/superpowers/acceptance/reports/2026-08-28-project-enumeration-completeness-live.md`
+
+**Interfaces:**
+- Consumes: completed PR 1 implementation and tests.
+- Produces: fresh automated evidence plus a precise read-only live runbook; it does not fabricate live evidence when no authorized V21 project was run.
+
+- [ ] **Step 1: Run all focused PR 1 tests**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTraversalSourceContractTests|Name~ProjectCompletenessFixture|FullyQualifiedName~HardwareDeviceSelectionTests|FullyQualifiedName~ProjectTreeFilterTests"
+```
+
+Expected: exit 0 with zero failed tests.
+
+- [ ] **Step 2: Run the serial stub build**
+
+Run:
+
+```powershell
+dotnet build TiaMcpServer.sln -m:1 --no-restore --disable-build-servers /p:UseTiaPortalReferenceStubs=true
+```
+
+Expected: exit 0 with no compile errors. Report warnings exactly rather than calling the build clean if warnings remain.
+
+- [ ] **Step 3: Run the complete test project**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers
+```
+
+Expected: exit 0 with zero failed tests. If an unrelated known flake occurs, record its exact name and rerun that exact test; do not modify unrelated code under this scope.
+
+- [ ] **Step 4: Inspect scope and repository state**
+
+Run:
+
+```powershell
+git diff --check
+git status --short
+git diff --stat main...HEAD
+```
+
+Then review the branch diff and confirm:
+
+- no pagination field, cursor codec, response envelope, or write path was added;
+- no `DeviceFolder` node was added;
+- only system-hierarchy blocks receive `IsSystemBlock`;
+- no authorship or vendor inference was added;
+- source-contract/FakeWorker evidence is described as non-live; and
+
+- [ ] **Step 5: Stop at the live-TIA authorization gate unless separately approved**
+
+Do not run this step as part of ordinary tests. With separate authorization and an explicitly selected read-only V21 project:
+
+1. Start the built MCP host with `--access-mode read-only` and bind it to the authorized project.
+2. Call `browse_project_tree` with `depth: 1`; record the total root `Device` count and at least two known devices that live inside nested device groups.
+3. Call `read_hardware_config` separately for those known grouped devices using exact `deviceName` filters; record that each returns exactly one matching device.
+4. Call `browse_project_tree` with the exact PLC block-folder `startPath`; record every `SystemBlockFolder`, the system-block count, representative functional node types, and `details.IsSystemBlock: "true"`.
+5. Record worker stderr separately from returned hardware `messages` and do not describe either channel as complete if the result was truncated or omitted.
+6. Save project identity, tool inputs, counts, representative safe identities, timings, result-budget outcomes, and the exact tested commit in a new acceptance report. Add that report to `docs/superpowers/README.md` and `docs/README.md` before committing it.
+
+The live report must say explicitly that the run was read-only. It must not include confidential project content beyond user-approved safe identities and aggregate counts.
+
+- [ ] **Step 6: Report the evidence boundary**
+
+The completion report must separate:
+
+```text
+Automated: source-contract tests, FakeWorker public shapes, stub build, full net8 test suite.
+Live Openness: not run unless the separately authorized Step 5 completed.
+Mutation/commissioning: not applicable; PR 1 is read-only enumeration.
+```
+
+Do not create an empty verification commit. If authorized live evidence adds a report, commit only that report and its two index entries with a separately approved commit message.

--- a/docs/superpowers/specs/2026-08-28-issue-31-project-completeness-pagination-design.md
+++ b/docs/superpowers/specs/2026-08-28-issue-31-project-completeness-pagination-design.md
@@ -1,0 +1,359 @@
+# Issue #31 Project Completeness and Hardware Pagination Design
+
+**Date:** 2026-08-28
+
+**Status:** Approved for implementation planning
+**Scope:** Complete grouped-device and system-block enumeration, then add opt-in,
+budget-aware pagination to `read_hardware_config`
+
+## Goal
+
+Resolve the two related problems reported in
+[issue #31](https://github.com/Czarnak/tia-portal-mcp/issues/31):
+
+1. Project reads omit devices stored under device groups and omit PLC system-block groups.
+2. A complete hardware snapshot can exceed the structured-operation result budget once those
+   omissions are fixed.
+
+The work is intentionally delivered as two separately reviewable pull requests:
+
+- **PR 1 — traversal completeness:** enumerate grouped devices and system blocks without changing
+  the public hardware-read request contract.
+- **PR 2 — hardware pagination:** add opt-in, cursor-based, budget-aware pagination after the
+  complete entity set is available on `main`.
+
+PR 2 starts from the updated `main` branch after PR 1 is merged. This keeps the traversal repair
+independently reviewable while making pagination operate on the corrected data set.
+
+## Non-goals
+
+- Adding device-folder nodes to the public project tree.
+- Inferring vendor, library, or author provenance from system-block location.
+- Enriching blocks with `HeaderAuthor` or another authorship field.
+- Changing the existing best-effort per-item error policy in PR 1.
+- Adding a diagnostics envelope to `browse_project_tree`.
+- Automatically switching legacy unpaged callers to partial results.
+- Providing a transactionally frozen TIA Portal snapshot across pages.
+- Paginating inside a device, subnet, warning, or other entity.
+- Changing write-safety, project-selection, or access-mode rules.
+
+## Current failure modes
+
+### Grouped devices are invisible
+
+`HardwareConfigReader.SelectDevices` and `ProjectTreeWalker.Walk` enumerate only
+`project.Devices`. They do not recurse through `project.DeviceGroups`, so a device placed under a
+group is missing from both `read_hardware_config` and `browse_project_tree`.
+
+The customer project cited in issue #31 demonstrates the practical size of the omission: the
+current path reports three devices while a recursive traversal finds 95.
+
+### System blocks are invisible
+
+`ProjectTreeWalker.WalkBlockGroup` walks user block groups but not
+`PlcBlockSystemGroup.SystemBlockGroups`. The system-group type does not inherit from
+`PlcBlockGroup`, so the existing recursive method cannot simply be reused through polymorphism.
+
+### A complete hardware read can exceed the result budget
+
+Structured operation batches impose a 60,000-character limit per operation result and a
+180,000-character limit on the full batch document. The complete customer hardware snapshot
+reported in issue #31 is approximately 1.7 million characters. Returning the complete set in one
+result therefore remains impossible even after traversal is corrected.
+
+## Delivery structure
+
+### PR 1: traversal completeness
+
+PR 1 changes only collection completeness and the documented meaning of returned system-block
+nodes. It preserves the current unpaged hardware response behavior, including existing
+whole-result omission when the structured result exceeds its item budget.
+
+### PR 2: hardware pagination
+
+PR 2 adds an explicitly requested paged mode to `read_hardware_config`. Unpaged calls retain the
+post-PR-1 behavior. Paged calls receive complete top-level entities plus continuation metadata,
+with every successful page kept within the 60,000-character item budget.
+
+## PR 1 architecture
+
+### One shared device enumeration path
+
+Introduce one worker-local ordered device enumerator and use it from both
+`HardwareConfigReader` and `ProjectTreeWalker`. The enumerator yields:
+
+1. devices directly under the project; and
+2. devices found by recursively walking every nested device group.
+
+The helper preserves the TIA collection order during traversal. Public consumers continue to
+apply their established presentation ordering where they already do so. Centralizing discovery
+prevents the two read tools from acquiring different definitions of a complete project later.
+
+Grouped devices remain ordinary flat `Device` nodes in `browse_project_tree`. PR 1 does not expose
+`DeviceFolder` nodes or a folder hierarchy, so existing consumers do not need to understand a new
+node type merely to see all devices.
+
+### Separate system-block traversal
+
+Add a dedicated recursive walker for `PlcBlockSystemGroup` rather than forcing the type into the
+user-block-group method. For each system group:
+
+- return a folder node with `nodeType: "SystemBlockFolder"`;
+- recurse through its nested `SystemBlockGroups`; and
+- return each contained block with its existing functional node type, such as `FB`, `FC`, or
+  `GlobalDB`.
+
+Each returned system block adds `details.IsSystemBlock: "true"`. The marker means that the block
+was enumerated through the TIA system-block hierarchy. It does **not** claim that Siemens authored
+the block or establish any other provenance.
+
+### Diagnostics boundary
+
+PR 1 retains the current best-effort behavior:
+
+- `read_hardware_config` continues to return available warnings through
+  `HardwareConfigInfo.Messages`;
+- per-item project-tree failures continue to be reported to worker stderr while
+  `browse_project_tree` returns its existing bare array; and
+- traversal continues past an item that the current code already treats as recoverable.
+
+Adding caller-visible project-tree diagnostics would require a public response-envelope change
+and is outside this repair.
+
+## PR 2 public contract
+
+### Opt-in request
+
+`read_hardware_config` reuses the existing request fields `pageSize` and `cursor`:
+
+- `pageSize` is valid from 1 through 200;
+- supplying `cursor` without `pageSize` uses a default maximum page size of 50;
+- omitting both fields selects the unpaged contract; and
+- `pageSize` is a maximum, not a promise that the page will contain that many entities.
+
+The page size is not part of the cursor query binding. A caller may change it between pages
+without changing which logical snapshot the cursor addresses.
+
+### Response shape
+
+Unpaged responses do not contain pagination metadata. Paged `HardwareConfigInfo` responses add an
+optional nested object:
+
+```json
+{
+  "pagination": {
+    "totalDevices": 95,
+    "totalSubnets": 4,
+    "returnedDevices": 3,
+    "returnedSubnets": 0,
+    "nextCursor": "opaque-or-null"
+  }
+}
+```
+
+The existing `devices`, `subnets`, and `messages` properties retain their meanings. Messages are
+per-call observations; a consumer reconstructing a larger result may concatenate them or
+deduplicate them according to its needs.
+
+### Pagination unit and ordering
+
+Treat a hardware snapshot as one ordered stream of complete top-level entities:
+
+1. devices, ordered by the existing ordinal device-name rule; then
+2. subnets, ordered by ordinal `SubnetId`.
+
+Stable source traversal order resolves any equal-key tie. A page may end in the device segment or
+cross into the subnet segment. Devices and subnets are never repeated within one valid cursor
+sequence. A consumer reconstructs the snapshot by concatenating each page's device list and each
+page's subnet list in page order.
+
+Messages are not cursor-addressed entities and do not affect the logical entity offset.
+
+## PR 2 worker/host seam
+
+Use a cooperative worker/host implementation.
+
+### Worker responsibilities
+
+The net48 worker:
+
+1. recursively enumerates the complete ordered top-level entity descriptors;
+2. computes a stable-set hash from their ordered identities and an ordering-version marker;
+3. validates the cursor's project, query, snapshot, and offset evidence;
+4. materializes at most the requested candidate range starting at the cursor offset; and
+5. returns a typed internal contracts-layer payload containing the candidates, counts, stable-set
+   evidence, and worker-observed session identity.
+
+Descriptor identity includes the entity kind and a deterministic TIA container path or key so
+that grouped devices with the same display name remain distinguishable. Deep hardware attributes
+are excluded from the stable-set hash.
+
+### Host responsibilities
+
+The net8 host:
+
+1. decodes the internal payload as exactly the declared candidate type;
+2. builds the public `HardwareConfigInfo` document through the canonical JSON seam;
+3. measures the complete canonical operation result against the 60,000-character item limit;
+4. removes only trailing complete entities until the result fits; and
+5. emits a next cursor whose offset advances by the number of entities actually returned.
+
+Candidates trimmed by the host are not lost. Because the cursor advances only by actual progress,
+the worker materializes those candidates again on the next call.
+
+The text content and `structuredContent` must continue to derive from the same
+`CanonicalJson.Serialize` result. The host must not estimate size from worker JSON or maintain a
+second serialization path.
+
+### Why the seam is split
+
+A host-only design would require the worker to materialize and transfer the complete snapshot on
+every page. A worker-only design cannot authoritatively enforce a limit measured on the host's
+canonical structured-operation envelope. Splitting enumeration from final budget sizing avoids
+both failure modes.
+
+## Cursor and consistency model
+
+### Cursor binding
+
+The cursor is opaque to callers and binds:
+
+- a cursor schema version and hardware-ordering version;
+- the complete worker-observed project/session identity from the first page;
+- the host project-binding revision observed for that page;
+- the query shape: `deviceName`, `plcName`, `includeIoDetails`, and `includeTagMatches`;
+- the ordered top-level entity stable-set hash; and
+- the next entity offset.
+
+The first page must return a complete worker-observed identity before a continuation cursor can be
+issued. Issuing a cursor does not silently change the host's project binding. Continuations use
+the cursor identity to ensure that the worker is still reading the same observed session, and a
+host binding revision change invalidates the sequence.
+
+### Stable-set, non-transactional guarantee
+
+The cursor guarantees a stable ordered entity set, not a frozen deep snapshot.
+
+Adding, removing, renaming, regrouping, or reordering a device or subnet changes the descriptor
+hash and invalidates continuation. A deep attribute change that leaves the ordered descriptor set
+unchanged may appear on a later page. This trade-off avoids rereading and hashing the full deep
+hardware graph solely to validate every continuation.
+
+## Validation and failure behavior
+
+Validate request fields and cursor structure before ordinary worker access where the necessary
+evidence is host-owned. Continuation failures are explicit and distinguish:
+
+- malformed or unsupported cursor payload;
+- query/filter mismatch;
+- host binding or worker-observed project/session mismatch;
+- stable-set snapshot mismatch; and
+- offset outside the current entity set.
+
+No failure returns a partial page or advances the cursor.
+
+The host may trim only trailing complete entities. It must never cut serialized JSON, an entity,
+or a warning in half. A malformed typed candidate payload produces `protocol_error`; rejected
+worker-shaped data is not echoed to the caller.
+
+If the canonical result containing one entity cannot fit within the item budget, return the
+operation as `omitted` with reason `hardwarePageEntityExceededItemCharLimit`. Include only a safe
+entity identity and guidance to retry the same cursor with narrower filters or fewer detail
+options. Do not return an empty successful page and do not skip the oversized entity.
+
+Paged mode guarantees that a successful operation result is within the 60,000-character item
+limit. The existing 180,000-character batch-document limit still applies. A caller that batches
+too many otherwise valid pages may therefore receive whole-operation omission and should retry
+with a smaller batch.
+
+## TDD and verification
+
+### PR 1 RED-GREEN cycles
+
+Start with failing tests that prove the current omissions:
+
+- net48 source-contract tests for recursive `DeviceGroups` traversal and the separate
+  `SystemBlockGroups` walker, following the repository's existing worker-test pattern;
+- FakeWorker-backed public-shape tests proving grouped devices remain flat `Device` nodes;
+- tree-shape tests for `SystemBlockFolder`, functional block node types, and
+  `details.IsSystemBlock: "true"`; and
+- regression tests for direct project devices, user block groups, filtering, ordering, and
+  recoverable item failures.
+
+After the narrow implementation, run the serial stub build, focused and full test suites, and
+repository diff checks.
+
+A separately authorized read-only live TIA acceptance run should use a representative V21
+project containing nested device groups and system blocks. It must record counts and selected
+identities proving those entities are visible. Static source-contract tests and FakeWorker tests
+are implementation evidence, not proof that the real Openness collections behave as expected.
+
+### PR 2 RED-GREEN cycles
+
+Add failing tests before each production slice for:
+
+- request validation, the 1–200 page-size range, cursor-only defaulting, and unpaged compatibility;
+- cursor codec round trips and exact failures for malformed payloads, query mismatch, binding or
+  session mismatch, snapshot mismatch, and out-of-range offsets;
+- deterministic device/subnet ordering, segment crossing, totals, and returned counts;
+- host budget shrinking, actual-offset advancement, final-page behavior, and a single oversized
+  entity;
+- typed candidate decoding and `protocol_error` rejection;
+- canonical text/structured-content identity; and
+- FakeWorker multi-page reconstruction in which every top-level entity appears exactly once.
+
+Run a separately authorized read-only live TIA acceptance harness against a representative large
+project. It should iterate every page, reconstruct the full device and subnet sets exactly once,
+and verify that each successful canonical operation result is at most 60,000 characters. Record
+timing separately from correctness; acceptable duration is an operational assessment, not a
+substitute for completeness evidence.
+
+For each PR, finish with:
+
+```powershell
+dotnet build TiaMcpServer.sln -m:1 /p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers
+git diff --check
+git status --short
+```
+
+Live acceptance requires a separately authorized TIA Portal project and is reported independently
+from static, stub-build, and FakeWorker verification.
+
+## Documentation changes
+
+PR 1 updates the current operation reference and relevant architecture text to describe:
+
+- recursive grouped-device completeness;
+- flat grouped-device presentation in the project tree;
+- `SystemBlockFolder` and the exact meaning of `IsSystemBlock`; and
+- the existing unpaged payload limitation and available filter/detail narrowing guidance.
+
+PR 2 updates the operation reference, tool description, architecture seam, troubleshooting or
+retry guidance, and engineering log to describe the opt-in request, page reconstruction, cursor
+invalidation, budget behavior, and oversized-entity response.
+
+## Acceptance criteria
+
+### PR 1
+
+- Both hardware and tree reads discover devices recursively through all device-group levels.
+- Both reads use the same device-discovery helper.
+- Grouped devices remain flat `Device` nodes.
+- Every nested system-block group and contained block is returned.
+- System folders and blocks use the approved node and details semantics without provenance claims.
+- Existing filters, ordering, best-effort diagnostics, and unpaged result-budget behavior remain
+  intact.
+- Automated and stub-build evidence passes, with live Openness evidence reported separately when
+  authorized.
+
+### PR 2
+
+- Paging is opt-in and unpaged callers retain the post-PR-1 contract.
+- Every valid page contains complete entities and fits the per-result character budget.
+- Concatenating a valid page sequence reconstructs every top-level device and subnet exactly once.
+- Cursor validation detects query, binding/session, stable-set, and offset drift without returning
+  partial data.
+- A single oversized entity is reported explicitly without skipping it or advancing the cursor.
+- Worker payloads are typed and host text/structured content remain one canonical document.
+- The batch-document limit remains enforced independently and is documented for callers.


### PR DESCRIPTION
Introduce a comprehensive project device enumeration that flattens grouped devices into ordinary nodes while including system blocks. Update documentation to reflect the new implementation plan and ensure tests cover the complete project enumeration shapes. This enhancement improves the traversal and representation of devices within the project structure.