### PR TITLE
fix(tests): stop CI-only failures in hardware-page and worker tests

### DIFF
--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -1108,11 +1108,17 @@ List<HardwarePageFixtureDevice> HardwarePaginationDevices()
 
     if (string.Equals(ScenarioKey(currentProjectPath), "hardware-pagination-trimming", StringComparison.Ordinal))
     {
+        // Sized so a single LARGE_DEVICE candidate lands just under HardwarePageProjector's
+        // 60,000-char page budget (~60 chars of headroom) while LARGE_DEVICE plus the next
+        // candidate lands just over it (~60 chars over): exactly one device is kept per page.
+        // Calibrated against HardwarePaginationFakeWorkerTests.TrimmingScenarioProjectPath, which
+        // is a fixed, already-rooted literal — see the comment there for why the path must be
+        // fixed for this size to be portable across machines/checkouts.
         devices.Insert(0, new HardwarePageFixtureDevice(
             new DeviceInfo
             {
                 Name = "LARGE_DEVICE",
-                TypeIdentifier = new string('L', 58_500),
+                TypeIdentifier = new string('L', 58_747),
                 Items = new List<DeviceItemInfo>(),
             },
             new[] { "Candidate diagnostic: large device." }));

--- a/TiaMcpServer.Tests/Network/HardwarePaginationFakeWorkerTests.cs
+++ b/TiaMcpServer.Tests/Network/HardwarePaginationFakeWorkerTests.cs
@@ -15,6 +15,18 @@ public sealed class HardwarePaginationFakeWorkerTests
 {
     private const string Scenario = "hardware-pagination";
 
+    // The trimming scenario below deliberately sits close to HardwarePageProjector's 60,000-char
+    // page budget to prove the "only complete trailing candidates" trimming behavior. A bare
+    // scenario key (e.g. "hardware-pagination-trimming") gets absolutized by
+    // ProjectPathNormalization.Canonicalize (Path.GetFullPath) against the FakeWorker process's
+    // current working directory, and that resolved path is itself embedded in the page's
+    // nextCursor. Its length therefore varies with wherever the repository happens to be checked
+    // out, which silently shifts the trimming boundary — this is what made the assertion below
+    // pass on some machines/checkouts and fail on others (observed: CI). Using an already-rooted
+    // literal makes Canonicalize a no-op, so the resolved path — and the boundary — stop depending
+    // on the checkout location.
+    private const string TrimmingScenarioProjectPath = @"C:\FakeWorker\hardware-pagination-trimming";
+
     [Fact]
     public async Task NetworkRead_PagedHardwareReconstructsTheStableDeviceThenSubnetSequence()
     {
@@ -168,7 +180,7 @@ public sealed class HardwarePaginationFakeWorkerTests
     public async Task NetworkRead_CanonicalItemTrimmingResumesWithTheUnemittedCandidatesAndDiagnostics()
     {
         using var client = CreateClient();
-        var first = await ReadPage(client, 6, "hardware-pagination-trimming");
+        var first = await ReadPage(client, 6, TrimmingScenarioProjectPath);
         var second = await ReadPage(client, 6, cursor: Cursor(first));
 
         var firstReturned = first.GetProperty("pagination").GetProperty("returnedDevices").GetInt32()

--- a/TiaMcpServer.Tests/Safety/WriteSafetyLeaseConcurrencyTests.cs
+++ b/TiaMcpServer.Tests/Safety/WriteSafetyLeaseConcurrencyTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace TiaMcpServer.Tests.Safety;
 
+[Collection(RealWorkerProcessCollection.Name)]
 public sealed class WriteSafetyLeaseConcurrencyTests
 {
     [Fact]

--- a/TiaMcpServer.Tests/TestSupport/RealWorkerProcessCollection.cs
+++ b/TiaMcpServer.Tests/TestSupport/RealWorkerProcessCollection.cs
@@ -1,0 +1,20 @@
+using Xunit;
+
+namespace TiaMcpServer.Tests;
+
+/// <summary>
+/// Groups the test classes that spawn a real OS process (powershell.exe, scripted to speak the
+/// worker IPC protocol) behind a fixed request timeout (1-5s). xUnit runs test collections in
+/// parallel by default; on a CI runner with few cores, several of these classes launching
+/// PowerShell concurrently can starve each other long enough to blow through their timeout and
+/// fail with a transport-level error (WorkerTimeout/WorkerCrashed), even though nothing in the
+/// production code or the scripted worker is wrong. Tagging every such class with
+/// <c>[Collection(Name)]</c> makes xUnit run them sequentially relative to each other while still
+/// running the rest of the (fast, in-process) suite in parallel, removing the contention without
+/// serializing the whole test run.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class RealWorkerProcessCollection
+{
+    public const string Name = "Real worker process";
+}

--- a/TiaMcpServer.Tests/Worker/HardwarePageWorkerClientTests.cs
+++ b/TiaMcpServer.Tests/Worker/HardwarePageWorkerClientTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace TiaMcpServer.Tests.Worker;
 
+[Collection(RealWorkerProcessCollection.Name)]
 public sealed class HardwarePageWorkerClientTests
 {
     private const string ProjectPath = @"C:\fixtures\echo";

--- a/TiaMcpServer.Tests/Worker/LifecycleIdentityContinuityTests.cs
+++ b/TiaMcpServer.Tests/Worker/LifecycleIdentityContinuityTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace TiaMcpServer.Tests.Worker;
 
+[Collection(RealWorkerProcessCollection.Name)]
 public sealed class LifecycleIdentityContinuityTests
 {
     private const string ProjectA = "C:\\Projects\\A.ap21";

--- a/TiaMcpServer.Tests/Worker/WorkerProtocolHandshakeTests.cs
+++ b/TiaMcpServer.Tests/Worker/WorkerProtocolHandshakeTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace TiaMcpServer.Tests.Worker;
 
+[Collection(RealWorkerProcessCollection.Name)]
 public sealed class WorkerProtocolHandshakeTests
 {
     [Fact]


### PR DESCRIPTION
## Summary

Fixes the three CI failures from the latest `main` run
(https://github.com/Czarnak/tia-portal-mcp/actions/runs/33426903986), traced to two independent
root causes — no symptom patches.

### 1. `HardwarePaginationFakeWorkerTests.NetworkRead_CanonicalItemTrimmingResumesWithTheUnemittedCandidatesAndDiagnostics` (deterministic, not flaky)

The test passed a bare scenario key (`"hardware-pagination-trimming"`) as `projectPath`.
`FakeWorker` echoes that back as `resolvedProjectPath`, which `ProjectPathNormalization.Canonicalize`
runs through `Path.GetFullPath` — absolutizing it against the FakeWorker child process's *working
directory*. That resolved path is embedded in the page's `nextCursor`, so the page's serialized
byte size (and therefore which side of `HardwarePageProjector`'s 60,000-char trimming boundary the
`LARGE_DEVICE` fixture landed on) depended on how long the repo's checkout path happens to be —
confirmed by measuring the exact boundary locally (~120 chars per candidate, ~230 chars of margin
originally). Fixed by using an already-rooted literal path (`Canonicalize` becomes a no-op) and
retuning `LARGE_DEVICE`'s padding against that now-fixed path, with comments on both sides
documenting the coupling.

### 2. `HardwarePageWorkerClientTests.Continuation_MapsEnvelopeIdentityFailures` (CI-runner contention, not a logic bug)

This spawns a real `powershell.exe` behind a 1-5s request timeout. Checking CI history
(`gh run view --log-failed`) across several past runs shows the same failure shape
(`WorkerTimeout`/`WorkerCrashed`, "the write outcome is unknown") also hitting
`WorkerProtocolHandshakeTests` and `WriteSafetyLeaseConcurrencyTests` — including in an unrelated
PR (#29) weeks earlier, confirming a pre-existing, recurring class of flakiness rather than
something this branch introduced. xUnit parallelizes test collections by default; several
PowerShell-spawning classes running concurrently on a low-core CI runner can starve each other
past the timeout. Fixed by grouping the four real-process-spawning worker test classes
(`HardwarePageWorkerClientTests`, `WorkerProtocolHandshakeTests`, `WriteSafetyLeaseConcurrencyTests`,
`LifecycleIdentityContinuityTests`) into one new non-parallel xUnit collection
(`RealWorkerProcessCollection`), so they stop contending with each other while the rest of the
~2500-test suite keeps running in parallel.

## Test plan

- [x] `dotnet build TiaMcpServer.sln -m:1 -c Release /p:UseTiaPortalReferenceStubs=true` — clean
- [x] `dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-build --configuration Release
      --collect:"XPlat Code Coverage" --settings TiaMcpServer.Tests/coverage.runsettings
      --results-directory TestResults` (the exact CI command) — **2514/2514 passed**, 5 consecutive
      full-suite runs
- [x] The two originally-failing tests re-run in isolation 5 times each — deterministic pass

## Notes

- Verification surfaced an unrelated, pre-existing flaky test once locally:
  `OpennessWorkerClientIntegrationTests.UncertainOutcome_IssuesFailedWriteOnce_ThenRestartedWorkerServesTheNextRequests(scenario: "malformed")`
  — same process-timeout-contention class, not part of the reported CI failure, left out of scope
  for this PR.
