### PR TITLE
feat(write-safety): add explicit MCP tool annotations

### DIFF
--- a/TiaMcpServer.Tests/Batch/BatchToolsTests.cs
+++ b/TiaMcpServer.Tests/Batch/BatchToolsTests.cs
@@ -39,6 +39,27 @@ public class BatchToolsTests
         Assert.Equal(expectedToolName, toolAttribute!.Name);
     }
 
+    [Theory]
+    [InlineData(nameof(WriteBatchTools.PreviewWriteBatch), "preview_write_batch", true, false, false)]
+    [InlineData(nameof(WriteBatchTools.ApplyWriteBatch), "apply_write_batch", false, true, false)]
+    public void WriteBatchTools_RegisteredMethodsExposeExplicitMcpAnnotations(
+        string methodName,
+        string expectedToolName,
+        bool readOnly,
+        bool destructive,
+        bool openWorld)
+    {
+        var method = typeof(WriteBatchTools).GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        var toolAttribute = method!.GetCustomAttribute<McpServerToolAttribute>();
+        Assert.NotNull(toolAttribute);
+        Assert.Equal(expectedToolName, toolAttribute!.Name);
+        Assert.Equal(readOnly, toolAttribute.ReadOnly);
+        Assert.Equal(destructive, toolAttribute.Destructive);
+        Assert.Equal(openWorld, toolAttribute.OpenWorld);
+    }
+
     [Fact]
     public async Task ExecuteReadBatch_RejectsWriteOperation()
     {

--- a/TiaMcpServer.Tests/Project/ProjectLifecycleToolTests.cs
+++ b/TiaMcpServer.Tests/Project/ProjectLifecycleToolTests.cs
@@ -44,6 +44,28 @@ public class ProjectLifecycleToolTests
         }
     }
 
+    [Theory]
+    [InlineData(nameof(ProjectWriteTools.OpenProject), "open_project")]
+    [InlineData(nameof(ProjectWriteTools.CreateProject), "create_project")]
+    [InlineData(nameof(ProjectWriteTools.SaveProject), "save_project")]
+    [InlineData(nameof(ProjectWriteTools.SaveProjectAs), "save_project_as")]
+    [InlineData(nameof(ProjectWriteTools.ArchiveProject), "archive_project")]
+    [InlineData(nameof(ProjectWriteTools.CloseProject), "close_project")]
+    public void ProjectWriteTools_RegisteredMethodsExposeExplicitMutatingAnnotations(
+        string methodName,
+        string expectedToolName)
+    {
+        var method = typeof(ProjectWriteTools).GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        var toolAttribute = method!.GetCustomAttribute<McpServerToolAttribute>();
+        Assert.NotNull(toolAttribute);
+        Assert.Equal(expectedToolName, toolAttribute!.Name);
+        Assert.False(toolAttribute.ReadOnly);
+        Assert.True(toolAttribute.Destructive);
+        Assert.False(toolAttribute.OpenWorld);
+    }
+
     /// <summary>
     /// Single source of truth for the public project-lifecycle surface of
     /// <see cref="OpennessWorkerClient"/> - both the per-name Theory below and the exact-count

--- a/TiaMcpServer.Tests/TestSupport/McpProtocolTestHarness.cs
+++ b/TiaMcpServer.Tests/TestSupport/McpProtocolTestHarness.cs
@@ -4,9 +4,12 @@ using Microsoft.Extensions.Options;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using TiaMcpServer.Batch;
 using TiaMcpServer.Contracts;
+using TiaMcpServer.Network;
 using TiaMcpServer.Tests.Network;
 using TiaMcpServer.Safety;
+using TiaMcpServer.Tools;
 using TiaMcpServer.Worker;
 
 namespace TiaMcpServer.Tests;
@@ -72,7 +75,11 @@ internal sealed class McpProtocolTestHarness : IAsyncDisposable
         string? auditDirectory = null,
         string? startupProjectPath = null)
         where TTools : class
-        => StartAsync(auditDirectory, startupProjectPath, builder => builder.WithTools<TTools>());
+        => StartAsync(
+            McpAccessMode.ReadWrite,
+            builder => builder.WithTools<TTools>(),
+            auditDirectory,
+            startupProjectPath);
 
     /// <summary>
     /// Starts a server exposing BOTH <typeparamref name="TTools1"/> and <typeparamref name="TTools2"/>
@@ -86,14 +93,46 @@ internal sealed class McpProtocolTestHarness : IAsyncDisposable
         where TTools1 : class
         where TTools2 : class
         => StartAsync(
+            McpAccessMode.ReadWrite,
+            builder => builder.WithTools<TTools1>().WithTools<TTools2>(),
             auditDirectory,
-            startupProjectPath,
-            builder => builder.WithTools<TTools1>().WithTools<TTools2>());
+            startupProjectPath);
 
-    private static async Task<McpProtocolTestHarness> StartAsync(
+    public static Task<McpProtocolTestHarness> StartAsync(
+        McpAccessMode accessMode,
+        Action<IMcpServerBuilder> registerTools,
+        string? auditDirectory = null,
+        string? startupProjectPath = null)
+        => StartCoreAsync(accessMode, registerTools, auditDirectory, startupProjectPath);
+
+    public static Task<McpProtocolTestHarness> StartProductionSurfaceAsync(
+        McpAccessMode accessMode,
+        string? auditDirectory = null,
+        string? startupProjectPath = null)
+        => StartAsync(
+            accessMode,
+            builder =>
+            {
+                builder.WithTools<ProjectReadTools>()
+                       .WithTools<ReadBatchTools>()
+                       .WithTools<NetworkReadTools>();
+
+                if (accessMode == McpAccessMode.ReadWrite)
+                {
+                    builder.WithTools<ProjectEngineeringTools>()
+                           .WithTools<ProjectWriteTools>()
+                           .WithTools<WriteBatchTools>()
+                           .WithTools<NetworkWriteTools>();
+                }
+            },
+            auditDirectory,
+            startupProjectPath);
+
+    private static async Task<McpProtocolTestHarness> StartCoreAsync(
+        McpAccessMode accessMode,
+        Action<IMcpServerBuilder> registerTools,
         string? auditDirectory,
-        string? startupProjectPath,
-        Action<IMcpServerBuilder> registerTools)
+        string? startupProjectPath)
     {
         var clientWrites = new AnonymousPipeServerStream(PipeDirection.Out, HandleInheritability.None);
         var serverReads = new AnonymousPipeClientStream(
@@ -103,7 +142,7 @@ internal sealed class McpProtocolTestHarness : IAsyncDisposable
             PipeDirection.In, serverWrites.ClientSafePipeHandle);
 
         var binding = new ProjectSessionBinding(null);
-        var accessPolicy = new OperationAccessPolicy(McpAccessMode.ReadWrite);
+        var accessPolicy = new OperationAccessPolicy(accessMode);
         var workerClient = new OpennessWorkerClient(
             binding,
             logger: null,

--- a/TiaMcpServer.Tests/Tools/WriteToolMcpAnnotationProtocolTests.cs
+++ b/TiaMcpServer.Tests/Tools/WriteToolMcpAnnotationProtocolTests.cs
@@ -32,6 +32,18 @@ public class WriteToolMcpAnnotationProtocolTests
         "save_project_as",
     };
 
+    private static readonly (string Name, bool ReadOnly, bool Destructive, bool OpenWorld)[] ExpectedWriteToolAnnotations =
+    {
+        ("preview_write_batch", true, false, false),
+        ("apply_write_batch", false, true, false),
+        ("open_project", false, true, false),
+        ("create_project", false, true, false),
+        ("save_project", false, true, false),
+        ("save_project_as", false, true, false),
+        ("archive_project", false, true, false),
+        ("close_project", false, true, false),
+    };
+
     [Fact]
     public async Task ToolsList_ReadWriteProductionSurface_ExposesExactNamesCountsAnnotations_AndRepresentativeSchemas()
     {
@@ -42,23 +54,14 @@ public class WriteToolMcpAnnotationProtocolTests
         Assert.Equal(ReadWriteToolNames, tools.Select(tool => tool.Name));
         Assert.Equal(14, tools.Length);
 
-        var previewAnnotations = byName["preview_write_batch"].ProtocolTool.Annotations;
-        Assert.NotNull(previewAnnotations);
-        Assert.True(previewAnnotations!.ReadOnlyHint);
-        Assert.False(previewAnnotations.DestructiveHint);
-        Assert.False(previewAnnotations.OpenWorldHint);
-
-        var applyAnnotations = byName["apply_write_batch"].ProtocolTool.Annotations;
-        Assert.NotNull(applyAnnotations);
-        Assert.False(applyAnnotations!.ReadOnlyHint);
-        Assert.True(applyAnnotations.DestructiveHint);
-        Assert.False(applyAnnotations.OpenWorldHint);
-
-        var openAnnotations = byName["open_project"].ProtocolTool.Annotations;
-        Assert.NotNull(openAnnotations);
-        Assert.False(openAnnotations!.ReadOnlyHint);
-        Assert.True(openAnnotations.DestructiveHint);
-        Assert.False(openAnnotations.OpenWorldHint);
+        foreach (var expected in ExpectedWriteToolAnnotations)
+        {
+            var annotations = byName[expected.Name].ProtocolTool.Annotations;
+            Assert.NotNull(annotations);
+            Assert.Equal(expected.ReadOnly, annotations!.ReadOnlyHint);
+            Assert.Equal(expected.Destructive, annotations.DestructiveHint);
+            Assert.Equal(expected.OpenWorld, annotations.OpenWorldHint);
+        }
 
         Assert.Contains("\"operations\"", byName["preview_write_batch"].ProtocolTool.InputSchema.GetRawText(), StringComparison.Ordinal);
         Assert.Contains("\"projectPath\"", byName["open_project"].ProtocolTool.InputSchema.GetRawText(), StringComparison.Ordinal);

--- a/TiaMcpServer.Tests/Tools/WriteToolMcpAnnotationProtocolTests.cs
+++ b/TiaMcpServer.Tests/Tools/WriteToolMcpAnnotationProtocolTests.cs
@@ -1,0 +1,84 @@
+using TiaMcpServer.Contracts;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Tools;
+
+[Collection("Mcp protocol serial")]
+public class WriteToolMcpAnnotationProtocolTests
+{
+    private static readonly string[] ReadOnlyToolNames =
+    {
+        "browse_project_tree",
+        "execute_read_batch",
+        "get_project_status",
+        "network_read",
+    };
+
+    private static readonly string[] ReadWriteToolNames =
+    {
+        "apply_write_batch",
+        "archive_project",
+        "browse_project_tree",
+        "close_project",
+        "compile_check",
+        "create_project",
+        "execute_read_batch",
+        "get_project_status",
+        "network_read",
+        "network_write",
+        "open_project",
+        "preview_write_batch",
+        "save_project",
+        "save_project_as",
+    };
+
+    [Fact]
+    public async Task ToolsList_ReadWriteProductionSurface_ExposesExactNamesCountsAnnotations_AndRepresentativeSchemas()
+    {
+        await using var harness = await McpProtocolTestHarness.StartProductionSurfaceAsync(McpAccessMode.ReadWrite);
+        var tools = (await harness.Client.ListToolsAsync()).OrderBy(tool => tool.Name).ToArray();
+        var byName = tools.ToDictionary(tool => tool.Name, StringComparer.Ordinal);
+
+        Assert.Equal(ReadWriteToolNames, tools.Select(tool => tool.Name));
+        Assert.Equal(14, tools.Length);
+
+        var previewAnnotations = byName["preview_write_batch"].ProtocolTool.Annotations;
+        Assert.NotNull(previewAnnotations);
+        Assert.True(previewAnnotations!.ReadOnlyHint);
+        Assert.False(previewAnnotations.DestructiveHint);
+        Assert.False(previewAnnotations.OpenWorldHint);
+
+        var applyAnnotations = byName["apply_write_batch"].ProtocolTool.Annotations;
+        Assert.NotNull(applyAnnotations);
+        Assert.False(applyAnnotations!.ReadOnlyHint);
+        Assert.True(applyAnnotations.DestructiveHint);
+        Assert.False(applyAnnotations.OpenWorldHint);
+
+        var openAnnotations = byName["open_project"].ProtocolTool.Annotations;
+        Assert.NotNull(openAnnotations);
+        Assert.False(openAnnotations!.ReadOnlyHint);
+        Assert.True(openAnnotations.DestructiveHint);
+        Assert.False(openAnnotations.OpenWorldHint);
+
+        Assert.Contains("\"operations\"", byName["preview_write_batch"].ProtocolTool.InputSchema.GetRawText(), StringComparison.Ordinal);
+        Assert.Contains("\"projectPath\"", byName["open_project"].ProtocolTool.InputSchema.GetRawText(), StringComparison.Ordinal);
+        Assert.Contains("\"confirm\"", byName["open_project"].ProtocolTool.InputSchema.GetRawText(), StringComparison.Ordinal);
+        Assert.Contains("\"safetyToken\"", byName["open_project"].ProtocolTool.InputSchema.GetRawText(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ToolsList_ReadOnlyProductionSurface_ExposesExactReadOnlyTools_AndNoWriteTools()
+    {
+        await using var harness = await McpProtocolTestHarness.StartProductionSurfaceAsync(McpAccessMode.ReadOnly);
+        var tools = (await harness.Client.ListToolsAsync()).OrderBy(tool => tool.Name).ToArray();
+        var toolNames = tools.Select(tool => tool.Name).ToArray();
+
+        Assert.Equal(ReadOnlyToolNames, toolNames);
+        Assert.Equal(4, tools.Length);
+
+        foreach (var writeToolName in ReadWriteToolNames.Except(ReadOnlyToolNames, StringComparer.Ordinal))
+        {
+            Assert.DoesNotContain(writeToolName, toolNames);
+        }
+    }
+}

--- a/TiaMcpServer.Tests/Tools/WriteToolMetadataLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Tools/WriteToolMetadataLiveHarnessContractTests.cs
@@ -161,10 +161,20 @@ public class WriteToolMetadataLiveHarnessContractTests
             new Regex(@"Get-RequiredBooleanProperty\s+-Object\s+\$statusEnvelope\s+-Name\s+'success'\s+-ExpectedValue\s+\$true"),
             parser);
         Assert.Matches(
-            new Regex(@"Get-RequiredBooleanProperty\s+-Object\s+\$statusPayload\s+-Name\s+'isOpen'\s+-ExpectedValue\s+\$true"),
+            new Regex(@"Get-RequiredBooleanProperty\s+-Object\s+\$statusPayload\s+-Name\s+'success'\s+-ExpectedValue\s+\$true"),
             parser);
         Assert.Matches(
-            new Regex(@"Get-RequiredNormalizedPathProperty\s+-Object\s+\$statusPayload\s+-Name\s+'path'\s+-ExpectedPath\s+\$resolvedExpectedProjectPath"),
+            new Regex(@"Get-RequiredNormalizedPathProperty\s+-Object\s+\$statusPayload\s+-Name\s+'projectPath'\s+-ExpectedPath\s+\$resolvedExpectedProjectPath"),
+            parser);
+        Assert.Matches(
+            new Regex(@"\$project\s*=\s*Get-PropertyValue\s+-Object\s+\$statusPayload\s+-Name\s+'project'"),
+            parser);
+        Assert.Contains("$null -eq $project", parser, StringComparison.Ordinal);
+        Assert.Matches(
+            new Regex(@"Get-RequiredBooleanProperty\s+-Object\s+\$project\s+-Name\s+'isOpen'\s+-ExpectedValue\s+\$true"),
+            parser);
+        Assert.Matches(
+            new Regex(@"Get-RequiredNormalizedPathProperty\s+-Object\s+\$project\s+-Name\s+'path'\s+-ExpectedPath\s+\$resolvedExpectedProjectPath"),
             parser);
         Assert.Matches(
             new Regex(@"Get-RequiredNormalizedPathProperty\s+-Object\s+\$sessionIdentity\s+-Name\s+'projectPath'\s+-ExpectedPath\s+\$resolvedExpectedProjectPath"),

--- a/TiaMcpServer.Tests/Tools/WriteToolMetadataLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Tools/WriteToolMetadataLiveHarnessContractTests.cs
@@ -179,6 +179,15 @@ public class WriteToolMetadataLiveHarnessContractTests
         Assert.Matches(
             new Regex(@"Get-RequiredNormalizedPathProperty\s+-Object\s+\$sessionIdentity\s+-Name\s+'projectPath'\s+-ExpectedPath\s+\$resolvedExpectedProjectPath"),
             parser);
+        Assert.Matches(
+            new Regex(@"try\s*\{\s*\[int\]\s+\$normalizedPortalProcessId\s*=\s+\$portalProcessId\s*\}\s*catch"),
+            parser);
+        Assert.Matches(
+            new Regex(@"if\s*\(\$normalizedPortalProcessId\s+-le\s+0\)\s*\{\s*throw\s+'get_project_status did not return a positive portalProcessId\.'"),
+            parser);
+        Assert.Matches(
+            new Regex(@"portalProcessId\s*=\s+\$normalizedPortalProcessId"),
+            parser);
         Assert.Contains("throw", parser, StringComparison.Ordinal);
         Assert.DoesNotContain("metadata", parser, StringComparison.OrdinalIgnoreCase);
 

--- a/TiaMcpServer.Tests/Tools/WriteToolMetadataLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Tools/WriteToolMetadataLiveHarnessContractTests.cs
@@ -152,6 +152,32 @@ public class WriteToolMetadataLiveHarnessContractTests
     }
 
     [Fact]
+    public void Script_FailsClosedOnInvalidProjectStatusEvidence_AndRecordsOnlySanitizedSummary()
+    {
+        var text = ReadScript();
+        var parser = ReadScriptFunction("Get-ProjectStatusEvidence");
+
+        Assert.Matches(
+            new Regex(@"Get-RequiredBooleanProperty\s+-Object\s+\$statusEnvelope\s+-Name\s+'success'\s+-ExpectedValue\s+\$true"),
+            parser);
+        Assert.Matches(
+            new Regex(@"Get-RequiredBooleanProperty\s+-Object\s+\$statusPayload\s+-Name\s+'isOpen'\s+-ExpectedValue\s+\$true"),
+            parser);
+        Assert.Matches(
+            new Regex(@"Get-RequiredNormalizedPathProperty\s+-Object\s+\$statusPayload\s+-Name\s+'path'\s+-ExpectedPath\s+\$resolvedExpectedProjectPath"),
+            parser);
+        Assert.Matches(
+            new Regex(@"Get-RequiredNormalizedPathProperty\s+-Object\s+\$sessionIdentity\s+-Name\s+'projectPath'\s+-ExpectedPath\s+\$resolvedExpectedProjectPath"),
+            parser);
+        Assert.Contains("throw", parser, StringComparison.Ordinal);
+        Assert.DoesNotContain("metadata", parser, StringComparison.OrdinalIgnoreCase);
+
+        Assert.Contains("projectStatusSummary", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("projectStatusResult", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("ConvertFrom-Json -Depth 80)),", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void NoOrdinaryTestInvokesTheLiveHarnessScript()
     {
         var testDirectory = Path.Combine(GetRepositoryRoot(), "TiaMcpServer.Tests");
@@ -185,6 +211,16 @@ public class WriteToolMetadataLiveHarnessContractTests
 
         var nextFact = source.IndexOf("\n    [Fact]", methodStart + 1, StringComparison.Ordinal);
         return nextFact >= 0 ? source[methodStart..nextFact] : source[methodStart..];
+    }
+
+    private static string ReadScriptFunction(string functionName)
+    {
+        var text = ReadScript();
+        var functionStart = text.IndexOf($"function {functionName}", StringComparison.Ordinal);
+        Assert.True(functionStart >= 0, $"Expected PowerShell function '{functionName}'.");
+
+        var nextFunction = text.IndexOf("\nfunction ", functionStart + 1, StringComparison.Ordinal);
+        return nextFunction >= 0 ? text[functionStart..nextFunction] : text[functionStart..];
     }
 
     private static string GetRepositoryRoot()

--- a/TiaMcpServer.Tests/Tools/WriteToolMetadataLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Tools/WriteToolMetadataLiveHarnessContractTests.cs
@@ -49,7 +49,7 @@ public class WriteToolMetadataLiveHarnessContractTests
     {
         var text = ReadScript();
 
-        Assert.DoesNotMatch(new Regex(@"confirm\s*=\s*\$true"), text);
+        Assert.DoesNotMatch(new Regex(@"confirm\s*=\s*\$true", RegexOptions.IgnoreCase), text);
     }
 
     [Fact]
@@ -57,12 +57,57 @@ public class WriteToolMetadataLiveHarnessContractTests
     {
         var text = ReadScript();
 
-        Assert.Matches(new Regex(@"Invoke-McpToolCall\s+-Name\s+'get_project_status'"), text);
+        var toolsCallRequests = Regex.Matches(
+            text,
+            "Invoke-McpRequest\\s+-Method\\s+['\\\"]tools/call['\\\"]",
+            RegexOptions.IgnoreCase);
+        Assert.Single(toolsCallRequests);
+
+        Assert.Matches(
+            new Regex(@"Invoke-McpToolCall\s+-Name\s+'get_project_status'", RegexOptions.IgnoreCase),
+            text);
         Assert.True(
-            Regex.Matches(text, @"Invoke-McpToolCall\s+-Name\s+'([^']+)'")
+            Regex.Matches(text, @"Invoke-McpToolCall\s+-Name\s+'([^']+)'", RegexOptions.IgnoreCase)
                 .Cast<Match>()
-                .All(match => string.Equals(match.Groups[1].Value, "get_project_status", StringComparison.Ordinal)),
+                .All(match => string.Equals(match.Groups[1].Value, "get_project_status", StringComparison.OrdinalIgnoreCase)),
             "The harness may call only get_project_status through tools/call.");
+    }
+
+    [Fact]
+    public void Script_FailsClosedOnAnyApprovedWriteAnnotationMismatch()
+    {
+        var text = ReadScript();
+
+        Assert.Contains("$script:ExpectedWriteToolAnnotations", text, StringComparison.Ordinal);
+        Assert.Contains("function Assert-ToolAnnotationEvidence", text, StringComparison.Ordinal);
+
+        foreach (var (toolName, readOnlyHint, destructiveHint, openWorldHint) in new[]
+                 {
+                     ("preview_write_batch", true, false, false),
+                     ("apply_write_batch", false, true, false),
+                     ("open_project", false, true, false),
+                     ("create_project", false, true, false),
+                     ("save_project", false, true, false),
+                     ("save_project_as", false, true, false),
+                     ("archive_project", false, true, false),
+                     ("close_project", false, true, false),
+                 })
+        {
+            var expected = $@"(?s)'{toolName}'\s*=\s*@\{{.*?readOnlyHint\s*=\s*\${readOnlyHint.ToString().ToLowerInvariant()}.*?destructiveHint\s*=\s*\${destructiveHint.ToString().ToLowerInvariant()}.*?openWorldHint\s*=\s*\${openWorldHint.ToString().ToLowerInvariant()}";
+            Assert.Matches(new Regex(expected), text);
+        }
+    }
+
+    [Fact]
+    public void StaticSafetyGuard_IsCaseInsensitiveAndCountsEveryToolsCallRequest()
+    {
+        var confirmingWriteGuard = ReadThisTestMethod("Script_NeverIssuesConfirmingApply");
+        Assert.Contains("RegexOptions.IgnoreCase", confirmingWriteGuard, StringComparison.Ordinal);
+
+        var benignCallGuard = ReadThisTestMethod("Script_CallsOnlyBenignProjectStatusTool");
+        Assert.Contains("Invoke-McpRequest", benignCallGuard, StringComparison.Ordinal);
+        Assert.Contains("Assert.Single", benignCallGuard, StringComparison.Ordinal);
+        Assert.Contains("RegexOptions.IgnoreCase", benignCallGuard, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -126,6 +171,20 @@ public class WriteToolMetadataLiveHarnessContractTests
     {
         Assert.True(File.Exists(ScriptPath), $"Expected the live harness at '{ScriptPath}'.");
         return File.ReadAllText(ScriptPath);
+    }
+
+    private static string ReadThisTestMethod(string methodName)
+    {
+        var source = File.ReadAllText(Path.Combine(
+            GetRepositoryRoot(),
+            "TiaMcpServer.Tests",
+            "Tools",
+            "WriteToolMetadataLiveHarnessContractTests.cs"));
+        var methodStart = source.IndexOf($"public void {methodName}()", StringComparison.Ordinal);
+        Assert.True(methodStart >= 0, $"Expected test method '{methodName}'.");
+
+        var nextFact = source.IndexOf("\n    [Fact]", methodStart + 1, StringComparison.Ordinal);
+        return nextFact >= 0 ? source[methodStart..nextFact] : source[methodStart..];
     }
 
     private static string GetRepositoryRoot()

--- a/TiaMcpServer.Tests/Tools/WriteToolMetadataLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Tools/WriteToolMetadataLiveHarnessContractTests.cs
@@ -1,0 +1,140 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Tools;
+
+/// <summary>
+/// Static, execution-free contract tests for the separately authorized live TIA Portal V21
+/// acceptance harness. These tests inspect source only; they never launch TIA Portal, the MCP
+/// host, or the script itself.
+/// </summary>
+public class WriteToolMetadataLiveHarnessContractTests
+{
+    private static readonly string ScriptPath = Path.GetFullPath(
+        Path.Combine(GetRepositoryRoot(), "scripts", "live-test-write-tool-metadata.ps1"));
+
+    [Fact]
+    public void Script_Exists()
+    {
+        Assert.True(File.Exists(ScriptPath), $"Expected the live harness at '{ScriptPath}'.");
+    }
+
+    [Fact]
+    public void Script_LaunchesTheRealMcpHostTwice_AndSpeaksInitializeListCallProtocol()
+    {
+        var text = ReadScript();
+
+        Assert.Matches(new Regex(@"--read-only"), text);
+        Assert.Matches(new Regex(@"--read-write"), text);
+        Assert.Contains("'initialize'", text, StringComparison.Ordinal);
+        Assert.Contains("notifications/initialized", text, StringComparison.Ordinal);
+        Assert.Contains("tools/list", text, StringComparison.Ordinal);
+        Assert.Contains("tools/call", text, StringComparison.Ordinal);
+        Assert.Contains("TiaMcpServer", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("OpennessWorker.exe", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_RequiresPowerShell7AndMandatoryProjectAndReportPaths()
+    {
+        var text = ReadScript();
+
+        Assert.Matches(new Regex(@"^\s*#Requires\s+-Version\s+7(\.\d+)?\s*$", RegexOptions.Multiline), text);
+        Assert.Matches(new Regex(@"\[Parameter\(Mandatory\)\]\s*\[string\]\s*\$ProjectPath"), text);
+        Assert.Matches(new Regex(@"\[Parameter\(Mandatory\)\]\s*\[string\]\s*\$ReportPath"), text);
+    }
+
+    [Fact]
+    public void Script_NeverIssuesConfirmingApply()
+    {
+        var text = ReadScript();
+
+        Assert.DoesNotMatch(new Regex(@"confirm\s*=\s*\$true"), text);
+    }
+
+    [Fact]
+    public void Script_CallsOnlyBenignProjectStatusTool()
+    {
+        var text = ReadScript();
+
+        Assert.Matches(new Regex(@"Invoke-McpToolCall\s+-Name\s+'get_project_status'"), text);
+        Assert.True(
+            Regex.Matches(text, @"Invoke-McpToolCall\s+-Name\s+'([^']+)'")
+                .Cast<Match>()
+                .All(match => string.Equals(match.Groups[1].Value, "get_project_status", StringComparison.Ordinal)),
+            "The harness may call only get_project_status through tools/call.");
+    }
+
+    [Fact]
+    public void Script_RecordsTheExactFourAndFourteenToolSurfaces()
+    {
+        var text = ReadScript();
+
+        Assert.Matches(new Regex(@"\$script:ExpectedReadOnlyToolNames\s*=\s*@\s*\("), text);
+        Assert.Matches(new Regex(@"\$script:ExpectedReadWriteToolNames\s*=\s*@\s*\("), text);
+        Assert.Matches(new Regex(@"\$script:ExpectedReadOnlyToolCount\s*=\s*4"), text);
+        Assert.Matches(new Regex(@"\$script:ExpectedReadWriteToolCount\s*=\s*14"), text);
+
+        foreach (var toolName in new[]
+                 {
+                     "get_project_status", "browse_project_tree", "execute_read_batch", "network_read",
+                 })
+        {
+            Assert.Contains($"'{toolName}'", text, StringComparison.Ordinal);
+        }
+
+        foreach (var toolName in new[]
+                 {
+                     "get_project_status", "browse_project_tree", "execute_read_batch", "network_read",
+                     "compile_check", "open_project", "create_project", "save_project", "save_project_as",
+                     "archive_project", "close_project", "preview_write_batch", "apply_write_batch", "network_write",
+                 })
+        {
+            Assert.Contains($"'{toolName}'", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Script_UsesTheVersionedAcceptanceReportDirectory()
+    {
+        var text = ReadScript();
+
+        Assert.Contains("docs", text, StringComparison.Ordinal);
+        Assert.Contains("superpowers", text, StringComparison.Ordinal);
+        Assert.Contains("acceptance", text, StringComparison.Ordinal);
+        Assert.Contains("reports", text, StringComparison.Ordinal);
+        Assert.Contains("2026-09-01-pr1-explicit-mcp-tool-annotations-live.md", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NoOrdinaryTestInvokesTheLiveHarnessScript()
+    {
+        var testDirectory = Path.Combine(GetRepositoryRoot(), "TiaMcpServer.Tests");
+        var thisFile = Path.Combine(testDirectory, "Tools", "WriteToolMetadataLiveHarnessContractTests.cs");
+
+        var offendingFiles = Directory
+            .EnumerateFiles(testDirectory, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !string.Equals(Path.GetFullPath(path), Path.GetFullPath(thisFile), StringComparison.OrdinalIgnoreCase))
+            .Where(path => File.ReadAllText(path).Contains(
+                "live-test-write-tool-metadata.ps1", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Empty(offendingFiles);
+    }
+
+    private static string ReadScript()
+    {
+        Assert.True(File.Exists(ScriptPath), $"Expected the live harness at '{ScriptPath}'.");
+        return File.ReadAllText(ScriptPath);
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        return Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            ".."));
+    }
+}

--- a/TiaMcpServer/Batch/WriteBatchTools.cs
+++ b/TiaMcpServer/Batch/WriteBatchTools.cs
@@ -16,7 +16,11 @@ public class WriteBatchTools
     private const string PreviewToolName = "preview_write_batch";
     private const string ApplyToolName = "apply_write_batch";
 
-    [McpServerTool(Name = "preview_write_batch")]
+    [McpServerTool(
+        Name = "preview_write_batch",
+        ReadOnly = true,
+        Destructive = false,
+        OpenWorld = false)]
     [Description("Preview up to 50 write operations and return one batch-level safetyToken bound to the exact ordered operation list and the combined current state. The token is single-use and expires after 10 minutes. Pass the token to apply_write_batch after reviewing the preview. All items must target the same project. "
         + "Valid operations (parentheses list required fields): update_block_logic (blockPath, yamlContent), create_block (blockPath, blockType), delete_block (blockPath), create_block_group (blockPath), delete_block_group (blockPath), create_tag_table (tableName), delete_tag_table (tableName), create_tag (tableName, name, dataType), update_tag (tableName, name), delete_tag (tableName, name), create_user_constant (tableName, name, dataType, value), update_user_constant (tableName, name), delete_user_constant (tableName, name), start_plc, stop_plc, update_type_content (typePath, sourceContent).")]
     public static async Task<string> PreviewWriteBatch(
@@ -74,7 +78,11 @@ public class WriteBatchTools
             : OperationBatchResultFormatter.Error(PreviewToolName, previewExecution.Failure!.Error!);
     }
 
-    [McpServerTool(Name = "apply_write_batch")]
+    [McpServerTool(
+        Name = "apply_write_batch",
+        ReadOnly = false,
+        Destructive = true,
+        OpenWorld = false)]
     [Description("Apply a previewed batch of write operations sequentially, stopping on the first failure (later items are skipped; no rollback). Requires confirm=true and a safetyToken from preview_write_batch; pass the identical operations list. "
         + "Valid operations (parentheses list required fields): update_block_logic (blockPath, yamlContent), create_block (blockPath, blockType), delete_block (blockPath), create_block_group (blockPath), delete_block_group (blockPath), create_tag_table (tableName), delete_tag_table (tableName), create_tag (tableName, name, dataType), update_tag (tableName, name), delete_tag (tableName, name), create_user_constant (tableName, name, dataType, value), update_user_constant (tableName, name), delete_user_constant (tableName, name), start_plc, stop_plc, update_type_content (typePath, sourceContent).")]
     public static async Task<string> ApplyWriteBatch(

--- a/TiaMcpServer/Tools/ProjectWriteTools.cs
+++ b/TiaMcpServer/Tools/ProjectWriteTools.cs
@@ -18,7 +18,11 @@ public class ProjectWriteTools
         "Two-step safety flow in one tool: call WITHOUT safetyToken to get a preview and a single-use token "
         + "(expires after 10 minutes), review it, then call again with the same arguments plus confirm=true and the safetyToken.";
 
-    [McpServerTool(Name = "open_project")]
+    [McpServerTool(
+        Name = "open_project",
+        ReadOnly = false,
+        Destructive = true,
+        OpenWorld = false)]
     [Description("Open a TIA Portal project and bind this MCP session to it. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
     public static async Task<string> OpenProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Path to the .ap21 project file to open.")] string projectPath, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null, [Description("Set true to allow rebinding this MCP session from a previously bound project.")] bool forceRebind = false)
     {
@@ -38,7 +42,11 @@ public class ProjectWriteTools
         return WriteSafetyTooling.BuildApplyResult("open_project", result, "get_project_status", apply.VerificationResult);
     }
 
-    [McpServerTool(Name = "create_project")]
+    [McpServerTool(
+        Name = "create_project",
+        ReadOnly = false,
+        Destructive = true,
+        OpenWorld = false)]
     [Description("Create a new TIA Portal project and bind this MCP session to it. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
     public static async Task<string> CreateProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Directory where the project folder should be created.")] string projectDirectory, [Description("Name of the new TIA Portal project.")] string projectName, [Description("Optional project author metadata.")] string? author = null, [Description("Optional project comment metadata.")] string? comment = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
     {
@@ -58,7 +66,11 @@ public class ProjectWriteTools
         return WriteSafetyTooling.BuildApplyResult("create_project", result, "get_project_status", apply.VerificationResult);
     }
 
-    [McpServerTool(Name = "save_project")]
+    [McpServerTool(
+        Name = "save_project",
+        ReadOnly = false,
+        Destructive = true,
+        OpenWorld = false)]
     [Description("Save the active TIA Portal project. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
     public static async Task<string> SaveProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
     {
@@ -80,7 +92,11 @@ public class ProjectWriteTools
         return WriteSafetyTooling.BuildApplyResult("save_project", result, "get_project_status", apply.VerificationResult);
     }
 
-    [McpServerTool(Name = "save_project_as")]
+    [McpServerTool(
+        Name = "save_project_as",
+        ReadOnly = false,
+        Destructive = true,
+        OpenWorld = false)]
     [Description("Save the active TIA Portal project to a copy directory. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
     public static async Task<string> SaveProjectAs(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Parent directory for the copied project.")] string targetDirectory, [Description("Name of the copied project directory.")] string targetName, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Bind this MCP session to the copied project after save-as. Must be true; rebind=false is not supported.")] bool rebind = true, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
     {
@@ -109,7 +125,11 @@ public class ProjectWriteTools
         return WriteSafetyTooling.BuildApplyResult("save_project_as", result, "get_project_status", apply.VerificationResult);
     }
 
-    [McpServerTool(Name = "archive_project")]
+    [McpServerTool(
+        Name = "archive_project",
+        ReadOnly = false,
+        Destructive = true,
+        OpenWorld = false)]
     [Description("Archive the active TIA Portal project. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
     public static async Task<string> ArchiveProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Directory where the archive should be written. TIA Portal rejects a combined directory+file path longer than roughly 140 characters.")] string archiveDirectory, [Description("Archive file name. For Compressed and DiscardRestorableDataAndCompressed modes, .zap21 is appended automatically if not already present.")] string archiveName, [Description("Archive mode: None, DiscardRestorableData, Compressed, or DiscardRestorableDataAndCompressed.")] string? mode = null, [Description("Save the project before archiving.")] bool saveBeforeArchive = true, [Description("Optional path to a .ap21 project file. If omitted, uses the project currently open in TIA Portal.")] string? projectPath = null, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
     {
@@ -134,7 +154,11 @@ public class ProjectWriteTools
         return WriteSafetyTooling.BuildApplyResult("archive_project", result, "get_project_status", apply.VerificationResult);
     }
 
-    [McpServerTool(Name = "close_project")]
+    [McpServerTool(
+        Name = "close_project",
+        ReadOnly = false,
+        Destructive = true,
+        OpenWorld = false)]
     [Description("Close the active TIA Portal project and clear this MCP session binding. Requires confirm=true and a safetyToken. " + SafetyFlowDescription)]
     public static async Task<string> CloseProject(OpennessWorkerClient workerClient, WriteSafetyService safety, [Description("Optional path to a .ap21 project file. If omitted, closes the currently bound/open project.")] string? projectPath = null, [Description("Save the project before closing it.")] bool saveBeforeClose = true, [Description("Set to true together with safetyToken to apply. Ignored on the preview call.")] bool confirm = false, [Description("Safety token from this tool's preview call. Omit to get a preview + token.")] string? safetyToken = null)
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -472,6 +472,16 @@ status.
 Generic batch data writes use a two-tool flow; lifecycle and network writes are
 self-previewing:
 
+### MCP tool annotations
+
+The MCP `readOnlyHint`, `destructiveHint`, and `openWorldHint` annotations are explicit,
+client-facing metadata. They are untrusted advisory hints for a client deciding how to present a
+tool; they neither authorize a request nor relax server behavior. In particular,
+`preview_write_batch` is marked as a non-destructive preview even though the follow-up
+`apply_write_batch` is destructive, and lifecycle writes carry conservative mutating hints even
+though their first call remains a preview. The access policy, safety-token validation, pinned
+binding lease, current-state re-read, and audit trail below remain the server-enforced authority.
+
 1. The preview call (`preview_write_batch`, or the same lifecycle/network tool with no
    token and `confirm:false`) reads current state, produces a human-readable description,
    and creates a short-lived, single-use safety token bound to the tool,

--- a/docs/IMPROVEMENT_LOG.md
+++ b/docs/IMPROVEMENT_LOG.md
@@ -8,6 +8,19 @@ plus manual verification of the highest-stakes claims. Test suite at authoring t
 (pure-logic tests only; no integration coverage of the worker or IPC layer). As of 2026-07-20 the
 suite is 341/341 green and does cover the worker/IPC layer via the fake-worker harness.
 
+## PR 1 explicit MCP tool annotations — live acceptance pending (2026-09-01)
+
+The registered 4-tool read-only and 14-tool read-write MCP surfaces now expose the approved
+client-facing write metadata, with the server-enforced preview/token/apply safety model unchanged.
+The separately authorized, non-mutating host-level harness is ready at
+`scripts/live-test-write-tool-metadata.ps1`; its intended evidence destination is
+[`docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md`](superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md).
+
+This entry is deliberately **not** a completion record: no live TIA Portal V21 harness run has
+been recorded, so PR 1 remains incomplete. Offline, stub, FakeWorker, and static harness-contract
+evidence do not substitute for the pending live run. PLC `start_plc` and `stop_plc` remain
+deferred and out of scope.
+
 ## Overall verdict
 
 Solid foundation: the batch-tool consolidation (45 → 16 tools), typed batch item schema with

--- a/docs/IMPROVEMENT_LOG.md
+++ b/docs/IMPROVEMENT_LOG.md
@@ -8,18 +8,18 @@ plus manual verification of the highest-stakes claims. Test suite at authoring t
 (pure-logic tests only; no integration coverage of the worker or IPC layer). As of 2026-07-20 the
 suite is 341/341 green and does cover the worker/IPC layer via the fake-worker harness.
 
-## PR 1 explicit MCP tool annotations — live acceptance pending (2026-09-01)
+## PR 1 explicit MCP tool annotations — live acceptance completed (2026-09-01)
 
 The registered 4-tool read-only and 14-tool read-write MCP surfaces now expose the approved
 client-facing write metadata, with the server-enforced preview/token/apply safety model unchanged.
-The separately authorized, non-mutating host-level harness is ready at
-`scripts/live-test-write-tool-metadata.ps1`; its intended evidence destination is
+The separately authorized, non-mutating host-level harness completed with exit code `0` against
+the current-branch read-only and read-write hosts. Its live evidence is recorded at
 [`docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md`](superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md).
 
-This entry is deliberately **not** a completion record: no live TIA Portal V21 harness run has
-been recorded, so PR 1 remains incomplete. Offline, stub, FakeWorker, and static harness-contract
-evidence do not substitute for the pending live run. PLC `start_plc` and `stop_plc` remain
-deferred and out of scope.
+This completion applies only to the exact host, attached TIA Portal session, and disposable
+project documented in that report. Offline, stub, FakeWorker, and static harness-contract evidence
+remain separate development evidence; neither evidence class substitutes for the other. PLC
+`start_plc` and `stop_plc` remain deferred and out of scope.
 
 ## Overall verdict
 

--- a/docs/IMPROVEMENT_LOG.md
+++ b/docs/IMPROVEMENT_LOG.md
@@ -8,19 +8,6 @@ plus manual verification of the highest-stakes claims. Test suite at authoring t
 (pure-logic tests only; no integration coverage of the worker or IPC layer). As of 2026-07-20 the
 suite is 341/341 green and does cover the worker/IPC layer via the fake-worker harness.
 
-## PR 1 explicit MCP tool annotations — live acceptance completed (2026-09-01)
-
-The registered 4-tool read-only and 14-tool read-write MCP surfaces now expose the approved
-client-facing write metadata, with the server-enforced preview/token/apply safety model unchanged.
-The separately authorized, non-mutating host-level harness completed with exit code `0` against
-the current-branch read-only and read-write hosts. Its live evidence is recorded at
-[`docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md`](superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md).
-
-This completion applies only to the exact host, attached TIA Portal session, and disposable
-project documented in that report. Offline, stub, FakeWorker, and static harness-contract evidence
-remain separate development evidence; neither evidence class substitutes for the other. PLC
-`start_plc` and `stop_plc` remain deferred and out of scope.
-
 ## Overall verdict
 
 Solid foundation: the batch-tool consolidation (45 → 16 tools), typed batch item schema with
@@ -425,3 +412,16 @@ failures, malformed worker payloads, process-key invalidation, and byte-for-byte
 equivalence. The separately authorized read-only harness
 `scripts/live-test-hardware-pagination.ps1` is contract-tested but has not been executed against
 live TIA Portal V21; live pagination acceptance remains unverified.
+
+## PR 1 explicit MCP tool annotations — live acceptance completed (2026-09-01)
+
+The registered 4-tool read-only and 14-tool read-write MCP surfaces now expose the approved
+client-facing write metadata, with the server-enforced preview/token/apply safety model unchanged.
+The separately authorized, non-mutating host-level harness completed with exit code `0` against
+the current-branch read-only and read-write hosts. Its live evidence is recorded at
+[`docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md`](superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md).
+
+This completion applies only to the exact host, attached TIA Portal session, and disposable
+project documented in that report. Offline, stub, FakeWorker, and static harness-contract evidence
+remain separate development evidence; neither evidence class substitutes for the other. PLC
+`start_plc` and `stop_plc` remain deferred and out of scope.

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,14 @@ Agent-facing build and convention reference lives in [AGENTS.md](../AGENTS.md).
 acceptance reports produced while building features. It is historical process material, not
 current documentation — see its index for what is there and how to read it.
 
-Latest process entries: [project completeness and hardware pagination design](superpowers/specs/2026-08-28-issue-31-project-completeness-pagination-design.md),
+Latest process entries: [write-safety preview and registered-surface hardening design](superpowers/specs/2026-09-01-write-safety-hardening-design.md),
+with separate plans for [PR 1 explicit MCP tool annotations](superpowers/plans/2026-09-01-pr1-explicit-mcp-tool-annotations.md),
+[PR 2 registered-tool delegation](superpowers/plans/2026-09-01-pr2-registered-tool-delegation.md),
+[PR 3 exact `update_tag` safety snapshots](superpowers/plans/2026-09-01-pr3-update-tag-safety-snapshot.md),
+[PR 4 bounded structured preview diffs](superpowers/plans/2026-09-01-pr4-structured-preview-diff.md),
+[PR 5 tag-operation safety scopes](superpowers/plans/2026-09-01-pr5-tag-operation-safety-scopes.md),
+and [PR 6 project-tree safety scopes](superpowers/plans/2026-09-01-pr6-project-tree-safety-scopes.md);
+[project completeness and hardware pagination design](superpowers/specs/2026-08-28-issue-31-project-completeness-pagination-design.md),
 its [PR 1 project enumeration completeness plan](superpowers/plans/2026-08-28-project-enumeration-completeness.md),
 the [PR 2 hardware pagination plan](superpowers/plans/2026-08-29-hardware-pagination.md),
 [PR #29 binding findings repair design](superpowers/specs/2026-08-28-pr29-binding-findings-repair-design.md),

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ current documentation — see its index for what is there and how to read it.
 
 Latest process entries: [write-safety preview and registered-surface hardening design](superpowers/specs/2026-09-01-write-safety-hardening-design.md),
 with separate plans for [PR 1 explicit MCP tool annotations](superpowers/plans/2026-09-01-pr1-explicit-mcp-tool-annotations.md),
+[its pending live acceptance evidence template](superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md),
 [PR 2 registered-tool delegation](superpowers/plans/2026-09-01-pr2-registered-tool-delegation.md),
 [PR 3 exact `update_tag` safety snapshots](superpowers/plans/2026-09-01-pr3-update-tag-safety-snapshot.md),
 [PR 4 bounded structured preview diffs](superpowers/plans/2026-09-01-pr4-structured-preview-diff.md),

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ current documentation — see its index for what is there and how to read it.
 
 Latest process entries: [write-safety preview and registered-surface hardening design](superpowers/specs/2026-09-01-write-safety-hardening-design.md),
 with separate plans for [PR 1 explicit MCP tool annotations](superpowers/plans/2026-09-01-pr1-explicit-mcp-tool-annotations.md),
-[its pending live acceptance evidence template](superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md),
+[its completed live acceptance report](superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md),
 [PR 2 registered-tool delegation](superpowers/plans/2026-09-01-pr2-registered-tool-delegation.md),
 [PR 3 exact `update_tag` safety snapshots](superpowers/plans/2026-09-01-pr3-update-tag-safety-snapshot.md),
 [PR 4 bounded structured preview diffs](superpowers/plans/2026-09-01-pr4-structured-preview-diff.md),

--- a/docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md
+++ b/docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md
@@ -52,6 +52,15 @@ the plain project status only — it never enumerates history or the extended me
 
 Supported archive modes are `None`, `DiscardRestorableData`, `Compressed`, and `DiscardRestorableDataAndCompressed`. Lifecycle tools are single-tool operations and cannot be included in a batch.
 
+### MCP client hints
+
+`open_project`, `create_project`, `save_project`, `save_project_as`, `archive_project`, and
+`close_project` are advertised with conservative mutating MCP hints: `readOnlyHint: false`,
+`destructiveHint: true`, and `openWorldHint: false`. These are client-facing metadata only; they
+do not bypass the safety model. The first lifecycle call still returns a preview and single-use
+safety token. It applies only on a later call with the unchanged input, `confirm=true`, and that
+token.
+
 ## Safety and session binding
 
 - A lifecycle call without a safety token returns a preview and a single-use token. Applying the change requires the same tool input, `confirm=true`, and that token.

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -21,6 +21,7 @@ Design documents, written before implementation.
 
 | Date | Document |
 | --- | --- |
+| 2026-09-01 | [Write-safety preview and registered-surface hardening](specs/2026-09-01-write-safety-hardening-design.md) |
 | 2026-08-28 | [Issue #31 project completeness and hardware pagination](specs/2026-08-28-issue-31-project-completeness-pagination-design.md) |
 | 2026-08-28 | [PR #29 binding findings repair](specs/2026-08-28-pr29-binding-findings-repair-design.md) |
 | 2026-08-07 | [Documentation reorganization](specs/2026-08-07-docs-reorganization-design.md) |
@@ -38,6 +39,12 @@ Task-level implementation plans derived from the specs above.
 
 | Date | Document |
 | --- | --- |
+| 2026-09-01 | [PR 1 — explicit MCP tool annotations](plans/2026-09-01-pr1-explicit-mcp-tool-annotations.md) |
+| 2026-09-01 | [PR 2 — registered-tool delegation](plans/2026-09-01-pr2-registered-tool-delegation.md) |
+| 2026-09-01 | [PR 3 — exact `update_tag` safety snapshot](plans/2026-09-01-pr3-update-tag-safety-snapshot.md) |
+| 2026-09-01 | [PR 4 — bounded structured preview diff](plans/2026-09-01-pr4-structured-preview-diff.md) |
+| 2026-09-01 | [PR 5 — tag-operation safety scopes](plans/2026-09-01-pr5-tag-operation-safety-scopes.md) |
+| 2026-09-01 | [PR 6 — project-tree safety scopes](plans/2026-09-01-pr6-project-tree-safety-scopes.md) |
 | 2026-08-29 | [Hardware configuration pagination](plans/2026-08-29-hardware-pagination.md) |
 | 2026-08-28 | [Project enumeration completeness](plans/2026-08-28-project-enumeration-completeness.md) |
 | 2026-08-28 | [PR #29 binding findings repair](plans/2026-08-28-pr29-binding-findings-repair.md) |

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -59,10 +59,19 @@ Task-level implementation plans derived from the specs above.
 
 ## Acceptance reports
 
-Evidence from live runs against TIA Portal V21.
+Evidence from completed live runs against TIA Portal V21.
 
 | Date | Document |
 | --- | --- |
 | 2026-08-14 | [Structured I/O map defect fixes — live](acceptance/reports/2026-08-14-io-map-defect-fixes-live.md) |
 | 2026-08-01 | [Network Phase 1 — rerun](acceptance/reports/2026-08-01-16-56-00-network-operations-phase1-rerun.md) |
 | 2026-08-01 | [Network Phase 1](acceptance/reports/2026-08-01-16-48-48-network-operations-phase1.md) |
+
+## Pending live acceptance evidence
+
+These dated templates are intentionally not evidence of a completed live run. They state the
+required evidence boundary and are replaced by their separately authorized harness when run.
+
+| Date | Document |
+| --- | --- |
+| 2026-09-01 | [PR 1 — explicit MCP tool annotations (pending)](acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md) |

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -63,15 +63,7 @@ Evidence from completed live runs against TIA Portal V21.
 
 | Date | Document |
 | --- | --- |
+| 2026-09-01 | [PR 1 — explicit MCP tool annotations — live](acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md) |
 | 2026-08-14 | [Structured I/O map defect fixes — live](acceptance/reports/2026-08-14-io-map-defect-fixes-live.md) |
 | 2026-08-01 | [Network Phase 1 — rerun](acceptance/reports/2026-08-01-16-56-00-network-operations-phase1-rerun.md) |
 | 2026-08-01 | [Network Phase 1](acceptance/reports/2026-08-01-16-48-48-network-operations-phase1.md) |
-
-## Pending live acceptance evidence
-
-These dated templates are intentionally not evidence of a completed live run. They state the
-required evidence boundary and are replaced by their separately authorized harness when run.
-
-| Date | Document |
-| --- | --- |
-| 2026-09-01 | [PR 1 — explicit MCP tool annotations (pending)](acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md) |

--- a/docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md
+++ b/docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md
@@ -1,38 +1,144 @@
 # PR 1 Explicit MCP Tool Annotations — Live TIA Portal V21 Acceptance
 
-## Status
+## Evidence status
 
-**Pending live acceptance.** This is an evidence template, not a live-run report. The harness has
-not been run against TIA Portal V21, no project path or version is recorded here, and PR 1 remains
-incomplete until a separately authorized non-mutating live run replaces this template.
+Live acceptance completed by this separately authorized, non-mutating run. This evidence proves only the exact live TiaMcpServer host, attached TIA Portal session, and disposable project path recorded below. It does not replace offline, stub, or FakeWorker evidence, and those evidence classes do not replace this live run.
 
-## Intended harness and report path
+- Harness exit code: `0`
+- Host modes: current-branch `--read-only` and `--read-write` sessions
 
-- Harness: `scripts/live-test-write-tool-metadata.ps1`
-- Intended report path: `docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md`
-- Required inputs: an approved disposable `.ap21` project path and the explicit report path above.
+## Tested environment
 
-## Required live evidence
+- TIA Portal product version: 2100.0.121.1
+- Project copy path: `C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21`
+- Harness report path: `C:\Users\LCZ\Desktop\RnD\TIA-Portal\tia-portal-mcp\docs\superpowers\acceptance\reports\2026-09-01-pr1-explicit-mcp-tool-annotations-live.md`
+- Read-only server: TiaMcpServer 1.0.0.0
+- Read-write server: TiaMcpServer 1.0.0.0
+- Attached Portal PID: 3152 in both sanitized status summaries
 
-The authorized harness must launch the real `TiaMcpServer` host in both `--read-only` and
-`--read-write` modes, use the public `initialize`, `notifications/initialized`, `tools/list`, and
-benign `get_project_status` protocol calls, and record:
+## Read-only MCP surface
 
-- exact TIA Portal V21 product version and tested project-copy path;
-- the exact 4-tool read-only and 14-tool read-write surfaces;
-- emitted annotation hints for `preview_write_batch`, `apply_write_batch`, `open_project`,
-  `create_project`, `save_project`, `save_project_as`, `archive_project`, and `close_project`;
-- a result summary for the benign `get_project_status` call in each access mode; and
-- the evidence boundary: only that host/project/session combination is live-proven.
+Expected and observed exactly 4 tools:
 
-## Non-mutation and deferred scope
+```json
+[
+  "browse_project_tree",
+  "execute_read_batch",
+  "get_project_status",
+  "network_read"
+]
+```
 
-The harness must not call a write, preview, apply, compile, network-write, or PLC-control route.
-It proves metadata and a benign read only; it does not weaken the server-enforced preview/token/
-apply safety model. PLC `start_plc` and `stop_plc` remain deferred.
+Benign call: `tools/call` for `get_project_status` with the project copy path. Result summary:
 
-## Evidence boundary
+```json
+{
+  "success": true,
+  "isOpen": true,
+  "path": "C:\\Users\\LCZ\\Desktop\\RnD\\plc-prompt-injections\\SimpleProject\\SimpleProject.ap21",
+  "sessionIdentity": {
+    "projectPath": "C:\\Users\\LCZ\\Desktop\\RnD\\plc-prompt-injections\\SimpleProject\\SimpleProject.ap21",
+    "portalProcessId": 3152
+  }
+}
+```
 
-Offline, reference-stub, FakeWorker, and static source-contract checks are necessary development
-evidence but are not live TIA Portal V21 acceptance. No live result, tool surface, annotation value,
-TIA Portal version, or project path is asserted by this pending template.
+## Read-write MCP surface
+
+Expected and observed exactly 14 tools:
+
+```json
+[
+  "apply_write_batch",
+  "archive_project",
+  "browse_project_tree",
+  "close_project",
+  "compile_check",
+  "create_project",
+  "execute_read_batch",
+  "get_project_status",
+  "network_read",
+  "network_write",
+  "open_project",
+  "preview_write_batch",
+  "save_project",
+  "save_project_as"
+]
+```
+
+Emitted annotations for the approved write-tool matrix:
+
+```json
+[
+  {
+    "name": "preview_write_batch",
+    "readOnlyHint": true,
+    "destructiveHint": false,
+    "openWorldHint": false
+  },
+  {
+    "name": "apply_write_batch",
+    "readOnlyHint": false,
+    "destructiveHint": true,
+    "openWorldHint": false
+  },
+  {
+    "name": "open_project",
+    "readOnlyHint": false,
+    "destructiveHint": true,
+    "openWorldHint": false
+  },
+  {
+    "name": "create_project",
+    "readOnlyHint": false,
+    "destructiveHint": true,
+    "openWorldHint": false
+  },
+  {
+    "name": "save_project",
+    "readOnlyHint": false,
+    "destructiveHint": true,
+    "openWorldHint": false
+  },
+  {
+    "name": "save_project_as",
+    "readOnlyHint": false,
+    "destructiveHint": true,
+    "openWorldHint": false
+  },
+  {
+    "name": "archive_project",
+    "readOnlyHint": false,
+    "destructiveHint": true,
+    "openWorldHint": false
+  },
+  {
+    "name": "close_project",
+    "readOnlyHint": false,
+    "destructiveHint": true,
+    "openWorldHint": false
+  }
+]
+```
+
+Benign call: `tools/call` for `get_project_status` with the project copy path. Result summary:
+
+```json
+{
+  "success": true,
+  "isOpen": true,
+  "path": "C:\\Users\\LCZ\\Desktop\\RnD\\plc-prompt-injections\\SimpleProject\\SimpleProject.ap21",
+  "sessionIdentity": {
+    "projectPath": "C:\\Users\\LCZ\\Desktop\\RnD\\plc-prompt-injections\\SimpleProject\\SimpleProject.ap21",
+    "portalProcessId": 3152
+  }
+}
+```
+
+## Non-mutation and evidence boundary
+
+The harness sent only `initialize`, `notifications/initialized`, `tools/list`, and one `get_project_status` `tools/call` per access mode. It did not call any lifecycle, preview, apply, compilation, network-write, or PLC-control operation; no project mutation was performed. PLC `start_plc` and `stop_plc` remain deferred.
+
+A post-run read-only status check reported `isModified:false` for the project copy.
+
+The explicit MCP annotations are client-facing, untrusted metadata. Server-enforced access policy, preview/token/apply validation, binding checks, and auditing remain the write-safety authority.

--- a/docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md
+++ b/docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md
@@ -1,0 +1,38 @@
+# PR 1 Explicit MCP Tool Annotations — Live TIA Portal V21 Acceptance
+
+## Status
+
+**Pending live acceptance.** This is an evidence template, not a live-run report. The harness has
+not been run against TIA Portal V21, no project path or version is recorded here, and PR 1 remains
+incomplete until a separately authorized non-mutating live run replaces this template.
+
+## Intended harness and report path
+
+- Harness: `scripts/live-test-write-tool-metadata.ps1`
+- Intended report path: `docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md`
+- Required inputs: an approved disposable `.ap21` project path and the explicit report path above.
+
+## Required live evidence
+
+The authorized harness must launch the real `TiaMcpServer` host in both `--read-only` and
+`--read-write` modes, use the public `initialize`, `notifications/initialized`, `tools/list`, and
+benign `get_project_status` protocol calls, and record:
+
+- exact TIA Portal V21 product version and tested project-copy path;
+- the exact 4-tool read-only and 14-tool read-write surfaces;
+- emitted annotation hints for `preview_write_batch`, `apply_write_batch`, `open_project`,
+  `create_project`, `save_project`, `save_project_as`, `archive_project`, and `close_project`;
+- a result summary for the benign `get_project_status` call in each access mode; and
+- the evidence boundary: only that host/project/session combination is live-proven.
+
+## Non-mutation and deferred scope
+
+The harness must not call a write, preview, apply, compile, network-write, or PLC-control route.
+It proves metadata and a benign read only; it does not weaken the server-enforced preview/token/
+apply safety model. PLC `start_plc` and `stop_plc` remain deferred.
+
+## Evidence boundary
+
+Offline, reference-stub, FakeWorker, and static source-contract checks are necessary development
+evidence but are not live TIA Portal V21 acceptance. No live result, tool surface, annotation value,
+TIA Portal version, or project path is asserted by this pending template.

--- a/docs/superpowers/plans/2026-09-01-pr1-explicit-mcp-tool-annotations.md
+++ b/docs/superpowers/plans/2026-09-01-pr1-explicit-mcp-tool-annotations.md
@@ -1,0 +1,490 @@
+# PR 1 Explicit MCP Tool Annotations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove and ship explicit MCP annotation hints for the registered batch-write and lifecycle-write tools by starting with production-equivalent `tools/list` tests, then adding the minimal production annotations, and finally completing the mandatory live TIA Portal V21 acceptance/reporting gate.
+
+**Architecture:** PR 1 does not change the write-safety model, public tool names, input schemas, or wrapper delegation. It first extends `McpProtocolTestHarness` so tests can start the exact `Program.cs` tool surface in both access modes, then uses `ListToolsAsync()` as the milestone RED/GREEN path for the real client-visible metadata, and only after that adds explicit `McpServerTool` hint values on `WriteBatchTools` and `ProjectWriteTools`. Reflection tests remain supplemental pinning on the registered classes, while the live PowerShell harness launches `TiaMcpServer` twice, captures `tools/list` in read-only and read-write modes, performs one benign project read per run, and writes the durable acceptance report.
+
+**Tech Stack:** C#; .NET 8 host; .NET Framework 4.8 worker; ModelContextProtocol 1.2.0; xUnit; PowerShell 7; the existing FakeWorker-backed MCP protocol harness; serial Windows `dotnet` verification commands.
+
+**Spec:** [`docs/superpowers/specs/2026-09-01-write-safety-hardening-design.md`](../specs/2026-09-01-write-safety-hardening-design.md)
+
+## Global Constraints
+
+- Improve the reviewability, MCP metadata, test fidelity, and state-snapshot precision of the existing write-safety system without weakening its server-enforced guarantees or changing the public write-tool names and input schemas.
+- Every pull request in this design must pass both repository verification and scope-specific live TIA Portal V21 acceptance. Offline, stub, and FakeWorker evidence is necessary but never sufficient for completion.
+- The public tools remain `preview_write_batch`, `apply_write_batch`, the six lifecycle write tools, and `network_write`. No active milestone renames, combines, or removes a tool.
+- Preview remains non-mutating. Apply still requires the unchanged request, `confirm=true`, and the matching single-use safety token.
+- Tokens continue to bind tool name, normalized project path, ordered targets, exact requested input, exact current state, and the complete verified project/session binding.
+- Add protocol-level tests that call `ListToolsAsync`, not reflection-only tests.
+- Assert exact annotations, names, and availability in read-only and read-write server modes.
+- Preserve existing input schemas and tool counts.
+- Run a live V21 host, complete MCP initialization, call `tools/list`, and record the emitted annotations. The same run must make one benign project read so the report proves that the host is connected to a real TIA session rather than only testing an in-memory SDK server.
+- No project mutation is required for this milestone.
+- A failed or unavailable live-TIA gate leaves the pull request incomplete. It is not converted into an offline-only acceptance claim.
+
+---
+
+## File Map
+
+- `TiaMcpServer.Tests/TestSupport/McpProtocolTestHarness.cs`
+  Add one reusable production-equivalent startup path for protocol tests:
+  `Task<McpProtocolTestHarness> StartAsync(McpAccessMode accessMode, Action<IMcpServerBuilder> registerTools, string? auditDirectory = null, string? startupProjectPath = null)`
+  and
+  `Task<McpProtocolTestHarness> StartProductionSurfaceAsync(McpAccessMode accessMode, string? auditDirectory = null, string? startupProjectPath = null)`.
+  `StartProductionSurfaceAsync` must mirror `Program.cs` exactly:
+  read-only registers `ProjectReadTools`, `ReadBatchTools`, `NetworkReadTools`;
+  read-write additionally registers `ProjectEngineeringTools`, `ProjectWriteTools`, `WriteBatchTools`, and `NetworkWriteTools`.
+
+- `TiaMcpServer.Tests/Tools/WriteToolMcpAnnotationProtocolTests.cs`
+  New protocol-first milestone tests that call `await harness.Client.ListToolsAsync()` against the production-equivalent surface and assert the exact 4-tool read-only surface, exact 14-tool read-write surface, conservative write annotations, and unchanged representative schemas.
+
+- `TiaMcpServer/Batch/WriteBatchTools.cs`
+  Add explicit `McpServerTool` hint values to the registered `PreviewWriteBatch` and `ApplyWriteBatch` methods only.
+
+- `TiaMcpServer/Tools/ProjectWriteTools.cs`
+  Add explicit `McpServerTool` hint values to the six registered lifecycle write methods only: `OpenProject`, `CreateProject`, `SaveProject`, `SaveProjectAs`, `ArchiveProject`, and `CloseProject`.
+
+- `TiaMcpServer.Tests/Batch/BatchToolsTests.cs`
+  Supplemental reflection regression on the registered batch-write class after the protocol milestone is green. This is not the milestone RED path.
+
+- `TiaMcpServer.Tests/Project/ProjectLifecycleToolTests.cs`
+  Supplemental reflection regression on the registered lifecycle-write class after the protocol milestone is green. This is not the milestone RED path.
+
+- `TiaMcpServer.Tests/Tools/McpToolSchemaTests.cs`
+  Existing schema authority that must continue to prove the public schema stays unchanged and DI-only parameters do not leak into model-facing tool inputs.
+
+- `TiaMcpServer.Tests/Safety/ReadOnlyModeTests.cs`
+  Existing exact approved-tool-count guard that must remain green. Reuse only if a tiny helper improves consistency with the new protocol tests.
+
+- `TiaMcpServer.Tests/Project/ProjectStandaloneToolTests.cs`
+  Existing `compile_check` metadata regression that remains part of the protocol/surface verification bundle because read-write mode must still expose the full 14-tool production surface.
+
+- `scripts/live-test-write-tool-metadata.ps1`
+  New live TIA Portal V21 acceptance harness. It launches `TiaMcpServer` in both `--read-only` and `--read-write` modes, performs `initialize`, `notifications/initialized`, `tools/list`, and one benign `get_project_status` call per mode, then writes the acceptance report.
+
+- `TiaMcpServer.Tests/Tools/WriteToolMetadataLiveHarnessContractTests.cs`
+  Static contract tests for the live harness source: PowerShell 7 requirement, exact MCP protocol shape, both access-mode launches, report location, no direct worker IPC, and no confirming writes.
+
+- `docs/ARCHITECTURE.md`
+  Document that explicit MCP hints are client-facing metadata layered on top of the unchanged server-enforced preview/apply safety flow.
+
+- `docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md`
+  Document that lifecycle write tools now advertise conservative mutating hints while remaining self-previewing.
+
+- `docs/IMPROVEMENT_LOG.md`
+  Record PR 1 completion, the live acceptance report path, and the still-deferred PLC start/stop investigation.
+
+- `docs/README.md`
+  Add the PR 1 live acceptance report to the docs index.
+
+- `docs/superpowers/README.md`
+  Add both this plan and the PR 1 live acceptance report to the superpowers index if not already listed.
+
+- `docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md`
+  Durable acceptance report with exact tool names/counts and emitted annotations for both access modes, the benign read evidence, the tested TIA version/project copy, and the explicit live-evidence boundary.
+
+### Task 1: Production-Equivalent Protocol Coverage and Registered Annotation Hints
+
+**Files:**
+- Modify: `TiaMcpServer.Tests/TestSupport/McpProtocolTestHarness.cs`
+- Create: `TiaMcpServer.Tests/Tools/WriteToolMcpAnnotationProtocolTests.cs`
+- Modify: `TiaMcpServer/Batch/WriteBatchTools.cs`
+- Modify: `TiaMcpServer/Tools/ProjectWriteTools.cs`
+- Modify: `TiaMcpServer.Tests/Batch/BatchToolsTests.cs`
+- Modify: `TiaMcpServer.Tests/Project/ProjectLifecycleToolTests.cs`
+- Modify: `TiaMcpServer.Tests/Tools/McpToolSchemaTests.cs` only if a tiny helper reduces duplication without changing coverage intent
+- Modify: `TiaMcpServer.Tests/Safety/ReadOnlyModeTests.cs` only if a tiny helper reduces duplication without changing coverage intent
+
+**Interfaces:**
+- Produces: `public static Task<McpProtocolTestHarness> StartAsync(McpAccessMode accessMode, Action<IMcpServerBuilder> registerTools, string? auditDirectory = null, string? startupProjectPath = null)` in `McpProtocolTestHarness`
+- Produces: `public static Task<McpProtocolTestHarness> StartProductionSurfaceAsync(McpAccessMode accessMode, string? auditDirectory = null, string? startupProjectPath = null)` in `McpProtocolTestHarness`
+- Consumes: exact production-equivalent read-only tool set: `ProjectReadTools`, `ReadBatchTools`, `NetworkReadTools`
+- Consumes: exact production-equivalent read-write tool set: `ProjectReadTools`, `ReadBatchTools`, `NetworkReadTools`, `ProjectEngineeringTools`, `ProjectWriteTools`, `WriteBatchTools`, `NetworkWriteTools`
+- Produces: protocol assertions for the exact read-only tool names:
+  `browse_project_tree`, `execute_read_batch`, `get_project_status`, `network_read`
+- Produces: protocol assertions for the exact read-write tool names:
+  `apply_write_batch`, `archive_project`, `browse_project_tree`, `close_project`, `compile_check`, `create_project`, `execute_read_batch`, `get_project_status`, `network_read`, `network_write`, `open_project`, `preview_write_batch`, `save_project`, `save_project_as`
+- Produces: explicit registered annotations for `preview_write_batch` -> `ReadOnly=true`, `Destructive=false`, `OpenWorld=false`
+- Produces: explicit registered annotations for `apply_write_batch` -> `ReadOnly=false`, `Destructive=true`, `OpenWorld=false`
+- Produces: explicit registered annotations for each lifecycle write tool -> `ReadOnly=false`, `Destructive=true`, `OpenWorld=false`
+
+- [ ] **Step 1: Add the reusable production-equivalent protocol harness setup**
+
+  Extend `McpProtocolTestHarness` before writing the milestone tests so the test surface matches `Program.cs` exactly:
+
+  ```csharp
+  public static Task<McpProtocolTestHarness> StartAsync(
+      McpAccessMode accessMode,
+      Action<IMcpServerBuilder> registerTools,
+      string? auditDirectory = null,
+      string? startupProjectPath = null)
+
+  public static Task<McpProtocolTestHarness> StartProductionSurfaceAsync(
+      McpAccessMode accessMode,
+      string? auditDirectory = null,
+      string? startupProjectPath = null)
+      => StartAsync(
+          accessMode,
+          builder =>
+          {
+              builder.WithTools<ProjectReadTools>()
+                     .WithTools<ReadBatchTools>()
+                     .WithTools<NetworkReadTools>();
+
+              if (accessMode == McpAccessMode.ReadWrite)
+              {
+                  builder.WithTools<ProjectEngineeringTools>()
+                         .WithTools<ProjectWriteTools>()
+                         .WithTools<WriteBatchTools>()
+                         .WithTools<NetworkWriteTools>();
+              }
+          },
+          auditDirectory,
+          startupProjectPath);
+  ```
+
+  Keep the existing generic overloads as thin delegates over `StartAsync(McpAccessMode.ReadWrite, ...)` so existing tests do not change behavior.
+
+- [ ] **Step 2: Write the failing protocol-first milestone tests**
+
+  Create `WriteToolMcpAnnotationProtocolTests.cs` with the real client-visible RED path:
+
+  ```csharp
+  private static readonly string[] ReadOnlyToolNames =
+  {
+      "browse_project_tree",
+      "execute_read_batch",
+      "get_project_status",
+      "network_read",
+  };
+
+  private static readonly string[] ReadWriteToolNames =
+  {
+      "apply_write_batch",
+      "archive_project",
+      "browse_project_tree",
+      "close_project",
+      "compile_check",
+      "create_project",
+      "execute_read_batch",
+      "get_project_status",
+      "network_read",
+      "network_write",
+      "open_project",
+      "preview_write_batch",
+      "save_project",
+      "save_project_as",
+  };
+
+  [Fact]
+  public async Task ToolsList_ReadWriteProductionSurface_ExposesExactNamesCountsAnnotations_AndRepresentativeSchemas()
+  {
+      await using var harness = await McpProtocolTestHarness.StartProductionSurfaceAsync(McpAccessMode.ReadWrite);
+      var tools = (await harness.Client.ListToolsAsync()).OrderBy(tool => tool.Name).ToArray();
+      var byName = tools.ToDictionary(tool => tool.Name, StringComparer.Ordinal);
+
+      Assert.Equal(ReadWriteToolNames, tools.Select(tool => tool.Name));
+      Assert.Equal(14, tools.Length);
+
+      Assert.True(byName["preview_write_batch"].Annotations!.ReadOnlyHint);
+      Assert.False(byName["preview_write_batch"].Annotations.DestructiveHint);
+      Assert.False(byName["preview_write_batch"].Annotations.OpenWorldHint);
+
+      Assert.False(byName["apply_write_batch"].Annotations!.ReadOnlyHint);
+      Assert.True(byName["apply_write_batch"].Annotations.DestructiveHint);
+      Assert.False(byName["apply_write_batch"].Annotations.OpenWorldHint);
+
+      Assert.False(byName["open_project"].Annotations!.ReadOnlyHint);
+      Assert.True(byName["open_project"].Annotations.DestructiveHint);
+      Assert.False(byName["open_project"].Annotations.OpenWorldHint);
+
+      Assert.Contains("\"operations\"", byName["preview_write_batch"].ProtocolTool.InputSchema.GetRawText(), StringComparison.Ordinal);
+      Assert.Contains("\"projectPath\"", byName["open_project"].ProtocolTool.InputSchema.GetRawText(), StringComparison.Ordinal);
+      Assert.Contains("\"confirm\"", byName["open_project"].ProtocolTool.InputSchema.GetRawText(), StringComparison.Ordinal);
+      Assert.Contains("\"safetyToken\"", byName["open_project"].ProtocolTool.InputSchema.GetRawText(), StringComparison.Ordinal);
+  }
+  ```
+
+  Add a second fact that starts `StartProductionSurfaceAsync(McpAccessMode.ReadOnly)`, asserts the exact `ReadOnlyToolNames` array and count `4`, and proves every write tool plus `compile_check` is absent.
+
+- [ ] **Step 3: Run the milestone RED and confirm the failure is protocol metadata, not reflection**
+
+  Run:
+
+  ```powershell
+  dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~WriteToolMcpAnnotationProtocolTests"
+  ```
+
+  Expected RED: `tools/list` returns the exact production-equivalent tool surface, but the write-tool annotation hints fail because `WriteBatchTools` and `ProjectWriteTools` have not yet declared the explicit mutability values required by the spec.
+
+- [ ] **Step 4: Add the smallest production annotation change across both registered write surfaces**
+
+  Update only the `McpServerTool` attributes on the registered write methods:
+
+  ```csharp
+  [McpServerTool(
+      Name = "preview_write_batch",
+      ReadOnly = true,
+      Destructive = false,
+      OpenWorld = false)]
+  public static Task<string> PreviewWriteBatch(...)
+
+  [McpServerTool(
+      Name = "apply_write_batch",
+      ReadOnly = false,
+      Destructive = true,
+      OpenWorld = false)]
+  public static Task<string> ApplyWriteBatch(...)
+  ```
+
+  and
+
+  ```csharp
+  [McpServerTool(
+      Name = "open_project",
+      ReadOnly = false,
+      Destructive = true,
+      OpenWorld = false)]
+  public static Task<string> OpenProject(...)
+  ```
+
+  Apply the same `ReadOnly=false`, `Destructive=true`, `OpenWorld=false` values to `CreateProject`, `SaveProject`, `SaveProjectAs`, `ArchiveProject`, and `CloseProject`.
+
+  Do not change descriptions, parameters, wrapper behavior, token flow, access-mode policy, or worker calls.
+
+- [ ] **Step 5: Re-run the focused protocol bundle and confirm GREEN**
+
+  Run:
+
+  ```powershell
+  dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~WriteToolMcpAnnotationProtocolTests|FullyQualifiedName~McpToolSchemaTests|FullyQualifiedName~ReadOnlyModeTests|FullyQualifiedName~ProjectStandaloneToolTests|FullyQualifiedName~NetworkToolsTests"
+  ```
+
+  Confirm all of the following in one bundle:
+
+  - `ListToolsAsync()` now emits the exact 14-tool read-write surface and 4-tool read-only surface;
+  - `compile_check` remains present only in read-write mode;
+  - the explicit write-tool hints are correct;
+  - representative protocol-visible schemas stay unchanged; and
+  - the existing schema tests still prove `workerClient` and `safety` never leak into model-facing inputs.
+
+- [ ] **Step 6: Add supplemental registered-class reflection regressions**
+
+  After the protocol milestone is green, add direct pinning tests to `BatchToolsTests` and `ProjectLifecycleToolTests`:
+
+  ```csharp
+  [Theory]
+  [InlineData(nameof(WriteBatchTools.PreviewWriteBatch), "preview_write_batch", true, false, false)]
+  [InlineData(nameof(WriteBatchTools.ApplyWriteBatch), "apply_write_batch", false, true, false)]
+  public void WriteBatchTools_RegisteredMethodsExposeExplicitMcpAnnotations(...)
+  ```
+
+  and
+
+  ```csharp
+  [Theory]
+  [InlineData(nameof(ProjectWriteTools.OpenProject), "open_project")]
+  [InlineData(nameof(ProjectWriteTools.CreateProject), "create_project")]
+  [InlineData(nameof(ProjectWriteTools.SaveProject), "save_project")]
+  [InlineData(nameof(ProjectWriteTools.SaveProjectAs), "save_project_as")]
+  [InlineData(nameof(ProjectWriteTools.ArchiveProject), "archive_project")]
+  [InlineData(nameof(ProjectWriteTools.CloseProject), "close_project")]
+  public void ProjectWriteTools_RegisteredMethodsExposeExplicitMutatingAnnotations(...)
+  ```
+
+  These are regression pins only. They are not the milestone RED evidence.
+
+- [ ] **Step 7: Run the supplemental metadata and safety regressions**
+
+  Run:
+
+  ```powershell
+  dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~BatchToolsTests|FullyQualifiedName~ProjectLifecycleToolTests|FullyQualifiedName~WriteToolSafetyTokenTests|FullyQualifiedName~LifecycleSecondIdentityValidationContractTests|FullyQualifiedName~BatchToolMetadataTests"
+  ```
+
+  Confirm only explicit annotation hints changed. Preview/apply behavior, token guidance, safety failures, and wrapper compatibility stay intact.
+
+- [ ] **Step 8: Stop at the commit boundary**
+
+  Do not commit without explicit authorization. When authorized, use:
+
+  ```powershell
+  git add TiaMcpServer.Tests/TestSupport/McpProtocolTestHarness.cs TiaMcpServer.Tests/Tools/WriteToolMcpAnnotationProtocolTests.cs TiaMcpServer/Batch/WriteBatchTools.cs TiaMcpServer/Tools/ProjectWriteTools.cs TiaMcpServer.Tests/Batch/BatchToolsTests.cs TiaMcpServer.Tests/Project/ProjectLifecycleToolTests.cs TiaMcpServer.Tests/Tools/McpToolSchemaTests.cs TiaMcpServer.Tests/Safety/ReadOnlyModeTests.cs
+  git commit -m "feat(write-safety): annotate registered MCP write tools"
+  ```
+
+### Task 2: Live V21 Harness, Acceptance Report, and Current Documentation
+
+**Files:**
+- Create: `scripts/live-test-write-tool-metadata.ps1`
+- Create: `TiaMcpServer.Tests/Tools/WriteToolMetadataLiveHarnessContractTests.cs`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md`
+- Modify: `docs/IMPROVEMENT_LOG.md`
+- Modify: `docs/README.md`
+- Modify: `docs/superpowers/README.md`
+- Create: `docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md`
+
+**Interfaces:**
+- Consumes: real `TiaMcpServer` stdio JSON-RPC startup in both `--read-only` and `--read-write` modes
+- Consumes: live calls `initialize`, `notifications/initialized`, `tools/list`, and `tools/call` to `get_project_status`
+- Produces: a read-only PowerShell 7 harness that records the exact 4-tool and 14-tool surfaces and the emitted write-tool hints from a live TIA Portal V21 session
+- Produces: a durable live report at `docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md`
+
+- [ ] **Step 1: Write the failing live-harness contract tests**
+
+  Create `WriteToolMetadataLiveHarnessContractTests.cs` using the same static source-inspection style as `NetworkLiveHarnessContractTests`:
+
+  ```csharp
+  [Fact]
+  public void Script_LaunchesTheRealMcpHostTwice_AndSpeaksInitializeListCallProtocol()
+  {
+      var text = ReadScript();
+
+      Assert.Matches(new Regex(@"--read-only"), text);
+      Assert.Matches(new Regex(@"--read-write"), text);
+      Assert.Contains("'initialize'", text, StringComparison.Ordinal);
+      Assert.Contains("notifications/initialized", text, StringComparison.Ordinal);
+      Assert.Contains("tools/list", text, StringComparison.Ordinal);
+      Assert.Contains("tools/call", text, StringComparison.Ordinal);
+      Assert.Contains("TiaMcpServer", text, StringComparison.Ordinal);
+      Assert.DoesNotContain("OpennessWorker.exe", text, StringComparison.Ordinal);
+  }
+  ```
+
+  Add companion facts that prove:
+
+  - `#Requires -Version 7` is present;
+  - `-ProjectPath` and `-ReportPath` are mandatory;
+  - the script never issues `confirm = $true`;
+  - the only `tools/call` target is `get_project_status`;
+  - the script records both exact expected tool-name arrays and counts `4` and `14`;
+  - the report path is under `docs/superpowers/acceptance/reports`;
+  - no ordinary test invokes the script.
+
+- [ ] **Step 2: Run the live-harness contract RED**
+
+  Run:
+
+  ```powershell
+  dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~WriteToolMetadataLiveHarnessContractTests"
+  ```
+
+  Expected RED: the script file does not exist yet, so the existence and protocol-shape assertions fail.
+
+- [ ] **Step 3: Implement the read-only live acceptance harness**
+
+  Build `scripts/live-test-write-tool-metadata.ps1` as a non-mutating harness:
+
+  ```powershell
+  #Requires -Version 7
+  [CmdletBinding()]
+  param(
+      [Parameter(Mandatory)]
+      [string]$ProjectPath,
+
+      [Parameter(Mandatory)]
+      [string]$ReportPath
+  )
+  ```
+
+  The script must:
+
+  - launch `TiaMcpServer`, not the worker executable;
+  - run one session with `--read-only` and one with `--read-write`;
+  - perform `initialize`, `notifications/initialized`, `tools/list`, and one benign `get_project_status` call in each session;
+  - capture the exact read-only and read-write tool names/counts and the emitted hints for `preview_write_batch`, `apply_write_batch`, `open_project`, `create_project`, `save_project`, `save_project_as`, `archive_project`, and `close_project`;
+  - write the markdown report to `docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md`;
+  - state explicitly that the run is non-mutating and proves only the tested live host/project/session combination.
+
+- [ ] **Step 4: Re-run the contract tests and review the harness source**
+
+  Run the Step 2 command again.
+
+  Then confirm by source review that the script:
+
+  - never reaches an apply path;
+  - never speaks direct worker IPC;
+  - never hides the report destination;
+  - never claims offline or FakeWorker evidence completes PR 1.
+
+- [ ] **Step 5: Update the current documentation authorities**
+
+  Make the smallest doc changes that keep the repository current:
+
+  - `docs/ARCHITECTURE.md`: explain that explicit MCP hints are untrusted client-facing metadata layered on top of the unchanged server-enforced preview/apply model.
+  - `docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md`: document the conservative mutating hints on lifecycle write tools and reiterate that the first call still previews.
+  - `docs/IMPROVEMENT_LOG.md`: record PR 1 completion, the live report path, and that PLC `start_plc` / `stop_plc` remains deferred.
+  - `docs/README.md`: add the acceptance report entry.
+  - `docs/superpowers/README.md`: ensure both this plan and the acceptance report are indexed.
+
+  Do not broaden scope into wrapper delegation, tag snapshot work, block/type diff evidence, or PLC control changes.
+
+- [ ] **Step 6: Run full offline verification**
+
+  Run serially:
+
+  ```powershell
+  dotnet build TiaMcpServer.sln --no-restore -m:1 --disable-build-servers /p:UseTiaPortalReferenceStubs=true
+  dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers
+  git diff --check
+  git status --short
+  ```
+
+  Record exact build/test totals. Review the final diff for accidental tool-surface drift, schema drift, write behavior hidden in the live harness, or missing documentation index entries.
+
+- [ ] **Step 7: Run the mandatory live V21 acceptance harness**
+
+  Run only with separate explicit authorization and an approved live `.ap21` project path:
+
+  ```powershell
+  pwsh -NoProfile -File scripts/live-test-write-tool-metadata.ps1 -ProjectPath "C:\Path\To\Disposable.ap21" -ReportPath "docs\superpowers\acceptance\reports\2026-09-01-pr1-explicit-mcp-tool-annotations-live.md"
+  ```
+
+  The saved report must include:
+
+  - exact TIA Portal V21 version;
+  - tested project copy path;
+  - exact 4-tool read-only surface and 14-tool read-write surface;
+  - emitted annotation hints for all PR 1 write tools;
+  - exact benign read call and result summary for each mode;
+  - confirmation that no mutation was performed; and
+  - the evidence boundary separating live MCP proof from offline/stub/FakeWorker proof.
+
+- [ ] **Step 8: Stop at the final commit boundary**
+
+  Do not commit without explicit authorization. When authorized, use:
+
+  ```powershell
+  git add scripts/live-test-write-tool-metadata.ps1 TiaMcpServer.Tests/Tools/WriteToolMetadataLiveHarnessContractTests.cs docs/ARCHITECTURE.md docs/SupportedOperations/PROJECT_OPERATIONS_SUMMARY.md docs/IMPROVEMENT_LOG.md docs/README.md docs/superpowers/README.md docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md
+  git commit -m "docs(write-safety): record explicit MCP tool annotations"
+  ```
+
+## Deferred and Out of Scope
+
+- Wrapper delegation belongs to PR 2. `BatchTools` and `ProjectLifecycleTools` remain compiled compatibility seams in PR 1.
+- `network_write` remains unchanged and serves only as the regression reference for conservative mutating hints.
+- No public tool names, tool counts, parameter names, output schemas, safety-token semantics, audit behavior, or access-mode policies change in PR 1.
+- PLC `start_plc` / `stop_plc` remains explicitly deferred. This plan must not quarantine, remove, or redesign those tools.
+- Offline, stub, and FakeWorker evidence does not complete PR 1. The pull request remains incomplete until the live TIA Portal V21 harness has run and the acceptance report exists.
+- No project mutation is authorized or required for PR 1 live acceptance.
+
+## Completion Gate
+
+PR 1 is complete only when all of the following are true:
+
+- [ ] The protocol milestone RED was observed through `ListToolsAsync()` on the production-equivalent surface before any production annotation change.
+- [ ] `WriteBatchTools` emits explicit registered hints matching the approved matrix.
+- [ ] `ProjectWriteTools` emits explicit registered hints matching the approved matrix.
+- [ ] The real MCP protocol `tools/list` surface proves the exact 4-tool read-only surface and 14-tool read-write surface.
+- [ ] `compile_check` remains present only in read-write mode.
+- [ ] Existing schema tests still prove no injected service parameters leaked into public tool inputs.
+- [ ] Supplemental reflection tests pin the registered-class hint values after the protocol milestone is green.
+- [ ] Full serial stub build and test verification passed with exact totals recorded.
+- [ ] `git diff --check` passed and `git status --short` shows only intended PR 1 files.
+- [ ] `scripts/live-test-write-tool-metadata.ps1` exists, passes its static contract tests, and launches the real host over MCP in both access modes.
+- [ ] `docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md` exists and records the live TIA V21 surfaces, hints, benign reads, and evidence boundary.
+- [ ] The final docs still state that PLC start/stop is deferred and that metadata hints do not replace server-enforced write safety.
+- [ ] Any commit happened only after explicit user authorization.

--- a/docs/superpowers/plans/2026-09-01-pr2-registered-tool-delegation.md
+++ b/docs/superpowers/plans/2026-09-01-pr2-registered-tool-delegation.md
@@ -1,0 +1,1453 @@
+# PR 2 Registered Tool Delegation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `WriteBatchTools` and `ProjectWriteTools` the direct behavioral authority for write safety, then reduce `BatchTools` and `ProjectLifecycleTools` to compatibility wrappers that delegate to the registered read/write classes without changing any public tool name, schema, or safety semantics.
+
+**Architecture:** Keep the registered MCP tool types as the only place that owns write-tool behavior. Migrate existing wrapper-oriented FakeWorker and protocol coverage onto the registered classes first, then replace the duplicated wrapper bodies with thin forwarding calls into `ReadBatchTools`/`WriteBatchTools` and `ProjectReadTools`/`ProjectWriteTools`. Acceptance is incomplete until a separately authorized live V21 MCP harness proves that the real host advertises the registered write surface and can perform one non-mutating generic-batch preview plus one non-mutating self-previewing lifecycle call.
+
+**Tech Stack:** C# 12, .NET 8 host/tests/FakeWorker, .NET Standard 2.0 contracts, .NET Framework 4.8 Openness worker, xUnit, ModelContextProtocol client/server SDK, PowerShell 7, newline-delimited JSON IPC.
+
+**Spec:** [Write-safety preview and registered-surface hardening design](../specs/2026-09-01-write-safety-hardening-design.md)
+
+## Global Constraints
+
+- Preserve the public MCP write-tool names and input schemas exactly: `preview_write_batch`, `apply_write_batch`, `open_project`, `create_project`, `save_project`, `save_project_as`, `archive_project`, and `close_project`.
+- `WriteBatchTools` and `ProjectWriteTools` are the behavioral authority after this PR. Delegation flows from `BatchTools` to `ReadBatchTools`/`WriteBatchTools` and from `ProjectLifecycleTools` to `ProjectReadTools`/`ProjectWriteTools`, never the other way around.
+- Do not weaken read-only denial, verified-binding requirements, envelope validation before expensive state reads, pinned binding lease behavior, single-use token behavior, token lifetime, current-state hashing, or audit append behavior.
+- Keep Siemens Openness calls in the net48 worker only. This PR changes host/wrapper ownership and tests, not the worker architecture.
+- Wrapper deletion is deferred. `BatchTools` and `ProjectLifecycleTools` must remain compiled compatibility seams after this PR.
+- `start_plc` and `stop_plc` remain explicitly deferred. Do not change their contracts, state binding, or implementation in this PR, and do not use them as evidence that PLC control is now supported.
+- Offline, stub, FakeWorker, and protocol tests are required but never sufficient. The PR is not complete until the live V21 harness runs and a dated acceptance report is written.
+- Use behavioral TDD where a production change is required: add the focused regression first, observe RED, implement the smallest production change, rerun to GREEN, then widen verification. Characterization tests that already pass on the registered classes are acceptable only before delegation; they do not satisfy acceptance on their own.
+- Run Windows .NET verification serially with `--no-restore -m:1 --disable-build-servers`. Use the stub build for repository verification: `/p:UseTiaPortalReferenceStubs=true`.
+- Do not rename tools, delete wrappers, change README landing-page promises, or broaden scope into PR 3+ snapshot work.
+
+---
+
+## File / Interface Map
+
+- `TiaMcpServer/Batch/WriteBatchTools.cs`
+  Registered generic write MCP tool type. Owns `PreviewWriteBatch(OpennessWorkerClient, WriteSafetyService, BatchOperationRequest[])` and `ApplyWriteBatch(OpennessWorkerClient, WriteSafetyService, BatchOperationRequest[], bool, string?)`.
+
+- `TiaMcpServer/Batch/ReadBatchTools.cs`
+  Registered generic read MCP tool type. Owns `ExecuteReadBatch(OpennessWorkerClient, BatchOperationRequest[])`.
+
+- `TiaMcpServer/Batch/BatchTools.cs`
+  Compatibility wrapper. After this PR it should contain only the existing descriptions plus thin delegating methods to the registered batch classes.
+
+- `TiaMcpServer/Tools/ProjectWriteTools.cs`
+  Registered lifecycle write MCP tool type. Owns `OpenProject`, `CreateProject`, `SaveProject`, `SaveProjectAs`, `ArchiveProject`, and `CloseProject`.
+
+- `TiaMcpServer/Tools/ProjectReadTools.cs`
+  Registered lifecycle read MCP tool type. Owns `GetProjectStatus(OpennessWorkerClient, string?)` and `BrowseProjectTree(...)`.
+
+- `TiaMcpServer/Tools/ProjectLifecycleTools.cs`
+  Compatibility wrapper. After this PR it should contain only the existing descriptions plus thin delegating methods to `ProjectReadTools` and `ProjectWriteTools`.
+
+- `TiaMcpServer.Tests/Batch/TypeOperationFakeWorkerTests.cs`
+  Existing registered-behavior candidate. Today it proves `update_type_content` preview/apply/replay through `BatchTools`; this PR should move that evidence onto `WriteBatchTools`.
+
+- `TiaMcpServer.Tests/Batch/BlockCurrentStateReadTests.cs`
+  Existing current-state format regression. Today it proves source-format block reads through `BatchTools`; this PR should move the end-to-end half onto `WriteBatchTools`.
+
+- `TiaMcpServer.Tests/Batch/BatchToolsTests.cs`
+  Keep as wrapper-compatibility coverage only. After delegation it should prove metadata and deterministic wrapper forwarding behavior, not remain the primary behavioral authority for registered writes.
+
+- `TiaMcpServer.FakeWorker/Program.cs`
+  Extend only as needed for PR 2 test support: add a dedicated generic-batch registered-write scenario that preserves current-state reads, returns one successful write, then one malformed worker response so the registered batch tests can prove request order, skip-on-failure semantics, and fail-closed protocol propagation.
+
+- `TiaMcpServer.Tests/Project/ProjectLifecycleToolTests.cs`
+  Keep as wrapper-compatibility coverage only. After delegation it should prove metadata and deterministic forwarding behavior, not remain the primary behavioral authority for registered lifecycle writes.
+
+- `TiaMcpServer.Tests/Safety/WriteToolSafetyTokenTests.cs`
+  Existing lifecycle token and surface-count authority. Retarget its direct lifecycle preview/replay/state-change cases from `ProjectLifecycleTools` to `ProjectWriteTools`, and retarget `ProjectReadAndLifecycleSurfaceIsExactlyEightTools` to the registered `ProjectReadTools` + `ProjectWriteTools` pair.
+
+- `TiaMcpServer.Tests/Worker/OpennessWorkerClientIntegrationTests.cs`
+  Already contains lifecycle FakeWorker scenarios such as `CollapsedOpenProject_PreviewThenApply_RoundTrips`, `CollapsedOpenProject_PreviewThenApply_WorkerFailureRendersFailureCategoryNeverSuccessShaped`, `SaveProject_PreviewAndApply_UseLifecycleProbeNotDirectStatus`, `SaveProjectAs_PreviewAndApply_UseLifecycleProbeNotDirectStatus`, `ArchiveProject_PreviewAndApply_UseLifecycleProbeNotDirectStatus`, and `CloseProject_PreviewAndApply_UseLifecycleProbeNotDirectStatus`. Move the tool-call authority in those tests from `ProjectLifecycleTools` to `ProjectWriteTools`.
+
+- `TiaMcpServer.Tests/Safety/ReadOnlyModeTests.cs`
+  Already has light registered coverage for `ProjectWriteTools`. Extend it only for targeted read-only/binding guards if a new dedicated test file would be thinner than widening the existing mega-fixture.
+
+- `TiaMcpServer.Tests/Safety/WriteSafetyLeaseConcurrencyTests.cs`
+  Existing direct `ProjectWriteTools.SaveProject(...)` lease evidence. Treat it as authoritative registered coverage and keep it green.
+
+- `TiaMcpServer.Tests/Safety/AuditIsolationTests.cs`
+  Existing lifecycle audit-isolation coverage. Move its direct behavior assertions from `ProjectLifecycleTools` to `ProjectWriteTools`, and add one registered generic-batch audit-isolation assertion so wrapper parity is no longer the only audit evidence.
+
+- `TiaMcpServer.Tests/TestSupport/McpProtocolTestHarness.cs`
+  In-process real MCP client/server harness over anonymous pipes. Use it for `tools/list` and `tools/call` assertions against the registered tool types.
+
+- `TiaMcpServer.Tests/Tools/McpToolSchemaTests.cs`
+  Existing whole-surface schema enumerator. Extend it so registered `WriteBatchTools` and `ProjectWriteTools` are asserted directly for exact public tool names, production surface counts, and DI-hidden service parameters, while the wrapper schema checks remain only compatibility coverage.
+
+- `scripts/live-test-write-safety-pr2-registered-tools.ps1`
+  New separately authorized live V21 MCP harness. Must start the real host, verify the registered surface via `tools/list`, perform a non-mutating lifecycle preview, and perform a non-mutating generic-batch preview against a verified startup binding.
+
+- `TiaMcpServer.Tests/Tools/RegisteredWriteToolsLiveHarnessContractTests.cs`
+  New static contract tests for the PR 2 live script. Must read the script text only; never execute it.
+
+- `docs/ARCHITECTURE.md`
+  Update the host tool-registration and compatibility-wrapper discussion so the current architecture states that the registered classes are the behavioral authority and the wrappers are compatibility shims.
+
+- `docs/IMPROVEMENT_LOG.md`
+  Record the completion of PR 2 and restate the deferred items that still remain out of scope.
+
+- `docs/README.md`
+  Add the new acceptance report to the docs index.
+
+- `docs/superpowers/README.md`
+  Add the new acceptance report entry in the superpowers historical index.
+
+- `docs/superpowers/acceptance/reports/2026-09-01-pr2-registered-tool-delegation-live.md`
+  Durable acceptance artifact for the separately authorized live run. Must record exact project copy, exact tool calls, and the explicit non-mutating evidence boundary.
+
+## Deferred And Out Of Scope
+
+- Wrapper deletion stays deferred. This PR ends with delegating wrappers still present and compiled.
+- `start_plc` / `stop_plc` state-binding and implementation hardening stay deferred exactly as described in the spec.
+- No new mutable-state snapshot fields, preview diff payloads, tag-scope narrowing, or project-tree narrowing belong in this PR.
+- No offline-only sign-off. A passing stub build, FakeWorker suite, or MCP protocol suite does not complete PR 2.
+- No user-facing tool renames, no schema edits, no token-format changes, no audit-format changes, and no landing-page README rewrite.
+
+### Task 1: Move Generic Batch Behavioral Authority To `WriteBatchTools`
+
+**Files:**
+
+- Create: `TiaMcpServer.Tests/Batch/WriteBatchToolsBehaviorTests.cs`
+- Modify: `TiaMcpServer.Tests/Batch/TypeOperationFakeWorkerTests.cs`
+- Modify: `TiaMcpServer.Tests/Batch/BlockCurrentStateReadTests.cs`
+- Modify: `TiaMcpServer.FakeWorker/Program.cs`
+- Review only: `TiaMcpServer/Batch/WriteBatchTools.cs`
+
+**Interfaces:**
+
+- Consumes: `WriteBatchTools.PreviewWriteBatch(OpennessWorkerClient workerClient, WriteSafetyService safety, BatchOperationRequest[] operations) -> Task<string>`
+- Consumes: `WriteBatchTools.ApplyWriteBatch(OpennessWorkerClient workerClient, WriteSafetyService safety, BatchOperationRequest[] operations, bool confirm = false, string? safetyToken = null) -> Task<string>`
+- Reuses unchanged: `FakeWorkerBinding.BindVerifiedAsync(OpennessWorkerClient client, ProjectSessionBinding binding, string projectPath) -> Task`
+- Reuses unchanged: `TempAuditDirectory.Path -> string`
+- Preserves: `BatchOperationRequest` public shape and every current `WriteBatchTools` description string
+
+- [ ] **Step 1: Add direct read-only and binding-gate characterization tests for the registered batch class**
+
+Create `WriteBatchToolsBehaviorTests.cs` with helpers copied from existing FakeWorker tests:
+
+```csharp
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tests.Worker;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class WriteBatchToolsBehaviorTests
+{
+    private static WriteSafetyService CreateSafety(TempAuditDirectory audit, ProjectSessionBinding binding)
+        => new(binding, () => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, audit.Path);
+
+    private static OpennessWorkerClient CreateClient(
+        ProjectSessionBinding binding,
+        McpAccessMode mode = McpAccessMode.ReadWrite)
+        => new(
+            binding,
+            logger: null,
+            workerExecutablePath: FakeWorkerLocator.Locate(),
+            accessPolicy: new OperationAccessPolicy(mode));
+
+    private static BatchOperationRequest CreateUserConstantOp(
+        string operationId,
+        string projectPath = "type-content-roundtrip",
+        string name = "Gain") => new()
+    {
+        OperationId = operationId,
+        Operation = "create_user_constant",
+        ProjectPath = projectPath,
+        TableName = "Constants",
+        Name = name,
+        DataType = "Int",
+        Value = "1",
+    };
+
+    [Fact]
+    public async Task PreviewWriteBatch_ReadOnlyMode_IsRejectedBeforeTokenIssuance()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        using var client = CreateClient(binding, McpAccessMode.ReadOnly);
+
+        var result = await WriteBatchTools.PreviewWriteBatch(
+            client,
+            CreateSafety(audit, binding),
+            new[] { CreateUserConstantOp("op-1") });
+
+        using var doc = JsonDocument.Parse(result);
+        Assert.False(doc.RootElement.GetProperty("success").GetBoolean());
+        Assert.Contains("read-only mode", doc.RootElement.GetProperty("error").GetString());
+        Assert.False(doc.RootElement.TryGetProperty("safetyToken", out _));
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_UnverifiedBinding_IsRejectedBeforeCurrentStateRead()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        using var client = CreateClient(binding);
+
+        var result = await WriteBatchTools.PreviewWriteBatch(
+            client,
+            CreateSafety(audit, binding),
+            new[] { CreateUserConstantOp("op-1") });
+
+        using var doc = JsonDocument.Parse(result);
+        Assert.False(doc.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal(
+            WorkerFailureCategories.BindingConflict,
+            doc.RootElement.GetProperty("failureCategory").GetString());
+        Assert.False(doc.RootElement.TryGetProperty("safetyToken", out _));
+    }
+}
+```
+
+These are characterization tests: they should pass immediately and capture the current registered behavior before any wrapper work begins.
+
+- [ ] **Step 2: Move the existing type-content preview/apply/replay test onto the registered class**
+
+In `TypeOperationFakeWorkerTests.cs`, replace the three wrapper calls with direct registered calls and rename the methods so the file advertises the correct authority:
+
+```csharp
+var result = await WriteBatchTools.PreviewWriteBatch(
+    client,
+    safety,
+    new[] { UpdateTypeContentOp("w1") });
+
+var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+var firstApply = await WriteBatchTools.ApplyWriteBatch(
+    client,
+    safety,
+    operations,
+    confirm: true,
+    safetyToken: token);
+var secondApply = await WriteBatchTools.ApplyWriteBatch(
+    client,
+    safety,
+    operations,
+    confirm: true,
+    safetyToken: token);
+```
+
+Rename:
+
+- `PreviewWriteBatch_UpdateTypeContent_ReturnsTokenAndDescriptivePreview`
+- `ApplyWriteBatch_UpdateTypeContent_SucceedsOnceThenRejectsReplayedToken`
+
+Do not leave `BatchTools` as the only tool name in the test text or comments.
+
+- [ ] **Step 3: Move the block source-format current-state regression onto the registered class**
+
+In `BlockCurrentStateReadTests.cs`, keep the invoker-only assertions as they are, but switch the end-to-end write-safety test to `WriteBatchTools`:
+
+```csharp
+var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+using var previewDoc = JsonDocument.Parse(preview);
+var token = previewDoc.RootElement.GetProperty("safetyToken").GetString();
+
+var apply = await WriteBatchTools.ApplyWriteBatch(
+    client,
+    safety,
+    operations,
+    confirm: true,
+    safetyToken: token);
+```
+
+Rename the test to `PreviewAndApplyWriteBatch_UpdateBlockLogicWithSourceFormat_ReadsCurrentStateAsSource_ThroughRegisteredTool`.
+
+- [ ] **Step 4: Run the direct registered batch slice**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~WriteBatchToolsBehaviorTests|FullyQualifiedName~TypeOperationFakeWorkerTests|FullyQualifiedName~BlockCurrentStateReadTests"
+```
+
+Expected: GREEN. If any characterization test is RED here, stop and fix the registered class before touching the wrappers.
+
+- [ ] **Step 5: Add a real MCP protocol test for the registered batch surface**
+
+Create `TiaMcpServer.Tests/Batch/WriteBatchToolsProtocolTests.cs`:
+
+```csharp
+using ModelContextProtocol.Protocol;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class WriteBatchToolsProtocolTests
+{
+    [Fact]
+    public async Task WriteBatchTools_AdvertisePreviewAndApplyOverToolsList()
+    {
+        await using var harness = await McpProtocolTestHarness.StartAsync<WriteBatchTools>();
+
+        var names = (await harness.Client.ListToolsAsync())
+            .Select(tool => tool.Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(new[] { "apply_write_batch", "preview_write_batch" }, names);
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_ProtocolCall_RejectsReadOperationsThroughTheRegisteredSurface()
+    {
+        await using var harness = await McpProtocolTestHarness.StartAsync<WriteBatchTools>();
+
+        var result = await harness.Client.CallToolAsync(
+            "preview_write_batch",
+            new Dictionary<string, object?>
+            {
+                ["operations"] = new object[]
+                {
+                    new
+                    {
+                        operationId = "bad-read",
+                        operation = "get_block_content",
+                        blockPath = "PLC_1/Blocks/Main"
+                    }
+                }
+            });
+
+        var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
+        Assert.Contains("\"success\":false", text, StringComparison.Ordinal);
+        Assert.Contains("get_block_content", text, StringComparison.Ordinal);
+    }
+}
+```
+
+The protocol test must go through `tools/list` and `tools/call`; direct method invocation is not enough.
+
+- [ ] **Step 6: Run the protocol slice**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~WriteBatchToolsProtocolTests"
+```
+
+Expected: GREEN.
+
+- [ ] **Step 7: Add direct registered coverage for ordered results, audit isolation, and protocol failure propagation**
+
+Extend `WriteBatchToolsBehaviorTests.cs` with an exact audit helper and one multi-item registered apply regression:
+
+```csharp
+private static int CountAuditLines(string directory)
+    => Directory.Exists(directory)
+        ? Directory.GetFiles(directory).Sum(file => File.ReadAllLines(file).Length)
+        : 0;
+
+[Fact]
+public async Task ApplyWriteBatch_RegisteredPath_PreservesRequestOrder_StopsOnProtocolFailure_SkipsLaterItems_AndWritesOnlyInjectedAudit()
+{
+    var defaultDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "TiaMcpServer",
+        "audit");
+    var defaultBefore = CountAuditLines(defaultDirectory);
+
+    using var audit = new TempAuditDirectory();
+    var binding = new ProjectSessionBinding(null);
+    using var client = CreateClient(binding);
+    var safety = CreateSafety(audit, binding);
+    const string scenario = "type-content-ordered-protocol-failure";
+    await FakeWorkerBinding.BindVerifiedAsync(client, binding, scenario);
+
+    var operations = new[]
+    {
+        UpdateTypeContentOp("first", scenario),
+        UpdateTypeContentOp("second", scenario),
+        UpdateTypeContentOp("third", scenario),
+    };
+
+    var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+    using var previewDoc = JsonDocument.Parse(preview);
+    var token = previewDoc.RootElement.GetProperty("safetyToken").GetString();
+
+    var applied = await WriteBatchTools.ApplyWriteBatch(
+        client,
+        safety,
+        operations,
+        confirm: true,
+        safetyToken: token);
+
+    using var appliedDoc = JsonDocument.Parse(applied);
+    var items = appliedDoc.RootElement.GetProperty("operations");
+
+    Assert.Equal(new[] { "first", "second", "third" }, items.EnumerateArray().Select(i => i.GetProperty("operationId").GetString()).ToArray());
+    Assert.Equal("succeeded", items[0].GetProperty("status").GetString());
+    Assert.Equal("failed", items[1].GetProperty("status").GetString());
+    Assert.Equal(WorkerFailureCategories.ProtocolError, items[1].GetProperty("failureCategory").GetString());
+    Assert.DoesNotContain("unexpectedShape", items[1].GetProperty("error").GetString(), StringComparison.Ordinal);
+    Assert.Equal("skipped", items[2].GetProperty("status").GetString());
+
+    Assert.True(Directory.Exists(audit.Path));
+    Assert.NotEmpty(Directory.GetFiles(audit.Path));
+    Assert.Equal(defaultBefore, CountAuditLines(defaultDirectory));
+}
+```
+
+This test makes the registered class, not `BatchTools`, prove:
+
+- request-order preservation in the returned operation list,
+- stop-on-first-failure semantics,
+- skip marking for later items,
+- `protocol_error` propagation without echoing raw malformed payloads, and
+- audit writes isolated to the injected directory.
+
+- [ ] **Step 8: Run the new registered batch regression and verify RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~WriteBatchToolsBehaviorTests.ApplyWriteBatch_RegisteredPath_PreservesRequestOrder_StopsOnProtocolFailure_SkipsLaterItems_AndWritesOnlyInjectedAudit"
+```
+
+Expected RED: the dedicated FakeWorker scenario does not exist yet, so the preview/apply path fails against `unknown scenario 'type-content-ordered-protocol-failure'`.
+
+- [ ] **Step 9: Add the dedicated FakeWorker scenario for registered batch ordering and protocol failure**
+
+In `TiaMcpServer.FakeWorker/Program.cs`, add one process-local counter near `updateBlockPostconditionAttempt`:
+
+```csharp
+var orderedTypeWriteCount = 0;
+```
+
+Then add this scenario next to `type-content-roundtrip`:
+
+```csharp
+case "type-content-ordered-protocol-failure":
+    Respond(ReadMethod(line) switch
+    {
+        "get_project_status" => """{"success":true,"payload":"{\"isOpen\":true}"}""",
+        "get_type_content" => """{"success":true,"payload":"TYPE AnalogInputSettings STRUCT Value : Real; END_STRUCT END_TYPE"}""",
+        "update_type_content" => ++orderedTypeWriteCount switch
+        {
+            1 => """{"success":true,"payload":"{}"}""",
+            2 => "this is not json",
+            _ => """{"success":false,"error":"third write should have been skipped"}"""
+        },
+        _ => $$"""{"success":false,"error":"expected get_project_status, get_type_content, or update_type_content, got '{{ReadMethod(line)}}'"}"""
+    });
+    break;
+```
+
+The third write must never be reached. Returning an explicit failure if it is reached prevents the test from silently passing with broken skip semantics.
+
+- [ ] **Step 10: Run the complete registered batch slice**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~WriteBatchToolsBehaviorTests|FullyQualifiedName~WriteBatchToolsProtocolTests|FullyQualifiedName~TypeOperationFakeWorkerTests|FullyQualifiedName~BlockCurrentStateReadTests"
+```
+
+Expected GREEN.
+
+- [ ] **Step 11: Review checkpoint**
+
+Confirm:
+
+- `WriteBatchTools` now carries direct FakeWorker and protocol evidence for read-only denial, binding gate, preview issuance, apply/replay, request-ordered write results, audit isolation, and fail-closed protocol propagation.
+- `BatchTools` is no longer the sole route exercised by type-content or block-write end-to-end tests.
+- No production MCP tool behavior changed in this task; only registered-class tests and FakeWorker test support changed.
+
+### Task 2: Move Lifecycle Behavioral Authority To `ProjectWriteTools`
+
+**Files:**
+
+- Create: `TiaMcpServer.Tests/Project/ProjectWriteToolsBehaviorTests.cs`
+- Create: `TiaMcpServer.Tests/Project/ProjectWriteToolsProtocolTests.cs`
+- Modify: `TiaMcpServer.Tests/Worker/OpennessWorkerClientIntegrationTests.cs`
+- Modify: `TiaMcpServer.Tests/Project/ProjectLifecycleToolTests.cs`
+- Modify: `TiaMcpServer.Tests/Safety/AuditIsolationTests.cs`
+- Modify: `TiaMcpServer.Tests/Safety/WriteToolSafetyTokenTests.cs`
+- Modify: `TiaMcpServer.Tests/Tools/McpToolSchemaTests.cs`
+- Review only: `TiaMcpServer/Tools/ProjectWriteTools.cs`
+
+**Interfaces:**
+
+- Consumes: `ProjectWriteTools.OpenProject(...) -> Task<string>`
+- Consumes: `ProjectWriteTools.CreateProject(...) -> Task<string>`
+- Consumes: `ProjectWriteTools.SaveProject(...) -> Task<string>`
+- Consumes: `ProjectWriteTools.SaveProjectAs(...) -> Task<string>`
+- Consumes: `ProjectWriteTools.ArchiveProject(...) -> Task<string>`
+- Consumes: `ProjectWriteTools.CloseProject(...) -> Task<string>`
+- Reuses unchanged: `FakeWorkerBinding.BindVerifiedAsync(OpennessWorkerClient client, ProjectSessionBinding binding, string projectPath) -> Task`
+- Preserves: `ProjectLifecycleTools` public signatures until the later delegation task
+
+- [ ] **Step 1: Move the deterministic lifecycle safety-token authority onto `ProjectWriteTools`**
+
+First retarget the existing lifecycle safety/token file so it no longer proves registered behavior through the compatibility wrapper:
+
+- keep `SeparatePreviewToolsAreGone`
+- change `ProjectReadAndLifecycleSurfaceIsExactlyEightTools` to enumerate `typeof(ProjectReadTools)` + `typeof(ProjectWriteTools)` instead of `ProjectLifecycleTools`
+- change `WriteToolWithoutToken_ReturnsPreviewWithTokenAndInstructions` to call `ProjectWriteTools.OpenProject(...)`
+- change `WriteToolWithTokenButNoConfirm_RejectsBeforeAnyWork` to call `ProjectWriteTools.CloseProject(...)`
+- change `WriteToolWithBadToken_PointsBackAtTheTokenlessCall`, `WriteToolWithChangedProjectPath_RendersBindingConflictEnvelope`, `WriteToolWithChangedInput_RendersValidationErrorEnvelope`, `WriteToolWithUsedToken_RendersValidationErrorEnvelope`, and `WriteToolWithChangedCurrentState_RendersStateChangedEnvelope` to call `ProjectWriteTools.OpenProject(...)`
+
+That should look like:
+
+```csharp
+var result = await ProjectWriteTools.OpenProject(
+    workerClient: null!,
+    safety,
+    projectPath: @"C:\Projects\Line.ap21");
+```
+
+and:
+
+```csharp
+var result = await ProjectWriteTools.CloseProject(
+    workerClient: null!,
+    safety,
+    confirm: false,
+    safetyToken: "some-token");
+```
+
+Then create `ProjectWriteToolsBehaviorTests.cs` and move the light wrapper-oriented `ProjectLifecycleToolTests` checks onto the registered class:
+
+```csharp
+using System.Text.Json;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tools;
+
+namespace TiaMcpServer.Tests.Project;
+
+public sealed class ProjectWriteToolsBehaviorTests
+{
+    [Fact]
+    public async Task OpenProject_WithTokenButNoConfirm_ReturnsRegisteredConfirmEnvelope()
+    {
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
+
+        var result = await ProjectWriteTools.OpenProject(
+            workerClient: null!,
+            safety,
+            projectPath: @"C:\Projects\Line.ap21",
+            confirm: false,
+            safetyToken: "fake-token");
+
+        Assert.Contains("confirm=true", result);
+        Assert.Contains("without safetyToken", result);
+    }
+
+    [Fact]
+    public async Task SaveProjectAs_WithTokenButNoConfirm_ReturnsRegisteredConfirmEnvelope()
+    {
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
+
+        var result = await ProjectWriteTools.SaveProjectAs(
+            workerClient: null!,
+            safety,
+            targetDirectory: @"C:\Target",
+            targetName: "Copy",
+            projectPath: null,
+            rebind: true,
+            confirm: false,
+            safetyToken: "fake-token");
+
+        Assert.Contains("confirm=true", result);
+        Assert.Contains("without safetyToken", result);
+    }
+
+    [Fact]
+    public async Task SaveProjectAs_RebindFalse_RejectsBeforePreviewTokenGeneration_OnRegisteredTool()
+    {
+        using var audit = new TempAuditDirectory();
+        var safety = audit.CreateSafety();
+
+        var response = await ProjectWriteTools.SaveProjectAs(
+            workerClient: null!,
+            safety,
+            targetDirectory: @"C:\Target",
+            targetName: "Copy",
+            projectPath: null,
+            rebind: false);
+
+        using var doc = JsonDocument.Parse(response);
+        Assert.False(doc.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal(
+            WorkerFailureCategories.ValidationError,
+            doc.RootElement.GetProperty("failureCategory").GetString());
+        Assert.False(doc.RootElement.TryGetProperty("safetyToken", out _));
+    }
+
+    [Fact]
+    public async Task SaveProjectAs_Apply_MissingCopiedPath_PropagatesPostconditionFailedAndWarning()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        var safety = new WriteSafetyService(
+            binding,
+            () => DateTimeOffset.UtcNow,
+            WriteSafetyService.DefaultTokenLifetime,
+            audit.Path);
+        using var client = new OpennessWorkerClient(
+            binding,
+            logger: null,
+            workerExecutablePath: FakeWorkerLocator.Locate());
+        await FakeWorkerBinding.BindVerifiedAsync(
+            client,
+            binding,
+            "save-as-uncertain-state");
+
+        var preview = await ProjectWriteTools.SaveProjectAs(
+            client,
+            safety,
+            targetDirectory: @"C:\Target",
+            targetName: "Copy",
+            projectPath: "save-as-uncertain-state",
+            rebind: true);
+        using var previewDoc = JsonDocument.Parse(preview);
+        var token = previewDoc.RootElement.GetProperty("safetyToken").GetString();
+
+        var applied = await ProjectWriteTools.SaveProjectAs(
+            client,
+            safety,
+            targetDirectory: @"C:\Target",
+            targetName: "Copy",
+            projectPath: "save-as-uncertain-state",
+            rebind: true,
+            confirm: true,
+            safetyToken: token);
+        using var appliedDoc = JsonDocument.Parse(applied);
+
+        Assert.False(appliedDoc.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal(
+            WorkerFailureCategories.PostconditionFailed,
+            appliedDoc.RootElement.GetProperty("failureCategory").GetString());
+        Assert.Contains(
+            "Project state may have changed",
+            appliedDoc.RootElement.GetProperty("warnings")[0].GetString(),
+            StringComparison.Ordinal);
+    }
+}
+```
+
+- [ ] **Step 2: Move the FakeWorker lifecycle roundtrip and worker-failure authority onto `ProjectWriteTools`**
+
+In `OpennessWorkerClientIntegrationTests.cs`, switch these exact tests from `ProjectLifecycleTools` to `ProjectWriteTools` without changing their scenario setup or assertions:
+
+- `CollapsedOpenProject_PreviewThenApply_RoundTrips`
+- `CollapsedOpenProject_PreviewThenApply_WorkerFailureRendersFailureCategoryNeverSuccessShaped`
+- `SaveProject_PreviewAndApply_UseLifecycleProbeNotDirectStatus`
+- `PostWriteVerification_UsesBasicStatusRead_NotExtendedMetadataRead`
+- `SaveProjectAs_PreviewAndApply_UseLifecycleProbeNotDirectStatus`
+- `ArchiveProject_PreviewAndApply_UseLifecycleProbeNotDirectStatus`
+- `ArchiveProject_PreviewRejectsArchiveDirectoryInsideProjectFolder_WithoutIssuingSafetyToken`
+- `CloseProject_PreviewAndApply_UseLifecycleProbeNotDirectStatus`
+
+The archive preview rejection case is mandatory registered authority in this PR: it must continue to prove that `ProjectWriteTools.ArchiveProject(...)` rejects an archive directory inside the project folder before issuing any `safetyToken` and before any audit append occurs.
+
+The only code change inside those methods should be the called tool class:
+
+```csharp
+var preview = await ProjectWriteTools.SaveProject(client, safety, projectPath: projectPath);
+var applied = await ProjectWriteTools.SaveProject(
+    client,
+    safety,
+    projectPath: projectPath,
+    confirm: true,
+    safetyToken: token);
+```
+
+and:
+
+```csharp
+var preview = await ProjectWriteTools.SaveProjectAs(
+    client,
+    safety,
+    targetDirectory: @"C:\Target",
+    targetName: "Copy",
+    projectPath: projectPath,
+    rebind: true);
+```
+
+- [ ] **Step 3: Migrate lifecycle audit-isolation tests to the registered class**
+
+In `AuditIsolationTests.cs`, replace every direct `ProjectLifecycleTools` call with the equivalent `ProjectWriteTools` call and rename the first test to `ProjectWriteTool_WritesAuditOnlyToTheInjectedDirectory`.
+
+Keep the exact counting strategy:
+
+```csharp
+private static int CountAuditLines(string directory)
+    => Directory.Exists(directory)
+        ? Directory.GetFiles(directory).Sum(file => File.ReadAllLines(file).Length)
+        : 0;
+```
+
+After the migration, `AuditIsolationTests` must directly prove all three registered lifecycle behaviors:
+
+- successful `ProjectWriteTools.OpenProject(...)` apply appends only to `audit.Path`,
+- safety-rejected `ProjectWriteTools.OpenProject(...)` apply appends nowhere, and
+- rejected `ProjectWriteTools.SaveProjectAs(..., rebind: false)` appends nowhere and never leaks to the default directory.
+
+- [ ] **Step 4: Extend `McpToolSchemaTests` so the registered write types are asserted directly**
+
+Keep the existing wrapper theories as compatibility coverage, but add direct registered checks:
+
+- `ProjectWriteTools_SchemaNeverExposesInjectedServiceParameters` with `[InlineData(nameof(ProjectWriteTools.OpenProject))]`, `[InlineData(nameof(ProjectWriteTools.CreateProject))]`, `[InlineData(nameof(ProjectWriteTools.SaveProject))]`, `[InlineData(nameof(ProjectWriteTools.SaveProjectAs))]`, `[InlineData(nameof(ProjectWriteTools.ArchiveProject))]`, and `[InlineData(nameof(ProjectWriteTools.CloseProject))]`
+- `WriteBatchTools_SchemaNeverExposesInjectedServiceParameters` with `[InlineData(nameof(WriteBatchTools.PreviewWriteBatch))]` and `[InlineData(nameof(WriteBatchTools.ApplyWriteBatch))]`
+- `RegisteredWriteToolSurface_ExposesExactlyEightApprovedTools` over `typeof(ProjectWriteTools)` + `typeof(WriteBatchTools)` with the exact set `apply_write_batch`, `archive_project`, `close_project`, `create_project`, `open_project`, `preview_write_batch`, `save_project`, and `save_project_as`
+- `OpenProject_SchemaStillExposesProjectPathAsAModelArgument_OnRegisteredTool` proving the registered type still exposes `projectPath`, `confirm`, and `safetyToken`
+
+Leave `McpToolSurface_ExposesExactlyFourteenApprovedTools()` in place as the full production-surface census, but stop relying on wrapper-only schema theories as the registered authority.
+
+- [ ] **Step 5: Add a real MCP protocol test for the registered lifecycle surface**
+
+Create `ProjectWriteToolsProtocolTests.cs`:
+
+```csharp
+using TiaMcpServer.Batch;
+using TiaMcpServer.Tools;
+
+namespace TiaMcpServer.Tests.Project;
+
+public sealed class ProjectWriteToolsProtocolTests
+{
+    [Fact]
+    public async Task RegisteredWriteTools_ToolsList_AdvertisesExactlyEightWriteTools()
+    {
+        await using var harness = await McpProtocolTestHarness.StartAsync<ProjectWriteTools, WriteBatchTools>();
+
+        var names = (await harness.Client.ListToolsAsync())
+            .Select(tool => tool.Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(
+            new[]
+            {
+                "apply_write_batch",
+                "archive_project",
+                "close_project",
+                "create_project",
+                "open_project",
+                "preview_write_batch",
+                "save_project",
+                "save_project_as"
+            },
+            names);
+    }
+
+    [Fact]
+    public async Task OpenProject_ProtocolPreview_ReturnsSafetyTokenThroughRegisteredTool()
+    {
+        await using var harness = await McpProtocolTestHarness.StartAsync<ProjectWriteTools>();
+
+        var result = await harness.Client.CallToolAsync(
+            "open_project",
+            new Dictionary<string, object?>
+            {
+                ["projectPath"] = @"C:\open\Line.ap21"
+            });
+
+        var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
+        Assert.Contains("safetyToken", text, StringComparison.Ordinal);
+        Assert.Contains("open_project", text, StringComparison.Ordinal);
+        Assert.Contains("Preview only", text, StringComparison.Ordinal);
+    }
+}
+```
+
+- [ ] **Step 6: Run the registered lifecycle slice**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~ProjectWriteToolsBehaviorTests|FullyQualifiedName~ProjectWriteToolsProtocolTests|FullyQualifiedName~WriteToolSafetyTokenTests|FullyQualifiedName~McpToolSchemaTests|FullyQualifiedName~AuditIsolationTests|FullyQualifiedName~OpennessWorkerClientIntegrationTests.CollapsedOpenProject_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.SaveProject_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.SaveProjectAs_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.ArchiveProject_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.ArchiveProject_PreviewRejectsArchiveDirectoryInsideProjectFolder_WithoutIssuingSafetyToken|FullyQualifiedName~OpennessWorkerClientIntegrationTests.CloseProject_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.PostWriteVerification_UsesBasicStatusRead_NotExtendedMetadataRead|FullyQualifiedName~WriteSafetyLeaseConcurrencyTests"
+```
+
+Expected: GREEN. If a moved test goes RED, fix `ProjectWriteTools` before delegating the wrapper.
+
+- [ ] **Step 7: Re-scope `ProjectLifecycleToolTests.cs` to wrapper-compatibility only**
+
+Keep the metadata theory in place, but rewrite the two direct behavior tests so they describe wrapper compatibility rather than registered authority:
+
+- keep `ProjectLifecycleToolsHaveMcpMetadata`
+- move `SaveProjectAsWithTokenButNoConfirm_Rejects` and `SaveProjectAs_RebindFalse_RejectsBeforePreviewTokenGeneration` to `ProjectWriteToolsBehaviorTests`
+- replace them later in Task 4 with explicit delegation tests
+
+This step should leave `ProjectLifecycleToolTests.cs` temporarily smaller, not larger.
+
+- [ ] **Step 8: Review checkpoint**
+
+Confirm:
+
+- `WriteToolSafetyTokenTests` now proves lifecycle preview, replay, binding-conflict, changed-input, and state-changed behavior through `ProjectWriteTools`, not `ProjectLifecycleTools`.
+- FakeWorker lifecycle preview/apply evidence now executes `ProjectWriteTools`, not `ProjectLifecycleTools`.
+- Direct registered lifecycle authority includes the archive-directory guard rejecting before issuing a token, before worker mutation, and before any audit append.
+- `AuditIsolationTests` now use `ProjectWriteTools` directly, so injected-audit-path coverage no longer depends on the wrapper.
+- `McpToolSchemaTests` now asserts `ProjectWriteTools` and `WriteBatchTools` directly for exact names, counts, and DI-hidden parameters.
+- Direct registered lifecycle coverage includes fail-closed `postcondition_failed` propagation with the worker warning preserved.
+- The protocol surface is asserted through `tools/list` and `tools/call`.
+- `WriteSafetyLeaseConcurrencyTests` still provides direct `ProjectWriteTools.SaveProject(...)` lease evidence.
+
+### Task 3: Replace `BatchTools` Logic With Thin Delegation To Registered Batch Classes
+
+**Files:**
+
+- Create: `TiaMcpServer.Tests/Batch/BatchToolsDelegationTests.cs`
+- Modify: `TiaMcpServer/Batch/BatchTools.cs`
+- Modify: `TiaMcpServer.Tests/Batch/BatchToolsTests.cs`
+
+**Interfaces:**
+
+- Produces: `BatchTools.ExecuteReadBatch(OpennessWorkerClient workerClient, BatchOperationRequest[] operations) -> Task<string>` delegating to `ReadBatchTools.ExecuteReadBatch(...)`
+- Produces: `BatchTools.PreviewWriteBatch(OpennessWorkerClient workerClient, WriteSafetyService safety, BatchOperationRequest[] operations) -> Task<string>` delegating to `WriteBatchTools.PreviewWriteBatch(...)`
+- Produces: `BatchTools.ApplyWriteBatch(OpennessWorkerClient workerClient, WriteSafetyService safety, BatchOperationRequest[] operations, bool confirm = false, string? safetyToken = null) -> Task<string>` delegating to `WriteBatchTools.ApplyWriteBatch(...)`
+- Removes from wrapper: `ReadCombinedCurrentStateAsync(...)`
+- Preserves: wrapper method signatures, descriptions, and compatibility comments
+
+- [ ] **Step 1: Add a failing wrapper-delegation regression that exposes the current drift**
+
+Create `BatchToolsDelegationTests.cs`:
+
+```csharp
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tests.Worker;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class BatchToolsDelegationTests
+{
+    private static WriteSafetyService CreateSafety(TempAuditDirectory audit, ProjectSessionBinding binding)
+        => new(binding, () => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, audit.Path);
+
+    private static OpennessWorkerClient CreateReadOnlyClient(ProjectSessionBinding binding)
+        => new(
+            binding,
+            logger: null,
+            workerExecutablePath: FakeWorkerLocator.Locate(),
+            accessPolicy: new OperationAccessPolicy(McpAccessMode.ReadOnly));
+
+    [Fact]
+    public async Task PreviewWriteBatch_WrapperMatchesRegisteredReadOnlyRejection()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        using var client = CreateReadOnlyClient(binding);
+        var safety = CreateSafety(audit, binding);
+        var operations = new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "op-1",
+                Operation = "create_user_constant",
+                TableName = "Constants",
+                Name = "Gain",
+                DataType = "Int",
+                Value = "1",
+                ProjectPath = "type-content-roundtrip"
+            }
+        };
+
+        var registered = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+        var wrapper = await BatchTools.PreviewWriteBatch(client, safety, operations);
+
+        using var registeredDoc = JsonDocument.Parse(registered);
+        using var wrapperDoc = JsonDocument.Parse(wrapper);
+
+        Assert.Equal(
+            registeredDoc.RootElement.GetProperty("failureCategory").GetString(),
+            wrapperDoc.RootElement.GetProperty("failureCategory").GetString());
+        Assert.Equal(
+            registeredDoc.RootElement.GetProperty("error").GetString(),
+            wrapperDoc.RootElement.GetProperty("error").GetString());
+        Assert.False(wrapperDoc.RootElement.TryGetProperty("safetyToken", out _));
+    }
+}
+```
+
+Expected RED: `WriteBatchTools` returns the explicit read-only rejection, while `BatchTools` still runs its own stale path and does not match it.
+
+- [ ] **Step 2: Run the failing wrapper batch regression**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~BatchToolsDelegationTests.PreviewWriteBatch_WrapperMatchesRegisteredReadOnlyRejection"
+```
+
+Expected RED: assertion mismatch on `error` and possibly `failureCategory`.
+
+- [ ] **Step 3: Replace the wrapper bodies with direct forwarding calls**
+
+In `BatchTools.cs`, keep the class summary and descriptions, but replace the method bodies with thin forwarding only:
+
+```csharp
+public static Task<string> ExecuteReadBatch(
+    OpennessWorkerClient workerClient,
+    BatchOperationRequest[] operations)
+    => ReadBatchTools.ExecuteReadBatch(workerClient, operations);
+
+public static Task<string> PreviewWriteBatch(
+    OpennessWorkerClient workerClient,
+    WriteSafetyService safety,
+    BatchOperationRequest[] operations)
+    => WriteBatchTools.PreviewWriteBatch(workerClient, safety, operations);
+
+public static Task<string> ApplyWriteBatch(
+    OpennessWorkerClient workerClient,
+    WriteSafetyService safety,
+    BatchOperationRequest[] operations,
+    bool confirm = false,
+    string? safetyToken = null)
+    => WriteBatchTools.ApplyWriteBatch(
+        workerClient,
+        safety,
+        operations,
+        confirm,
+        safetyToken);
+```
+
+Delete the now-unused `ReadCombinedCurrentStateAsync` helper from `BatchTools.cs`.
+
+- [ ] **Step 4: Re-scope `BatchToolsTests.cs` to wrapper compatibility**
+
+Keep the metadata theory and deterministic invalid-input checks, but ensure the file no longer claims wrapper authority. Add one more exact forwarding assertion beside the new read-only regression:
+
+```csharp
+[Fact]
+public async Task ApplyWriteBatch_WrapperMatchesRegisteredBadTokenEnvelope()
+{
+    using var audit = new TempAuditDirectory();
+    var safety = audit.CreateSafety();
+    var operations = new[]
+    {
+        new BatchOperationRequest
+        {
+            OperationId = "op-1",
+            Operation = "create_user_constant",
+            TableName = "Constants",
+            Name = "Gain",
+            DataType = "Int",
+            Value = "1",
+            ProjectPath = "type-content-roundtrip"
+        }
+    };
+
+    var registered = await WriteBatchTools.ApplyWriteBatch(
+        workerClient: null!,
+        safety,
+        operations,
+        confirm: true,
+        safetyToken: "bogus-token");
+    var wrapper = await BatchTools.ApplyWriteBatch(
+        workerClient: null!,
+        safety,
+        operations,
+        confirm: true,
+        safetyToken: "bogus-token");
+
+    Assert.Equal(registered, wrapper);
+}
+```
+
+- [ ] **Step 5: Run the batch delegation slice**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~BatchToolsDelegationTests|FullyQualifiedName~BatchToolsTests|FullyQualifiedName~WriteBatchToolsBehaviorTests|FullyQualifiedName~TypeOperationFakeWorkerTests|FullyQualifiedName~BlockCurrentStateReadTests"
+```
+
+Expected GREEN.
+
+- [ ] **Step 6: Review checkpoint**
+
+Confirm:
+
+- `BatchTools.cs` is now a thin compatibility layer with no duplicated write-safety logic.
+- The registered batch classes still own every behavioral test that matters.
+- The wrapper still exists and still preserves the public static signatures.
+
+### Task 4: Replace `ProjectLifecycleTools` Logic With Thin Delegation To Registered Project Classes
+
+**Files:**
+
+- Create: `TiaMcpServer.Tests/Project/ProjectLifecycleDelegationTests.cs`
+- Modify: `TiaMcpServer/Tools/ProjectLifecycleTools.cs`
+- Modify: `TiaMcpServer.Tests/Project/ProjectLifecycleToolTests.cs`
+
+**Interfaces:**
+
+- Produces: `ProjectLifecycleTools.GetProjectStatus(OpennessWorkerClient workerClient, string? projectPath = null) -> Task<string>` delegating to `ProjectReadTools.GetProjectStatus(...)`
+- Produces: `ProjectLifecycleTools.OpenProject(...) -> Task<string>` delegating to `ProjectWriteTools.OpenProject(...)`
+- Produces: `ProjectLifecycleTools.CreateProject(...) -> Task<string>` delegating to `ProjectWriteTools.CreateProject(...)`
+- Produces: `ProjectLifecycleTools.SaveProject(...) -> Task<string>` delegating to `ProjectWriteTools.SaveProject(...)`
+- Produces: `ProjectLifecycleTools.SaveProjectAs(...) -> Task<string>` delegating to `ProjectWriteTools.SaveProjectAs(...)`
+- Produces: `ProjectLifecycleTools.ArchiveProject(...) -> Task<string>` delegating to `ProjectWriteTools.ArchiveProject(...)`
+- Produces: `ProjectLifecycleTools.CloseProject(...) -> Task<string>` delegating to `ProjectWriteTools.CloseProject(...)`
+- Removes from wrapper: `RejectIfArchiveDirectoryWithinProjectFolder`, `ApplyInstructions`, `ConfirmRequired`, `SafetyFailure`, `CreatePinnedPreviewAsync`, `PreviewHint`
+
+- [ ] **Step 1: Add a failing lifecycle wrapper-delegation regression**
+
+Create `ProjectLifecycleDelegationTests.cs`:
+
+```csharp
+using System.Text.Json;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tools;
+using TiaMcpServer.Tests.Worker;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Tests.Project;
+
+public sealed class ProjectLifecycleDelegationTests
+{
+    private static WriteSafetyService CreateSafety(TempAuditDirectory audit, ProjectSessionBinding binding)
+        => new(binding, () => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, audit.Path);
+
+    private static OpennessWorkerClient CreateClient(ProjectSessionBinding binding)
+        => new(
+            binding,
+            logger: null,
+            workerExecutablePath: FakeWorkerLocator.Locate(),
+            accessPolicy: new OperationAccessPolicy(McpAccessMode.ReadWrite));
+
+    [Fact]
+    public async Task SaveProject_WrapperMatchesRegisteredBindingGate()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        var safety = CreateSafety(audit, binding);
+        using var client = CreateClient(binding);
+
+        var registered = await ProjectWriteTools.SaveProject(client, safety, projectPath: null);
+        var wrapper = await ProjectLifecycleTools.SaveProject(client, safety, projectPath: null);
+
+        using var registeredDoc = JsonDocument.Parse(registered);
+        using var wrapperDoc = JsonDocument.Parse(wrapper);
+
+        Assert.Equal(
+            registeredDoc.RootElement.GetProperty("failureCategory").GetString(),
+            wrapperDoc.RootElement.GetProperty("failureCategory").GetString());
+        Assert.Equal(
+            registeredDoc.RootElement.GetProperty("error").GetString(),
+            wrapperDoc.RootElement.GetProperty("error").GetString());
+        Assert.False(wrapperDoc.RootElement.TryGetProperty("safetyToken", out _));
+    }
+}
+```
+
+Expected RED: `ProjectWriteTools.SaveProject(...)` rejects the unverified binding before preview, while `ProjectLifecycleTools.SaveProject(...)` still follows its duplicated older path.
+
+- [ ] **Step 2: Run the failing lifecycle wrapper regression**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~ProjectLifecycleDelegationTests.SaveProject_WrapperMatchesRegisteredBindingGate"
+```
+
+Expected RED: assertion mismatch on the returned failure envelope.
+
+- [ ] **Step 3: Replace `ProjectLifecycleTools` with thin forwarding methods**
+
+In `ProjectLifecycleTools.cs`, preserve the summaries and public signatures, but replace each body with a one-line forwarder:
+
+```csharp
+public static Task<string> GetProjectStatus(
+    OpennessWorkerClient workerClient,
+    string? projectPath = null)
+    => ProjectReadTools.GetProjectStatus(workerClient, projectPath);
+
+public static Task<string> SaveProject(
+    OpennessWorkerClient workerClient,
+    WriteSafetyService safety,
+    string? projectPath = null,
+    bool confirm = false,
+    string? safetyToken = null)
+    => ProjectWriteTools.SaveProject(
+        workerClient,
+        safety,
+        projectPath,
+        confirm,
+        safetyToken);
+```
+
+Repeat that exact pattern for `OpenProject`, `CreateProject`, `SaveProjectAs`, `ArchiveProject`, and `CloseProject`, forwarding every parameter unchanged and in order.
+
+After the last forwarder lands, remove the private helper methods that no longer have callers.
+
+- [ ] **Step 4: Re-scope `ProjectLifecycleToolTests.cs` to wrapper compatibility**
+
+Keep the metadata theory. Replace the old direct behavior tests with wrapper-vs-registered compatibility checks:
+
+```csharp
+[Fact]
+public async Task SaveProjectAs_WrapperMatchesRegisteredRebindFalseValidation()
+{
+    using var audit = new TempAuditDirectory();
+    var safety = audit.CreateSafety();
+
+    var registered = await ProjectWriteTools.SaveProjectAs(
+        workerClient: null!,
+        safety,
+        targetDirectory: @"C:\Target",
+        targetName: "Copy",
+        projectPath: null,
+        rebind: false);
+    var wrapper = await ProjectLifecycleTools.SaveProjectAs(
+        workerClient: null!,
+        safety,
+        targetDirectory: @"C:\Target",
+        targetName: "Copy",
+        projectPath: null,
+        rebind: false);
+
+    Assert.Equal(registered, wrapper);
+}
+```
+
+Add a similar read-path forwarding assertion for `GetProjectStatus` using the `status-no-project` FakeWorker scenario and exact text equality. Wrapper schema theories in `McpToolSchemaTests` remain compatibility checks only; they are no longer the registered write-surface authority.
+
+- [ ] **Step 5: Run the lifecycle delegation slice**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~ProjectLifecycleDelegationTests|FullyQualifiedName~ProjectLifecycleToolTests|FullyQualifiedName~ProjectWriteToolsBehaviorTests|FullyQualifiedName~ProjectWriteToolsProtocolTests|FullyQualifiedName~WriteToolSafetyTokenTests|FullyQualifiedName~McpToolSchemaTests|FullyQualifiedName~OpennessWorkerClientIntegrationTests.CollapsedOpenProject_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.SaveProject_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.SaveProjectAs_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.ArchiveProject_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.ArchiveProject_PreviewRejectsArchiveDirectoryInsideProjectFolder_WithoutIssuingSafetyToken|FullyQualifiedName~OpennessWorkerClientIntegrationTests.CloseProject_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.PostWriteVerification_UsesBasicStatusRead_NotExtendedMetadataRead|FullyQualifiedName~WriteSafetyLeaseConcurrencyTests"
+```
+
+Expected GREEN.
+
+- [ ] **Step 6: Review checkpoint**
+
+Confirm:
+
+- `ProjectLifecycleTools.cs` no longer owns any lifecycle write-safety behavior.
+- The registered project classes remain the only behavioral authority.
+- Wrapper compatibility still exists for direct callers and tests.
+
+### Task 5: Add The Mandatory Live V21 Registered-Surface Harness And Durable Acceptance Report
+
+**Files:**
+
+- Create: `scripts/live-test-write-safety-pr2-registered-tools.ps1`
+- Create: `TiaMcpServer.Tests/Tools/RegisteredWriteToolsLiveHarnessContractTests.cs`
+- Create: `docs/superpowers/acceptance/reports/2026-09-01-pr2-registered-tool-delegation-live.md`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/IMPROVEMENT_LOG.md`
+- Modify: `docs/README.md`
+- Modify: `docs/superpowers/README.md`
+
+**Interfaces:**
+
+- Consumes real host startup path support: `dotnet run --project TiaMcpServer -- --project C:\Sandbox\Pr2RegisteredTools.ap21`
+- Consumes registered MCP tool name census: `execute_read_batch`, `preview_write_batch`, `apply_write_batch`, `open_project`, `create_project`, `save_project`, `save_project_as`, `archive_project`, `close_project`
+- Produces actual preview-only `tools/call` traffic for `execute_read_batch`, `preview_write_batch`, and tokenless `save_project` only
+- Produces durable report sections: runtime/version, disposable target, tool list evidence, generic batch preview evidence, lifecycle preview evidence, and explicit non-mutation boundary
+- Preserves: no apply path in this PR 2 live harness
+
+- [ ] **Step 1: Add static contract tests for the live script**
+
+Create `RegisteredWriteToolsLiveHarnessContractTests.cs`:
+
+```csharp
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Tools;
+
+public sealed class RegisteredWriteToolsLiveHarnessContractTests
+{
+    private static readonly string ScriptPath = Path.GetFullPath(
+        Path.Combine(GetRepositoryRoot(), "scripts", "live-test-write-safety-pr2-registered-tools.ps1"));
+
+    [Fact]
+    public void Script_RequiresPowerShell7_AndRealMcpProtocol()
+    {
+        var text = File.ReadAllText(ScriptPath);
+        Assert.Matches(new Regex(@"^\s*#Requires\s+-Version\s+7(\.\d+)?\s*$", RegexOptions.Multiline), text);
+        Assert.Contains("'initialize'", text, StringComparison.Ordinal);
+        Assert.Contains("notifications/initialized", text, StringComparison.Ordinal);
+        Assert.Contains("'tools/list'", text, StringComparison.Ordinal);
+        Assert.Contains("'tools/call'", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_ListsAllRegisteredWriteTools_ButNeverConstructsAnApplyToolCall()
+    {
+        var text = File.ReadAllText(ScriptPath);
+        Assert.Contains("apply_write_batch", text, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Invoke-PreviewToolCall -ToolName 'apply_write_batch'",
+            text,
+            StringComparison.Ordinal);
+        var calls = ExtractPreviewToolCalls(text);
+
+        Assert.Equal(
+            new[] { "execute_read_batch", "preview_write_batch", "save_project" },
+            calls.Select(call => call.Name).ToArray());
+        Assert.All(
+            calls,
+            call =>
+            {
+                Assert.DoesNotContain("confirm = $true", call.ArgumentsBlock, StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain("safetyToken", call.ArgumentsBlock, StringComparison.OrdinalIgnoreCase);
+            });
+        Assert.DoesNotContain("Read-Host", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_RequiresProjectAndTypePath_AndStartsTheHostWithStartupBinding()
+    {
+        var text = File.ReadAllText(ScriptPath);
+        Assert.Matches(new Regex(@"\[Parameter\(Mandatory\)\]\s*\[string\]\s*\$ProjectPath"), text);
+        Assert.Matches(new Regex(@"\[Parameter\(Mandatory\)\]\s*\[string\]\s*\$TypePath"), text);
+        Assert.Contains("--project", text, StringComparison.Ordinal);
+        Assert.Contains("preview_write_batch", text, StringComparison.Ordinal);
+        Assert.Contains("save_project", text, StringComparison.Ordinal);
+    }
+
+    private static (string Name, string ArgumentsBlock)[] ExtractPreviewToolCalls(string text)
+        => Regex.Matches(
+                text,
+                @"Invoke-PreviewToolCall\s+-ToolName\s+'(?<name>[^']+)'\s+-Arguments\s+@\{(?<args>.*?)\}",
+                RegexOptions.Singleline)
+            .Select(match => (match.Groups["name"].Value, match.Groups["args"].Value))
+            .ToArray();
+
+    private static string GetRepositoryRoot()
+        => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+}
+```
+
+- [ ] **Step 2: Run the contract tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~RegisteredWriteToolsLiveHarnessContractTests"
+```
+
+Expected RED: the script and report do not exist yet.
+
+- [ ] **Step 3: Implement the preview-only live harness**
+
+Create `scripts/live-test-write-safety-pr2-registered-tools.ps1` with these fixed properties:
+
+- declare one explicit expected-name list for `tools/list` containing the nine names `execute_read_batch`, `preview_write_batch`, `apply_write_batch`, `open_project`, `create_project`, `save_project`, `save_project_as`, `archive_project`, and `close_project`
+- declare one preview-only helper call site with the exact form `Invoke-PreviewToolCall -ToolName '...' -Arguments @{ ... }`, and use it exactly three times: `execute_read_batch`, `preview_write_batch`, and `save_project`
+- never construct an `apply_write_batch` `tools/call` payload
+- never construct any lifecycle `confirm = $true` or `safetyToken` apply request
+- keep the script non-interactive: no `Read-Host`
+
+The presence of `apply_write_batch` in the script must come only from the expected-name list used to validate `tools/list`, never from any `tools/call` helper invocation or payload construction.
+
+```powershell
+#Requires -Version 7
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $ProjectPath,
+    [Parameter(Mandatory)] [string] $TypePath,
+    [string] $HostExecutable = 'dotnet',
+    [string[]] $HostArguments,
+    [int] $StartupTimeoutSeconds = 30
+)
+
+if (-not $HostArguments -or $HostArguments.Count -eq 0) {
+    $HostArguments = @('run', '--project', 'TiaMcpServer', '--', '--project', $ProjectPath)
+}
+```
+
+The script must:
+
+1. Start the real `TiaMcpServer` host, never `OpennessWorker.exe`.
+2. Speak newline-delimited JSON-RPC over stdio.
+3. Call `tools/list` and assert these nine names are present:
+
+```text
+execute_read_batch
+apply_write_batch
+archive_project
+close_project
+create_project
+open_project
+preview_write_batch
+save_project
+save_project_as
+```
+
+4. Call `execute_read_batch` with one `get_type_content` operation against `$TypePath` and `$ProjectPath`.
+5. Use the returned content verbatim as the `sourceContent` of a one-item `preview_write_batch` request for `update_type_content`.
+6. Call `save_project` without a `safetyToken`.
+7. Print the returned `safetyToken`, `requestedInputHash`, `currentStateHash`, `instructions`, and a final line stating that no apply call was issued.
+
+Do not add any apply mode, confirm switch, or mutation path to this script.
+
+- [ ] **Step 4: Run the contract tests and verify GREEN**
+
+Run the Step 2 command again.
+
+Expected GREEN: the script is present, PowerShell 7 only, preview only, host-launched, and bound to the registered tool names.
+
+- [ ] **Step 5: Execute the mandatory live V21 harness under the separate authorization gate**
+
+Run only after explicit live authorization and against a disposable or backed-up V21 project copy:
+
+```powershell
+pwsh -File scripts/live-test-write-safety-pr2-registered-tools.ps1 -ProjectPath C:\Sandbox\Pr2RegisteredTools.ap21 -TypePath "PLC_1/Types/AnalogInputSettings"
+```
+
+Acceptance requirements for the live run:
+
+- `tools/list` shows the eight registered write-tool names from the real host.
+- `tools/list` also shows `execute_read_batch`, because the harness uses the real registered read class for the non-mutating baseline read.
+- `execute_read_batch` returns the selected type content successfully.
+- `preview_write_batch` returns a token and hashes without mutating the project.
+- `save_project` without a token returns a self-previewing token and instructions without mutating the project.
+- The report states explicitly that no apply call was made.
+
+If the live run cannot be completed, the PR remains incomplete even if every offline test is green.
+
+- [ ] **Step 6: Write the durable acceptance report**
+
+Create `docs/superpowers/acceptance/reports/2026-09-01-pr2-registered-tool-delegation-live.md` with this structure and fill it with the actual observed values:
+
+```markdown
+# Acceptance Test Report - PR 2 Registered Tool Delegation (live TIA Portal V21)
+
+**Date:** 2026-09-01
+**Runtime:** Real TIA Portal V21, read-write MCP host started with the exact `--project` path used for the run
+**Harness:** `scripts/live-test-write-safety-pr2-registered-tools.ps1`
+**Boundary:** Preview only. No `apply_write_batch`, no lifecycle apply call, no project save, and no PLC mode change were performed.
+
+## Purpose
+
+Document that the real host advertises the registered write surface and that both a generic batch preview and a self-previewing lifecycle call succeed without mutation.
+
+## Tool List Evidence
+
+- exact eight advertised write-tool names
+- `execute_read_batch` also present and used only for the baseline non-mutating read
+
+## Generic Batch Preview Evidence
+
+- exact `TypePath`
+- exact `operationId`
+- token present
+- `requestedInputHash`
+- `currentStateHash`
+- instructions text
+
+## Lifecycle Preview Evidence
+
+- exact tool name (`save_project`)
+- token present
+- `requestedInputHash`
+- `currentStateHash`
+- instructions text
+
+## Notes And Limits
+
+- disposable project identity
+- whether the project was already open in TIA
+- no apply call issued
+- no production/plant acceptance claimed
+```
+
+Do not leave placeholder markers, blank fields, or omitted hashes in the committed report.
+
+- [ ] **Step 7: Update the current documentation authorities**
+
+Make only the documentation changes this PR actually justifies:
+
+- In `docs/ARCHITECTURE.md`, state that `Program.cs` registers `ProjectReadTools`, `ReadBatchTools`, `ProjectWriteTools`, and `WriteBatchTools`, and that `ProjectLifecycleTools` / `BatchTools` remain compatibility wrappers only.
+- In `docs/IMPROVEMENT_LOG.md`, record PR 2 as completed only after the live report exists, and restate that wrapper deletion and PLC start/stop hardening remain deferred.
+- In `docs/README.md` and `docs/superpowers/README.md`, add the new acceptance report entry so it is reachable.
+
+Do not change `README.md` unless the implementation uncovered a real landing-page behavior error.
+
+### Task 6: Full Verification And Final Scope Audit
+
+**Files:**
+
+- Review: every file changed by Tasks 1-5
+
+**Verification boundary:**
+
+- Establishes: registered-class behavioral authority, wrapper delegation correctness, protocol surface advertisement, FakeWorker round trips, lease behavior, and live preview-only acceptance.
+- Does not establish: PLC control support, PR 3+ snapshot changes, any write apply beyond preview semantics, or physical plant acceptance.
+
+- [ ] **Step 1: Run the complete focused PR 2 suite**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~WriteBatchToolsBehaviorTests|FullyQualifiedName~WriteBatchToolsProtocolTests|FullyQualifiedName~BatchToolsDelegationTests|FullyQualifiedName~TypeOperationFakeWorkerTests|FullyQualifiedName~BlockCurrentStateReadTests|FullyQualifiedName~ProjectWriteToolsBehaviorTests|FullyQualifiedName~ProjectWriteToolsProtocolTests|FullyQualifiedName~ProjectLifecycleDelegationTests|FullyQualifiedName~ProjectLifecycleToolTests|FullyQualifiedName~WriteToolSafetyTokenTests|FullyQualifiedName~McpToolSchemaTests|FullyQualifiedName~AuditIsolationTests|FullyQualifiedName~OpennessWorkerClientIntegrationTests.CollapsedOpenProject_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.SaveProject_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.SaveProjectAs_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.ArchiveProject_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.ArchiveProject_PreviewRejectsArchiveDirectoryInsideProjectFolder_WithoutIssuingSafetyToken|FullyQualifiedName~OpennessWorkerClientIntegrationTests.CloseProject_|FullyQualifiedName~OpennessWorkerClientIntegrationTests.PostWriteVerification_UsesBasicStatusRead_NotExtendedMetadataRead|FullyQualifiedName~WriteSafetyLeaseConcurrencyTests|FullyQualifiedName~RegisteredWriteToolsLiveHarnessContractTests"
+```
+
+Expected GREEN.
+
+- [ ] **Step 2: Run the full serial repository test suite**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo
+```
+
+Expected GREEN. Any failure in the moved registered-write paths is in scope and must be fixed before sign-off.
+
+- [ ] **Step 3: Run the stub solution build**
+
+Run:
+
+```powershell
+dotnet build TiaMcpServer.sln --no-restore -m:1 --disable-build-servers --nologo /p:UseTiaPortalReferenceStubs=true
+```
+
+Expected GREEN.
+
+- [ ] **Step 4: Audit whitespace and scope**
+
+Run:
+
+```powershell
+git diff --check
+git status --short
+git diff --stat
+```
+
+Confirm all of the following before reporting completion:
+
+- `BatchTools.cs` and `ProjectLifecycleTools.cs` are thin wrappers only.
+- `WriteBatchTools` and `ProjectWriteTools` own the direct behavioral tests.
+- No public tool name, description, or input schema changed.
+- No token format, token lifetime, current-state hash, or audit format changed.
+- `start_plc` / `stop_plc` were not modified.
+- The live acceptance report exists and states that no apply call was issued.
+- `docs/README.md` and `docs/superpowers/README.md` include the new report entry.
+
+- [ ] **Step 5: Final report**
+
+Report:
+
+- which tests were moved from wrapper authority to registered authority;
+- which wrapper regressions went RED before delegation and why;
+- the focused suite, full suite, stub build, and live harness results;
+- the explicit non-mutation boundary of the live acceptance run;
+- the deferred items still out of scope: wrapper deletion and PLC start/stop hardening.
+
+Stop before commit, push, merge, or PR comment posting unless separately authorized.

--- a/docs/superpowers/plans/2026-09-01-pr3-update-tag-safety-snapshot.md
+++ b/docs/superpowers/plans/2026-09-01-pr3-update-tag-safety-snapshot.md
@@ -1,0 +1,772 @@
+# PR 3 Update Tag Safety Snapshot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bind `update_tag` safety tokens to an exact-target typed snapshot that includes resolved PLC identity plus the three nullable external-access flags, while still composing that strict snapshot with the existing broad `list_tag_tables` state until PR 5.
+
+**Architecture:** Keep exact tag resolution and flag reads in the net48 worker, add a shared `TagUpdateSafetySnapshot` DTO in `TiaMcpServer.Contracts`, and reuse the ordinary bound host request seam so the strict snapshot read carries `ExpectedSessionIdentity` without duplicating transport or binding logic. Add a reusable `OperationCapability.SafetyRead` classification for side-effect-free internal reads whose result contributes to write-token state: it remains read-only safe, but unlike ordinary `Observe` it requires the exact verified worker/Portal/project identity. `BatchWorkerInvoker.ReadCurrentStateAsync` will special-case `update_tag` to compose the strict exact-target snapshot with the existing broad `ListTagTablesAsync` payload, fail closed when a requested flag is unreadable, and keep public `list_tag_tables` semantics unchanged until PR 5 narrows tag scopes.
+
+**Tech Stack:** C#; .NET 8 host; .NET Framework 4.8 worker; `netstandard2.0` shared contracts; xUnit; FakeWorker; PowerShell 7 live harnesses; existing write-safety token, host binding, and worker IPC infrastructure.
+
+**Spec:** [`docs/superpowers/specs/2026-09-01-write-safety-hardening-design.md`](../specs/2026-09-01-write-safety-hardening-design.md)
+
+## Global Constraints
+
+- Introduce a typed exact-target `TagUpdateSafetySnapshot` in `TiaMcpServer.Contracts` and a dedicated strict worker reader for `update_tag`.
+- Introduce `OperationCapability.SafetyRead` as the shared classification for side-effect-free internal safety-state reads. It is allowed by read-only access policy but, unlike `Observe` and `TemporaryExport`, `OperationPolicyCatalog.RequiresExpectedSessionIdentity` must return `true` for it.
+- Classify `read_update_tag_safety_snapshot` as `SafetyRead`, never as ordinary `Observe`, and keep it out of every public operation catalog. PR 5 and PR 6 must reuse this capability for their internal safety selectors rather than adding method-name exceptions.
+- Prove both halves of the identity boundary: the ordinary bound client sends a non-null complete `ExpectedSessionIdentity`, and the worker enforcement path rejects the same safety read when identity is missing or mismatched.
+- The snapshot binds deterministic PLC, folder, table, and tag identity plus every property the current mutator can change: name, data type, logical address, `ExternalAccessible`, `ExternalVisible`, and `ExternalWritable`.
+- The PLC field in the snapshot must serialize the resolved PLC name returned by `PlcSoftwareLocator.Find`, not the raw caller input. When `plcName` input is omitted, the snapshot still records the selected PLC deterministically.
+- The three external values are nullable so an actual `false` differs from a property that the selected PLC/tag does not expose.
+- If the request intends to change a flag whose current value cannot be read, preview fails before issuing a token.
+- For this milestone, `update_tag` composes the strict exact-target snapshot with the existing broad `ListTagTablesAsync` state instead of replacing it.
+- The exact-target reader must not skip or partially serialize the target.
+- The existing public `list_tag_tables` response, its best-effort behavior, and the other tag operation selectors remain unchanged.
+- `IsSafety` is not added because the current write path rejects it before mutation.
+- No whole-PLC strict scan in this PR. Scope narrowing and deduplication belong to PR 5.
+- Multilingual per-tag comment binding remains deferred; this PR does not change `delete_tag` safety shape.
+- PLC `start_plc` / `stop_plc` work remains deferred.
+- Preview remains non-mutating. Apply still requires the unchanged request, `confirm=true`, and the matching single-use safety token.
+- The mandatory live V21 gate stays within spec lines 213-215: real flag read, one flag-only drift on a disposable target, and stale-token rejection with `state_changed`.
+- Requested-unavailable-flag rejection is mandatory contract, worker, FakeWorker, and registered-path evidence. A live unavailable-flag probe is optional and may run only when the authorized disposable target actually exposes such a flag-unavailable case.
+- Offline, stub, and FakeWorker evidence are necessary but never sufficient for completion; this PR is incomplete without a separately authorized live TIA Portal V21 drift-acceptance run and a durable acceptance report.
+
+---
+
+## File and Interface Map
+
+**Create**
+
+- `TiaMcpServer.Contracts/TagUpdateSafetySnapshot.cs`
+- `TiaMcpServer/Batch/TagUpdateSafetyCurrentState.cs`
+- `TiaMcpServer.OpennessWorker/Openness/TagTargetResolver.cs`
+- `TiaMcpServer.OpennessWorker/Openness/TagUpdateSafetySnapshotReader.cs`
+- `TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs`
+- `TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotContractTests.cs`
+- `TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotSourceContractTests.cs`
+- `TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs`
+- `TiaMcpServer.Tests/Worker/TagUpdateSafetySnapshotIdentityEnforcementTests.cs`
+- `TiaMcpServer.Tests/Worker/TagUpdateSafetySnapshotWorkerClientTests.cs`
+- `scripts/live-test-update-tag-safety.ps1`
+- `docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md`
+
+**Modify**
+
+- `TiaMcpServer.Contracts/OperationCapability.cs`
+- `TiaMcpServer.Contracts/OperationPolicyCatalog.cs`
+- `TiaMcpServer.OpennessWorker/Program.cs`
+- `TiaMcpServer.OpennessWorker/Openness/TagMutationService.cs`
+- `TiaMcpServer/Batch/BatchWorkerInvoker.cs`
+- `TiaMcpServer/Worker/OpennessWorkerClient.cs`
+- `TiaMcpServer.FakeWorker/Program.cs`
+- `docs/ARCHITECTURE.md`
+- `docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md`
+- `docs/IMPROVEMENT_LOG.md`
+- `docs/README.md`
+- `docs/superpowers/README.md`
+
+**Interfaces**
+
+- `OperationCapability.SafetyRead` — side-effect-free internal safety-state read, allowed in read-only mode but always identity-required.
+- `public sealed record TagUpdateSafetySnapshot(string PlcName, string FolderPath, string TableName, string TagName, string DataType, string LogicalAddress, bool? ExternalAccessible, bool? ExternalVisible, bool? ExternalWritable);`
+- `internal sealed record ResolvedTagTarget(string PlcName, string FolderPath, PlcTagTable Table, PlcTag Tag);`
+- `public Task<WorkerCallResult> ReadUpdateTagSafetySnapshotAsync(string? plcName, string tableName, string? folderPath, string name, string? projectPath)`
+- `public static TagUpdateSafetySnapshot Read(Project project, string? plcName, string tableName, string? folderPath, string name)`
+- `internal static string Compose(TagUpdateSafetySnapshot snapshot, string broadTagTablesPayload)`
+- `internal static string? ValidateRequestedExternalFlags(BatchOperationRequest op, TagUpdateSafetySnapshot snapshot)`
+
+`ReadUpdateTagSafetySnapshotAsync` should reuse the ordinary bound host seam:
+
+```csharp
+public Task<WorkerCallResult> ReadUpdateTagSafetySnapshotAsync(
+    string? plcName,
+    string tableName,
+    string? folderPath,
+    string name,
+    string? projectPath)
+{
+    return SendBoundProjectRequestAsync(
+        "read_update_tag_safety_snapshot",
+        projectPath,
+        request =>
+        {
+            request.PlcName = plcName;
+            request.TableName = tableName;
+            request.FolderPath = folderPath;
+            request.Name = name;
+        },
+        "{}");
+}
+```
+
+`SendBoundProjectRequestCoreAsync` already sets `ExpectedSessionIdentity = bindingBeforeCall.ToWorkerIdentity()` for bound calls, so this PR needs a request-JSON regression proving that the full identity object is present, not a duplicate transport/binding implementation. Worker-side enforcement is a separate boundary: ordinary `Observe` permits a missing identity, therefore the new method must use `SafetyRead` and the shared `RequiresExpectedSessionIdentity` path must reject missing and mismatched identities before the snapshot reader runs.
+
+### Task 1: Bind `update_tag` to the Exact Snapshot End to End
+
+**Files:**
+
+- Create: `TiaMcpServer.Contracts/TagUpdateSafetySnapshot.cs`
+- Create: `TiaMcpServer/Batch/TagUpdateSafetyCurrentState.cs`
+- Create: `TiaMcpServer.OpennessWorker/Openness/TagTargetResolver.cs`
+- Create: `TiaMcpServer.OpennessWorker/Openness/TagUpdateSafetySnapshotReader.cs`
+- Create: `TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs`
+- Create: `TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotContractTests.cs`
+- Create: `TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotSourceContractTests.cs`
+- Create: `TiaMcpServer.Tests/Worker/TagUpdateSafetySnapshotIdentityEnforcementTests.cs`
+- Create: `TiaMcpServer.Tests/Worker/TagUpdateSafetySnapshotWorkerClientTests.cs`
+- Modify: `TiaMcpServer.Contracts/OperationCapability.cs`
+- Modify: `TiaMcpServer.Contracts/OperationPolicyCatalog.cs`
+- Modify: `TiaMcpServer.OpennessWorker/Program.cs`
+- Modify: `TiaMcpServer.OpennessWorker/Openness/TagMutationService.cs`
+- Modify: `TiaMcpServer/Batch/BatchWorkerInvoker.cs`
+- Modify: `TiaMcpServer/Worker/OpennessWorkerClient.cs`
+- Modify: `TiaMcpServer.FakeWorker/Program.cs`
+- Test: `TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs`
+- Test: `TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotContractTests.cs`
+- Test: `TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotSourceContractTests.cs`
+- Test: `TiaMcpServer.Tests/Worker/TagUpdateSafetySnapshotIdentityEnforcementTests.cs`
+- Test: `TiaMcpServer.Tests/Worker/TagUpdateSafetySnapshotWorkerClientTests.cs`
+
+**Interfaces:**
+
+- Consumes: `WriteBatchTools.PreviewWriteBatch(OpennessWorkerClient workerClient, WriteSafetyService safety, BatchOperationRequest[] operations)`
+- Consumes: `WriteBatchTools.ApplyWriteBatch(OpennessWorkerClient workerClient, WriteSafetyService safety, BatchOperationRequest[] operations, bool confirm = false, string? safetyToken = null)`
+- Consumes: `TagMutationService.UpdateTag(Project project, string? plcName, string tableName, string? folderPath, string name, string? newName, string? dataType, string? logicalAddress, bool? externalAccessible, bool? externalVisible, bool? externalWritable, bool? isSafety)`
+- Produces: `ResolvedTagTarget TagTargetResolver.Resolve(Project project, string? plcName, string tableName, string? folderPath, string name)`
+- Produces: `TagUpdateSafetySnapshotReader.Read(Project project, string? plcName, string tableName, string? folderPath, string name)`
+- Produces: `OperationCapability.SafetyRead` and its reusable identity-required policy semantics.
+- Produces: `OpennessWorkerClient.ReadUpdateTagSafetySnapshotAsync(string? plcName, string tableName, string? folderPath, string name, string? projectPath)`
+- Produces: `TagUpdateSafetyCurrentState.Compose(TagUpdateSafetySnapshot snapshot, string broadTagTablesPayload)`
+- Produces: `TagUpdateSafetyCurrentState.ValidateRequestedExternalFlags(BatchOperationRequest op, TagUpdateSafetySnapshot snapshot)`
+
+- [ ] **Step 1: Write the failing registered runtime tests first**
+
+Add focused FakeWorker-backed tests that drive the registered `WriteBatchTools` preview/apply path before touching production contracts or worker code:
+
+```csharp
+[Fact]
+public async Task PreviewWriteBatch_UpdateTagRejectsRequestedUnavailableFlagBeforeTokenIssuance()
+{
+    var operations = new[] { UpdateTagOp(externalVisible: true) };
+
+    var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+
+    Assert.Contains("externalVisible", preview, StringComparison.OrdinalIgnoreCase);
+    Assert.DoesNotContain("\"safetyToken\":", preview, StringComparison.Ordinal);
+}
+
+[Fact]
+public async Task ApplyWriteBatch_UpdateTagFlagOnlyDriftFailsWithStateChanged()
+{
+    var operations = new[] { UpdateTagOp(externalAccessible: true) };
+    var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+    var token = JsonDocument.Parse(preview).RootElement.GetProperty("safetyToken").GetString();
+
+    var apply = await WriteBatchTools.ApplyWriteBatch(client, safety, operations, confirm: true, safetyToken: token);
+
+    Assert.Contains("\"failureCategory\":\"state_changed\"", apply, StringComparison.Ordinal);
+}
+```
+
+Use two FakeWorker scenarios:
+
+- `tag-update-snapshot-unavailable-visible`: broad `list_tag_tables` succeeds, but the exact target would report `ExternalVisible = null`.
+- `tag-update-flag-drift`: preview and apply see the same broad `list_tag_tables` payload while only one exact-target external flag changes between the two calls.
+
+- [ ] **Step 2: Run the registered runtime tests and confirm meaningful RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~TagUpdateCurrentStateFakeWorkerTests"
+```
+
+Expected RED:
+
+- preview still issues a token when a requested external flag is unavailable because `update_tag` is bound only to broad `list_tag_tables` state;
+- apply does not reject a flag-only drift as `state_changed` because the exact snapshot is not yet part of the bound current-state hash.
+
+- [ ] **Step 3: Write the failing contract, request-JSON, and source-contract tests**
+
+```csharp
+[Fact]
+public void Snapshot_SerializesFalseDifferentlyFromUnavailable()
+{
+    var concrete = JsonSerializer.Serialize(new TagUpdateSafetySnapshot(
+        "ResolvedPLC", "/", "Default tag table", "MotorReady", "Bool", "%I0.0", false, true, false));
+    var unavailable = JsonSerializer.Serialize(new TagUpdateSafetySnapshot(
+        "ResolvedPLC", "/", "Default tag table", "MotorReady", "Bool", "%I0.0", null, null, null));
+
+    Assert.Contains("\"externalAccessible\":false", concrete, StringComparison.Ordinal);
+    Assert.Contains("\"externalAccessible\":null", unavailable, StringComparison.Ordinal);
+}
+
+[Fact]
+public async Task BoundSnapshotRead_RequestJsonStillCarriesExpectedSessionIdentity()
+{
+    var call = await client.ReadUpdateTagSafetySnapshotAsync(
+        plcName: null,
+        tableName: "Default tag table",
+        folderPath: "/",
+        name: "MotorReady",
+        projectPath: "echo");
+
+    Assert.True(call.Success, call.Error);
+    using var echoed = JsonDocument.Parse(call.Payload);
+    var expected = echoed.RootElement.GetProperty("expectedSessionIdentity");
+    Assert.Equal(JsonValueKind.Object, expected.ValueKind);
+    Assert.False(string.IsNullOrWhiteSpace(expected.GetProperty("workerSessionId").GetString()));
+    Assert.True(expected.GetProperty("sessionGeneration").GetInt64() >= 0);
+    Assert.True(expected.GetProperty("portalProcessId").GetInt32() > 0);
+    Assert.False(string.IsNullOrWhiteSpace(expected.GetProperty("projectPath").GetString()));
+}
+
+[Fact]
+public void SnapshotRead_IsAReusableIdentityRequiredSafetyRead()
+{
+    const string method = "read_update_tag_safety_snapshot";
+
+    Assert.Equal(OperationCapability.SafetyRead, OperationPolicyCatalog.GetCapability(method));
+    Assert.True(OperationPolicyCatalog.IsAllowed(McpAccessMode.ReadOnly, method));
+    Assert.True(OperationPolicyCatalog.RequiresExpectedSessionIdentity(method));
+}
+
+[Fact]
+public async Task WorkerRejectsSnapshotReadWithMissingIdentity()
+{
+    using var transport = CreateFakeWorkerTransport();
+    var observed = await PrimeAndReadIdentityAsync(transport);
+    var response = await transport.SendAsync(new WorkerRequest
+    {
+        Method = "read_update_tag_safety_snapshot",
+        ProjectPath = observed.ProjectPath,
+        PlcName = "PLC_1",
+        TableName = "Default tag table",
+        FolderPath = "/",
+        Name = "MotorReady",
+        ExpectedSessionIdentity = null
+    });
+
+    Assert.False(response.Success);
+    Assert.Equal(WorkerFailureCategories.BindingConflict, response.FailureCategory);
+}
+
+[Theory]
+[InlineData("workerSessionId")]
+[InlineData("sessionGeneration")]
+[InlineData("portalProcessId")]
+[InlineData("projectPath")]
+public async Task WorkerRejectsEveryMismatchedSnapshotIdentityField(string field)
+{
+    using var transport = CreateFakeWorkerTransport();
+    var observed = await PrimeAndReadIdentityAsync(transport);
+    var response = await transport.SendAsync(new WorkerRequest
+    {
+        Method = "read_update_tag_safety_snapshot",
+        ProjectPath = observed.ProjectPath,
+        PlcName = "PLC_1",
+        TableName = "Default tag table",
+        FolderPath = "/",
+        Name = "MotorReady",
+        ExpectedSessionIdentity = CopyWithChangedField(observed, field)
+    });
+
+    Assert.False(response.Success);
+    Assert.Equal(WorkerFailureCategories.BindingConflict, response.FailureCategory);
+}
+
+[Fact]
+public void Reader_UsesResolvedPlcNameFromLocator()
+{
+    var source = ReadRepositorySource("TiaMcpServer.OpennessWorker", "Openness", "TagUpdateSafetySnapshotReader.cs");
+    Assert.Contains("resolved.PlcName", source, StringComparison.Ordinal);
+    Assert.DoesNotContain("plcName ?? string.Empty", source, StringComparison.Ordinal);
+}
+```
+
+Put the transport rejection tests in `TagUpdateSafetySnapshotIdentityEnforcementTests`; its `CopyWithChangedField` helper must copy all four identity fields and change exactly the selected field. They prove the shared policy through the executable FakeWorker enforcement path; do not substitute a source-text-only assertion for those missing/mismatched requests. Also add source-contract evidence that the real worker's `Program.cs` dispatches `"read_update_tag_safety_snapshot" => ReadUpdateTagSafetySnapshot(request)`, the handler runs through `WithProject(request, ...)`, and `AllowsMissingExpectedSessionIdentity` delegates to `!OperationPolicyCatalog.RequiresExpectedSessionIdentity(method)`. Assert that the internal method is absent from every public batch/network catalog.
+
+- [ ] **Step 4: Run the seam tests and confirm RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~TagUpdateSafetySnapshotContractTests|FullyQualifiedName~TagUpdateSafetySnapshotSourceContractTests|FullyQualifiedName~TagUpdateSafetySnapshotIdentityEnforcementTests|FullyQualifiedName~TagUpdateSafetySnapshotWorkerClientTests"
+```
+
+Expected RED:
+
+- `TagUpdateSafetySnapshot` and the new worker method do not exist;
+- `OperationCapability.SafetyRead` and the explicit reusable policy do not exist; classifying the method as ordinary `Observe` would make the policy and missing-identity runtime assertions fail;
+- the client wrapper does not exist;
+- request-JSON evidence for the bound snapshot read cannot pass yet;
+- the worker enforcement test cannot accept a missing or mismatched identity while still satisfying the new explicit classification contract;
+- the reader cannot serialize resolved PLC identity because the resolver output does not exist yet.
+
+- [ ] **Step 5: Add the reusable safety-read policy, shared contract, and resolved target resolver**
+
+Add the capability once in the shared contract rather than special-casing `read_update_tag_safety_snapshot` inside host or worker transport code:
+
+```csharp
+public enum OperationCapability
+{
+    Observe,
+    TemporaryExport,
+    SafetyRead,
+    // existing capabilities remain unchanged
+}
+
+// OperationPolicyCatalog.IsAllowed
+return cap.Value is OperationCapability.Observe
+    or OperationCapability.TemporaryExport
+    or OperationCapability.SafetyRead;
+
+// OperationPolicyCatalog.RequiresExpectedSessionIdentity, after the existing
+// open_project/create_project establishment exception
+return GetCapability(operation) switch
+{
+    OperationCapability.Observe => false,
+    OperationCapability.TemporaryExport => false,
+    OperationCapability.SafetyRead => true,
+    _ => true
+};
+```
+
+Add the method to the `BuildClassifications` dictionary initializer:
+
+```csharp
+["read_update_tag_safety_snapshot"] = OperationCapability.SafetyRead,
+```
+
+`SafetyRead` means side-effect-free but identity-required. Preserve fail-closed behavior for null, blank, and unknown operations. Do not add a second collection of identity-required method names: PR 5 and PR 6 must classify their internal safety selectors with the same capability.
+
+```csharp
+public sealed record TagUpdateSafetySnapshot(
+    string PlcName,
+    string FolderPath,
+    string TableName,
+    string TagName,
+    string DataType,
+    string LogicalAddress,
+    bool? ExternalAccessible,
+    bool? ExternalVisible,
+    bool? ExternalWritable);
+
+internal sealed record ResolvedTagTarget(
+    string PlcName,
+    string FolderPath,
+    PlcTagTable Table,
+    PlcTag Tag);
+
+internal static class TagTargetResolver
+{
+    internal static ResolvedTagTarget Resolve(
+        Project project,
+        string? plcName,
+        string tableName,
+        string? folderPath,
+        string name)
+    {
+        PlcSoftware plcSoftware = PlcSoftwareLocator.Find(project, plcName);
+        PlcTagTableGroup group = plcSoftware.TagTableGroup;
+        foreach (var segment in SplitFolderPath(folderPath))
+        {
+            group = group.Groups.Find(segment)
+                ?? throw new InvalidOperationException($"Tag table folder '{NormalizeFolderPath(folderPath)}' was not found.");
+        }
+
+        var table = group.TagTables.Find(tableName)
+            ?? throw new InvalidOperationException($"Tag table '{tableName}' was not found in '{NormalizeFolderPath(folderPath)}'.");
+        var tag = table.Tags.Find(name)
+            ?? throw new InvalidOperationException($"Tag '{name}' was not found in tag table '{tableName}'.");
+
+        return new ResolvedTagTarget(plcSoftware.Name, NormalizeFolderPath(folderPath), table, tag);
+    }
+}
+```
+
+Refactor `TagMutationService` to reuse `TagTargetResolver` so the write path and strict snapshot path share exact PLC, folder, table, and tag resolution.
+
+- [ ] **Step 6: Implement the worker dispatch, reader, and ordinary bound client wrapper**
+
+```csharp
+private static WorkerResponse ReadUpdateTagSafetySnapshot(WorkerRequest request)
+{
+    return WithProject(request, project => Success(
+        TagUpdateSafetySnapshotReader.Read(
+            project,
+            request.PlcName,
+            request.TableName!,
+            request.FolderPath,
+            request.Name!)));
+}
+
+public static TagUpdateSafetySnapshot Read(
+    Project project,
+    string? plcName,
+    string tableName,
+    string? folderPath,
+    string name)
+{
+    var resolved = TagTargetResolver.Resolve(project, plcName, tableName, folderPath, name);
+    return new TagUpdateSafetySnapshot(
+        resolved.PlcName,
+        resolved.FolderPath,
+        resolved.Table.Name,
+        resolved.Tag.Name,
+        resolved.Tag.DataTypeName,
+        resolved.Tag.LogicalAddress,
+        ReadOptionalFlag(() => resolved.Tag.ExternalAccessible),
+        ReadOptionalFlag(() => resolved.Tag.ExternalVisible),
+        ReadOptionalFlag(() => resolved.Tag.ExternalWritable));
+}
+```
+
+`ReadOptionalFlag` must return `null` only when the selected live tag truly does not expose the property; it must never degrade by skipping the target or falling back to broad state.
+
+Keep the handler on `WithProject(request, ...)`. That shared path evaluates `AllowsMissingExpectedSessionIdentity`, which now resolves `SafetyRead` to `false`, and therefore rejects a missing or mismatched identity before `TagUpdateSafetySnapshotReader.Read` reaches Siemens objects. Do not add handler-local validation or bypass the central policy.
+
+- [ ] **Step 7: Compose the strict snapshot with broad state only for `update_tag`**
+
+```csharp
+internal static class TagUpdateSafetyCurrentState
+{
+    internal static string? ValidateRequestedExternalFlags(BatchOperationRequest op, TagUpdateSafetySnapshot snapshot)
+    {
+        if (op.ExternalAccessible.HasValue && snapshot.ExternalAccessible is null) return "externalAccessible";
+        if (op.ExternalVisible.HasValue && snapshot.ExternalVisible is null) return "externalVisible";
+        if (op.ExternalWritable.HasValue && snapshot.ExternalWritable is null) return "externalWritable";
+        return null;
+    }
+
+    internal static string Compose(TagUpdateSafetySnapshot snapshot, string broadTagTablesPayload)
+        => JsonSerializer.Serialize(new
+        {
+            exactTarget = snapshot,
+            broadTagTables = JsonDocument.Parse(broadTagTablesPayload).RootElement
+        });
+}
+```
+
+Route only `update_tag` through that helper:
+
+```csharp
+"update_tag" => ReadUpdateTagCurrentStateAsync(client, op),
+"create_tag_table" or "delete_tag_table"
+    or "create_tag" or "delete_tag"
+    or "create_user_constant" or "update_user_constant" or "delete_user_constant"
+    => client.ListTagTablesAsync(op.PlcName, op.ProjectPath),
+```
+
+`ReadUpdateTagCurrentStateAsync` must:
+
+- read the strict exact-target snapshot first;
+- fail closed if that read fails;
+- reject a requested external flag whose current value is `null`;
+- read the existing broad `list_tag_tables` payload second;
+- return one composed deterministic state string for token issuance/validation.
+
+- [ ] **Step 8: Extend FakeWorker to express the new behavior**
+
+Add scripted responses for:
+
+- `read_update_tag_safety_snapshot` success with resolved PLC name and explicit `false`/`true` flag values;
+- shared identity enforcement before scenario dispatch, so the safety read returns `binding_conflict` with no stamped response identity when `ExpectedSessionIdentity` is absent or differs in any binding field;
+- `tag-update-snapshot-unavailable-visible` where `externalVisible` is omitted or `null` in the strict snapshot while broad `list_tag_tables` still succeeds;
+- `tag-update-flag-drift` where only one strict-snapshot flag changes between preview and apply and the broad payload stays byte-stable;
+- `tag-update-snapshot-read-fails` where the exact-target read returns a structural failure and preview issues no token;
+- `tag-update-broad-best-effort-omission` where the broad `list_tag_tables` payload carries unrelated warnings but the strict target snapshot succeeds.
+
+- [ ] **Step 9: Re-run focused tests and confirm GREEN**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~TagUpdateCurrentStateFakeWorkerTests|FullyQualifiedName~TagUpdateSafetySnapshotContractTests|FullyQualifiedName~TagUpdateSafetySnapshotSourceContractTests|FullyQualifiedName~TagUpdateSafetySnapshotIdentityEnforcementTests|FullyQualifiedName~TagUpdateSafetySnapshotWorkerClientTests"
+```
+
+Then run the broader slice:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~BatchFieldForwardingTests|FullyQualifiedName~BatchSafetyTokenTests|FullyQualifiedName~WriteSafetyServiceTests|FullyQualifiedName~ReadOnlyModeTests|FullyQualifiedName~TagUpdateCurrentStateFakeWorkerTests|FullyQualifiedName~TagUpdateSafetySnapshotContractTests|FullyQualifiedName~TagUpdateSafetySnapshotSourceContractTests|FullyQualifiedName~TagUpdateSafetySnapshotIdentityEnforcementTests|FullyQualifiedName~TagUpdateSafetySnapshotWorkerClientTests"
+```
+
+- [ ] **Step 10: Run full serial repository verification**
+
+Run:
+
+```powershell
+dotnet build TiaMcpServer.sln -m:1 /p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers
+git diff --check
+git status --short
+```
+
+- [ ] **Step 11: Review the PR 3 boundary before any commit**
+
+Verify all of these are true:
+
+- the first observed RED came from the registered `WriteBatchTools` preview/apply path, not only from missing symbols;
+- `SafetyRead` is a reusable shared capability, remains side-effect-free/read-only-safe, and requires expected session identity without a per-method allow/deny list;
+- the bound host wrapper sends all expected identity fields, while executable worker-policy tests reject both missing and mismatched identity as `binding_conflict` before the reader runs;
+- `update_tag` now binds resolved PLC identity, folder path, table name, tag name, data type, logical address, and the three external flags;
+- `false` and `null` remain distinguishable in both serialization and current-state hashing;
+- requested-unavailable-flag rejection is proven through contract, worker, FakeWorker, and registered-path evidence;
+- `list_tag_tables` public behavior and best-effort skips are unchanged;
+- no other tag operation is narrowed yet;
+- PR 5 remains responsible for removing the broad composed state and deduplicating selectors.
+
+- [ ] **Step 12: Stop at the commit boundary**
+
+Do not commit without explicit authorization. When authorized, stage only:
+
+```powershell
+git add TiaMcpServer.Contracts/TagUpdateSafetySnapshot.cs TiaMcpServer.Contracts/OperationCapability.cs TiaMcpServer.Contracts/OperationPolicyCatalog.cs TiaMcpServer.OpennessWorker/Program.cs TiaMcpServer.OpennessWorker/Openness/TagTargetResolver.cs TiaMcpServer.OpennessWorker/Openness/TagUpdateSafetySnapshotReader.cs TiaMcpServer.OpennessWorker/Openness/TagMutationService.cs TiaMcpServer/Batch/TagUpdateSafetyCurrentState.cs TiaMcpServer/Batch/BatchWorkerInvoker.cs TiaMcpServer/Worker/OpennessWorkerClient.cs TiaMcpServer.FakeWorker/Program.cs TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotContractTests.cs TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotSourceContractTests.cs TiaMcpServer.Tests/Worker/TagUpdateSafetySnapshotIdentityEnforcementTests.cs TiaMcpServer.Tests/Worker/TagUpdateSafetySnapshotWorkerClientTests.cs
+```
+
+### Task 2: Add the Guarded Live Harness, Docs, and Durable Acceptance Report
+
+**Files:**
+
+- Create: `TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs`
+- Create: `scripts/live-test-update-tag-safety.ps1`
+- Create: `docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md`
+- Modify: `docs/IMPROVEMENT_LOG.md`
+- Modify: `docs/README.md`
+- Modify: `docs/superpowers/README.md`
+- Test: `TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs`
+
+**Interfaces:**
+
+- Consumes: `read_update_tag_safety_snapshot` (worker-level exact-target preflight)
+- Consumes: `get_project_status` (worker session-identity establishment before a direct internal safety read)
+- Consumes: `list_tag_tables`
+- Consumes: `preview_write_batch`
+- Consumes: `apply_write_batch`
+- Produces: `scripts/live-test-update-tag-safety.ps1` modes `Read`, `PreviewDrift`, `ApplyDrift`, and optional `ProbeUnavailable`
+- Produces: `docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md`
+
+- [ ] **Step 1: Write the failing live-harness contract tests**
+
+```csharp
+[Fact]
+public void Script_DefaultModeIsReadOnly()
+{
+    var text = ReadScript();
+    Assert.Matches(new Regex(@"\[ValidateSet\(\s*'Read'\s*,\s*'PreviewDrift'\s*,\s*'ApplyDrift'\s*,\s*'ProbeUnavailable'\s*\)\]"), text);
+    Assert.Matches(new Regex(@"\[string\]\s*\$Mode\s*=\s*'Read'"), text);
+}
+
+[Fact]
+public void Script_ApplyDriftRequiresExplicitAuthorizationAndPreflightedReadableFlag()
+{
+    var text = ReadScript();
+    Assert.Matches(new Regex(@"\[switch\]\s*\$AllowApply"), text);
+    Assert.Contains("$DriftFlagName", text, StringComparison.Ordinal);
+    Assert.Contains("read_update_tag_safety_snapshot", text, StringComparison.Ordinal);
+    Assert.Contains("state_changed", text, StringComparison.Ordinal);
+}
+
+[Fact]
+public void Script_InternalSafetyReadCarriesObservedSessionIdentity()
+{
+    var text = ReadScript();
+    Assert.Contains("get_project_status", text, StringComparison.Ordinal);
+    Assert.Contains("sessionIdentity", text, StringComparison.Ordinal);
+    Assert.Contains("expectedSessionIdentity", text, StringComparison.Ordinal);
+    Assert.Contains("read_update_tag_safety_snapshot", text, StringComparison.Ordinal);
+}
+
+[Fact]
+public void Script_OptionalUnavailableProbeUsesSeparateTargetInputs()
+{
+    var text = ReadScript();
+    Assert.Contains("$ProbeTagName", text, StringComparison.Ordinal);
+    Assert.Contains("$ProbeFlagName", text, StringComparison.Ordinal);
+    Assert.Contains("'ProbeUnavailable'", text, StringComparison.Ordinal);
+}
+```
+
+- [ ] **Step 2: Run the focused tests and confirm RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~TagUpdateSafetyLiveHarnessContractTests"
+```
+
+Expected RED:
+
+- the harness script and contract tests do not exist;
+- there is no explicit mandatory drift run and no separate optional unavailable probe shape.
+
+- [ ] **Step 3: Implement the harness with exact preflight and separate live scopes**
+
+```powershell
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$ProjectPath,
+    [Parameter(Mandatory)][string]$TableName,
+    [Parameter(Mandatory)][string]$TagName,
+    [string]$PlcName,
+    [ValidateSet('ExternalAccessible','ExternalVisible','ExternalWritable')][string]$DriftFlagName = 'ExternalVisible',
+    [string]$ProbeTableName,
+    [string]$ProbeTagName,
+    [ValidateSet('ExternalAccessible','ExternalVisible','ExternalWritable')][string]$ProbeFlagName = 'ExternalVisible',
+    [ValidateSet('Read','PreviewDrift','ApplyDrift','ProbeUnavailable')][string]$Mode = 'Read',
+    [switch]$AllowApply
+)
+```
+
+Harness behavior:
+
+- Shared worker preflight: after the protocol handshake, call `get_project_status`, require a complete returned `sessionIdentity`, and copy that exact object into `expectedSessionIdentity` on every direct `read_update_tag_safety_snapshot` request. Never synthesize identity from `ProjectPath` and never retry the internal safety read without identity.
+- `Read`: use the identity-bound helper to call `read_update_tag_safety_snapshot`, assert the resolved PLC name is present, assert `$DriftFlagName` is readable (`$null` is a hard live-gate failure for the drift run), then print the unchanged public `list_tag_tables` row.
+- `PreviewDrift`: repeat the exact-target preflight, call `preview_write_batch` for an `update_tag` that changes only `$DriftFlagName`, and print the token plus the strict snapshot values that backed it.
+- `ApplyDrift`: require `-AllowApply`, repeat the readable-flag preflight, issue the preview token, perform one separately authorized intermediate `update_tag` flag change against the disposable copy, call `apply_write_batch` with the original unchanged request, assert `failureCategory = state_changed`, then restore the original flag or discard the copy and print the final strict snapshot.
+- `ProbeUnavailable`: optional only. Require `$ProbeTableName`, `$ProbeTagName`, and `$ProbeFlagName`, call `read_update_tag_safety_snapshot` for that second target, and stop with a non-passing result unless the selected flag is actually `null`. Only then attempt the preview that must fail before token issuance.
+
+The harness may use the worker executable for the internal strict snapshot read and the real `TiaMcpServer` MCP JSON-RPC host for `list_tag_tables`, `preview_write_batch`, and `apply_write_batch`. A direct worker request is valid only after the harness has captured the worker-stamped session identity and supplied it unchanged as `expectedSessionIdentity`; the automated TDD suite, not a source inspection, separately proves missing/mismatched rejection. The harness must never claim the optional unavailable probe as part of the mandatory live gate.
+
+- [ ] **Step 4: Make the live commands exact**
+
+Mandatory preflight:
+
+```powershell
+pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -DriftFlagName ExternalVisible -Mode Read
+```
+
+Mandatory preview:
+
+```powershell
+pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -DriftFlagName ExternalVisible -Mode PreviewDrift
+```
+
+Mandatory drift acceptance:
+
+```powershell
+pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -DriftFlagName ExternalVisible -Mode ApplyDrift -AllowApply
+```
+
+Optional unavailable probe, only when an authorized second target actually exposes an unavailable flag:
+
+```powershell
+pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -ProbeTableName 'Legacy table' -ProbeTagName 'LegacyTag' -ProbeFlagName ExternalWritable -Mode ProbeUnavailable
+```
+
+- [ ] **Step 5: Write the durable acceptance report with mandatory and optional evidence separated**
+
+Create `docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md` with this exact structure:
+
+```markdown
+# Acceptance Test Report - PR 3 update_tag safety snapshot (live TIA Portal V21)
+
+**Date:** 2026-09-01
+**Runtime:** Real TIA Portal V21
+**Harness:** `scripts/live-test-update-tag-safety.ps1`
+**Boundary:** Disposable project copy; the mandatory live gate is exact-target read plus one authorized flag-only drift and stale-token rejection.
+
+## Mandatory Live Target
+
+- Project copy path
+- Requested `plcName` input
+- Resolved PLC name from `read_update_tag_safety_snapshot`
+- Tag table name
+- Tag name
+- Drift flag proved
+
+## Mandatory Calls Performed
+
+- `get_project_status` identity establishment for the worker-level preflight
+- `read_update_tag_safety_snapshot` preflight on the drift target
+- `list_tag_tables` comparison read
+- `preview_write_batch`
+- one authorized intermediate flag-only drift write on the disposable copy
+- stale-token `apply_write_batch`
+- restoration or discard step
+
+## Mandatory Live Results
+
+| Criterion | Command | Observed |
+|---|---|---|
+| Identity-bound internal safety read succeeds with the worker-stamped identity | `... -Mode Read` | PASS/FAIL |
+| Exact-target snapshot resolves PLC identity and the chosen drift flag is readable | `... -Mode Read` | PASS/FAIL |
+| Flag-only drift causes stale-token `state_changed` before mutation | `... -Mode ApplyDrift -AllowApply` | PASS/FAIL |
+| Public `list_tag_tables` semantics remain unchanged | `... -Mode Read` | PASS/FAIL |
+
+## Required Offline and Registered Evidence
+
+| Criterion | Evidence source | Observed |
+|---|---|---|
+| Bound client sends a complete expected identity; worker rejects missing and mismatched identity as `binding_conflict` | `TagUpdateSafetySnapshotWorkerClientTests` plus `TagUpdateSafetySnapshotIdentityEnforcementTests` | PASS/FAIL |
+| Requested unavailable flag fails before token issuance | `TagUpdateCurrentStateFakeWorkerTests` plus contract/worker tests | PASS/FAIL |
+
+## Optional Live Unavailable Probe
+
+| Criterion | Command | Observed |
+|---|---|---|
+| Second target exposes an unavailable flag and preview rejects it before token issuance | `... -Mode ProbeUnavailable` | PASS/FAIL/NOT RUN |
+
+If the authorized disposable target does not expose an unavailable flag for the chosen second target, record `NOT RUN` here and keep the acceptance gate anchored to the mandatory live rows plus the required offline/registered evidence.
+```
+
+- [ ] **Step 6: Update current docs and indexes**
+
+Apply these documentation changes:
+
+- `docs/ARCHITECTURE.md`: document that `update_tag` now binds one strict exact-target snapshot plus the legacy broad tag-table payload until PR 5, that the snapshot records resolved PLC identity, and that reusable `SafetyRead` methods are side-effect-free/read-only-safe but require the exact expected session identity.
+- `docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md`: document that `update_tag` preview fails before token issuance when a requested external flag is unreadable, while `list_tag_tables` remains best-effort and unchanged.
+- `docs/IMPROVEMENT_LOG.md`: close the missing external-flag safety snapshot gap and keep PR 5 narrowing, multilingual per-tag comment binding, and PLC start/stop work deferred.
+- `docs/README.md` and `docs/superpowers/README.md`: add the new plan/report references so the artifacts are discoverable.
+
+- [ ] **Step 7: Re-run the harness contract test and full serial verification**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~TagUpdateSafetyLiveHarnessContractTests"
+dotnet build TiaMcpServer.sln -m:1 /p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers
+git diff --check
+git status --short
+```
+
+- [ ] **Step 8: Run the separately authorized live V21 acceptance**
+
+Run only after explicit authorization, in this order:
+
+1. Mandatory preflight `-Mode Read`
+2. Mandatory preview `-Mode PreviewDrift`
+3. Mandatory drift acceptance `-Mode ApplyDrift -AllowApply`
+4. Optional `-Mode ProbeUnavailable` only if an authorized second target actually exposes an unavailable flag
+
+The live gate fails if:
+
+- the worker-level preflight cannot establish a complete session identity or the identity-bound safety read does not succeed;
+- the mandatory drift target does not expose the chosen drift flag as readable;
+- the stale apply does not fail with `state_changed`;
+- the disposable target is neither restored nor explicitly discarded and recorded.
+
+The live gate does not fail merely because no authorized second target exposes an unavailable flag; in that case the optional live probe is `NOT RUN` and the unavailable-flag behavior stays proven by required offline and registered evidence.
+
+- [ ] **Step 9: Stop at the commit boundary**
+
+Do not commit without explicit authorization. When authorized, stage only:
+
+```powershell
+git add scripts/live-test-update-tag-safety.ps1 TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs docs/ARCHITECTURE.md docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md docs/IMPROVEMENT_LOG.md docs/README.md docs/superpowers/README.md docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
+```
+
+## Deferred and Out of Scope
+
+- No whole-PLC strict tag scan in PR 3. Keep using `ListTagTablesAsync` broad state composition for `update_tag` until PR 5 replaces it with scoped collision selectors.
+- No public `list_tag_tables` schema or behavior change. Best-effort skipped tag or user-constant reads remain public read semantics, not preview failures by themselves.
+- No multilingual per-tag comment binding work in this PR. That remains deferred for future `delete_tag` hardening.
+- No selector narrowing for `create_tag`, `delete_tag`, tag tables, or user constants beyond what this PR needs for `update_tag`.
+- `SafetyRead` lands here as reusable infrastructure only. PR 5 and PR 6 remain responsible for defining and classifying their own scoped selector methods; this PR must not implement those selectors.
+- No PLC `start_plc` / `stop_plc` work.
+- No acceptance claim based only on offline, stub, or FakeWorker evidence.
+- No commit, push, or live mutation without explicit authorization for the exact target and command.

--- a/docs/superpowers/plans/2026-09-01-pr4-structured-preview-diff.md
+++ b/docs/superpowers/plans/2026-09-01-pr4-structured-preview-diff.md
@@ -1,0 +1,1276 @@
+# PR 4 Structured Preview Diff Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add bounded, structured current-versus-requested preview evidence to `preview_write_batch` for `update_block_logic` and `update_type_content`, without changing token binding, canonical-network behavior, or any non-content write preview.
+
+**Architecture:** Keep the worker and the current-state hash exactly as they are: the host already reads the exact-format current text that the token binds to, so PR 4 only adds a response-only comparison layer on top of those strings. Build one pure host-side diff composer with explicit per-line, per-side, and per-batch budgets; thread its typed output through the existing text preview envelope by widening `diff` from `string?` to a structured response-only value; and leave canonical JSON tools and lifecycle/network previews untouched.
+
+**Tech Stack:** C# 12, .NET 8 host/tests, .NET Standard 2.0 contracts, .NET Framework 4.8 worker, xUnit, System.Text.Json, PowerShell 7 live harness, NDJSON MCP host protocol.
+
+**Spec:** [docs/superpowers/specs/2026-09-01-write-safety-hardening-design.md](../specs/2026-09-01-write-safety-hardening-design.md)
+
+## Global Constraints
+
+- PR 4 starts only after the PR 2 wrapper-delegation baseline is present on the working branch. Implement against `WriteBatchTools`; do not fork a second preview-diff path in compatibility wrappers.
+- The worker read that feeds the token is already authoritative. Do not add a second worker read for preview evidence, and do not predict post-import or post-compile Siemens state.
+- Structured preview evidence is response-only. It must never participate in `IssueToken`, `ValidateEnvelope`, `ValidateAndConsume`, audit hashing, or any current-state hash.
+- Only `update_block_logic` and `update_type_content` emit structured preview evidence. Lifecycle previews, `network_write`, and every non-content generic batch write continue to emit `diff: null`.
+- Preserve the canonical structured-network seam exactly as shipped. `CanonicalWriteSafety.cs`, `StructuredToolResult.cs`, `NetworkReadTools.cs`, `NetworkWriteTools.cs`, and `StructuredOperationBatchPayloadBudget.cs` do not change behavior in this PR.
+- Preserve exact current-state binding semantics: raw hashes and equality use the original text; line-window comparison alone normalizes CRLF and CR to LF and reports `lineEndingOnly`.
+- The display budgets are fixed and exact: 40 excerpt lines and 8,192 excerpt characters per side per operation; first 20 plus last 20 lines when a changed span exceeds 40 lines; 512 characters max per displayed line; 320 excerpt lines and 32,768 excerpt characters across the whole batch, allocated strictly in request order.
+- Every eligible operation keeps raw SHA-256, raw character count, raw line count, and equality flags even when the batch excerpt budget is exhausted.
+- `offline` and `FakeWorker` evidence are necessary but insufficient. Completion requires the separately authorized live TIA Portal V21 host-level preview/apply/restore/compile gate plus a dated acceptance report.
+- Run all Windows .NET verification serially: `dotnet build ... -m:1 /p:UseTiaPortalReferenceStubs=true`, `dotnet test ... --no-restore -m:1 --disable-build-servers`, then `git diff --check` and `git status --short`.
+- Do not commit, push, or run the live apply mode without fresh explicit authorization for the exact disposable project target.
+
+---
+
+## File And Interface Map
+
+| Path | Role |
+| --- | --- |
+| `TiaMcpServer/Batch/BatchPreviewDiff.cs` | New pure host-side diff models, constants, line normalization/comparison, truncation accounting, and request-order batch budgeting for eligible content writes only. |
+| `TiaMcpServer/Batch/WriteBatchTools.cs` | Registered preview path; read ordered current-state payloads once, build the structured diff from those already-bound strings, and pass it into `WriteSafetyService.CreatePreview`. |
+| `TiaMcpServer/Safety/WriteSafetyService.cs` | Widen the generic text-preview `diff` seam from `string?` to a structured response-only value, still outside token issuance and validation. |
+| `TiaMcpServer/Safety/WriteSafetyTooling.cs` | Match the widened `diff` seam and retire the unused string-only `CreateLineDiff` helper. |
+| `TiaMcpServer.Tests/TiaMcpServer.Tests.csproj` | Link the new host file into the test assembly. |
+| `TiaMcpServer.Tests/Batch/BatchPreviewDiffTests.cs` | Pure RED/GREEN coverage for eligibility, hashes/stats, normalized equality, line-ending-only reporting, per-line truncation, per-side truncation, and request-order batch-budget exhaustion. |
+| `TiaMcpServer.Tests/Batch/BatchSafetyTokenTests.cs` | Prove display evidence does not affect token validation when target, request, state, and binding stay unchanged. |
+| `TiaMcpServer.Tests/Batch/WriteBatchPreviewDiffIntegrationTests.cs` | Registered-class end-to-end preview tests through `WriteBatchTools` and `FakeWorker`, asserting real preview JSON shape and `diff: null` for ineligible writes. |
+| `TiaMcpServer.Tests/Diagnostics/CiWorkflowTests.cs` | Pin the documentation authority text that describes the new preview evidence bounds. |
+| `scripts/live-test-preview-write-diff.ps1` | New host-level MCP live harness for preview-only evidence checks and explicitly authorized apply/restore/compile verification on a disposable project copy. |
+| `TiaMcpServer.Tests/Batch/WritePreviewDiffLiveHarnessContractTests.cs` | Execution-free tests that inspect the live harness source for safety gates, host-level protocol use, and restore/compile/report requirements. |
+| `docs/ARCHITECTURE.md` | Update write-safety documentation to describe the response-only structured diff seam and its non-participation in token hashing. |
+| `docs/SupportedOperations/IMPORT_EXPORT_OPTIONS_SUMMARY.md` | Document additive preview evidence for block/type replacement previews, the eligible operations, and the exact budgets/flags. |
+| `docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md` | Document that `preview_write_batch` can now return bounded structured diff evidence for the two content-replacement writes only. |
+| `docs/IMPROVEMENT_LOG.md` | Record PR 4 completion and any explicitly retained follow-up. |
+| `docs/superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md` | Durable live acceptance report with project copy, preview evidence, apply/restore/compile outcome, and explicit evidence boundary. |
+| `docs/README.md` | Index the new acceptance report so the `docs/` tree stays reachable. |
+| `docs/superpowers/README.md` | Index the new acceptance report under historical process evidence. |
+
+### Task 1: Capture The Registered Runtime RED Through `WriteBatchTools`
+
+**Files:**
+- Create: `TiaMcpServer.Tests/Batch/WriteBatchPreviewDiffIntegrationTests.cs`
+
+**Interfaces:**
+- Consume: `WriteBatchTools.PreviewWriteBatch(OpennessWorkerClient workerClient, WriteSafetyService safety, BatchOperationRequest[] operations)`
+- Consume: `FakeWorkerBinding.BindVerifiedAsync(...)`
+- Preserve current behavior: `preview_write_batch` still returns `diff: null`
+- Consume the existing FakeWorker scenarios: `block-source-roundtrip`, `type-content-roundtrip`, and `echo`
+
+- [ ] **Step 1: Add the registered runtime RED tests**
+
+Create `TiaMcpServer.Tests/Batch/WriteBatchPreviewDiffIntegrationTests.cs`:
+
+```csharp
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tests.Worker;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class WriteBatchPreviewDiffIntegrationTests
+{
+    private const string SourceBlockCurrent =
+        "DATA_BLOCK \"Recipe\"\r\nSTRUCT\r\nEND_STRUCT;\r\nBEGIN\r\nEND_DATA_BLOCK\r\n";
+    private const string TypeCurrent =
+        "TYPE AnalogInputSettings STRUCT Value : Real; END_STRUCT END_TYPE";
+
+    private static OpennessWorkerClient CreateClient(ProjectSessionBinding binding)
+        => new(binding, logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+
+    private static WriteSafetyService CreateSafety(TempAuditDirectory audit, ProjectSessionBinding binding)
+        => new(binding, () => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, audit.Path);
+
+    private static async Task<(OpennessWorkerClient Client, WriteSafetyService Safety, ProjectSessionBinding Binding)> BoundAsync(
+        TempAuditDirectory audit,
+        string projectPath)
+    {
+        var binding = new ProjectSessionBinding(null);
+        var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, projectPath);
+        return (client, CreateSafety(audit, binding), binding);
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_UpdateBlockLogicWithSourceFormat_EmitsStructuredDiff()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "block-source-roundtrip");
+        using (client)
+        {
+            var result = await WriteBatchTools.PreviewWriteBatch(
+                client,
+                safety,
+                new[]
+                {
+                    new BatchOperationRequest
+                    {
+                        OperationId = "block-source",
+                        Operation = "update_block_logic",
+                        ProjectPath = "block-source-roundtrip",
+                        BlockPath = "PLC_1/Blocks/Recipe_DB",
+                        Format = SourceFormatNames.Source,
+                        YamlContent = "DATA_BLOCK \"Recipe\"\r\nSTRUCT\r\n  Value : Int;\r\nEND_STRUCT;\r\nBEGIN\r\nEND_DATA_BLOCK\r\n"
+                    }
+                });
+
+            using var doc = JsonDocument.Parse(result);
+            var entry = doc.RootElement.GetProperty("diff").GetProperty("operations")[0];
+            Assert.Equal("block-source", entry.GetProperty("operationId").GetString());
+            Assert.Equal(SourceFormatNames.Source, entry.GetProperty("format").GetString());
+            Assert.True(entry.GetProperty("requested").GetProperty("excerpt").GetProperty("lines").GetArrayLength() > 0);
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_UpdateBlockLogicWithoutFormat_DefaultsToXmlAndEmitsStructuredDiff()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "echo");
+        using (client)
+        {
+            var result = await WriteBatchTools.PreviewWriteBatch(
+                client,
+                safety,
+                new[]
+                {
+                    new BatchOperationRequest
+                    {
+                        OperationId = "block-default",
+                        Operation = "update_block_logic",
+                        ProjectPath = "echo",
+                        BlockPath = "PLC_1/Blocks/Main",
+                        YamlContent = "--- FILE: Main.xml\r\n<Document />\r\n"
+                    }
+                });
+
+            using var doc = JsonDocument.Parse(result);
+            var entry = doc.RootElement.GetProperty("diff").GetProperty("operations")[0];
+            Assert.Equal("block-default", entry.GetProperty("operationId").GetString());
+            Assert.Equal(SourceFormatNames.Xml, entry.GetProperty("format").GetString());
+            Assert.True(entry.GetProperty("current").GetProperty("characterCount").GetInt32() > 0);
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_UpdateBlockLogicWithExplicitXmlFormat_EmitsStructuredDiff()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "echo");
+        using (client)
+        {
+            var result = await WriteBatchTools.PreviewWriteBatch(
+                client,
+                safety,
+                new[]
+                {
+                    new BatchOperationRequest
+                    {
+                        OperationId = "block-xml",
+                        Operation = "update_block_logic",
+                        ProjectPath = "echo",
+                        BlockPath = "PLC_1/Blocks/Main",
+                        Format = SourceFormatNames.Xml,
+                        YamlContent = "--- FILE: Main.xml\r\n<Document Id=\"next\" />\r\n"
+                    }
+                });
+
+            using var doc = JsonDocument.Parse(result);
+            var entry = doc.RootElement.GetProperty("diff").GetProperty("operations")[0];
+            Assert.Equal("block-xml", entry.GetProperty("operationId").GetString());
+            Assert.Equal(SourceFormatNames.Xml, entry.GetProperty("format").GetString());
+            Assert.True(entry.GetProperty("requested").GetProperty("characterCount").GetInt32() > 0);
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_UpdateTypeContent_EmitsStructuredDiff()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "type-content-roundtrip");
+        using (client)
+        {
+            var result = await WriteBatchTools.PreviewWriteBatch(
+                client,
+                safety,
+                new[]
+                {
+                    new BatchOperationRequest
+                    {
+                        OperationId = "type-source",
+                        Operation = "update_type_content",
+                        ProjectPath = "type-content-roundtrip",
+                        TypePath = "PLC_1/Types/AnalogInputSettings",
+                        SourceContent = "TYPE AnalogInputSettings STRUCT Value : Int; END_STRUCT END_TYPE"
+                    }
+                });
+
+            using var doc = JsonDocument.Parse(result);
+            var entry = doc.RootElement.GetProperty("diff").GetProperty("operations")[0];
+            Assert.Equal("type-source", entry.GetProperty("operationId").GetString());
+            Assert.True(entry.GetProperty("current").GetProperty("characterCount").GetInt32() > 0);
+            Assert.True(entry.GetProperty("requested").GetProperty("excerpt").GetProperty("lines").GetArrayLength() > 0);
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_MixedEligibleAndIneligibleWrites_PreservesEligibleRequestOrder()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "echo");
+        using (client)
+        {
+            var result = await WriteBatchTools.PreviewWriteBatch(
+                client,
+                safety,
+                new[]
+                {
+                    new BatchOperationRequest
+                    {
+                        OperationId = "block-1",
+                        Operation = "update_block_logic",
+                        ProjectPath = "echo",
+                        BlockPath = "PLC_1/Blocks/Main",
+                        YamlContent = "--- FILE: Main.xml\r\n<Document />\r\n"
+                    },
+                    new BatchOperationRequest
+                    {
+                        OperationId = "tag-1",
+                        Operation = "create_tag_table",
+                        ProjectPath = "echo",
+                        TableName = "Inputs"
+                    },
+                    new BatchOperationRequest
+                    {
+                        OperationId = "type-3",
+                        Operation = "update_type_content",
+                        ProjectPath = "echo",
+                        TypePath = "PLC_1/Types/AnalogInputSettings",
+                        SourceContent = "TYPE AnalogInputSettings STRUCT Value : Int; END_STRUCT END_TYPE"
+                    }
+                });
+
+            using var doc = JsonDocument.Parse(result);
+            var operations = doc.RootElement.GetProperty("diff").GetProperty("operations");
+            Assert.Equal(new[] { "block-1", "type-3" }, operations.EnumerateArray().Select(x => x.GetProperty("operationId").GetString()).ToArray());
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_IdenticalContent_ReportsRawAndNormalizedEqualityWithNoChangedExcerpt()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "block-source-roundtrip");
+        using (client)
+        {
+            var result = await WriteBatchTools.PreviewWriteBatch(
+                client,
+                safety,
+                new[]
+                {
+                    new BatchOperationRequest
+                    {
+                        OperationId = "block-same",
+                        Operation = "update_block_logic",
+                        ProjectPath = "block-source-roundtrip",
+                        BlockPath = "PLC_1/Blocks/Recipe_DB",
+                        Format = SourceFormatNames.Source,
+                        YamlContent = SourceBlockCurrent
+                    }
+                });
+
+            using var doc = JsonDocument.Parse(result);
+            var entry = doc.RootElement.GetProperty("diff").GetProperty("operations")[0];
+            Assert.True(entry.GetProperty("rawTextEqual").GetBoolean());
+            Assert.True(entry.GetProperty("normalizedLinesEqual").GetBoolean());
+            Assert.False(entry.GetProperty("lineEndingOnly").GetBoolean());
+            Assert.Equal(0, entry.GetProperty("currentChangedLineCount").GetInt32());
+            Assert.Equal(0, entry.GetProperty("requestedChangedLineCount").GetInt32());
+            Assert.Equal(0, entry.GetProperty("current").GetProperty("excerpt").GetProperty("lines").GetArrayLength());
+            Assert.Equal(0, entry.GetProperty("requested").GetProperty("excerpt").GetProperty("lines").GetArrayLength());
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_LineEndingOnlyChange_ReportsNormalizedEqualityButNotRawEquality()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "block-source-roundtrip");
+        using (client)
+        {
+            var requested = SourceBlockCurrent.Replace("\r\n", "\n");
+            var result = await WriteBatchTools.PreviewWriteBatch(
+                client,
+                safety,
+                new[]
+                {
+                    new BatchOperationRequest
+                    {
+                        OperationId = "block-eol",
+                        Operation = "update_block_logic",
+                        ProjectPath = "block-source-roundtrip",
+                        BlockPath = "PLC_1/Blocks/Recipe_DB",
+                        Format = SourceFormatNames.Source,
+                        YamlContent = requested
+                    }
+                });
+
+            using var doc = JsonDocument.Parse(result);
+            var entry = doc.RootElement.GetProperty("diff").GetProperty("operations")[0];
+            Assert.False(entry.GetProperty("rawTextEqual").GetBoolean());
+            Assert.True(entry.GetProperty("normalizedLinesEqual").GetBoolean());
+            Assert.True(entry.GetProperty("lineEndingOnly").GetBoolean());
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_TruncatesOversizedEntriesAndExhaustsTheBatchBudget()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "type-content-roundtrip");
+        using (client)
+        {
+            const int retainedLineLength = 80;
+            var oversizedLine = new string('x', retainedLineLength);
+            var requested = string.Join(
+                "\r\n",
+                Enumerable.Range(1, 60).Select(_ => oversizedLine)) + "\r\n";
+            var operations = Enumerable.Range(1, 9).Select(i => new BatchOperationRequest
+            {
+                OperationId = $"type-{i}",
+                Operation = "update_type_content",
+                ProjectPath = "type-content-roundtrip",
+                TypePath = "PLC_1/Types/AnalogInputSettings",
+                SourceContent = requested
+            }).ToArray();
+
+            var result = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+
+            using var doc = JsonDocument.Parse(result);
+            var diffOperations = doc.RootElement.GetProperty("diff").GetProperty("operations").EnumerateArray().ToArray();
+            Assert.Equal(40, diffOperations[0].GetProperty("requested").GetProperty("excerpt").GetProperty("lines").GetArrayLength());
+            Assert.Equal(
+                retainedLineLength,
+                diffOperations[0].GetProperty("requested").GetProperty("excerpt").GetProperty("lines")[0].GetProperty("text").GetString()!.Length);
+            Assert.False(diffOperations[6].GetProperty("batchBudgetExhausted").GetBoolean());
+            Assert.True(diffOperations[7].GetProperty("batchBudgetExhausted").GetBoolean());
+            Assert.Empty(diffOperations[7].GetProperty("current").GetProperty("excerpt").GetProperty("lines").EnumerateArray());
+            Assert.Empty(diffOperations[7].GetProperty("requested").GetProperty("excerpt").GetProperty("lines").EnumerateArray());
+            Assert.True(diffOperations[8].GetProperty("batchBudgetExhausted").GetBoolean());
+            Assert.Empty(diffOperations[8].GetProperty("current").GetProperty("excerpt").GetProperty("lines").EnumerateArray());
+            Assert.Empty(diffOperations[8].GetProperty("requested").GetProperty("excerpt").GetProperty("lines").EnumerateArray());
+            Assert.NotEmpty(diffOperations[8].GetProperty("requested").GetProperty("sha256").GetString());
+            Assert.True(diffOperations[8].GetProperty("requested").GetProperty("lineCount").GetInt32() > 0);
+            Assert.True(diffOperations[8].GetProperty("requested").GetProperty("characterCount").GetInt32() > 0);
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_AllIneligibleWrites_ReturnsNullDiff()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "echo");
+        using (client)
+        {
+            var result = await WriteBatchTools.PreviewWriteBatch(
+                client,
+                safety,
+                new[]
+                {
+                    new BatchOperationRequest
+                    {
+                        OperationId = "tag-1",
+                        Operation = "create_tag_table",
+                        ProjectPath = "echo",
+                        TableName = "Inputs"
+                    }
+                });
+
+            using var doc = JsonDocument.Parse(result);
+            Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("diff").ValueKind);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the registered runtime RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~WriteBatchPreviewDiffIntegrationTests"
+```
+
+Expected RED: every eligible-case assertion fails because `WriteBatchTools.PreviewWriteBatch` still serializes `diff: null`. This runtime RED is the justification for the first production edit in PR 4.
+
+- [ ] **Step 3: Review checkpoint**
+
+Confirm the failing tests all route through registered `WriteBatchTools`, not `BatchPreviewDiff` or a widened preview signature alone. Do not edit production before this runtime RED is observed.
+
+Suggested commit if separately authorized: `test: add registered preview diff regressions`
+
+---
+
+### Task 2: Implement The Smallest End-To-End Registered Preview Diff
+
+**Files:**
+- Create: `TiaMcpServer/Batch/BatchPreviewDiff.cs`
+- Modify: `TiaMcpServer/Batch/WriteBatchTools.cs`
+- Modify: `TiaMcpServer/Safety/WriteSafetyService.cs`
+- Modify: `TiaMcpServer/Safety/WriteSafetyTooling.cs`
+- Modify: `TiaMcpServer.Tests/TiaMcpServer.Tests.csproj`
+
+**Interfaces:**
+- Add: `public static class BatchPreviewDiff`
+- Add: `public const int MaxExcerptLinesPerSide = 40`
+- Add: `public const int MaxExcerptCharsPerSide = 8_192`
+- Add: `public const int MaxExcerptCharsPerLine = 512`
+- Add: `public const int MaxBatchExcerptLines = 320`
+- Add: `public const int MaxBatchExcerptChars = 32_768`
+- Add: `public static BatchPreviewDiffDocument? Build(IReadOnlyList<BatchOperationRequest> operations, IReadOnlyList<OperationBatchCurrentState> states)`
+- Add: `public sealed record BatchPreviewDiffDocument(IReadOnlyList<BatchPreviewDiffEntry> Operations)`
+- Add: `public sealed record BatchPreviewDiffEntry(string OperationId, string Operation, string Format, BatchPreviewDiffSide Current, BatchPreviewDiffSide Requested, bool RawTextEqual, bool NormalizedLinesEqual, bool LineEndingOnly, int UnchangedPrefixLineCount, int UnchangedSuffixLineCount, int CurrentChangedLineCount, int RequestedChangedLineCount, bool BatchBudgetExhausted)`
+- Add: `public sealed record BatchPreviewDiffSide(string Sha256, int CharacterCount, int LineCount, BatchPreviewDiffExcerpt Excerpt)`
+- Add: `public sealed record BatchPreviewDiffExcerpt(IReadOnlyList<BatchPreviewDiffLine> Lines, int OmittedLineCount, int OmittedCharacterCount, bool BudgetExhausted)`
+- Add: `public sealed record BatchPreviewDiffLine(int LineNumber, string Text, int OmittedCharacterCount)`
+- Change: `WriteSafetyService.CreatePreview(..., object? diff = null, string? instructions = null) -> string`
+- Change: `WriteSafetyTooling.CreatePreview(..., object? diff = null, string? instructions = null) -> string`
+- Change: `private static async Task<(IReadOnlyList<OperationBatchCurrentState> States, string CombinedState, string? Error)> ReadCombinedCurrentStateAsync(...)`
+- Preserve: `WriteSafetyService.CreateCanonicalPreview<TTarget, TInput, TState>(..., JsonElement? diff = null)` unchanged
+
+- [ ] **Step 1: Implement the end-to-end production path**
+
+Create `TiaMcpServer/Batch/BatchPreviewDiff.cs` and wire the registered preview path to it. Use this exact high-level structure:
+
+```csharp
+public static BatchPreviewDiffDocument? Build(
+    IReadOnlyList<BatchOperationRequest> operations,
+    IReadOnlyList<OperationBatchCurrentState> states)
+{
+    if (operations.Count != states.Count)
+    {
+        throw new ArgumentException("Operations and current-state rows must align by index.");
+    }
+
+    var remainingBatchLines = MaxBatchExcerptLines;
+    var remainingBatchChars = MaxBatchExcerptChars;
+    var entries = new List<BatchPreviewDiffEntry>();
+
+    for (var index = 0; index < operations.Count; index++)
+    {
+        var op = operations[index];
+        if (!IsEligible(op, out var requestedText, out var normalizedFormat))
+        {
+            continue;
+        }
+
+        var compared = Compare(states[index].CurrentState, requestedText);
+        var currentExcerpt = BuildExcerpt(
+            compared.CurrentLines,
+            compared.FirstChangedCurrentLineIndex,
+            compared.LastChangedCurrentLineIndex,
+            ref remainingBatchLines,
+            ref remainingBatchChars);
+        var requestedExcerpt = BuildExcerpt(
+            compared.RequestedLines,
+            compared.FirstChangedRequestedLineIndex,
+            compared.LastChangedRequestedLineIndex,
+            ref remainingBatchLines,
+            ref remainingBatchChars);
+
+        entries.Add(new BatchPreviewDiffEntry(
+            op.OperationId,
+            op.Operation,
+            normalizedFormat,
+            new BatchPreviewDiffSide(Sha256(states[index].CurrentState), states[index].CurrentState.Length, CountLines(states[index].CurrentState), currentExcerpt),
+            new BatchPreviewDiffSide(Sha256(requestedText), requestedText.Length, CountLines(requestedText), requestedExcerpt),
+            compared.RawTextEqual,
+            compared.NormalizedLinesEqual,
+            compared.LineEndingOnly,
+            compared.UnchangedPrefixLineCount,
+            compared.UnchangedSuffixLineCount,
+            compared.CurrentChangedLineCount,
+            compared.RequestedChangedLineCount,
+            currentExcerpt.BudgetExhausted || requestedExcerpt.BudgetExhausted));
+    }
+
+    return entries.Count == 0 ? null : new BatchPreviewDiffDocument(entries);
+}
+```
+
+Implementation rules:
+
+- `IsEligible(...)` returns true only for `update_block_logic` and `update_type_content`, pulling `YamlContent` or `SourceContent` and normalizing `format` with the existing defaults: `xml` for blocks, `source` for types.
+- `Compare(...)` computes raw equality from the original strings, then computes normalized-line equality by replacing CRLF and CR with LF only for line comparison.
+- Identical normalized lines produce zero changed-line counts and empty excerpts on both sides.
+- The excerpt builder enforces the exact limits from the spec: 40 lines and 8,192 characters per side, first 20 plus last 20 lines for oversized spans, 512 characters per displayed line, and 320 lines plus 32,768 characters across the whole batch in request order.
+- When the batch budget is exhausted, later eligible entries keep hashes, line counts, character counts, and omission totals but return empty `excerpt.lines`.
+
+Change `ReadCombinedCurrentStateAsync` in `WriteBatchTools.cs` so preview retains the already-read per-operation strings:
+
+```csharp
+private static async Task<(IReadOnlyList<OperationBatchCurrentState> States, string CombinedState, string? Error)>
+    ReadCombinedCurrentStateAsync(
+        OpennessWorkerClient workerClient,
+        BatchOperationRequest[] operations)
+{
+    var states = new List<OperationBatchCurrentState>(operations.Length);
+    foreach (var op in operations)
+    {
+        var state = await BatchWorkerInvoker.ReadCurrentStateAsync(workerClient, op).ConfigureAwait(false);
+        if (!state.Success)
+        {
+            return (Array.Empty<OperationBatchCurrentState>(), string.Empty,
+                $"Could not read current state for operationId '{op.OperationId}' ({op.Operation}). Error: {state.Error}");
+        }
+
+        states.Add(new OperationBatchCurrentState(op.OperationId, op.Operation, state.Payload));
+    }
+
+    return (states, BatchSafetySnapshot.CombineCurrentState(states), null);
+}
+```
+
+Then replace the preview call site's `diff: null` with:
+
+```csharp
+var previewDiff = BatchPreviewDiff.Build(operations, snapshot.States);
+
+return safety.CreatePreview(
+    ApplyToolName,
+    projectPath,
+    targets,
+    summary,
+    operations,
+    snapshot.CombinedState,
+    diff: previewDiff,
+    instructions: "Preview only — nothing was changed. To apply, call apply_write_batch with the identical operations list, confirm=true, and this safetyToken.");
+```
+
+Do not call `BatchPreviewDiff.Build(...)` from `ApplyWriteBatch`. Widen the generic preview seam in `WriteSafetyService` and `WriteSafetyTooling` to `object? diff`, and remove `WriteSafetyTooling.CreateLineDiff`.
+
+Link the new host file into `TiaMcpServer.Tests/TiaMcpServer.Tests.csproj`:
+
+```xml
+<Compile Include="..\TiaMcpServer\Batch\BatchPreviewDiff.cs"
+  Link="Host\Batch\BatchPreviewDiff.cs" />
+```
+
+- [ ] **Step 2: Run the registered runtime suite to GREEN**
+
+Run the Task 1 command again.
+
+Expected GREEN: the registered preview JSON now emits structured diff entries for source blocks, default/xml blocks, types, mixed eligible/ineligible batches, identical content, line-ending-only changes, and truncation cases, while an all-ineligible batch still returns `diff: null`.
+
+- [ ] **Step 3: Review checkpoint**
+
+Inspect `TiaMcpServer/Batch/BatchPreviewDiff.cs`, `TiaMcpServer/Batch/WriteBatchTools.cs`, `TiaMcpServer/Safety/WriteSafetyService.cs`, `TiaMcpServer/Safety/WriteSafetyTooling.cs`, and `TiaMcpServer.Tests/TiaMcpServer.Tests.csproj`. Confirm:
+
+- the first runtime seam that emits structured diff data is `WriteBatchTools`;
+- the only token inputs remain tool name, project path, target, requested input, and current state;
+- canonical network preview paths remain unchanged; and
+- no worker file changed.
+
+Suggested commit if separately authorized: `feat: wire structured preview diff into registered batch preview`
+
+---
+
+### Task 3: Refine The Pure Builder And Token-Independence Coverage
+
+**Files:**
+- Create: `TiaMcpServer.Tests/Batch/BatchPreviewDiffTests.cs`
+- Modify: `TiaMcpServer.Tests/Batch/BatchSafetyTokenTests.cs`
+
+**Interfaces:**
+- Consume: `BatchPreviewDiff.Build(IReadOnlyList<BatchOperationRequest> operations, IReadOnlyList<OperationBatchCurrentState> states)`
+- Consume: `WriteSafetyService.CreatePreview(..., object? diff = null, string? instructions = null)`
+- Preserve: all runtime behavior added in Task 2
+
+- [ ] **Step 1: Add the pure builder and token-independence tests**
+
+Create `TiaMcpServer.Tests/Batch/BatchPreviewDiffTests.cs`:
+
+```csharp
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.OperationBatches;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class BatchPreviewDiffTests
+{
+    private static BatchOperationRequest BlockOp(string id, string path, string requested, string? format = null)
+        => new()
+        {
+            OperationId = id,
+            Operation = "update_block_logic",
+            BlockPath = path,
+            YamlContent = requested,
+            Format = format,
+        };
+
+    private static BatchOperationRequest TypeOp(string id, string path, string requested, string? format = null)
+        => new()
+        {
+            OperationId = id,
+            Operation = "update_type_content",
+            TypePath = path,
+            SourceContent = requested,
+            Format = format,
+        };
+
+    private static OperationBatchCurrentState State(BatchOperationRequest op, string current)
+        => new(op.OperationId, op.Operation, current);
+
+    private static string Sha256(string value)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
+
+    [Fact]
+    public void Build_ReturnsNullWhenBatchHasNoEligibleTextReplacement()
+    {
+        var operations = new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "tag-1",
+                Operation = "create_tag_table",
+                TableName = "Inputs",
+            }
+        };
+
+        var states = new[]
+        {
+            new OperationBatchCurrentState("tag-1", "create_tag_table", "{\"table\":\"Inputs\"}")
+        };
+
+        Assert.Null(BatchPreviewDiff.Build(operations, states));
+    }
+
+    [Fact]
+    public void Build_UsesNormalizedWriteFormatAndRawHashesForEligibleOperations()
+    {
+        const string current = "DATA_BLOCK \"Recipe\"\r\nBEGIN\r\nEND_DATA_BLOCK\r\n";
+        const string requested = "DATA_BLOCK \"Recipe\"\r\nBEGIN\r\n  Value := 1;\r\nEND_DATA_BLOCK\r\n";
+        var op = BlockOp("block-1", "PLC_1/Blocks/Recipe_DB", requested, SourceFormatNames.Source);
+
+        var diff = BatchPreviewDiff.Build(new[] { op }, new[] { State(op, current) })!;
+        var entry = Assert.Single(diff.Operations);
+
+        Assert.Equal(SourceFormatNames.Source, entry.Format);
+        Assert.Equal(Sha256(current), entry.Current.Sha256);
+        Assert.Equal(Sha256(requested), entry.Requested.Sha256);
+    }
+
+    [Fact]
+    public void Build_IdenticalContent_ProducesEmptyExcerptsAndZeroChangedSpans()
+    {
+        const string content = "TYPE \"A\"\r\nSTRUCT\r\nEND_STRUCT;\r\nEND_TYPE\r\n";
+        var op = TypeOp("type-1", "PLC_1/Types/A", content);
+
+        var diff = BatchPreviewDiff.Build(new[] { op }, new[] { State(op, content) })!;
+        var entry = Assert.Single(diff.Operations);
+
+        Assert.True(entry.RawTextEqual);
+        Assert.True(entry.NormalizedLinesEqual);
+        Assert.False(entry.LineEndingOnly);
+        Assert.Equal(0, entry.CurrentChangedLineCount);
+        Assert.Equal(0, entry.RequestedChangedLineCount);
+        Assert.Empty(entry.Current.Excerpt.Lines);
+        Assert.Empty(entry.Requested.Excerpt.Lines);
+    }
+
+    [Fact]
+    public void Build_DetectsLineEndingOnlyDifference()
+    {
+        const string current = "TYPE \"A\"\r\nSTRUCT\r\nEND_STRUCT;\r\nEND_TYPE\r\n";
+        const string requested = "TYPE \"A\"\nSTRUCT\nEND_STRUCT;\nEND_TYPE\n";
+        var op = TypeOp("type-1", "PLC_1/Types/A", requested);
+
+        var diff = BatchPreviewDiff.Build(new[] { op }, new[] { State(op, current) })!;
+        var entry = Assert.Single(diff.Operations);
+
+        Assert.False(entry.RawTextEqual);
+        Assert.True(entry.NormalizedLinesEqual);
+        Assert.True(entry.LineEndingOnly);
+    }
+
+    [Fact]
+    public void Build_TruncatesChangedSpanToFirstAndLastTwentyLinesPerSide()
+    {
+        var current = string.Join("\r\n", Enumerable.Range(1, 60).Select(i => $"OLD {i}")) + "\r\n";
+        var requested = string.Join("\r\n", Enumerable.Range(1, 60).Select(i => $"NEW {i}")) + "\r\n";
+        var op = TypeOp("type-1", "PLC_1/Types/A", requested);
+
+        var diff = BatchPreviewDiff.Build(new[] { op }, new[] { State(op, current) })!;
+        var entry = Assert.Single(diff.Operations);
+
+        Assert.Equal(40, entry.Current.Excerpt.Lines.Count);
+        Assert.Equal(40, entry.Requested.Excerpt.Lines.Count);
+        Assert.Equal("OLD 1", entry.Current.Excerpt.Lines[0].Text);
+        Assert.Equal("OLD 60", entry.Current.Excerpt.Lines[^1].Text);
+        Assert.Equal("NEW 1", entry.Requested.Excerpt.Lines[0].Text);
+        Assert.Equal("NEW 60", entry.Requested.Excerpt.Lines[^1].Text);
+        Assert.Equal(20, entry.Current.Excerpt.OmittedLineCount);
+        Assert.Equal(20, entry.Requested.Excerpt.OmittedLineCount);
+    }
+
+    [Fact]
+    public void Build_TruncatesLongLinesAndReportsOmittedCharacters()
+    {
+        var longLine = new string('x', BatchPreviewDiff.MaxExcerptCharsPerLine + 37);
+        var current = "TYPE \"A\"\r\nEND_TYPE\r\n";
+        var requested = $"TYPE \"A\"\r\n{longLine}\r\nEND_TYPE\r\n";
+        var op = TypeOp("type-1", "PLC_1/Types/A", requested);
+
+        var diff = BatchPreviewDiff.Build(new[] { op }, new[] { State(op, current) })!;
+        var line = diff.Operations[0].Requested.Excerpt.Lines.Single(x => x.LineNumber == 2);
+
+        Assert.Equal(BatchPreviewDiff.MaxExcerptCharsPerLine, line.Text.Length);
+        Assert.Equal(37, line.OmittedCharacterCount);
+        Assert.Equal(37, diff.Operations[0].Requested.Excerpt.OmittedCharacterCount);
+    }
+
+    [Fact]
+    public void Build_ExhaustsTheWholeBatchLineBudgetAtTheFifthEligibleOperation_AndLaterEntriesKeepHashesAndCounts()
+    {
+        var current = string.Join("\r\n", Enumerable.Range(1, 60).Select(i => $"OLD {i}")) + "\r\n";
+        var requested = string.Join("\r\n", Enumerable.Range(1, 60).Select(i => $"NEW {i}")) + "\r\n";
+        var operations = Enumerable.Range(1, 6)
+            .Select(i => TypeOp($"type-{i}", $"PLC_1/Types/T{i}", requested))
+            .ToArray();
+        var states = operations.Select(op => State(op, current)).ToArray();
+
+        var diff = BatchPreviewDiff.Build(operations, states)!;
+
+        Assert.All(diff.Operations.Take(4), entry => Assert.NotEmpty(entry.Requested.Excerpt.Lines));
+        Assert.True(diff.Operations[4].BatchBudgetExhausted);
+        Assert.Empty(diff.Operations[4].Current.Excerpt.Lines);
+        Assert.Empty(diff.Operations[4].Requested.Excerpt.Lines);
+        Assert.True(diff.Operations[5].BatchBudgetExhausted);
+        Assert.Empty(diff.Operations[5].Current.Excerpt.Lines);
+        Assert.Empty(diff.Operations[5].Requested.Excerpt.Lines);
+        Assert.NotEmpty(diff.Operations[5].Requested.Sha256);
+        Assert.True(diff.Operations[5].Requested.LineCount > 0);
+        Assert.True(diff.Operations[5].Requested.CharacterCount > 0);
+    }
+}
+```
+
+Extend `TiaMcpServer.Tests/Batch/BatchSafetyTokenTests.cs` with:
+
+```csharp
+[Fact]
+public void DisplayDiff_IsNotRequiredForTokenValidation()
+{
+    using var audit = new TempAuditDirectory();
+    var service = audit.CreateSafety();
+    var (ops, states) = TwoItemBatch();
+    var targets = BatchSafetySnapshot.BuildTargets(ops);
+    var combined = BatchSafetySnapshot.CombineCurrentState(
+        ops.Select((o, i) => new OperationBatchCurrentState(o.OperationId, o.Operation, states[i])).ToList());
+    var project = BatchSafetySnapshot.ResolveProjectPath(ops);
+
+    var preview = service.CreatePreview(
+        ApplyToolName,
+        project,
+        targets,
+        "summary",
+        ops,
+        combined,
+        diff: new { operations = new[] { new { operationId = "b", operation = "update_block_logic" } } });
+    var token = JsonDocument.Parse(preview).RootElement.GetProperty("safetyToken").GetString()!;
+
+    Assert.True(service.ValidateAndConsume(token, ApplyToolName, project, targets, ops, combined).IsValid);
+}
+
+[Fact]
+public void DifferentDisplayDiffs_IssueTokensThatValidateAgainstTheSameState()
+{
+    using var audit = new TempAuditDirectory();
+    var service = audit.CreateSafety();
+    var (ops, states) = TwoItemBatch();
+    var targets = BatchSafetySnapshot.BuildTargets(ops);
+    var combined = BatchSafetySnapshot.CombineCurrentState(
+        ops.Select((o, i) => new OperationBatchCurrentState(o.OperationId, o.Operation, states[i])).ToList());
+    var project = BatchSafetySnapshot.ResolveProjectPath(ops);
+
+    var first = JsonDocument.Parse(service.CreatePreview(
+        ApplyToolName,
+        project,
+        targets,
+        "summary",
+        ops,
+        combined,
+        diff: new { version = 1 }));
+    var second = JsonDocument.Parse(service.CreatePreview(
+        ApplyToolName,
+        project,
+        targets,
+        "summary",
+        ops,
+        combined,
+        diff: new { version = 2, extra = true }));
+
+    Assert.True(service.ValidateEnvelope(first.RootElement.GetProperty("safetyToken").GetString(), ApplyToolName, project, targets, ops).IsValid);
+    Assert.True(service.ValidateEnvelope(second.RootElement.GetProperty("safetyToken").GetString(), ApplyToolName, project, targets, ops).IsValid);
+}
+```
+
+- [ ] **Step 2: Run the refinement RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~BatchPreviewDiffTests|FullyQualifiedName~BatchSafetyTokenTests.DisplayDiff_|FullyQualifiedName~BatchSafetyTokenTests.DifferentDisplayDiffs_"
+```
+
+Expected RED: any incompleteness in the minimal Task 2 implementation now shows up in exact helper-level assertions, especially the per-side omitted-line accounting, per-line character truncation, or the fifth-operation whole-batch exhaustion boundary.
+
+- [ ] **Step 3: Tighten the pure helper behavior until the refinement suite passes**
+
+Keep the runtime JSON property names from Task 2 unchanged. Fix only the pure helper accounting or generic preview seam details needed to satisfy the new tests; do not introduce a second response projection layer.
+
+- [ ] **Step 4: Run the refinement suite to GREEN**
+
+Run the Step 2 command again.
+
+Expected GREEN: the pure builder now proves no-eligible behavior, hashes/stats, identical-content handling, line-ending-only handling, per-side truncation, per-line truncation, the exact fifth-operation batch-exhaustion boundary, and token independence from display evidence.
+
+- [ ] **Step 5: Run the combined preview verification slice**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~WriteBatchPreviewDiffIntegrationTests|FullyQualifiedName~BatchPreviewDiffTests|FullyQualifiedName~BatchSafetyTokenTests.DisplayDiff_|FullyQualifiedName~BatchSafetyTokenTests.DifferentDisplayDiffs_"
+```
+
+Expected GREEN: the registered runtime surface and the pure helper assertions now agree on the same diff shape and the same response-only token boundary.
+
+- [ ] **Step 6: Review checkpoint**
+
+Confirm:
+
+- the first production edit was justified by Task 1's runtime RED through `WriteBatchTools`;
+- `BatchPreviewDiffTests` now use enough eligible operations to cross the real 320-line batch budget, with exhaustion beginning at the fifth eligible operation and later entries retaining hashes/counts but empty excerpts;
+- `BatchSafetyTokenTests` prove display evidence is outside token semantics; and
+- no test relies on a compile-time seam mismatch as the milestone's primary RED.
+
+Suggested commit if separately authorized: `test: harden pure preview diff accounting`
+
+---
+
+### Task 4: Update The Architecture And Supported-Operation Authorities
+
+**Files:**
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/SupportedOperations/IMPORT_EXPORT_OPTIONS_SUMMARY.md`
+- Modify: `docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md`
+- Modify: `docs/IMPROVEMENT_LOG.md`
+- Modify: `TiaMcpServer.Tests/Diagnostics/CiWorkflowTests.cs`
+
+**Interfaces:**
+- Document only. No code, schema, or contract changes in this task.
+
+- [ ] **Step 1: Add the documentation RED check**
+
+Before editing docs, add these assertions to `TiaMcpServer.Tests/Diagnostics/CiWorkflowTests.cs` so the behavior is pinned:
+
+```csharp
+[Fact]
+public void ImportExportSummary_DocumentsStructuredPreviewDiffBounds()
+{
+    var text = File.ReadAllText(Path.Combine(GetRepositoryRoot(), "docs", "SupportedOperations", "IMPORT_EXPORT_OPTIONS_SUMMARY.md"));
+
+    Assert.Contains("update_block_logic", text, StringComparison.Ordinal);
+    Assert.Contains("update_type_content", text, StringComparison.Ordinal);
+    Assert.Contains("40 excerpt lines", text, StringComparison.OrdinalIgnoreCase);
+    Assert.Contains("8,192", text, StringComparison.Ordinal);
+    Assert.Contains("32,768", text, StringComparison.Ordinal);
+    Assert.Contains("line-ending-only", text, StringComparison.OrdinalIgnoreCase);
+}
+```
+
+If `CiWorkflowTests` already contains a more natural documentation-authority section for import/export summaries, place this assertion there rather than inventing a second helper.
+
+- [ ] **Step 2: Run the focused RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ImportExportSummary_DocumentsStructuredPreviewDiffBounds"
+```
+
+Expected RED: the current docs do not mention structured preview diff budgets, eligible operations, or line-ending-only reporting.
+
+- [ ] **Step 3: Update the four authority documents**
+
+Apply these exact documentation additions:
+
+- In `docs/ARCHITECTURE.md` §8, add one short paragraph after the preview/apply description stating that `preview_write_batch` may include a response-only structured `diff` object for `update_block_logic` and `update_type_content`, built from the already-bound exact-format current text and the submitted replacement text, and that the object is outside token issuance and validation.
+- In `docs/SupportedOperations/IMPORT_EXPORT_OPTIONS_SUMMARY.md`, add one subsection named `Preview evidence` containing the exact budgets and flags from the spec:
+  - 40 excerpt lines and 8,192 excerpt characters per side per eligible operation;
+  - first 20 plus last 20 lines when a changed span exceeds 40 lines;
+  - 512 characters per displayed line;
+  - 320 excerpt lines and 32,768 excerpt characters across the whole batch in request order;
+  - raw SHA-256, raw character count, raw line count, `rawTextEqual`, `normalizedLinesEqual`, and `lineEndingOnly`;
+  - `diff: null` for every other operation.
+- In `docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md`, add one bullet under `Update and write behavior` stating that block/type replacement previews can include bounded structured evidence and that it is current-versus-requested only, not predicted post-write state.
+- In `docs/IMPROVEMENT_LOG.md`, record PR 4 as complete only after live acceptance is finished. Until then, keep it in the open follow-up section as "PR 4 structured preview diff live gate pending."
+
+- [ ] **Step 4: Run the documentation test to GREEN**
+
+Run the Step 2 command again.
+
+Expected GREEN: the documentation-authority test now passes against the updated wording.
+
+- [ ] **Step 5: Review checkpoint**
+
+Inspect the docs diff and confirm it does all of the following:
+
+- documents the exact budgets and line-ending-only semantics;
+- says the evidence is response-only and outside token hashing;
+- limits the feature to `update_block_logic` and `update_type_content`; and
+- does not claim lifecycle, network, or predicted post-state diff support.
+
+Suggested commit if separately authorized: `docs: describe structured preview diff bounds`
+
+---
+
+### Task 5: Add The Guarded Host-Level Live Harness And Durable Acceptance Report
+
+**Files:**
+- Create: `scripts/live-test-preview-write-diff.ps1`
+- Create: `TiaMcpServer.Tests/Batch/WritePreviewDiffLiveHarnessContractTests.cs`
+- Create: `docs/superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md`
+- Modify: `docs/README.md`
+- Modify: `docs/superpowers/README.md`
+
+**Interfaces:**
+- Add script modes: `[ValidateSet('Preview', 'Apply')] [string] $Mode = 'Preview'`
+- Add explicit apply gate: `[switch] $AllowApply`
+- Add explicit CI bypass gate for authorized runs only: `[switch] $ConfirmApplyForCi`
+- Add mandatory live-target parameters: `[Parameter(Mandatory)] [string] $ProjectPath`, `[Parameter(Mandatory)] [string] $BlockPath`, `[Parameter(Mandatory)] [string] $TypePath`
+- Add optional host artifact parameter: `[string] $HostDllPath = "TiaMcpServer/bin/Debug/net8.0/TiaMcpServer.dll"`
+
+- [ ] **Step 1: Add the execution-free contract RED tests**
+
+Create `TiaMcpServer.Tests/Batch/WritePreviewDiffLiveHarnessContractTests.cs`:
+
+```csharp
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class WritePreviewDiffLiveHarnessContractTests
+{
+    private static readonly string ScriptPath = Path.GetFullPath(
+        Path.Combine(GetRepositoryRoot(), "scripts", "live-test-preview-write-diff.ps1"));
+
+    [Fact]
+    public void Script_ExistsAndRequiresPowerShell7()
+    {
+        var text = ReadScript();
+        Assert.Matches(new Regex(@"^\s*#Requires\s+-Version\s+7(\.\d+)?\s*$", RegexOptions.Multiline), text);
+        Assert.Contains("$ErrorActionPreference = 'Stop'", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_DefaultsToPreviewAndGuardsApplyBehindAnExplicitSwitch()
+    {
+        var text = ReadScript();
+        Assert.Matches(new Regex(@"\[ValidateSet\(\s*'Preview'\s*,\s*'Apply'\s*\)\]"), text);
+        Assert.Matches(new Regex(@"\[string\]\s*\$Mode\s*=\s*'Preview'"), text);
+        Assert.Matches(new Regex(@"\[switch\]\s*\$AllowApply"), text);
+        Assert.Matches(new Regex(@"if\s*\(\s*\$Mode\s*-eq\s*'Apply'\s*-and\s*-not\s*\$AllowApply\s*\)"), text);
+    }
+
+    [Fact]
+    public void Script_UsesTheRealHostLevelMcpProtocolRatherThanDirectWorkerIpc()
+    {
+        var text = ReadScript();
+        Assert.Contains("TiaMcpServer.dll", text, StringComparison.Ordinal);
+        Assert.Contains("--project", text, StringComparison.Ordinal);
+        Assert.Contains("'initialize'", text, StringComparison.Ordinal);
+        Assert.Contains("notifications/initialized", text, StringComparison.Ordinal);
+        Assert.Contains("'tools/call'", text, StringComparison.Ordinal);
+        Assert.Contains("get_project_status", text, StringComparison.Ordinal);
+        Assert.Contains("preview_write_batch", text, StringComparison.Ordinal);
+        Assert.Contains("apply_write_batch", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("OpennessWorker.exe", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("open_project", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_ApplyPathRestoresOriginalBytesAndCompilesTheDisposableProject()
+    {
+        var text = ReadScript();
+        Assert.Contains("compile_check", text, StringComparison.Ordinal);
+        Assert.Contains("byte-identical", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("restore", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Read-Host", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_DocumentsDisposableProjectScopeAndWritesTheAcceptanceReportPath()
+    {
+        var text = ReadScript();
+        Assert.Matches(new Regex(@"disposable", RegexOptions.IgnoreCase), text);
+        Assert.Contains("2026-09-01-pr4-structured-preview-diff-live.md", text, StringComparison.Ordinal);
+    }
+
+    private static string ReadScript()
+    {
+        Assert.True(File.Exists(ScriptPath), $"Expected the live harness at '{ScriptPath}'.");
+        return File.ReadAllText(ScriptPath);
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        return Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            ".."));
+    }
+}
+```
+
+- [ ] **Step 2: Run the contract RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~WritePreviewDiffLiveHarnessContractTests"
+```
+
+Expected RED: the script file does not exist yet.
+
+- [ ] **Step 3: Create the live harness**
+
+Create `scripts/live-test-preview-write-diff.ps1` with the same static safety shape as the network live harnesses:
+
+```powershell
+#Requires -Version 7
+[CmdletBinding()]
+param(
+    [ValidateSet('Preview', 'Apply')]
+    [string] $Mode = 'Preview',
+    [Parameter(Mandatory)] [string] $ProjectPath,
+    [Parameter(Mandatory)] [string] $BlockPath,
+    [Parameter(Mandatory)] [string] $TypePath,
+    [switch] $AllowApply,
+    [switch] $ConfirmApplyForCi,
+    [string] $HostDllPath = "TiaMcpServer/bin/Debug/net8.0/TiaMcpServer.dll"
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Mode -eq 'Apply' -and -not $AllowApply) {
+    throw "Apply mode is disabled by default. Re-run with -AllowApply only for an explicitly authorized disposable project copy."
+}
+```
+
+Harness requirements:
+
+- Launch the real host (`TiaMcpServer.dll`) in read-write mode with the exact disposable `--project` path, speak NDJSON MCP, and verify the active binding through the public read-only `get_project_status` path before any batch preview/apply call.
+- In both modes, read the current block/type text first through `execute_read_batch` so the harness owns the exact original bytes it later compares and, in `Apply` mode, restores.
+- In `Preview` mode, run three non-mutating checks and write their findings into the report body:
+  - block source preview with a real content change and structured diff present;
+  - type source preview with a real content change and structured diff present;
+  - line-ending-only preview where the submitted replacement changes only CRLF vs LF and the preview reports `rawTextEqual = false`, `normalizedLinesEqual = true`, and `lineEndingOnly = true`.
+- Also in `Preview` mode, generate enough oversized requested replacements with 512-character retained lines so the returned preview proves per-line truncation, per-side truncation, and deterministic request-order whole-batch exhaustion without applying anything.
+- In `Apply` mode, after an interactive confirmation unless `-ConfirmApplyForCi` is supplied:
+  - preview a two-item batch (`update_block_logic` and `update_type_content`);
+  - apply it with the unchanged operation list and issued token;
+  - preview and apply a second batch restoring the original bytes exactly;
+  - re-read both objects and assert byte-identical restoration;
+  - run `compile_check` and require zero errors;
+  - record the final clean state in the acceptance report.
+
+- [ ] **Step 4: Create the dated acceptance report template and index entries**
+
+Create `docs/superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md` with these fixed sections:
+
+```markdown
+# PR 4 Structured Preview Diff Live Acceptance
+
+## Environment
+
+- Date:
+- TIA Portal version:
+- Host build:
+- Disposable project path:
+- Binding verification:
+- Block target:
+- Type target:
+
+## Preview-Only Evidence
+
+- Block preview:
+- Type preview:
+- Line-ending-only preview:
+- Oversized batch preview:
+
+## Apply / Restore / Compile
+
+- Apply authorization:
+- Applied changes:
+- Restore result:
+- Byte-identical re-read:
+- Compile result:
+
+## Evidence Boundary
+
+- Proven:
+- Not proven:
+```
+
+Then update both indexes:
+
+- `docs/README.md`: add the new acceptance report to the `Latest process entries` sentence.
+- `docs/superpowers/README.md`: add one row under `Acceptance reports` for `2026-09-01` and this file.
+
+- [ ] **Step 5: Run the contract tests to GREEN**
+
+Run the Step 2 command again.
+
+Expected GREEN: the script source is now present and statically proves host-level protocol use, startup `--project` binding plus read-only `get_project_status` verification, preview-default safety, explicit apply gating, restore/compile behavior, and durable report naming.
+
+- [ ] **Step 6: Review checkpoint**
+
+Inspect `scripts/live-test-preview-write-diff.ps1`, `WritePreviewDiffLiveHarnessContractTests.cs`, the new acceptance report file, and the two doc indexes. Confirm:
+
+- the script defaults to preview-only;
+- the only `confirm = $true` write path is inside the explicit apply branch;
+- the harness starts the host with the exact disposable `--project` path and verifies binding through `get_project_status` without any lifecycle preview/apply call;
+- the harness never talks directly to `OpennessWorker.exe`;
+- the report names the exact evidence boundary; and
+- the docs indexes reference the new report.
+
+Suggested commit if separately authorized: `test: add live harness for structured preview diff`
+
+---
+
+### Task 6: Run Full Offline Verification And The Separately Authorized Live Gate
+
+**Files:**
+- Review: every file changed by Tasks 1-5
+
+**Verification boundary:**
+- Establishes offline: pure diff behavior, registered preview JSON shape, token independence, documentation authority, host build, and full test-suite status.
+- Establishes live: host-level preview evidence, startup `--project` binding plus read-only `get_project_status` verification, explicit apply/restore with unchanged inputs and issued tokens, byte-identical restoration, and clean compile on a disposable V21 project copy.
+- Does not establish: lifecycle or network diff behavior, predicted post-write Siemens state, PLC start/stop correctness, plant acceptance, or physical-hardware acceptance.
+
+- [ ] **Step 1: Run the focused offline verification set**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~BatchPreviewDiffTests|FullyQualifiedName~BatchSafetyTokenTests.DisplayDiff_|FullyQualifiedName~BatchSafetyTokenTests.DifferentDisplayDiffs_|FullyQualifiedName~WriteBatchPreviewDiffIntegrationTests|FullyQualifiedName~WritePreviewDiffLiveHarnessContractTests|FullyQualifiedName~ImportExportSummary_DocumentsStructuredPreviewDiffBounds"
+```
+
+Expected GREEN: all new pure, integration, contract, and documentation-authority tests pass together.
+
+- [ ] **Step 2: Build the full stubbed solution**
+
+Run:
+
+```powershell
+dotnet build TiaMcpServer.sln -m:1 /p:UseTiaPortalReferenceStubs=true
+```
+
+Expected GREEN: the host, tests, worker, and scripts/docs-adjacent code compile without a live Siemens installation.
+
+- [ ] **Step 3: Run the full serial test suite**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers
+```
+
+Expected GREEN: the complete offline suite passes. If an unrelated pre-existing flake appears, rerun only that exact test once, record both outcomes in the implementation notes, and do not expand PR 4 into unrelated repairs.
+
+- [ ] **Step 4: Run scope and whitespace checks**
+
+Run:
+
+```powershell
+git diff --check
+git status --short
+git diff --stat
+```
+
+Confirm:
+
+- `CanonicalWriteSafety.cs`, `StructuredToolResult.cs`, `NetworkReadTools.cs`, `NetworkWriteTools.cs`, and `StructuredOperationBatchPayloadBudget.cs` are unchanged.
+- `preview_write_batch` is the only runtime call site that now emits structured diff data.
+- No worker file changed.
+- No non-content write preview changed from `diff: null`.
+
+- [ ] **Step 5: Run the live preview-only harness**
+
+Run only after explicit authorization for the exact disposable project target:
+
+```powershell
+pwsh -NoProfile -File scripts/live-test-preview-write-diff.ps1 `
+  -Mode Preview `
+  -ProjectPath "C:\Path\To\Disposable\Line.ap21" `
+  -BlockPath "PLC_1/Blocks/Recipe_DB" `
+  -TypePath "PLC_1/Types/AnalogInputSettings"
+```
+
+Expected GREEN: the script records the startup `--project` plus `get_project_status` binding proof, emits structured preview evidence for the block and type routes, proves the line-ending-only case, proves truncation/batch-exhaustion behavior non-mutatingly, and writes the preview section of `docs/superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md`.
+
+- [ ] **Step 6: Run the live apply / restore / compile harness**
+
+Run only after separate explicit authorization for mutation on that same disposable project copy:
+
+```powershell
+pwsh -NoProfile -File scripts/live-test-preview-write-diff.ps1 `
+  -Mode Apply `
+  -AllowApply `
+  -ProjectPath "C:\Path\To\Disposable\Line.ap21" `
+  -BlockPath "PLC_1/Blocks/Recipe_DB" `
+  -TypePath "PLC_1/Types/AnalogInputSettings"
+```
+
+Expected GREEN: the script applies exactly one two-item batch through `preview_write_batch` then `apply_write_batch`, restores the original bytes through a second preview/apply pair, re-reads both objects byte-identically, compiles cleanly, and completes the dated acceptance report with the exact mutation/restore boundary while keeping lifecycle preview/apply and rebinding out of scope.
+
+- [ ] **Step 7: Final review checkpoint**
+
+Report exactly:
+
+- which files changed;
+- the focused test, full build, and full-suite results;
+- the preview-only live result;
+- the apply/restore/compile live result;
+- the path to the acceptance report; and
+- any remaining deferred work that stayed out of PR 4.
+
+Suggested commit if separately authorized: `feat: add structured preview diff for block and type writes`
+
+---
+
+## Deferred / Out Of Scope
+
+- No generalized diff engine for lifecycle tools, `network_write`, create/delete operations, tree operations, or any other non-content preview.
+- No predicted post-import, post-compile, or post-write Siemens state. PR 4 compares only the exact currently bound current text and the submitted replacement text.
+- No token format, token lifetime, token single-use, audit format, project binding, or pinned-lease behavior change.
+- No canonical-network behavior change. This PR does not alter `CanonicalWriteSafety`, `StructuredToolResult`, network response schemas, or network payload budgeting.
+- No PLC `start_plc` / `stop_plc` work. Those remain deferred exactly as the 2026-09-01 hardening design says.
+- No claim that offline or FakeWorker coverage is sufficient. Live TIA Portal V21 host-level acceptance on a disposable project copy remains mandatory.
+- No README landing-page update unless a reviewer explicitly decides the additive preview field materially changes the public landing-page contract.

--- a/docs/superpowers/plans/2026-09-01-pr5-tag-operation-safety-scopes.md
+++ b/docs/superpowers/plans/2026-09-01-pr5-tag-operation-safety-scopes.md
@@ -1,0 +1,1704 @@
+# PR 5 Tag Operation Safety Scopes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the blanket `ListTagTablesAsync` batch write-safety selector with operation-specific typed tag-table, tag, and user-constant snapshots that catch proven relevant drift, tolerate unrelated sibling drift, and preserve the existing token semantics.
+
+**Architecture:** Keep Siemens object resolution and deterministic table export inside the net48 worker, but move the host from one broad `list_tag_tables` current-state read to exact per-operation snapshot reads decoded through shared typed contracts. Add a pure selector-key layer in the host for within-phase dedup only, then expand reused payloads back into ordered per-operation state strings before `OperationBatchStateComposer` hashes them. Use FakeWorker to prove the host-side token behavior end to end, but treat it only as offline evidence; mandatory live TIA Portal V21 acceptance on a disposable project copy remains required for PR completion.
+
+**Tech Stack:** C# 12, .NET 8 host/FakeWorker/tests, .NET Standard 2.0 shared contracts, .NET Framework 4.8 Openness worker, xUnit, `System.Text.Json`, canonical JSON helpers, newline-delimited JSON worker IPC, PowerShell 7 live harnesses.
+
+**Spec:** [`docs/superpowers/specs/2026-09-01-write-safety-hardening-design.md`](../specs/2026-09-01-write-safety-hardening-design.md)
+
+## Global Constraints
+
+- Implement PR 5 only on top of the approved PR 2 and PR 3 baseline. If the branch still carries the pre-PR2 duplicated write path in `TiaMcpServer/Batch/BatchTools.cs`, merge or rebase the prerequisite first instead of backporting PR 5 into the old wrapper shape.
+- Work on the current branch. Do not create or switch branches or worktrees under this plan.
+- Scope is exactly PR 5 from the approved design: typed tag-safety snapshots, exact collision probes, deterministic timestamp-free full tag-table export for deletion, and within-phase dedup with ordered expansion.
+- Preserve public tool names, public input schemas, token lifetime, single-use behavior, ordered target hashing, apply-time pinned lease behavior, audit format, and failure categories.
+- Internal token-minting snapshot reads must consume the PR 3 `OperationCapability.SafetyRead` policy: allowed in read-only mode, but still requiring the verified `ExpectedSessionIdentity` on every request.
+- Keep the worker as the only authority for Siemens object resolution. The host may validate, decode, canonicalize, hash, deduplicate, and compose snapshots, but it must not reconstruct target identity from best-effort `list_tag_tables` output.
+- `list_tag_tables` remains best-effort and read-only. Do not change its public completeness semantics as part of PR 5.
+- `update_tag` already binds the three external-access flags from PR 3. PR 5 must replace the remaining broad table-list composition rather than reintroducing or duplicating that milestone.
+- Dedup may reuse only identical selector reads within one preview phase or one apply phase. The key must include normalized project path, selector kind, PLC identity, folder path, table name, target object name, the requested name semantics for that operation, and the effective requested logical address when relevant.
+- Dedup must not survive across preview and apply. Apply always performs fresh reads.
+- Every reused payload must expand back into one `OperationBatchCurrentState` entry per original operation in the original request order before `BatchSafetySnapshot.CombineCurrentState` runs.
+- Explicitly defer: multilingual per-tag comment binding, public `list_tag_tables` completeness changes, broader snapshot narrowing beyond the eight PR 5 operations, and all PLC `start_plc` / `stop_plc` work.
+- Follow behavioral TDD. Each task below starts with a focused failing test or contract test, then the smallest production change, then focused green verification.
+- Offline and FakeWorker evidence are required but cannot complete the PR. Mandatory live TIA Portal V21 acceptance requires a guarded live harness and report.
+- Do not run the live harness without separate explicit authorization for the exact disposable project copy and the exact restore-or-discard strategy for that run.
+- Use serial Windows .NET verification commands: `dotnet build ... --no-restore -m:1 --disable-build-servers` and `dotnet test ... --no-restore -m:1 --disable-build-servers`.
+- Do not commit, push, post comments, or run live mutation merely because a task reaches its checkpoint. Each checkpoint includes only a suggested commit if separately authorized.
+
+## Deferred / Out Of Scope
+
+- multilingual per-tag comment binding
+- public `list_tag_tables` completeness changes
+- broader snapshot narrowing beyond the eight PR 5 operations
+- PLC `start_plc` / `stop_plc`
+- any attempt to treat offline, FakeWorker, or static contract evidence as a substitute for mandatory live TIA Portal V21 acceptance
+
+## File / Interface Map
+
+- Create: `TiaMcpServer.Contracts/TagOperationSafetySnapshotInfo.cs`
+  Shared typed snapshot records for the eight tag-related write selectors:
+  `CreateTagTableSafetySnapshotInfo`, `DeleteTagTableSafetySnapshotInfo`,
+  `CreateTagSafetySnapshotInfo`, `UpdateTagSafetySnapshotInfo`,
+  `DeleteTagSafetySnapshotInfo`, `CreateUserConstantSafetySnapshotInfo`,
+  `UpdateUserConstantSafetySnapshotInfo`, and `DeleteUserConstantSafetySnapshotInfo`.
+- Create: `TiaMcpServer/Batch/TagOperationSafetySnapshotContract.cs`
+  Host-side exact payload decoder that rejects malformed worker payloads as `protocol_error`
+  and reserializes validated snapshots through one canonical JSON path for hashing.
+- Create: `TiaMcpServer/Batch/TagOperationSafetySelector.cs`
+  Pure selector-key builder for effective-name/effective-address normalization and within-phase dedup.
+- Modify: `TiaMcpServer/Batch/BatchWorkerInvoker.cs`
+  Replace the broad `ListTagTablesAsync` current-state read for tag operations with exact per-operation worker snapshot calls.
+- Modify: `TiaMcpServer/Batch/WriteBatchTools.cs`
+  Add the ephemeral dedup map inside `ReadCombinedCurrentStateAsync` and preserve ordered `OperationBatchCurrentState` expansion.
+- Modify: `TiaMcpServer/Worker/OpennessWorkerClient.cs`
+  Add internal worker-call methods for each exact tag safety snapshot read.
+- Modify: `TiaMcpServer.Contracts/OperationPolicyCatalog.cs`
+  Register the new internal worker read methods under the existing `SafetyRead` policy so they stay identity-bound without advertising them publicly.
+- Modify: `TiaMcpServer.OpennessWorker/Program.cs`
+  Dispatch the new internal worker methods to the worker reader.
+- Create: `TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotBuilder.cs`
+  Pure deterministic snapshot shaper and exact-content helper that the test project can link without Siemens assemblies; export determinism comes from the TIA export call options first, with any fallback normalization tightly proven and allowlisted.
+- Create: `TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotReader.cs`
+  Siemens-dependent resolver/exporter that produces the typed shared snapshot DTOs.
+- Modify: `TiaMcpServer.FakeWorker/Program.cs`
+  Add deterministic tag-safety scenarios for same-object drift, relevant collision drift, unrelated sibling tolerance, delete-table export drift, and apply re-read proof.
+- Modify: `TiaMcpServer.Tests/TiaMcpServer.Tests.csproj`
+  Link any new pure helper source file needed for net8 test coverage.
+- Create or modify focused tests:
+  `TiaMcpServer.Tests/Batch/TagOperationSafetySnapshotContractTests.cs`,
+  `TiaMcpServer.Tests/Batch/TagOperationSafetySelectorTests.cs`,
+  `TiaMcpServer.Tests/Batch/TagOperationPrerequisiteBaselineTests.cs`,
+  `TiaMcpServer.Tests/Batch/TagOperationSafetyWorkerSourceContractTests.cs`,
+  `TiaMcpServer.Tests/Batch/TagOperationCurrentStateReadFakeWorkerTests.cs`,
+  `TiaMcpServer.Tests/Batch/TagOperationFakeWorkerTests.cs`,
+  `TiaMcpServer.Tests/Worker/TagOperationSafetyClientIdentityTests.cs`,
+  `TiaMcpServer.Tests/Worker/TagOperationSafetyIdentityEnforcementTests.cs`,
+  `TiaMcpServer.Tests/Safety/TagOperationSafetyReadPolicyTests.cs`,
+  `TiaMcpServer.Tests/Batch/BatchSafetySnapshotTests.cs`,
+  and the live-harness contract test.
+- Create: `scripts/live-test-tag-operation-safety-scopes.ps1`
+  Guarded PowerShell 7 live harness with a non-mutating default and explicit mutation modes.
+- Create: `TiaMcpServer.Tests/Batch/TagOperationSafetyLiveHarnessContractTests.cs`
+  Static execution-free contract tests for the live harness.
+- Modify current docs after implementation:
+  `docs/ARCHITECTURE.md`,
+  `docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md`,
+  `docs/IMPROVEMENT_LOG.md`,
+  `docs/README.md`,
+  `docs/superpowers/README.md`.
+- Create after the authorized live run:
+  `docs/superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md`.
+
+---
+
+### Task 0: Prove the PR 2 and PR 3 Baseline Before Any PR 5 RED/GREEN Cycle
+
+**Files:**
+- Create: `TiaMcpServer.Tests/Batch/TagOperationPrerequisiteBaselineTests.cs`
+- Modify: `TiaMcpServer.Tests/TiaMcpServer.Tests.csproj`
+
+**Interfaces:**
+- Consumes existing registered write surface: `TiaMcpServer/Program.cs` must keep `.WithTools<WriteBatchTools>()`.
+- Consumes existing PR 3 baseline: `OperationCapability.SafetyRead` already exists, and `update_tag` must still forward `externalAccessible`, `externalVisible`, and `externalWritable` through the registered write path.
+- Produces a hard stop gate for the rest of this plan: if these proofs fail, do not continue with PR 5 until the branch is rebased/merged onto PR 2 and PR 3.
+
+- [ ] **Step 1: Add the prerequisite baseline tests**
+
+Create `TagOperationPrerequisiteBaselineTests.cs`:
+
+```csharp
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationPrerequisiteBaselineTests
+{
+    [Fact]
+    public void Program_RegistersWriteBatchTools()
+    {
+        var text = File.ReadAllText(Source("TiaMcpServer/Program.cs"));
+
+        Assert.Contains(".WithTools<WriteBatchTools>()", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UpdateTag_BaselineStillCarriesPr3MutableFlagsThroughTheRegisteredWritePath()
+    {
+        var capability = File.ReadAllText(Source("TiaMcpServer.Contracts/OperationCapability.cs"));
+        var catalog = File.ReadAllText(Source("TiaMcpServer/Batch/BatchOperationCatalog.cs"));
+        var invoker = File.ReadAllText(Source("TiaMcpServer/Batch/BatchWorkerInvoker.cs"));
+
+        Assert.Contains("SafetyRead", capability, StringComparison.Ordinal);
+        Assert.Contains("\"externalAccessible\"", catalog, StringComparison.Ordinal);
+        Assert.Contains("\"externalVisible\"", catalog, StringComparison.Ordinal);
+        Assert.Contains("\"externalWritable\"", catalog, StringComparison.Ordinal);
+        Assert.Contains(
+            "client.UpdateTagAsync(op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.NewName, op.DataType, op.LogicalAddress, op.ExternalAccessible, op.ExternalVisible, op.ExternalWritable, op.IsSafety, op.ProjectPath)",
+            invoker,
+            StringComparison.Ordinal);
+    }
+
+    private static string Source(string relative)
+        => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", relative));
+}
+```
+
+- [ ] **Step 2: Run the prerequisite checkpoint and require GREEN**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~TagOperationPrerequisiteBaselineTests"
+```
+
+Expected GREEN:
+
+- `Program.cs` already exposes the registered `WriteBatchTools` surface from PR 2.
+- `OperationCapability.SafetyRead` already exists from PR 3.
+- `update_tag` still carries the PR 3 external-access flag baseline through the registered write path.
+
+If this command is RED, stop. Rebase or merge the missing prerequisite before writing any PR 5 test or production change.
+
+- [ ] **Step 3: Review checkpoint**
+
+Confirm:
+
+- PR 5 work will run on the registered PR 2 write surface, not the obsolete wrapper shape.
+- PR 3's `SafetyRead` capability and `update_tag` mutable-state flag baseline are still present and must be preserved by the narrower PR 5 snapshot work.
+
+Suggested commit: none. This task is a prerequisite gate, not a deliverable.
+
+---
+
+### Task 1: Define the Shared Snapshot Contracts and Pure Host Decoders
+
+**Files:**
+- Create: `TiaMcpServer.Contracts/TagOperationSafetySnapshotInfo.cs`
+- Create: `TiaMcpServer/Batch/TagOperationSafetySnapshotContract.cs`
+- Create: `TiaMcpServer/Batch/TagOperationSafetySelector.cs`
+- Create: `TiaMcpServer.Tests/Batch/TagOperationSafetySnapshotContractTests.cs`
+- Create: `TiaMcpServer.Tests/Batch/TagOperationSafetySelectorTests.cs`
+- Modify: `TiaMcpServer.Tests/Batch/BatchSafetySnapshotTests.cs`
+
+**Interfaces:**
+- Add: `public sealed record TagTableSafetyIdentityInfo(string PlcName, string FolderPath, string TableName, string CanonicalPath);`
+- Add: `public sealed record TagSafetyIdentityInfo(string PlcName, string FolderPath, string TableName, string TagName, string CanonicalPath, string DataType, string? LogicalAddress, bool? ExternalAccessible, bool? ExternalVisible, bool? ExternalWritable);`
+- Add: `public sealed record UserConstantSafetyIdentityInfo(string PlcName, string FolderPath, string TableName, string ConstantName, string CanonicalPath, string DataType, string Value);`
+- Add: `public sealed record TagCollisionProbeInfo(string Kind, string CandidateName, string CanonicalPath, string? LogicalAddress, bool IsTarget);`
+- Add one typed record per operation snapshot with only the fields that operation needs.
+- Add: `internal sealed record TagOperationSafetyDecodeResult(bool Success, string CanonicalState, string? Error = null, string? FailureCategory = null);`
+- Add: `internal sealed record TagOperationSafetySelectorKey(string SelectorKind, string? NormalizedProjectPath, string PlcName, string FolderPath, string TableName, string? ObjectName, string? EffectiveName, string? EffectiveLogicalAddress);`
+- Add: `public static TagOperationSafetyDecodeResult Decode(string operation, string payload)` in `TagOperationSafetySnapshotContract`.
+- Add: `public static TagOperationSafetySelectorKey Build(BatchOperationRequest op)` in `TagOperationSafetySelector`.
+- Add: `public static bool TryBuild(BatchOperationRequest op, out TagOperationSafetySelectorKey key)` in `TagOperationSafetySelector`.
+
+- [ ] **Step 1: Add failing contract and selector tests**
+
+Create `TagOperationSafetySnapshotContractTests.cs` with exact decode coverage:
+
+```csharp
+using TiaMcpServer.Batch;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationSafetySnapshotContractTests
+{
+    [Fact]
+    public void UpdateTagSnapshot_PreservesFalseFlagsAndEffectiveRename()
+    {
+        var payload = """
+        {
+          "targetTable":{"plcName":"PLC_1","folderPath":"","tableName":"Inputs","canonicalPath":"PLC_1/Tag tables/Inputs"},
+          "targetTag":{"plcName":"PLC_1","folderPath":"","tableName":"Inputs","tagName":"Start","canonicalPath":"PLC_1/Tag tables/Inputs/Start","dataType":"Bool","logicalAddress":"%I0.0","externalAccessible":false,"externalVisible":false,"externalWritable":false},
+          "effectiveName":"Start_1",
+          "effectiveLogicalAddress":"%I0.1",
+          "nameCollisions":[{"kind":"tag-name","candidateName":"Start_1","canonicalPath":"PLC_1/Tag tables/Inputs/Start_1","logicalAddress":"%I0.1","isTarget":false}],
+          "addressCollisions":[{"kind":"logical-address","candidateName":"Other","canonicalPath":"PLC_1/Tag tables/Inputs/Other","logicalAddress":"%I0.1","isTarget":false}]
+        }
+        """;
+
+        var result = TagOperationSafetySnapshotContract.Decode("update_tag", payload);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Contains("\"externalAccessible\":false", result.CanonicalState, StringComparison.Ordinal);
+        Assert.Contains("\"externalVisible\":false", result.CanonicalState, StringComparison.Ordinal);
+        Assert.Contains("\"externalWritable\":false", result.CanonicalState, StringComparison.Ordinal);
+        Assert.Contains("\"effectiveName\":\"Start_1\"", result.CanonicalState, StringComparison.Ordinal);
+        Assert.Contains("\"effectiveLogicalAddress\":\"%I0.1\"", result.CanonicalState, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeleteTagTableSnapshot_RequiresFullExport()
+    {
+        var payload = """
+        {
+          "targetTable":{"plcName":"PLC_1","folderPath":"","tableName":"Inputs","canonicalPath":"PLC_1/Tag tables/Inputs"},
+          "exportedSimaticMl":"<Document />",
+          "exportSha256":"abc123",
+          "characterCount":12
+        }
+        """;
+
+        var result = TagOperationSafetySnapshotContract.Decode("delete_tag_table", payload);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Contains("\"exportedSimaticMl\":\"<Document />\"", result.CanonicalState, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MalformedPayload_FailsClosedAsProtocolError()
+    {
+        var result = TagOperationSafetySnapshotContract.Decode("create_tag", "{\"targetTable\":42}");
+
+        Assert.False(result.Success);
+        Assert.Equal(WorkerFailureCategories.ProtocolError, result.FailureCategory);
+    }
+}
+```
+
+Create `TagOperationSafetySelectorTests.cs` with effective-name/effective-address coverage:
+
+```csharp
+using TiaMcpServer.Batch;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationSafetySelectorTests
+{
+    [Fact]
+    public void Build_UpdateTag_UsesRequestedRenameAndLogicalAddress()
+    {
+        var key = TagOperationSafetySelector.Build(new BatchOperationRequest
+        {
+            OperationId = "u1",
+            Operation = "update_tag",
+            ProjectPath = @"C:\Plant\Demo.ap21",
+            PlcName = "PLC_1",
+            TableName = "Inputs",
+            Name = "Start",
+            NewName = "Start_1",
+            LogicalAddress = "%I0.1"
+        });
+
+        Assert.Equal("update_tag", key.SelectorKind);
+        Assert.Equal(@"C:\Plant\Demo.ap21", key.NormalizedProjectPath);
+        Assert.Equal("Start_1", key.EffectiveName);
+        Assert.Equal("%I0.1", key.EffectiveLogicalAddress);
+    }
+
+    [Fact]
+    public void Build_DeleteTag_DoesNotCollapseIntoUpdateTagKey()
+    {
+        var update = TagOperationSafetySelector.Build(new BatchOperationRequest
+        {
+            OperationId = "u1",
+            Operation = "update_tag",
+            ProjectPath = @"C:\Plant\Demo.ap21",
+            PlcName = "PLC_1",
+            TableName = "Inputs",
+            Name = "Start"
+        });
+        var delete = TagOperationSafetySelector.Build(new BatchOperationRequest
+        {
+            OperationId = "d1",
+            Operation = "delete_tag",
+            ProjectPath = @"C:\Plant\Demo.ap21",
+            PlcName = "PLC_1",
+            TableName = "Inputs",
+            Name = "Start"
+        });
+
+        Assert.NotEqual(update.SelectorKind, delete.SelectorKind);
+    }
+}
+```
+
+Extend `BatchSafetySnapshotTests.cs` so the description and ordered-target assertions cover at least `delete_tag_table` and `create_user_constant`.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~TagOperationSafetySnapshotContractTests|FullyQualifiedName~TagOperationSafetySelectorTests|FullyQualifiedName~BatchSafetySnapshotTests"
+```
+
+Expected RED: the snapshot contract types, decoder, and selector key do not exist yet.
+
+- [ ] **Step 3: Implement the smallest shared DTO set**
+
+Create `TagOperationSafetySnapshotInfo.cs` with the exact operation records. Use one file so every host/worker/test reference stays in the same shared contract surface:
+
+```csharp
+namespace TiaMcpServer.Contracts;
+
+public sealed record TagTableSafetyIdentityInfo(
+    string PlcName,
+    string FolderPath,
+    string TableName,
+    string CanonicalPath);
+
+public sealed record TagSafetyIdentityInfo(
+    string PlcName,
+    string FolderPath,
+    string TableName,
+    string TagName,
+    string CanonicalPath,
+    string DataType,
+    string? LogicalAddress,
+    bool? ExternalAccessible,
+    bool? ExternalVisible,
+    bool? ExternalWritable);
+
+public sealed record UserConstantSafetyIdentityInfo(
+    string PlcName,
+    string FolderPath,
+    string TableName,
+    string ConstantName,
+    string CanonicalPath,
+    string DataType,
+    string Value);
+
+public sealed record TagCollisionProbeInfo(
+    string Kind,
+    string CandidateName,
+    string CanonicalPath,
+    string? LogicalAddress,
+    bool IsTarget);
+
+public sealed record CreateTagTableSafetySnapshotInfo(
+    string PlcName,
+    string FolderPath,
+    string RequestedTableName,
+    IReadOnlyList<TagCollisionProbeInfo> TableNameCollisions);
+
+public sealed record DeleteTagTableSafetySnapshotInfo(
+    TagTableSafetyIdentityInfo TargetTable,
+    string ExportedSimaticMl,
+    string ExportSha256,
+    int CharacterCount);
+
+public sealed record CreateTagSafetySnapshotInfo(
+    TagTableSafetyIdentityInfo TargetTable,
+    string EffectiveName,
+    string? EffectiveLogicalAddress,
+    IReadOnlyList<TagCollisionProbeInfo> NameCollisions,
+    IReadOnlyList<TagCollisionProbeInfo> AddressCollisions);
+
+public sealed record UpdateTagSafetySnapshotInfo(
+    TagTableSafetyIdentityInfo TargetTable,
+    TagSafetyIdentityInfo TargetTag,
+    string EffectiveName,
+    string? EffectiveLogicalAddress,
+    IReadOnlyList<TagCollisionProbeInfo> NameCollisions,
+    IReadOnlyList<TagCollisionProbeInfo> AddressCollisions);
+
+public sealed record DeleteTagSafetySnapshotInfo(
+    TagTableSafetyIdentityInfo TargetTable,
+    TagSafetyIdentityInfo TargetTag);
+
+public sealed record CreateUserConstantSafetySnapshotInfo(
+    TagTableSafetyIdentityInfo TargetTable,
+    string EffectiveName,
+    IReadOnlyList<TagCollisionProbeInfo> NameCollisions);
+
+public sealed record UpdateUserConstantSafetySnapshotInfo(
+    TagTableSafetyIdentityInfo TargetTable,
+    UserConstantSafetyIdentityInfo TargetConstant,
+    string EffectiveName,
+    IReadOnlyList<TagCollisionProbeInfo> NameCollisions);
+
+public sealed record DeleteUserConstantSafetySnapshotInfo(
+    TagTableSafetyIdentityInfo TargetTable,
+    UserConstantSafetyIdentityInfo TargetConstant);
+```
+
+The two `Delete*` snapshots intentionally omit collision lists: by design they bind the current exact target object and table identity, not hypothetical future occupancy.
+
+- [ ] **Step 4: Implement the exact decoder and pure selector key**
+
+`TagOperationSafetySnapshotContract.Decode` must deserialize to the exact CLR type for the requested operation, reject a wrong or malformed payload as `protocol_error`, and return canonical JSON using the existing canonical serializer:
+
+```csharp
+internal static class TagOperationSafetySnapshotContract
+{
+    public static TagOperationSafetyDecodeResult Decode(string operation, string payload)
+    {
+        try
+        {
+            var canonical = operation switch
+            {
+                "create_tag_table" => CanonicalJson.Serialize(
+                    JsonSerializer.Deserialize<CreateTagTableSafetySnapshotInfo>(payload, CanonicalJson.SerializerOptions)
+                    ?? throw new JsonException("Missing create_tag_table snapshot.")),
+                "delete_tag_table" => CanonicalJson.Serialize(
+                    JsonSerializer.Deserialize<DeleteTagTableSafetySnapshotInfo>(payload, CanonicalJson.SerializerOptions)
+                    ?? throw new JsonException("Missing delete_tag_table snapshot.")),
+                "create_tag" => CanonicalJson.Serialize(
+                    JsonSerializer.Deserialize<CreateTagSafetySnapshotInfo>(payload, CanonicalJson.SerializerOptions)
+                    ?? throw new JsonException("Missing create_tag snapshot.")),
+                "update_tag" => CanonicalJson.Serialize(
+                    JsonSerializer.Deserialize<UpdateTagSafetySnapshotInfo>(payload, CanonicalJson.SerializerOptions)
+                    ?? throw new JsonException("Missing update_tag snapshot.")),
+                "delete_tag" => CanonicalJson.Serialize(
+                    JsonSerializer.Deserialize<DeleteTagSafetySnapshotInfo>(payload, CanonicalJson.SerializerOptions)
+                    ?? throw new JsonException("Missing delete_tag snapshot.")),
+                "create_user_constant" => CanonicalJson.Serialize(
+                    JsonSerializer.Deserialize<CreateUserConstantSafetySnapshotInfo>(payload, CanonicalJson.SerializerOptions)
+                    ?? throw new JsonException("Missing create_user_constant snapshot.")),
+                "update_user_constant" => CanonicalJson.Serialize(
+                    JsonSerializer.Deserialize<UpdateUserConstantSafetySnapshotInfo>(payload, CanonicalJson.SerializerOptions)
+                    ?? throw new JsonException("Missing update_user_constant snapshot.")),
+                "delete_user_constant" => CanonicalJson.Serialize(
+                    JsonSerializer.Deserialize<DeleteUserConstantSafetySnapshotInfo>(payload, CanonicalJson.SerializerOptions)
+                    ?? throw new JsonException("Missing delete_user_constant snapshot.")),
+                _ => throw new InvalidOperationException($"Unsupported tag safety operation '{operation}'.")
+            };
+
+            return new(true, canonical);
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
+        {
+            return new(false, string.Empty, ex.Message, WorkerFailureCategories.ProtocolError);
+        }
+    }
+}
+```
+
+`TagOperationSafetySelector.Build` must normalize:
+
+```csharp
+var effectiveName = op.Operation switch
+{
+    "update_tag" => string.IsNullOrWhiteSpace(op.NewName) ? op.Name : op.NewName,
+    "update_user_constant" => op.Name,
+    _ => op.Name
+};
+```
+
+For `create_tag` and `update_tag`, `EffectiveLogicalAddress` is the requested `LogicalAddress`; for every other operation it is `null`.
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run the Step 2 command again.
+
+Also run:
+
+```powershell
+dotnet build TiaMcpServer.Contracts/TiaMcpServer.Contracts.csproj --no-restore -m:1 --disable-build-servers --nologo
+```
+
+Expected GREEN: the shared contracts build and the focused contract/selector tests pass.
+
+- [ ] **Step 6: Review checkpoint**
+
+Confirm:
+
+- every operation has exactly one typed snapshot DTO;
+- `false` and `null` remain distinguishable for the three tag external flags;
+- no public batch request shape changed;
+- the host decoder rejects malformed payloads without echoing them.
+
+Suggested commit if separately authorized:
+
+```bash
+git add TiaMcpServer.Contracts/TagOperationSafetySnapshotInfo.cs TiaMcpServer/Batch/TagOperationSafetySnapshotContract.cs TiaMcpServer/Batch/TagOperationSafetySelector.cs TiaMcpServer.Tests/Batch/TagOperationSafetySnapshotContractTests.cs TiaMcpServer.Tests/Batch/TagOperationSafetySelectorTests.cs TiaMcpServer.Tests/Batch/BatchSafetySnapshotTests.cs
+git commit -m "feat(batch): define tag operation safety contracts"
+```
+
+---
+
+### Task 2: Add the Guarded Internal Worker Snapshot Readers and Deterministic Export Helper
+
+**Files:**
+- Create: `TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotBuilder.cs`
+- Create: `TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotReader.cs`
+- Modify: `TiaMcpServer.OpennessWorker/Program.cs`
+- Modify: `TiaMcpServer/Worker/OpennessWorkerClient.cs`
+- Modify: `TiaMcpServer.Contracts/OperationPolicyCatalog.cs`
+- Modify: `TiaMcpServer.Tests/TiaMcpServer.Tests.csproj`
+- Create: `TiaMcpServer.Tests/Batch/TagOperationSafetyWorkerSourceContractTests.cs`
+- Create: `TiaMcpServer.Tests/Batch/TagOperationSafetyBuilderTests.cs`
+- Create: `TiaMcpServer.Tests/Worker/TagOperationSafetyClientIdentityTests.cs`
+- Create: `TiaMcpServer.Tests/Worker/TagOperationSafetyIdentityEnforcementTests.cs`
+- Create: `TiaMcpServer.Tests/Safety/TagOperationSafetyReadPolicyTests.cs`
+
+**Interfaces:**
+- Add: `internal static string PreserveDeterministicTagTableExport(string xml)` in `TagOperationSafetySnapshotBuilder` only if current repository evidence proves one specific unavoidable non-semantic field remains after the timestamp-free export option is used.
+- Add: `internal static DeleteTagTableSafetySnapshotInfo BuildDeleteTagTableSnapshot(...);`
+- Add worker methods:
+  `read_create_tag_table_safety_snapshot`,
+  `read_delete_tag_table_safety_snapshot`,
+  `read_create_tag_safety_snapshot`,
+  `read_update_tag_safety_snapshot`,
+  `read_delete_tag_safety_snapshot`,
+  `read_create_user_constant_safety_snapshot`,
+  `read_update_user_constant_safety_snapshot`,
+  `read_delete_user_constant_safety_snapshot`.
+- Add client calls:
+  `ReadCreateTagTableSafetySnapshotAsync(...)`,
+  `ReadDeleteTagTableSafetySnapshotAsync(...)`,
+  `ReadCreateTagSafetySnapshotAsync(...)`,
+  `ReadUpdateTagSafetySnapshotAsync(...)`,
+  `ReadDeleteTagSafetySnapshotAsync(...)`,
+  `ReadCreateUserConstantSafetySnapshotAsync(...)`,
+  `ReadUpdateUserConstantSafetySnapshotAsync(...)`,
+  `ReadDeleteUserConstantSafetySnapshotAsync(...)`.
+
+- [ ] **Step 1: Verify the real tag-table export overload and document-info option before hardcoding it**
+
+Run these checks in order:
+
+```powershell
+rg -n "PlcTagTable|DocumentInfoOptions|ExportOptions" ref TiaMcpServer.OpennessWorker
+```
+
+If the repository stubs do not expose the three-parameter overload or the exact document-info enum/member, inspect the installed V21 API on the implementation machine before writing the reader test:
+
+```powershell
+pwsh -NoProfile -Command "& {
+  $tiaDir = 'C:\Program Files\Siemens\Automation\Portal V21\PublicAPI\V21\net48'
+  if (-not (Test-Path $tiaDir)) { throw 'Installed TIA Portal V21 PublicAPI not found. Stop and verify the approved local Siemens package before continuing.' }
+  Get-ChildItem $tiaDir -Filter 'Siemens.Engineering*.dll' | ForEach-Object { try { Add-Type -Path $_.FullName -ErrorAction Stop } catch { } }
+  [AppDomain]::CurrentDomain.GetAssemblies()
+    | ForEach-Object {
+        try { $_.GetTypes() } catch [System.Reflection.ReflectionTypeLoadException] { $_.Types | Where-Object { $_ } }
+      }
+    | Where-Object { $_.FullName -like '*DocumentInfoOptions' -or $_.FullName -like '*PlcTagTable' }
+    | ForEach-Object {
+        if ($_.Name -eq 'PlcTagTable') {
+          $_.GetMethods() | Where-Object Name -eq 'Export' | ForEach-Object ToString
+        }
+        elseif ($_.IsEnum) {
+          $_.FullName
+          [Enum]::GetNames($_)
+        }
+      }
+}"
+```
+
+Record the exact three-parameter `PlcTagTable.Export(FileInfo, ExportOptions, ...)` signature and the exact document-info enum type/member that suppresses document-info timestamps before coding the reader. If neither repository evidence nor installed V21 inspection can prove the option, do not hardcode `DocumentInfoOptions.None`; plan only a bounded allowlisted normalization fallback backed by observed live export drift.
+
+- [ ] **Step 2: Add failing builder, policy, and source-contract tests**
+
+Create `TagOperationSafetyBuilderTests.cs`:
+
+```csharp
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationSafetyBuilderTests
+{
+    [Fact]
+    public void DeleteTagTableSnapshot_UsesTheVerifiedTimestampFreeExportCallFirst()
+    {
+        var text = File.ReadAllText(Source("TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotReader.cs"));
+
+        Assert.Contains("ExportOptions.None", text, StringComparison.Ordinal);
+        Assert.Contains(".Export(new FileInfo(", text, StringComparison.Ordinal);
+    }
+
+    private static string Source(string relative)
+        => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", relative));
+}
+```
+
+Create `TagOperationSafetyWorkerSourceContractTests.cs`:
+
+```csharp
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationSafetyWorkerSourceContractTests
+{
+    [Fact]
+    public void Program_DispatchesEveryInternalTagSafetyRead()
+    {
+        var text = File.ReadAllText(Source("TiaMcpServer.OpennessWorker/Program.cs"));
+
+        Assert.Contains("\"read_create_tag_table_safety_snapshot\" => ReadCreateTagTableSafetySnapshot(request)", text, StringComparison.Ordinal);
+        Assert.Contains("\"read_delete_tag_table_safety_snapshot\" => ReadDeleteTagTableSafetySnapshot(request)", text, StringComparison.Ordinal);
+        Assert.Contains("\"read_create_tag_safety_snapshot\" => ReadCreateTagSafetySnapshot(request)", text, StringComparison.Ordinal);
+        Assert.Contains("\"read_update_tag_safety_snapshot\" => ReadUpdateTagSafetySnapshot(request)", text, StringComparison.Ordinal);
+        Assert.Contains("\"read_delete_tag_safety_snapshot\" => ReadDeleteTagSafetySnapshot(request)", text, StringComparison.Ordinal);
+        Assert.Contains("\"read_create_user_constant_safety_snapshot\" => ReadCreateUserConstantSafetySnapshot(request)", text, StringComparison.Ordinal);
+        Assert.Contains("\"read_update_user_constant_safety_snapshot\" => ReadUpdateUserConstantSafetySnapshot(request)", text, StringComparison.Ordinal);
+        Assert.Contains("\"read_delete_user_constant_safety_snapshot\" => ReadDeleteUserConstantSafetySnapshot(request)", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OperationPolicyCatalog_RegistersTagSafetyReadersAsSafetyReads()
+    {
+        var text = File.ReadAllText(Source("TiaMcpServer.Contracts/OperationPolicyCatalog.cs"));
+
+        Assert.Contains("[\"read_create_tag_table_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+        Assert.Contains("[\"read_delete_tag_table_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+        Assert.Contains("[\"read_create_tag_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+        Assert.Contains("[\"read_update_tag_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+        Assert.Contains("[\"read_delete_tag_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+        Assert.Contains("[\"read_create_user_constant_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+        Assert.Contains("[\"read_update_user_constant_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+        Assert.Contains("[\"read_delete_user_constant_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+    }
+
+    private static string Source(string relative)
+        => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", relative));
+}
+```
+
+Create `TagOperationSafetyReadPolicyTests.cs`:
+
+```csharp
+using TiaMcpServer.Contracts;
+
+namespace TiaMcpServer.Tests.Safety;
+
+public sealed class TagOperationSafetyReadPolicyTests
+{
+    [Theory]
+    [InlineData("read_create_tag_table_safety_snapshot")]
+    [InlineData("read_delete_tag_table_safety_snapshot")]
+    [InlineData("read_create_tag_safety_snapshot")]
+    [InlineData("read_update_tag_safety_snapshot")]
+    [InlineData("read_delete_tag_safety_snapshot")]
+    [InlineData("read_create_user_constant_safety_snapshot")]
+    [InlineData("read_update_user_constant_safety_snapshot")]
+    [InlineData("read_delete_user_constant_safety_snapshot")]
+    public void EveryTagSafetyReader_UsesTheSafetyReadIdentityBoundPolicy(string operation)
+    {
+        Assert.Equal(OperationCapability.SafetyRead, OperationPolicyCatalog.GetCapability(operation));
+        Assert.True(OperationPolicyCatalog.RequiresExpectedSessionIdentity(operation));
+        Assert.True(OperationPolicyCatalog.IsAllowed(McpAccessMode.ReadOnly, operation));
+    }
+}
+```
+
+Create `TagOperationSafetyClientIdentityTests.cs` using the same request-inspection style the repo already uses for worker-field forwarding tests:
+
+```csharp
+using System.Text.Json;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Tests.Worker;
+
+public sealed class TagOperationSafetyClientIdentityTests
+{
+    [Theory]
+    [InlineData("create_tag_table")]
+    [InlineData("delete_tag_table")]
+    [InlineData("create_tag")]
+    [InlineData("update_tag")]
+    [InlineData("delete_tag")]
+    [InlineData("create_user_constant")]
+    [InlineData("update_user_constant")]
+    [InlineData("delete_user_constant")]
+    public async Task EveryTagSafetyClientMethod_SendsExpectedSessionIdentityInTheWorkerRequest(string selectorKind)
+    {
+        var binding = new ProjectSessionBinding(null);
+        Assert.True(binding.BindVerified(
+            new WorkerSessionIdentity
+            {
+                WorkerSessionId = "worker-a",
+                SessionGeneration = 7,
+                PortalProcessId = 4242,
+                ProjectPath = @"C:\FakeWorker\tag-safety-request-echo.ap21"
+            },
+            forceRebind: false,
+            out _));
+        using var client = new OpennessWorkerClient(
+            binding,
+            logger: null,
+            workerExecutablePath: FakeWorkerLocator.Locate(),
+            accessPolicy: new OperationAccessPolicy(McpAccessMode.ReadWrite));
+
+        var result = selectorKind switch
+        {
+            "create_tag_table" => await client.ReadCreateTagTableSafetySnapshotAsync("PLC_1", "Inputs", null, @"C:\FakeWorker\tag-safety-request-echo.ap21"),
+            "delete_tag_table" => await client.ReadDeleteTagTableSafetySnapshotAsync("PLC_1", "Inputs", null, @"C:\FakeWorker\tag-safety-request-echo.ap21"),
+            "create_tag" => await client.ReadCreateTagSafetySnapshotAsync("PLC_1", "Inputs", null, "Start", "Bool", "%I0.0", @"C:\FakeWorker\tag-safety-request-echo.ap21"),
+            "update_tag" => await client.ReadUpdateTagSafetySnapshotAsync("PLC_1", "Inputs", null, "Start", "Start_1", "%I0.1", @"C:\FakeWorker\tag-safety-request-echo.ap21"),
+            "delete_tag" => await client.ReadDeleteTagSafetySnapshotAsync("PLC_1", "Inputs", null, "Start", @"C:\FakeWorker\tag-safety-request-echo.ap21"),
+            "create_user_constant" => await client.ReadCreateUserConstantSafetySnapshotAsync("PLC_1", "Inputs", null, "DebounceMs", @"C:\FakeWorker\tag-safety-request-echo.ap21"),
+            "update_user_constant" => await client.ReadUpdateUserConstantSafetySnapshotAsync("PLC_1", "Inputs", null, "DebounceMs", @"C:\FakeWorker\tag-safety-request-echo.ap21"),
+            "delete_user_constant" => await client.ReadDeleteUserConstantSafetySnapshotAsync("PLC_1", "Inputs", null, "DebounceMs", @"C:\FakeWorker\tag-safety-request-echo.ap21"),
+            _ => throw new ArgumentOutOfRangeException(nameof(selectorKind))
+        };
+
+        using var document = JsonDocument.Parse(result.Payload);
+        var expected = document.RootElement.GetProperty("expectedSessionIdentity");
+
+        Assert.Equal("worker-a", expected.GetProperty("workerSessionId").GetString());
+        Assert.Equal(7, expected.GetProperty("sessionGeneration").GetInt32());
+        Assert.Equal(4242, expected.GetProperty("portalProcessId").GetInt32());
+        Assert.Equal(
+            @"C:\FakeWorker\tag-safety-request-echo.ap21",
+            expected.GetProperty("projectPath").GetString());
+    }
+}
+```
+
+Create `TagOperationSafetyIdentityEnforcementTests.cs` using the existing `PersistentWorkerTransport` pattern:
+
+```csharp
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Tests.Worker;
+
+public sealed class TagOperationSafetyIdentityEnforcementTests
+{
+    [Theory]
+    [InlineData("read_create_tag_table_safety_snapshot")]
+    [InlineData("read_delete_tag_table_safety_snapshot")]
+    [InlineData("read_create_tag_safety_snapshot")]
+    [InlineData("read_update_tag_safety_snapshot")]
+    [InlineData("read_delete_tag_safety_snapshot")]
+    [InlineData("read_create_user_constant_safety_snapshot")]
+    [InlineData("read_update_user_constant_safety_snapshot")]
+    [InlineData("read_delete_user_constant_safety_snapshot")]
+    public async Task EveryTagSafetyReader_RejectsMissingExpectedSessionIdentity(string method)
+    {
+        using var transport = new PersistentWorkerTransport(FakeWorkerLocator.Locate(), TimeSpan.FromSeconds(5));
+        var observed = await transport.SendAsync(new WorkerRequest
+        {
+            Method = "read_hardware_config",
+            ProjectPath = "tag-safety-request-echo"
+        });
+
+        Assert.True(observed.Success, observed.Error);
+
+        var response = await transport.SendAsync(new WorkerRequest
+        {
+            Method = method,
+            ProjectPath = "tag-safety-request-echo"
+        });
+
+        Assert.False(response.Success);
+        Assert.Equal(WorkerFailureCategories.BindingConflict, response.FailureCategory);
+    }
+}
+```
+
+- [ ] **Step 3: Run the focused tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~TagOperationSafetyBuilderTests|FullyQualifiedName~TagOperationSafetyWorkerSourceContractTests|FullyQualifiedName~TagOperationSafetyReadPolicyTests|FullyQualifiedName~TagOperationSafetyClientIdentityTests|FullyQualifiedName~TagOperationSafetyIdentityEnforcementTests"
+```
+
+Expected RED:
+
+- the reader does not yet make the verified three-parameter `PlcTagTable.Export(...)` call selected from Step 1;
+- the eight safety-read worker methods do not yet exist;
+- the catalog does not yet route these methods through the existing `SafetyRead` capability/policy from PR 3;
+- the client does not yet expose and verify the eight safety-read methods through the existing bound-request seam with a focused request-JSON regression proving `ExpectedSessionIdentity`;
+- the worker still allows missing identity for methods that are presently classified as ordinary `Observe`.
+
+- [ ] **Step 4: Implement the pure snapshot builder without inventing XML surgery as the primary mechanism**
+
+`TagOperationSafetySnapshotBuilder.cs` must stay Siemens-free so the test project can compile it directly. Give it deterministic helpers for canonical path normalization, collision ordering, and exact typed snapshot shaping. Do not make broad XML attribute deletion the primary determinism mechanism.
+
+Use the exact Step 1-verified three-parameter export overload and the exact Step 1-verified “no document info / timestamp-free” enum member. If, and only if, current repository evidence after that verified export call proves one unavoidable non-semantic field still drifts, add `PreserveDeterministicTagTableExport(string xml)` with an exact allowlist for that one field and cover it with a focused test plus live proof. Do not plan a generic `GeneratedOn`/`ModifiedDate` scrubber.
+
+- [ ] **Step 5: Implement the Siemens-dependent reader, the guarded policy, the bound client methods, and worker dispatch**
+
+In `TagOperationSafetySnapshotReader.cs`, resolve exact targets through Siemens objects and produce the typed records from Task 1. Follow these rules:
+
+- `create_tag_table`: resolve the exact PLC and parent folder, then return only occupancy probes for the requested table name.
+- `delete_tag_table`: resolve the exact table, export the full table through the Step 1-verified `PlcTagTable.Export(FileInfo, ExportOptions, ...)` overload with the Step 1-verified timestamp-free/document-info-free option, preserve that full Simatic ML content byte-for-byte unless current evidence proves one specific unavoidable non-semantic field remains, hash the exact preserved content, and return that content plus counts.
+- `create_tag`: resolve the exact table and collision probes for the requested effective name and logical address.
+- `update_tag`: resolve the exact current target tag, preserve the PR 3 flag fields, and probe collisions for the effective requested rename/address.
+- `delete_tag`: bind the exact current target tag and table identity only.
+- `create/update/delete user constant`: resolve the exact table, the exact current constant when it exists, and only name-collision probes for the existing requested/current name. Do not add rename semantics to `update_user_constant`.
+
+Consume the existing PR 3 `SafetyRead` policy in `OperationPolicyCatalog.cs` so these eight internal methods are not ordinary `Observe` reads:
+
+- `GetCapability("read_*_safety_snapshot") == OperationCapability.SafetyRead`
+- `RequiresExpectedSessionIdentity("read_*_safety_snapshot") == true`
+- `IsAllowed(McpAccessMode.ReadOnly, "read_*_safety_snapshot") == true`
+
+Implement the eight client methods in `OpennessWorkerClient.cs` on top of the existing bound request path, which already runs under the serialized binding gate and already sets `ExpectedSessionIdentity = bindingBeforeCall.ToWorkerIdentity()` for bound requests regardless of `Observe` capability:
+
+```csharp
+public Task<WorkerCallResult> ReadDeleteTagSafetySnapshotAsync(
+    string? plcName,
+    string tableName,
+    string? folderPath,
+    string name,
+    string? projectPath)
+    => SendBoundProjectRequestAsync(
+        "read_delete_tag_safety_snapshot",
+        projectPath,
+        request =>
+        {
+            request.PlcName = plcName;
+            request.TableName = tableName;
+            request.FolderPath = folderPath;
+            request.Name = name;
+        },
+        "{}");
+```
+
+The task's obligation is to prove that all eight safety snapshot methods actually use that existing seam, that the serialized request includes `expectedSessionIdentity`, and that the worker rejects every missing-identity request before scenario dispatch. Do not invent a duplicate client transport helper; instead change the policy so these methods are guarded reads, not ordinary `Observe`.
+
+- [ ] **Step 6: Run focused tests, then build the worker stub path**
+
+Run the Step 3 test command again.
+
+Then run:
+
+```powershell
+dotnet build TiaMcpServer.OpennessWorker/TiaMcpServer.OpennessWorker.csproj --no-restore -m:1 --disable-build-servers --nologo -p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~TagOperationSafetyBuilderTests|FullyQualifiedName~TagOperationSafetyWorkerSourceContractTests|FullyQualifiedName~TagOperationSafetyReadPolicyTests|FullyQualifiedName~TagOperationSafetyClientIdentityTests|FullyQualifiedName~TagOperationSafetyIdentityEnforcementTests"
+```
+
+Expected GREEN: the source contract sees the verified export call and worker dispatch, the policy test proves reuse of the PR 3 `SafetyRead` identity-bound classification, the client request-JSON test proves `ExpectedSessionIdentity` is present on every safety snapshot request, the worker rejection test proves missing identity fails before dispatch, and the net48 worker compiles with stubs.
+
+- [ ] **Step 7: Review checkpoint**
+
+Confirm:
+
+- the internal worker methods are not added to `BatchOperationCatalog`;
+- every internal worker method uses the existing PR 3 `SafetyRead` policy rather than ordinary `Observe`;
+- delete-table export determinism comes from the verified TIA export options first, with allowlisted normalization only if live evidence proves one unavoidable residual field;
+- every safety snapshot request carries the verified `ExpectedSessionIdentity` under the serialized/pinned binding gate, and the worker rejects missing identity before dispatch;
+- the worker, not the host, resolves exact tag/table/constant identity.
+
+Suggested commit if separately authorized:
+
+```bash
+git add TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotBuilder.cs TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotReader.cs TiaMcpServer.OpennessWorker/Program.cs TiaMcpServer/Worker/OpennessWorkerClient.cs TiaMcpServer.Contracts/OperationPolicyCatalog.cs TiaMcpServer.Tests/TiaMcpServer.Tests.csproj TiaMcpServer.Tests/Batch/TagOperationSafetyWorkerSourceContractTests.cs TiaMcpServer.Tests/Batch/TagOperationSafetyBuilderTests.cs TiaMcpServer.Tests/Safety/TagOperationSafetyReadPolicyTests.cs TiaMcpServer.Tests/Worker/TagOperationSafetyClientIdentityTests.cs TiaMcpServer.Tests/Worker/TagOperationSafetyIdentityEnforcementTests.cs
+git commit -m "feat(worker): add exact tag safety snapshot readers"
+```
+
+---
+
+### Task 3: Replace Broad Tag State Reads with Exact Per-Operation Reads and Within-Phase Dedup
+
+**Files:**
+- Modify: `TiaMcpServer/Batch/BatchWorkerInvoker.cs`
+- Modify: `TiaMcpServer/Batch/WriteBatchTools.cs`
+- Modify: `TiaMcpServer.FakeWorker/Program.cs`
+- Create: `TiaMcpServer.Tests/Batch/TagOperationCurrentStateReadFakeWorkerTests.cs`
+- Modify: `TiaMcpServer.Tests/TiaMcpServer.Tests.csproj`
+
+**Interfaces:**
+- Consume: `TagOperationSafetySnapshotContract.Decode(string operation, string payload)`
+- Consume: `TagOperationSafetySelector.TryBuild(BatchOperationRequest op, out TagOperationSafetySelectorKey key)`
+- Preserve: `OperationBatchStateComposer.CombineCurrentState(IReadOnlyList<OperationBatchCurrentState>)`
+- Preserve: `WriteBatchTools.ReadCombinedCurrentStateAsync(OpennessWorkerClient workerClient, BatchOperationRequest[] operations)`
+- Prove through the registered path: `WriteBatchTools.PreviewWriteBatch(...)` remains the preview entrypoint whose current-state read lives behind the new dedup logic.
+- Change inside `BatchWorkerInvoker.ReadCurrentStateAsync(...)`:
+  tag operations no longer call `ListTagTablesAsync(op.PlcName, op.ProjectPath)`.
+
+- [ ] **Step 1: Add failing registered-path routing and dedup regressions**
+
+Create `TagOperationCurrentStateReadFakeWorkerTests.cs` so the RED happens through the registered `WriteBatchTools` path, not only through pure helpers:
+
+```csharp
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationCurrentStateReadFakeWorkerTests
+{
+    [Fact]
+    public async Task PreviewWriteBatch_DeleteTag_UsesExactInternalSnapshotRouteInsteadOfListTagTables()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = VerifiedBinding(@"C:\FakeWorker\tag-safety-route-proof.ap21");
+        using var client = CreateClient(binding);
+        var safety = CreateSafety(audit, binding);
+        var operations = new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "d1",
+                Operation = "delete_tag",
+                ProjectPath = @"C:\FakeWorker\tag-safety-route-proof.ap21",
+                PlcName = "PLC_1",
+                TableName = "Inputs",
+                Name = "Start"
+            }
+        };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+
+        Assert.Contains("\"safetyToken\":", preview, StringComparison.Ordinal);
+        Assert.DoesNotContain("wrong route: list_tag_tables", preview, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_TwoIdenticalDeleteTagSelectors_PerformsOneSnapshotReadAndStillDescribesBothOperations()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = VerifiedBinding(@"C:\FakeWorker\tag-safety-dedup-proof.ap21");
+        using var client = CreateClient(binding);
+        var safety = CreateSafety(audit, binding);
+        var operations = new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "d1",
+                Operation = "delete_tag",
+                ProjectPath = @"C:\FakeWorker\tag-safety-dedup-proof.ap21",
+                PlcName = "PLC_1",
+                TableName = "Inputs",
+                Name = "Start"
+            },
+            new BatchOperationRequest
+            {
+                OperationId = "d2",
+                Operation = "delete_tag",
+                ProjectPath = @"C:\FakeWorker\tag-safety-dedup-proof.ap21",
+                PlcName = "PLC_1",
+                TableName = "Inputs",
+                Name = "Start"
+            }
+        };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+
+        Assert.Contains("\"safetyToken\":", preview, StringComparison.Ordinal);
+        Assert.Contains("Delete PLC tag 'Start' from table 'Inputs'.", preview, StringComparison.Ordinal);
+        Assert.Equal(
+            2,
+            Regex.Matches(
+                preview,
+                Regex.Escape("Delete PLC tag 'Start' from table 'Inputs'."),
+                RegexOptions.CultureInvariant).Count);
+    }
+
+    [Fact]
+    public void StateComposer_CanRepeatIdenticalCurrentStateForDifferentOperationsWithoutLosingOrder()
+    {
+        var combined = OperationBatchStateComposer.CombineCurrentState(new[]
+        {
+            new OperationBatchCurrentState("u1", "update_tag", "{\"k\":1}"),
+            new OperationBatchCurrentState("d1", "delete_tag", "{\"k\":1}")
+        });
+
+        Assert.Contains("u1::update_tag", combined, StringComparison.Ordinal);
+        Assert.Contains("d1::delete_tag", combined, StringComparison.Ordinal);
+        Assert.True(
+            combined.IndexOf("u1::update_tag", StringComparison.Ordinal) <
+            combined.IndexOf("d1::delete_tag", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TokenValidation_TreatsDuplicatedCurrentStateBodiesAsDistinctWhenOperationIdentityDiffers()
+    {
+        using var audit = new TempAuditDirectory();
+        var service = CreateService(audit.Path);
+        var operations = new[]
+        {
+            Op("u1", "update_tag"),
+            Op("d1", "delete_tag")
+        };
+        var sharedState = new[]
+        {
+            new OperationBatchCurrentState("u1", "update_tag", "{\"snapshot\":1}"),
+            new OperationBatchCurrentState("d1", "delete_tag", "{\"snapshot\":1}")
+        };
+
+        var token = CreatePreview(service, operations, sharedState);
+        var result = Consume(service, token, operations, sharedState);
+
+        Assert.True(result.IsValid, result.Error);
+    }
+}
+```
+
+The first two tests are the actual Task 3 RED gates: today the broad `ListTagTablesAsync` route and lack of within-phase dedup should make them fail. The last two tests are characterization baselines that protect ordered state composition after the route/dedup fix lands; do not use them as the primary RED evidence for this task.
+
+- [ ] **Step 2: Run only the registered-path RED tests and verify failure**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~TagOperationCurrentStateReadFakeWorkerTests.PreviewWriteBatch_DeleteTag_UsesExactInternalSnapshotRouteInsteadOfListTagTables|FullyQualifiedName~TagOperationCurrentStateReadFakeWorkerTests.PreviewWriteBatch_TwoIdenticalDeleteTagSelectors_PerformsOneSnapshotReadAndStillDescribesBothOperations"
+```
+
+Expected RED:
+
+- `PreviewWriteBatch_DeleteTag_UsesExactInternalSnapshotRouteInsteadOfListTagTables` fails because the current host path still asks FakeWorker for `list_tag_tables` rather than `read_delete_tag_safety_snapshot`.
+- `PreviewWriteBatch_TwoIdenticalDeleteTagSelectors_PerformsOneSnapshotReadAndStillDescribesBothOperations` fails because the current preview path performs two identical snapshot reads in one phase instead of one deduplicated read.
+
+- [ ] **Step 3: Add the FakeWorker route-proof and switch `BatchWorkerInvoker` to exact snapshot reads**
+
+In `TiaMcpServer.FakeWorker/Program.cs`, add two deterministic scenarios before changing the host:
+
+- `tag-safety-route-proof`: `list_tag_tables` returns `wrong route: list_tag_tables`, while `read_delete_tag_safety_snapshot` returns a valid `DeleteTagSafetySnapshotInfo` payload.
+- `tag-safety-dedup-proof`: the first `read_delete_tag_safety_snapshot` returns a valid payload, and the second identical read in the same preview returns `dedup missing: repeated read_delete_tag_safety_snapshot`.
+
+Then replace the tag-operation arm in `ReadCurrentStateAsync` with exact worker calls:
+
+```csharp
+"create_tag_table" => client.ReadCreateTagTableSafetySnapshotAsync(
+    op.PlcName, op.TableName!, op.FolderPath, op.ProjectPath),
+"delete_tag_table" => client.ReadDeleteTagTableSafetySnapshotAsync(
+    op.PlcName, op.TableName!, op.FolderPath, op.ProjectPath),
+"create_tag" => client.ReadCreateTagSafetySnapshotAsync(
+    op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.LogicalAddress, op.ProjectPath),
+"update_tag" => client.ReadUpdateTagSafetySnapshotAsync(
+    op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.NewName, op.LogicalAddress, op.ProjectPath),
+"delete_tag" => client.ReadDeleteTagSafetySnapshotAsync(
+    op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.ProjectPath),
+"create_user_constant" => client.ReadCreateUserConstantSafetySnapshotAsync(
+    op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.ProjectPath),
+"update_user_constant" => client.ReadUpdateUserConstantSafetySnapshotAsync(
+    op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.ProjectPath),
+"delete_user_constant" => client.ReadDeleteUserConstantSafetySnapshotAsync(
+    op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.ProjectPath),
+```
+
+Each success payload must pass through `TagOperationSafetySnapshotContract.Decode` before the current-state string is returned to the caller. A malformed typed payload becomes the worker call's failure result with `protocol_error`.
+
+- [ ] **Step 4: Add the within-phase dedup map in `WriteBatchTools.ReadCombinedCurrentStateAsync`**
+
+Inside `ReadCombinedCurrentStateAsync`, instantiate an ephemeral dictionary keyed by `TagOperationSafetySelectorKey`:
+
+```csharp
+var dedup = new Dictionary<TagOperationSafetySelectorKey, Task<WorkerCallResult>>();
+var states = new List<OperationBatchCurrentState>(operations.Length);
+
+foreach (var op in operations)
+{
+    WorkerCallResult state;
+    if (TagOperationSafetySelector.TryBuild(op, out var key))
+    {
+        if (!dedup.TryGetValue(key, out var task))
+        {
+            task = BatchWorkerInvoker.ReadCurrentStateAsync(workerClient, op);
+            dedup.Add(key, task);
+        }
+
+        state = await task.ConfigureAwait(false);
+    }
+    else
+    {
+        state = await BatchWorkerInvoker.ReadCurrentStateAsync(workerClient, op).ConfigureAwait(false);
+    }
+
+    if (!state.Success)
+    {
+        return (string.Empty, $"Could not read current state for operationId '{op.OperationId}' ({op.Operation}). Error: {state.Error}");
+    }
+
+    states.Add(new OperationBatchCurrentState(op.OperationId, op.Operation, state.Payload));
+}
+```
+
+Do not move the dedup map to a field or service. A local variable is the whole proof that no cross-phase cache exists.
+
+- [ ] **Step 5: Run the route/dedup tests to GREEN, then run the characterization baselines and adjacent regressions**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~TagOperationCurrentStateReadFakeWorkerTests.PreviewWriteBatch_DeleteTag_UsesExactInternalSnapshotRouteInsteadOfListTagTables|FullyQualifiedName~TagOperationCurrentStateReadFakeWorkerTests.PreviewWriteBatch_TwoIdenticalDeleteTagSelectors_PerformsOneSnapshotReadAndStillDescribesBothOperations"
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~TagOperationCurrentStateReadFakeWorkerTests.StateComposer_CanRepeatIdenticalCurrentStateForDifferentOperationsWithoutLosingOrder|FullyQualifiedName~TagOperationCurrentStateReadFakeWorkerTests.TokenValidation_TreatsDuplicatedCurrentStateBodiesAsDistinctWhenOperationIdentityDiffers|FullyQualifiedName~BatchToolsTests"
+```
+
+Expected GREEN: the registered preview path uses the exact internal worker method, identical selector keys are read once per phase, the preview still describes both ordered operations, and the characterization baselines confirm that duplicated state payloads do not collapse operation identity.
+
+- [ ] **Step 6: Review checkpoint**
+
+Confirm:
+
+- no tag-related arm in `BatchWorkerInvoker.ReadCurrentStateAsync` still calls `ListTagTablesAsync`;
+- the dedup map is local to one `ReadCombinedCurrentStateAsync` invocation;
+- the route/dedup REDs were proven through `WriteBatchTools.PreviewWriteBatch`, not only through pure helper tests;
+- reused payloads still expand to one ordered `OperationBatchCurrentState` per operation;
+- non-tag batch operations are unchanged.
+
+Suggested commit if separately authorized:
+
+```bash
+git add TiaMcpServer/Batch/BatchWorkerInvoker.cs TiaMcpServer/Batch/WriteBatchTools.cs TiaMcpServer.FakeWorker/Program.cs TiaMcpServer.Tests/TiaMcpServer.Tests.csproj TiaMcpServer.Tests/Batch/TagOperationCurrentStateReadFakeWorkerTests.cs
+git commit -m "feat(batch): narrow tag safety current-state reads"
+```
+
+---
+
+### Task 4: Prove Drift Detection, Sibling Tolerance, and Re-Read Semantics with FakeWorker
+
+**Files:**
+- Modify: `TiaMcpServer.FakeWorker/Program.cs`
+- Create: `TiaMcpServer.Tests/Batch/TagOperationFakeWorkerTests.cs`
+- Modify: `TiaMcpServer.Tests/TiaMcpServer.Tests.csproj`
+
+**Interfaces:**
+- Consume unchanged: `WriteBatchTools.PreviewWriteBatch(...)`
+- Consume unchanged: `WriteBatchTools.ApplyWriteBatch(...)`
+- Preserve unchanged public tool semantics: preview returns token, apply requires `confirm=true` and unchanged operations.
+- Extend the Task 3 route/dedup FakeWorker support with deterministic drift and apply scenarios keyed by project path or scenario name for:
+  `tag-safety-same-object-drift`,
+  `tag-safety-collision-drift`,
+  `tag-safety-unrelated-sibling`,
+  `tag-safety-delete-table-export-drift`,
+  `tag-safety-reread`,
+  `tag-safety-authorized-apply`.
+
+- [ ] **Step 1: Add failing end-to-end FakeWorker tests**
+
+Create `TagOperationFakeWorkerTests.cs`:
+
+```csharp
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Worker;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationFakeWorkerTests
+{
+    [Fact]
+    public async Task ApplyWriteBatch_UpdateTag_SameObjectDriftFailsWithStateChanged()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = VerifiedBinding(@"C:\FakeWorker\tag-safety-same-object-drift.ap21");
+        using var client = CreateClient(binding);
+        var safety = CreateSafety(audit, binding);
+        var operations = new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "u1",
+                Operation = "update_tag",
+                ProjectPath = @"C:\FakeWorker\tag-safety-same-object-drift.ap21",
+                PlcName = "PLC_1",
+                TableName = "Inputs",
+                Name = "Start",
+                NewName = "Start_1"
+            }
+        };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+        var token = ExtractToken(preview);
+        var apply = await WriteBatchTools.ApplyWriteBatch(client, safety, operations, confirm: true, safetyToken: token);
+
+        Assert.Contains("\"failureCategory\":\"state_changed\"", apply, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyWriteBatch_CreateTag_RelevantCollisionDriftFailsWithStateChanged()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = VerifiedBinding(@"C:\FakeWorker\tag-safety-collision-drift.ap21");
+        using var client = CreateClient(binding);
+        var safety = CreateSafety(audit, binding);
+        var operations = new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "c1",
+                Operation = "create_tag",
+                ProjectPath = @"C:\FakeWorker\tag-safety-collision-drift.ap21",
+                PlcName = "PLC_1",
+                TableName = "Inputs",
+                Name = "Start_1",
+                DataType = "Bool",
+                LogicalAddress = "%I0.1"
+            }
+        };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+        var apply = await WriteBatchTools.ApplyWriteBatch(client, safety, operations, confirm: true, safetyToken: ExtractToken(preview));
+
+        Assert.Contains("\"failureCategory\":\"state_changed\"", apply, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyWriteBatch_DeleteTag_IgnoresUnrelatedSiblingTableDrift()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = VerifiedBinding(@"C:\FakeWorker\tag-safety-unrelated-sibling.ap21");
+        using var client = CreateClient(binding);
+        var safety = CreateSafety(audit, binding);
+        var operations = new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "d1",
+                Operation = "delete_tag",
+                ProjectPath = @"C:\FakeWorker\tag-safety-unrelated-sibling.ap21",
+                PlcName = "PLC_1",
+                TableName = "Inputs",
+                Name = "Start"
+            }
+        };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+        var apply = await WriteBatchTools.ApplyWriteBatch(client, safety, operations, confirm: true, safetyToken: ExtractToken(preview));
+
+        Assert.Contains("\"status\":\"succeeded\"", apply, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyWriteBatch_DeleteTagTable_ExportDriftFailsWithStateChanged()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = VerifiedBinding(@"C:\FakeWorker\tag-safety-delete-table-export-drift.ap21");
+        using var client = CreateClient(binding);
+        var safety = CreateSafety(audit, binding);
+        var operations = new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "t1",
+                Operation = "delete_tag_table",
+                ProjectPath = @"C:\FakeWorker\tag-safety-delete-table-export-drift.ap21",
+                PlcName = "PLC_1",
+                TableName = "Inputs"
+            }
+        };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+        var apply = await WriteBatchTools.ApplyWriteBatch(client, safety, operations, confirm: true, safetyToken: ExtractToken(preview));
+
+        Assert.Contains("\"failureCategory\":\"state_changed\"", apply, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyWriteBatch_CreateUserConstant_ReReadsOnApplyInsteadOfReusingPreviewCache()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = VerifiedBinding(@"C:\FakeWorker\tag-safety-reread.ap21");
+        using var client = CreateClient(binding);
+        var safety = CreateSafety(audit, binding);
+        var operations = new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "uc1",
+                Operation = "create_user_constant",
+                ProjectPath = @"C:\FakeWorker\tag-safety-reread.ap21",
+                PlcName = "PLC_1",
+                TableName = "Inputs",
+                Name = "DebounceMs",
+                DataType = "Int",
+                Value = "50"
+            }
+        };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+        var apply = await WriteBatchTools.ApplyWriteBatch(client, safety, operations, confirm: true, safetyToken: ExtractToken(preview));
+
+        Assert.Contains("\"failureCategory\":\"state_changed\"", apply, StringComparison.Ordinal);
+    }
+}
+```
+
+The `tag-safety-reread` scenario must return a different exact snapshot on the apply-phase read before any mutation attempt. That is the offline proof that PR 5 did not keep a cross-phase cache.
+
+- [ ] **Step 2: Run the FakeWorker tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~TagOperationFakeWorkerTests"
+```
+
+Expected RED: the FakeWorker cannot yet serve the exact snapshot reader methods or the host still hashes the broad list-tag-table state.
+Expected RED after Task 3 is green: the exact route and within-phase dedup already work, but these scenario-specific drift/apply proofs do not exist yet, so preview/apply outcomes do not yet show the required `state_changed` or sibling-tolerance behavior.
+
+- [ ] **Step 3: Add deterministic FakeWorker scenarios for the new internal methods**
+
+Implement one deterministic snapshot payload per new worker method. Use exact typed JSON that matches Task 1's shared records. The scenario rules are:
+
+- `tag-safety-same-object-drift`: preview returns one `UpdateTagSafetySnapshotInfo`; apply returns the same selector with a changed target tag field.
+- `tag-safety-collision-drift`: preview sees no collision; apply sees a relevant name or address collision.
+- `tag-safety-unrelated-sibling`: preview/apply keep the target table/tag snapshot identical while changing a different sibling table that the old broad `list_tag_tables` path would have noticed.
+- `tag-safety-delete-table-export-drift`: preview/apply differ only in the normalized exported Simatic ML string.
+- `tag-safety-reread`: preview and apply return different snapshots for the same selector before any mutation executes.
+- `tag-safety-authorized-apply`: preview/apply keep the same snapshot so one tag or user-constant operation succeeds once and the replayed token still fails on the second apply attempt.
+
+Do not change existing non-tag FakeWorker scenarios.
+
+- [ ] **Step 4: Run the new integration tests and adjacent batch regressions**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~TagOperationFakeWorkerTests|FullyQualifiedName~BatchSafetyTokenTests|FullyQualifiedName~BatchToolsTests"
+```
+
+Expected GREEN: same-object drift and relevant collision drift fail with `state_changed`, unrelated sibling drift no longer causes a false invalidation, delete-table export drift fails, and apply re-reads instead of reusing preview state.
+
+- [ ] **Step 5: Run the full serial offline suite**
+
+Run:
+
+```powershell
+dotnet build TiaMcpServer.sln --no-restore -m:1 --disable-build-servers --nologo -p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo
+```
+
+Record exact totals. If any tag-safety test fails only on the old broad-selector assumptions, fix that regression inside PR 5. Do not expand into PR 6 tree-scope work.
+
+- [ ] **Step 6: Review checkpoint**
+
+Confirm:
+
+- FakeWorker now serves the exact internal tag snapshot methods;
+- same-object drift and relevant collision drift invalidate the token;
+- unrelated sibling-table drift no longer invalidates a target whose proven preconditions do not include that sibling;
+- apply re-reads before mutation and does not reuse preview-phase state.
+
+Suggested commit if separately authorized:
+
+```bash
+git add TiaMcpServer.FakeWorker/Program.cs TiaMcpServer.Tests/Batch/TagOperationFakeWorkerTests.cs TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+git commit -m "test(batch): verify tag safety scope behavior"
+```
+
+---
+
+### Task 5: Add the Guarded Live Harness and Update Current Documentation
+
+**Files:**
+- Create: `scripts/live-test-tag-operation-safety-scopes.ps1`
+- Create: `TiaMcpServer.Tests/Batch/TagOperationSafetyLiveHarnessContractTests.cs`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md`
+- Modify: `docs/IMPROVEMENT_LOG.md`
+- Modify: `docs/README.md`
+- Modify: `docs/superpowers/README.md`
+- Create after the authorized run: `docs/superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md`
+
+**Interfaces:**
+- Harness default mode: non-mutating preview/read checks only.
+- Explicit mutation modes:
+  `-Mode DriftAndRestore` for same-object drift, collision drift, and unrelated sibling tolerance;
+  `-Mode ApplyAndRestore` for one successful explicitly authorized apply followed by restore or discard.
+- Harness must launch the host process, not the worker executable directly.
+- Harness artifacts must be hygienic: PowerShell 7 + strict mode, dedicated artifact directory, token redaction in persisted evidence, and `finally` cleanup of host/transient files.
+- Harness stdout reads must use `StandardOutput.ReadLineAsync()`, never blocking `ReadLine()`, and must recompute the real per-iteration remaining timeout against a deadline.
+
+- [ ] **Step 1: Add failing live-harness contract tests**
+
+Create `TagOperationSafetyLiveHarnessContractTests.cs`:
+
+```csharp
+using System.Text.RegularExpressions;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationSafetyLiveHarnessContractTests
+{
+    [Fact]
+    public void Script_IsPresent_RequiresPowerShell7AndStrictMode_AndDefaultsToNonMutatingMode()
+    {
+        var text = File.ReadAllText(ScriptPath);
+
+        Assert.Matches(new Regex(@"^\s*#Requires\s+-Version\s+7(\.\d+)?\s*$", RegexOptions.Multiline), text);
+        Assert.Contains("Set-StrictMode -Version Latest", text, StringComparison.Ordinal);
+        Assert.Contains("$ErrorActionPreference = 'Stop'", text, StringComparison.Ordinal);
+        Assert.Contains("[ValidateSet('PreviewOnly','DriftAndRestore','ApplyAndRestore')]", text, StringComparison.Ordinal);
+        Assert.Contains("$Mode = 'PreviewOnly'", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_UsesTheHostRequiresExplicitMutationModeAndNeverRunsFromOrdinaryTests()
+    {
+        var text = File.ReadAllText(ScriptPath);
+
+        Assert.Contains("TiaMcpServer", text, StringComparison.Ordinal);
+        Assert.Contains("if ($Mode -eq 'ApplyAndRestore')", text, StringComparison.Ordinal);
+        Assert.Contains("disposable project copy", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("OpennessWorker.exe", text, StringComparison.Ordinal);
+
+        var testDirectory = Path.Combine(GetRepositoryRoot(), "TiaMcpServer.Tests");
+        var thisFile = Path.Combine(testDirectory, "Batch", "TagOperationSafetyLiveHarnessContractTests.cs");
+        var offendingFiles = Directory
+            .EnumerateFiles(testDirectory, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !string.Equals(Path.GetFullPath(path), Path.GetFullPath(thisFile), StringComparison.OrdinalIgnoreCase))
+            .Where(path => File.ReadAllText(path).Contains("live-test-tag-operation-safety-scopes.ps1", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Empty(offendingFiles);
+    }
+
+    [Fact]
+    public void Script_UsesFinallyCleanupArtifactHygieneAndTokenRedaction()
+    {
+        var text = File.ReadAllText(ScriptPath);
+
+        Assert.Contains("try {", text, StringComparison.Ordinal);
+        Assert.Contains("finally {", text, StringComparison.Ordinal);
+        Assert.Contains("Stop-McpHost", text, StringComparison.Ordinal);
+        Assert.Contains("artifact", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("failure.json", text, StringComparison.Ordinal);
+        Assert.Contains("Redact-SafetyToken", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Write-Host \"safetyToken:", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_UsesAsyncStdoutReadsBoundedByTheRemainingDeadline()
+    {
+        var text = File.ReadAllText(ScriptPath);
+
+        Assert.DoesNotContain("StandardOutput.ReadLine()", text, StringComparison.Ordinal);
+        Assert.Contains("StandardOutput.ReadLineAsync()", text, StringComparison.Ordinal);
+        Assert.Contains("$remaining = $deadline - (Get-Date)", text, StringComparison.Ordinal);
+        Assert.Contains("$readTask.WaitAsync($remaining)", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_CoversAllRequiredPr5LiveClaims()
+    {
+        var text = File.ReadAllText(ScriptPath);
+
+        Assert.Contains("same-object drift", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("relevant collision", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("unrelated sibling", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("restore or discard", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static readonly string ScriptPath = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "scripts", "live-test-tag-operation-safety-scopes.ps1"));
+
+    private static string GetRepositoryRoot()
+        => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+}
+```
+
+- [ ] **Step 2: Run the contract tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~TagOperationSafetyLiveHarnessContractTests"
+```
+
+Expected RED: the script and its contract do not exist yet.
+
+- [ ] **Step 3: Implement the guarded PowerShell harness**
+
+The script must:
+
+- require `#Requires -Version 7`, `Set-StrictMode -Version Latest`, and `$ErrorActionPreference = 'Stop'`;
+- accept the disposable project copy path, PLC name, target table, sibling table, target tag, collision tag, and user constant names explicitly;
+- start the host process and communicate through MCP/NDJSON like the other live harnesses;
+- read MCP stdout with `StandardOutput.ReadLineAsync()` only, never `StandardOutput.ReadLine()`, and recompute `$remaining = $deadline - (Get-Date)` on each loop before awaiting the next line;
+- create one dedicated artifact directory per run, persist request/response evidence there, and write a failure artifact before rethrowing if a guarded check fails;
+- keep any live safety token only in memory for the apply call, and redact it from console output and persisted artifacts through a helper such as `Redact-SafetyToken`;
+- in `PreviewOnly`, verify exact selector previews without mutation;
+- in `DriftAndRestore`, perform:
+  1. preview an exact-target operation,
+  2. mutate the exact same object through an explicitly authorized action,
+  3. prove stale-token `state_changed`,
+  4. restore the project copy or discard it;
+- in `DriftAndRestore`, also prove:
+  1. relevant name/address collision drift invalidates,
+  2. unrelated sibling-table drift does not invalidate the target operation;
+- in `ApplyAndRestore`, perform one successful explicitly authorized apply with the unchanged issued token, then restore or discard the copy;
+- wrap host startup, transient export files, and restore/discard cleanup in `try/finally` so the host is stopped and transient files are removed even on failure;
+- write a transcript/artifact directory describing every MCP call, the mutation performed, the redacted token flow, and the final cleanup result.
+
+Keep the default mode non-mutating.
+
+- [ ] **Step 4: Update the current documentation**
+
+Document the exact PR 5 behavior:
+
+- `docs/ARCHITECTURE.md`: replace the old blanket tag-table selector description with the eight exact selector shapes, the within-phase dedup rule, and the preview/apply no-cross-phase-cache invariant.
+- `docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md`: document that tag-related write safety now binds exact targets plus scoped collision probes rather than the full table-list payload.
+- `docs/IMPROVEMENT_LOG.md`: record PR 5 as completed only after the live harness report exists; keep the deferred items visible.
+- `docs/README.md` and `docs/superpowers/README.md`: add links to this implementation plan and to the acceptance report once the report exists.
+
+Explicitly restate the deferred items in the docs:
+
+- multilingual per-tag comment binding;
+- public `list_tag_tables` completeness changes;
+- broader snapshot narrowing;
+- PLC `start_plc` / `stop_plc`.
+
+- [ ] **Step 5: Run focused docs and harness checks**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~TagOperationSafetyLiveHarnessContractTests"
+git diff --check
+git status --short
+```
+
+Expected GREEN: the contract test passes and the doc/script diff is whitespace-clean.
+
+- [ ] **Step 6: Review checkpoint**
+
+Confirm:
+
+- the harness default is non-mutating;
+- the mutation modes are explicit and guarded;
+- the static contract now enforces PowerShell 7, strict mode, `finally` cleanup, artifact hygiene, token redaction, and "ordinary tests never invoke it";
+- the docs say offline/FakeWorker evidence is insufficient;
+- the deferred items remain explicitly out of scope.
+
+Suggested commit if separately authorized:
+
+```bash
+git add scripts/live-test-tag-operation-safety-scopes.ps1 TiaMcpServer.Tests/Batch/TagOperationSafetyLiveHarnessContractTests.cs docs/ARCHITECTURE.md docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md docs/IMPROVEMENT_LOG.md docs/README.md docs/superpowers/README.md
+git commit -m "docs(batch): document tag safety scopes"
+```
+
+---
+
+### Task 6: Run the Mandatory Verification Sequence and Write the Acceptance Report
+
+**Files:**
+- Review: every file changed by Tasks 1-5
+- Create after the live run: `docs/superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md`
+
+**Verification boundary:**
+- Establishes: PR 2/PR 3 prerequisite presence, shared contract correctness, guarded safety-read identity policy, exact worker dispatch, host dedup behavior, state-hash drift sensitivity, unrelated sibling tolerance, delete-table export determinism, full serial offline suite status, and guarded live V21 acceptance.
+- Does not establish: multilingual tag-comment drift detection, public `list_tag_tables` completeness changes, broader tree-scope narrowing, PLC run/stop control, or plant acceptance.
+
+- [ ] **Step 1: Run the complete focused PR 5 offline set**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~TagOperationPrerequisiteBaselineTests|FullyQualifiedName~TagOperationSafetySnapshotContractTests|FullyQualifiedName~TagOperationSafetySelectorTests|FullyQualifiedName~TagOperationSafetyBuilderTests|FullyQualifiedName~TagOperationSafetyWorkerSourceContractTests|FullyQualifiedName~TagOperationSafetyReadPolicyTests|FullyQualifiedName~TagOperationSafetyClientIdentityTests|FullyQualifiedName~TagOperationSafetyIdentityEnforcementTests|FullyQualifiedName~TagOperationFakeWorkerTests|FullyQualifiedName~BatchSafetyTokenTests|FullyQualifiedName~OperationBatchKernelTests"
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo --filter "FullyQualifiedName~TagOperationCurrentStateReadFakeWorkerTests"
+```
+
+Expected GREEN: the PR 2/PR 3 prerequisite checkpoint passes first, then every new contract, selector, guarded-policy, host, and FakeWorker regression passes.
+
+- [ ] **Step 2: Run the full serial repository verification**
+
+Run:
+
+```powershell
+dotnet build TiaMcpServer.sln --no-restore -m:1 --disable-build-servers --nologo -p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --nologo
+git diff --check
+git status --short
+```
+
+Record the exact build/test totals and the final working-tree status.
+
+- [ ] **Step 3: Run the guarded live harness only after explicit authorization**
+
+When, and only when, the user explicitly authorizes the exact disposable target and cleanup strategy, run:
+
+```powershell
+pwsh -NoProfile -File .\scripts\live-test-tag-operation-safety-scopes.ps1 `
+  -Mode DriftAndRestore `
+  -ProjectPath "C:\Path\To\Disposable.ap21" `
+  -PlcName "PLC_1" `
+  -TableName "Inputs" `
+  -SiblingTableName "Auxiliary" `
+  -TagName "Start" `
+  -CollisionTagName "Start_1" `
+  -UserConstantName "DebounceMs"
+```
+
+Then run the successful apply proof:
+
+```powershell
+pwsh -NoProfile -File .\scripts\live-test-tag-operation-safety-scopes.ps1 `
+  -Mode ApplyAndRestore `
+  -ProjectPath "C:\Path\To\Disposable.ap21" `
+  -PlcName "PLC_1" `
+  -TableName "Inputs" `
+  -SiblingTableName "Auxiliary" `
+  -TagName "Start" `
+  -CollisionTagName "Start_1" `
+  -UserConstantName "DebounceMs"
+```
+
+Expected live evidence:
+
+- same-object drift invalidates the stale token with `state_changed`;
+- relevant collision drift invalidates the stale token with `state_changed`;
+- unrelated sibling-table drift does not invalidate the target operation;
+- one explicitly authorized apply succeeds with the unchanged issued token;
+- the disposable project copy is restored to a clean state or explicitly discarded.
+
+- [ ] **Step 4: Write the acceptance report**
+
+Create `docs/superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md` with these sections:
+
+```markdown
+# PR 5 Tag Operation Safety Scopes Live Acceptance
+
+## Environment
+- TIA Portal version:
+- Harness script path:
+- Disposable project copy:
+- PLC identity:
+- Target table / sibling table:
+- Target tag / collision tag / user constant:
+
+## Calls Performed
+- Preview-only checks:
+- Drift-and-restore checks:
+- Apply-and-restore checks:
+
+## Evidence
+- Same-object drift result:
+- Relevant collision result:
+- Unrelated sibling tolerance result:
+- Successful apply result:
+- Restore or discard result:
+
+## Verification Boundary
+- Proven:
+- Not proven:
+```
+
+Populate every field with actual observed values. Do not leave a heading blank.
+
+- [ ] **Step 5: Final diff review**
+
+Inspect the whole PR 5 diff and confirm:
+
+- no public tool schema changed;
+- no tag operation still hashes the broad `list_tag_tables` payload;
+- no cache crosses preview/apply;
+- no internal worker method is publicly exposed;
+- the deferred items are documented as deferred, not silently solved.
+
+Suggested final commit only if separately authorized:
+
+```bash
+git add TiaMcpServer.Contracts TiaMcpServer TiaMcpServer.OpennessWorker TiaMcpServer.FakeWorker TiaMcpServer.Tests scripts docs
+git commit -m "feat(batch): narrow tag operation safety scopes"
+```
+
+---
+
+## Deferred and Out of Scope
+
+- Multilingual per-tag comment binding remains deferred and is not solved by PR 5.
+- Public `list_tag_tables` completeness or best-effort behavior changes remain deferred and out of scope.
+- Broader snapshot narrowing beyond the eight PR 5 tag operations remains deferred.
+- PLC `start_plc` / `stop_plc` work remains deferred.
+
+## Completion Gate
+
+PR 5 is complete only when all of the following are true:
+
+- [ ] Every new task-specific RED and GREEN result is recorded.
+- [ ] The full stubbed solution build passes serially.
+- [ ] The full serial offline test suite passes with exact totals recorded.
+- [ ] The exact tag/table/user-constant worker snapshot DTOs are in `TiaMcpServer.Contracts`.
+- [ ] No tag-related `BatchWorkerInvoker.ReadCurrentStateAsync` arm still calls `ListTagTablesAsync`.
+- [ ] Within-phase dedup reuses identical reads but preserves ordered per-operation state composition.
+- [ ] Same-object drift and relevant collision drift are proven to invalidate the token.
+- [ ] Unrelated sibling-table drift is proven not to invalidate a narrowly scoped tag operation.
+- [ ] Delete-tag-table safety binds deterministic timestamp-free full-table export content.
+- [ ] Apply is proven to re-read current state and never reuse preview-phase cached data.
+- [ ] The guarded live V21 harness proves same-object drift invalidation, relevant collision invalidation, unrelated sibling tolerance, and one successful authorized apply with restore or discard.
+- [ ] The acceptance report is written under `docs/superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md`.
+- [ ] The deferred items remain explicitly deferred: multilingual per-tag comment binding, public `list_tag_tables` completeness changes, broader snapshot narrowing, and PLC `start_plc` / `stop_plc`.
+- [ ] `git diff --check` passes and the final status contains only intended PR 5 changes.
+- [ ] Offline and FakeWorker evidence are reported as necessary but insufficient until the live harness report exists.

--- a/docs/superpowers/plans/2026-09-01-pr6-project-tree-safety-scopes.md
+++ b/docs/superpowers/plans/2026-09-01-pr6-project-tree-safety-scopes.md
@@ -1,0 +1,1464 @@
+# PR 6 Project-Tree Safety Scopes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the broad project-tree snapshot currently bound by registered `WriteBatchTools` for `create_block`, `create_block_group`, and `delete_block_group` with exact, deterministic, operation-specific safety snapshots that preserve software-unit ownership, detect relevant drift, avoid proven-unrelated false invalidations, and keep the existing preview/apply write-safety guarantees unchanged.
+
+**Architecture:** Keep all Siemens object resolution and export work in the net48 worker. Extend the existing `BlockAddress` and `BlockTargetResolver` deterministic PLC-versus-software-unit ownership path so the worker can emit typed exact-scope snapshots for the three structural block operations, then validate and canonicalize those payloads in the net8 host before hashing. Drive the implementation from registered `WriteBatchTools` behavioral REDs first, then add phase-local deduplication that reuses identical snapshot reads only within one preview or one apply state-read pass and still expands back into ordered `OperationBatchCurrentState` entries.
+
+**Tech Stack:** C# 12, .NET 8 host/tests/FakeWorker, .NET Standard 2.0 contracts, .NET Framework 4.8 Openness worker, xUnit, System.Text.Json, PowerShell 7 live harnesses, MCP stdio protocol.
+
+**Spec:** [Write-Safety Preview and Registered-Surface Hardening Design](../specs/2026-09-01-write-safety-hardening-design.md)
+
+## Global Constraints
+
+- Scope is exactly PR 6 from the approved design: narrow current-state reads only for `create_block`, `create_block_group`, and `delete_block_group`.
+- Preserve the registered public tool names, batch request shape, preview/apply flow, safety-token lifetime, single-use behavior, exact project/session binding, apply-time pinned binding lease, audit behavior, and read-only/write-only registration surface.
+- Behavioral TDD order is mandatory: the first RED must be a focused runtime failure through registered `WriteBatchTools`, not a compile-only or source-contract failure.
+- All new end-to-end, drift, and dedup tests must exercise `WriteBatchTools.PreviewWriteBatch` and `WriteBatchTools.ApplyWriteBatch`, not compatibility `BatchTools`.
+- Preserve software-unit ownership end to end. Any deterministic path under `PLC/Units/<unit>/Blocks/...` must branch through the current `BlockAddress` and `BlockTargetResolver` unit-aware logic, return the resolved owning unit name and root owner scope, walk that unit’s block group, and canonicalize unit-scoped parent and ancestor paths as `PLC/Units/<unit>/Blocks/...`.
+- `create_block` must bind the exact PLC or software-unit owner scope, exact parent group, ancestor chain, requested-name occupancy in that parent, and the exact occupied block export when the requested name is already occupied by a block because the write imports with override semantics.
+- `create_block_group` must bind the exact PLC or software-unit owner scope, exact parent group, ancestor chain, and both block and group occupancy for the requested name.
+- `delete_block_group` must bind the exact target group, its parent membership, and the complete deterministic content-bearing descendant subtree, including exact block exports for contained blocks, not just names.
+- Occupied-block and descendant-subtree exports must be deterministic and must reuse one existing authoritative XML export path instead of inventing a parallel ad hoc serializer.
+- Host-side typed snapshot decode must use explicit post-deserialization validators modeled on `NetworkPayloadContract`: missing, null, empty, malformed, or invalid required members and collections must fail closed as `protocol_error`, and the rejected payload must not be echoed.
+- Deduplication is phase-local only. Reuse identical selector reads only within one preview or one apply current-state read pass, then expand the reused payload back into ordered per-operation `OperationBatchCurrentState` items before `BatchSafetySnapshot.CombineCurrentState`.
+- PR 6 starts only after PR 3's identity-required `OperationCapability.SafetyRead` policy and its worker guard are present. Classify every new internal project-tree snapshot read as `SafetyRead`, never ordinary `Observe`; reuse the existing bound client seam so every request carries `ExpectedSessionIdentity`, and preserve worker-side rejection when that identity is missing.
+- The live harness must launch the host with the exact disposable startup binding: `dotnet run --project TiaMcpServer -- --project <DisposableProject.ap21>`.
+- Before any live preview, apply, or compile call, the harness must call public `get_project_status` and stop unless the tool succeeds, its decoded payload reports `isOpen:true` with `path` canonically equal to the intended disposable project, and the response envelope's `sessionIdentity.projectPath` canonically matches that same path. Record those public fields; do not assert unavailable `bindingState` or `connectionState` fields.
+- Reversible live mutation is required for completion. Any live apply must restore byte-equivalent disposable-project content, prove restoration by re-exporting and comparing the affected deterministic content to the pre-apply baseline, and only then run and record `compile_check` against that restored disposable project. Discarding the project copy is not an alternative to restoration.
+- Broader snapshot narrowing, generic tree-pruning heuristics, tag-scope changes, and all `start_plc` or `stop_plc` work remain explicitly out of scope.
+- Offline tests and FakeWorker scenarios are necessary but never sufficient for completion. PR 6 is incomplete until the guarded live V21 harness runs and its dated acceptance report is written.
+- Use serial Windows .NET verification commands: `dotnet build TiaMcpServer.sln --no-restore -m:1 --disable-build-servers -p:UseTiaPortalReferenceStubs=true`, `dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers`, `git diff --check`, and `git status --short`.
+
+---
+
+## File And Interface Map
+
+- `TiaMcpServer.Contracts/ProjectTreeSafetySnapshotInfo.cs`
+  Shared worker/host records for the three exact tree-snapshot payloads, including owner scope, software unit, ancestor chain, occupancy, occupied block export, and descendant subtree export nodes.
+- `TiaMcpServer/Batch/ProjectTreeSafetyPayloadContract.cs`
+  Host-side typed decode, required-member validation, and canonical projection for the new snapshot payloads. This is the fail-closed seam that turns worker JSON into deterministic current-state strings.
+- `TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs`
+  Existing authoritative deterministic block ownership resolver. Extend it rather than introducing a parallel resolver so PLC-scoped and software-unit-scoped paths share one owner-resolution authority.
+- `TiaMcpServer.OpennessWorker/Openness/BlockExporter.cs`
+  Existing authoritative block export surface. Reuse it for deterministic occupied-block and descendant-block XML exports.
+- `TiaMcpServer.OpennessWorker/Openness/ProjectTreeSafetySnapshotReader.cs`
+  Worker-only exact-scope snapshot reader for `read_create_block_safety_snapshot`, `read_create_block_group_safety_snapshot`, and `read_delete_block_group_safety_snapshot`.
+- `TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs`
+  Mutation path remains authoritative for the actual write semantics and must reuse the same ownership resolver seam as the snapshot reader.
+- `TiaMcpServer.Contracts/OperationPolicyCatalog.cs`
+  Must consume PR 3's guarded `OperationCapability.SafetyRead` classification for the three new internal worker methods. These reads remain internal and non-mutating, but `RequiresExpectedSessionIdentity(...)` must return `true`; ordinary `Observe` is forbidden for token-minting safety reads.
+- `TiaMcpServer.OpennessWorker/Program.cs`
+  Must dispatch the three new internal worker methods through `ProjectTreeSafetySnapshotReader` using the existing `WorkerRequest` fields.
+- `TiaMcpServer/Worker/OpennessWorkerClient.cs`
+  Must add bound helper methods for the three new internal worker snapshot reads and preserve current binding behavior.
+- `TiaMcpServer/Batch/BatchWorkerInvoker.cs`
+  Must route the three structural write operations to the new internal worker reads, decode them with `ProjectTreeSafetyPayloadContract`, and return `protocol_error` on malformed payloads without raw echo.
+- `TiaMcpServer/Batch/WriteBatchTools.cs`
+  Must remain the tested runtime path. Add phase-local identical-selector deduplication here and, if needed for exact order assertions, expose an internal current-state-read helper returning ordered `OperationBatchCurrentState` items plus the combined string.
+- `TiaMcpServer.FakeWorker/Program.cs`
+  Must add exact-scope snapshot scenarios for RED/GREEN behavior, malformed payloads, software-unit paths, and exact per-phase request counters for dedup assertions.
+- `TiaMcpServer.Tests/Batch/ProjectTreeSafetyBehaviorTests.cs`
+  Registered `WriteBatchTools` end-to-end RED/GREEN tests for occupied-target drift, false invalidation removal, relevant collision drift, and malformed payload handling.
+- `TiaMcpServer.Tests/Batch/ProjectTreeSafetyPayloadContractTests.cs`
+  Pure typed-decode and validator tests for required members, required arrays, and invalid enum/path/content values.
+- `TiaMcpServer.Tests/Batch/ProjectTreeCurrentStateReadTests.cs`
+  Request-routing and canonical current-state tests for exact internal worker methods, including root and nested software-unit canonical paths.
+- `TiaMcpServer.Tests/Batch/ProjectTreeSafetyDedupTests.cs`
+  Exact per-phase internal request-count assertions and ordered `OperationBatchCurrentState` expansion checks.
+- `TiaMcpServer.Tests/Project/ProjectTreeSafetySourceContractTests.cs`
+  Supplemental source-contract tests pinning internal worker registration, guarded `SafetyRead` policy, worker rejection of missing `ExpectedSessionIdentity`, and reuse of `BlockTargetResolver` rather than a parallel resolver.
+- `TiaMcpServer.Tests/Batch/ProjectTreeSafetyLiveHarnessScriptTests.cs`
+  Static contract tests for the live PowerShell harness.
+- `scripts/live-test-project-tree-safety-scopes.ps1`
+  Separately authorized live V21 harness using the public MCP protocol and the public `preview_write_batch`, `apply_write_batch`, `get_project_status`, and `compile_check` routes.
+- `docs/superpowers/acceptance/reports/2026-09-01-pr6-project-tree-safety-scopes-live.md`
+  Dated live acceptance report for the guarded V21 run.
+- `docs/ARCHITECTURE.md`, `docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md`, `docs/IMPROVEMENT_LOG.md`, `docs/README.md`, `docs/superpowers/README.md`
+  Required documentation updates after implementation and live acceptance complete.
+
+### Task 1: Add The First Registered `WriteBatchTools` Behavioral RED
+
+**Files:**
+- Create: `TiaMcpServer.Tests/Batch/ProjectTreeSafetyBehaviorTests.cs`
+- Modify: `TiaMcpServer.FakeWorker/Program.cs`
+
+**Interfaces:**
+- Exercise existing registered methods only:
+  - `WriteBatchTools.PreviewWriteBatch(...)`
+  - `WriteBatchTools.ApplyWriteBatch(...)`
+- Add FakeWorker scenarios:
+  - `tree-safety-create-block-content-drift`
+  - `tree-safety-unit-unrelated-sibling-drift`
+
+- [ ] **Step 1: Write the focused runtime regressions through registered `WriteBatchTools`**
+
+Create `ProjectTreeSafetyBehaviorTests.cs`:
+
+```csharp
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tests.Worker;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class ProjectTreeSafetyBehaviorTests
+{
+    [Fact]
+    public async Task WriteBatchTools_CreateBlock_OccupiedTargetContentDrift_InvalidatesTheToken()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        using var client = new OpennessWorkerClient(binding, logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+        var safety = new WriteSafetyService(binding, () => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, audit.Path);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, "tree-safety-create-block-content-drift");
+
+        var operations = new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "create",
+                Operation = "create_block",
+                BlockPath = "PLC_1/Blocks/Main/Mixer",
+                BlockType = "FB",
+                Language = "SCL",
+                ProjectPath = "tree-safety-create-block-content-drift"
+            }
+        };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+        using var previewDoc = JsonDocument.Parse(preview);
+        var token = previewDoc.RootElement.GetProperty("safetyToken").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(token));
+
+        var apply = await WriteBatchTools.ApplyWriteBatch(client, safety, operations, confirm: true, safetyToken: token);
+        using var applyDoc = JsonDocument.Parse(apply);
+
+        Assert.False(applyDoc.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("state_changed", applyDoc.RootElement.GetProperty("failureCategory").GetString());
+    }
+
+    [Fact]
+    public async Task WriteBatchTools_CreateBlockGroup_UnitScopedUnrelatedSiblingDrift_DoesNotInvalidateTheToken()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        using var client = new OpennessWorkerClient(binding, logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+        var safety = new WriteSafetyService(binding, () => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, audit.Path);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, "tree-safety-unit-unrelated-sibling-drift");
+
+        var operations = new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "create-group",
+                Operation = "create_block_group",
+                BlockPath = "PLC_1/Units/Line1/Blocks/Motion/AreaA",
+                ProjectPath = "tree-safety-unit-unrelated-sibling-drift"
+            }
+        };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+        using var previewDoc = JsonDocument.Parse(preview);
+        var token = previewDoc.RootElement.GetProperty("safetyToken").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(token));
+
+        var apply = await WriteBatchTools.ApplyWriteBatch(client, safety, operations, confirm: true, safetyToken: token);
+        using var applyDoc = JsonDocument.Parse(apply);
+
+        Assert.True(applyDoc.RootElement.GetProperty("success").GetBoolean(), apply);
+    }
+}
+```
+
+- [ ] **Step 2: Implement only the minimum FakeWorker scenarios needed for the RED**
+
+Add two scenario branches:
+
+```csharp
+case "tree-safety-create-block-content-drift":
+    Respond(CurrentBroadProjectTreePassesPreviewButNotContentDrift(line));
+    break;
+
+case "tree-safety-unit-unrelated-sibling-drift":
+    Respond(CurrentBroadProjectTreeFalseInvalidatesAcrossUnitSiblings(line));
+    break;
+```
+
+Make these scenarios reflect the current defect:
+
+- preview succeeds against the broad tree snapshot,
+- `create_block` apply does not see occupied-target content drift yet,
+- unit-scoped unrelated sibling drift still changes the broad tree snapshot and falsely invalidates.
+
+- [ ] **Step 3: Run the focused registered behavioral tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTreeSafetyBehaviorTests"
+```
+
+Expected RED:
+
+- `WriteBatchTools_CreateBlock_OccupiedTargetContentDrift_InvalidatesTheToken` fails because the current broad tree snapshot does not bind occupied block content.
+- `WriteBatchTools_CreateBlockGroup_UnitScopedUnrelatedSiblingDrift_DoesNotInvalidateTheToken` fails because the current broad tree snapshot still binds unrelated sibling branches.
+
+- [ ] **Step 4: Review checkpoint**
+
+Confirm the first failures are runtime failures through registered `WriteBatchTools`, not compile-only failures, and do not edit production code yet. Suggested commit if separately authorized: `test: add registered write-batch red for project tree safety scopes`
+
+---
+
+### Task 2: Add Typed Snapshot Contracts And Explicit Host Validators
+
+**Files:**
+- Create: `TiaMcpServer.Contracts/ProjectTreeSafetySnapshotInfo.cs`
+- Create: `TiaMcpServer/Batch/ProjectTreeSafetyPayloadContract.cs`
+- Create: `TiaMcpServer.Tests/Batch/ProjectTreeSafetyPayloadContractTests.cs`
+- Modify: `TiaMcpServer.Tests/Batch/ProjectTreeSafetyBehaviorTests.cs`
+
+**Interfaces:**
+- Add: `public sealed record ProjectTreeOwnerScopeInfo(string ScopeKind, string PlcName, string? SoftwareUnitName, string RootBlocksPath);`
+- Add: `public sealed record ProjectTreeAncestorInfo(string Name, string Path, string Kind);`
+- Add: `public sealed record ProjectTreeOccupancyInfo(string Kind, string Name, string Path);`
+- Add: `public sealed record ProjectTreeBlockExportInfo(string Name, string Path, string BlockKind, string Format, string ContentSha256, string Content);`
+- Add: `public sealed record ProjectTreeGroupDescendantInfo(string Kind, string Name, string Path, string? ContentSha256, string? Content, IReadOnlyList<ProjectTreeGroupDescendantInfo> Children);`
+- Add: `public sealed record CreateBlockSafetySnapshotInfo(ProjectTreeOwnerScopeInfo Owner, string ParentPath, IReadOnlyList<ProjectTreeAncestorInfo> Ancestors, IReadOnlyList<ProjectTreeOccupancyInfo> Occupancies, ProjectTreeBlockExportInfo? OccupiedBlock);`
+- Add: `public sealed record CreateBlockGroupSafetySnapshotInfo(ProjectTreeOwnerScopeInfo Owner, string ParentPath, IReadOnlyList<ProjectTreeAncestorInfo> Ancestors, IReadOnlyList<ProjectTreeOccupancyInfo> Occupancies);`
+- Add: `public sealed record DeleteBlockGroupSafetySnapshotInfo(ProjectTreeOwnerScopeInfo Owner, string ParentPath, string GroupPath, IReadOnlyList<ProjectTreeAncestorInfo> Ancestors, IReadOnlyList<ProjectTreeGroupDescendantInfo> Descendants);`
+- Add: `internal static string DecodeCreateBlockAndCanonicalize(string payload)`
+- Add: `internal static string DecodeCreateBlockGroupAndCanonicalize(string payload)`
+- Add: `internal static string DecodeDeleteBlockGroupAndCanonicalize(string payload)`
+
+- [ ] **Step 1: Write the typed contract and malformed-payload tests**
+
+Create `ProjectTreeSafetyPayloadContractTests.cs`:
+
+```csharp
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class ProjectTreeSafetyPayloadContractTests
+{
+    [Fact]
+    public void DecodeCreateBlockAndCanonicalize_RetainsSoftwareUnitOwnerAndOccupiedContent()
+    {
+        const string payload = """
+        {
+          "owner": {
+            "scopeKind": "SoftwareUnit",
+            "plcName": "PLC_1",
+            "softwareUnitName": "Line1",
+            "rootBlocksPath": "PLC_1/Units/Line1/Blocks"
+          },
+          "parentPath": "PLC_1/Units/Line1/Blocks/Motion",
+          "ancestors": [
+            { "name": "Motion", "path": "PLC_1/Units/Line1/Blocks/Motion", "kind": "UserBlockGroup" }
+          ],
+          "occupancies": [
+            { "kind": "FB", "name": "Mixer", "path": "PLC_1/Units/Line1/Blocks/Motion/Mixer" }
+          ],
+          "occupiedBlock": {
+            "name": "Mixer",
+            "path": "PLC_1/Units/Line1/Blocks/Motion/Mixer",
+            "blockKind": "FB",
+            "format": "xml",
+            "contentSha256": "abc",
+            "content": "<Document>v1</Document>"
+          }
+        }
+        """;
+
+        var canonical = ProjectTreeSafetyPayloadContract.DecodeCreateBlockAndCanonicalize(payload);
+
+        Assert.Contains("\"softwareUnitName\":\"Line1\"", canonical, StringComparison.Ordinal);
+        Assert.Contains("\"parentPath\":\"PLC_1/Units/Line1/Blocks/Motion\"", canonical, StringComparison.Ordinal);
+        Assert.Contains("<Document>v1</Document>", canonical, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DecodeCreateBlockGroupAndCanonicalize_RejectsMissingOwner()
+    {
+        const string payload = """
+        {
+          "parentPath": "PLC_1/Blocks/Main",
+          "ancestors": [],
+          "occupancies": []
+        }
+        """;
+
+        Assert.Throws<JsonException>(
+            () => ProjectTreeSafetyPayloadContract.DecodeCreateBlockGroupAndCanonicalize(payload));
+    }
+
+    [Fact]
+    public void DecodeDeleteBlockGroupAndCanonicalize_RejectsBlankDescendantContent()
+    {
+        const string payload = """
+        {
+          "owner": {
+            "scopeKind": "Plc",
+            "plcName": "PLC_1",
+            "softwareUnitName": null,
+            "rootBlocksPath": "PLC_1/Blocks"
+          },
+          "parentPath": "PLC_1/Blocks/Main",
+          "groupPath": "PLC_1/Blocks/Main/AreaA",
+          "ancestors": [],
+          "descendants": [
+            {
+              "kind": "FB",
+              "name": "Mixer",
+              "path": "PLC_1/Blocks/Main/AreaA/Mixer",
+              "contentSha256": "abc",
+              "content": "",
+              "children": []
+            }
+          ]
+        }
+        """;
+
+        Assert.Throws<JsonException>(
+            () => ProjectTreeSafetyPayloadContract.DecodeDeleteBlockGroupAndCanonicalize(payload));
+    }
+
+    [Theory]
+    [InlineData("""{"owner":{"scopeKind":"Nope","plcName":"PLC_1","softwareUnitName":null,"rootBlocksPath":"PLC_1/Blocks"},"parentPath":"PLC_1/Blocks","ancestors":[],"occupancies":[]}""")]
+    [InlineData("""{"owner":{"scopeKind":"Plc","plcName":"","softwareUnitName":null,"rootBlocksPath":"PLC_1/Blocks"},"parentPath":"PLC_1/Blocks","ancestors":[],"occupancies":[]}""")]
+    [InlineData("""{"owner":{"scopeKind":"Plc","plcName":"PLC_1","softwareUnitName":null,"rootBlocksPath":""},"parentPath":"PLC_1/Blocks","ancestors":[],"occupancies":[]}""")]
+    public void DecodeCreateBlockGroupAndCanonicalize_RejectsInvalidRequiredOwnerValues(string payload)
+    {
+        Assert.Throws<JsonException>(
+            () => ProjectTreeSafetyPayloadContract.DecodeCreateBlockGroupAndCanonicalize(payload));
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused validator tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTreeSafetyPayloadContractTests"
+```
+
+Expected RED: the new contract types and `ProjectTreeSafetyPayloadContract` do not exist yet.
+
+- [ ] **Step 3: Implement typed decode plus explicit validators modeled on `NetworkPayloadContract`**
+
+Create `ProjectTreeSafetyPayloadContract.cs` with the same pattern used by `NetworkPayloadContract`:
+
+```csharp
+internal static class ProjectTreeSafetyPayloadContract
+{
+    internal static string DecodeCreateBlockAndCanonicalize(string payload)
+    {
+        var snapshot = Deserialize<CreateBlockSafetySnapshotInfo>(payload);
+        ValidateCreateBlockSnapshot(snapshot, payload);
+        return CanonicalJson.Serialize(snapshot);
+    }
+
+    private static void ValidateCreateBlockSnapshot(CreateBlockSafetySnapshotInfo snapshot, string payload)
+    {
+        ValidateOwner(snapshot.Owner, payload);
+        RequireNonEmptyPath(snapshot.ParentPath, "parentPath");
+        RequireNonNullCollection(snapshot.Ancestors, "ancestors");
+        RequireNonNullCollection(snapshot.Occupancies, "occupancies");
+        foreach (var ancestor in snapshot.Ancestors)
+        {
+            ValidateAncestor(ancestor, "ancestors[]");
+        }
+        foreach (var occupancy in snapshot.Occupancies)
+        {
+            ValidateOccupancy(occupancy, "occupancies[]");
+        }
+        if (snapshot.OccupiedBlock is not null)
+        {
+            ValidateBlockExport(snapshot.OccupiedBlock, "occupiedBlock");
+        }
+    }
+}
+```
+
+Required validator behavior:
+
+- `Owner.ScopeKind` is only `Plc` or `SoftwareUnit`.
+- `Owner.PlcName` and `Owner.RootBlocksPath` are non-empty.
+- `Owner.SoftwareUnitName` must be non-empty when `ScopeKind == "SoftwareUnit"` and must be null when `ScopeKind == "Plc"`.
+- Every path field is non-empty and uses deterministic `PLC/...` or `PLC/Units/...` tree form.
+- Every `Kind` is from an explicit allow-list such as `UserBlockGroup`, `FB`, `FC`, `OB`, `GlobalDB`, `InstanceDB`, `ArrayDB`.
+- Every exported block node has non-empty `Format == "xml"`, `ContentSha256`, and `Content`.
+- `Descendants` and descendant `Children` collections must be non-null, and content-bearing descendant block nodes must not carry blank content.
+
+- [ ] **Step 4: Add a malformed worker-payload end-to-end regression through registered `WriteBatchTools`**
+
+Add this test to `ProjectTreeSafetyBehaviorTests.cs`:
+
+```csharp
+[Fact]
+public async Task WriteBatchTools_CreateBlock_MalformedSnapshotPayload_BecomesProtocolErrorWithoutRawEcho()
+{
+    using var audit = new TempAuditDirectory();
+    var binding = new ProjectSessionBinding(null);
+    using var client = new OpennessWorkerClient(binding, logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+    var safety = new WriteSafetyService(binding, () => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, audit.Path);
+    await FakeWorkerBinding.BindVerifiedAsync(client, binding, "tree-safety-malformed-payload");
+
+    var operations = new[]
+    {
+        new BatchOperationRequest
+        {
+            OperationId = "create",
+            Operation = "create_block",
+            BlockPath = "PLC_1/Blocks/Main/Mixer",
+            BlockType = "FB",
+            Language = "SCL",
+            ProjectPath = "tree-safety-malformed-payload"
+        }
+    };
+
+    var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+    using var previewDoc = JsonDocument.Parse(preview);
+
+    Assert.False(previewDoc.RootElement.GetProperty("success").GetBoolean());
+    Assert.Equal("protocol_error", previewDoc.RootElement.GetProperty("failureCategory").GetString());
+    Assert.DoesNotContain("content\":\"", preview, StringComparison.Ordinal);
+}
+```
+
+- [ ] **Step 5: Run the validator and malformed-payload tests and verify GREEN**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTreeSafetyPayloadContractTests|FullyQualifiedName~ProjectTreeSafetyBehaviorTests.WriteBatchTools_CreateBlock_MalformedSnapshotPayload_BecomesProtocolErrorWithoutRawEcho"
+```
+
+Expected GREEN: typed decode is explicit and fail-closed, and malformed worker payloads become `protocol_error` without raw payload echo.
+
+- [ ] **Step 6: Review checkpoint**
+
+Confirm the validator step happens after deserialization but before any token issuance, and that `JsonSerializer.Deserialize(...)` is never treated as sufficient validation by itself. Suggested commit if separately authorized: `feat: add validated project tree snapshot payload contract`
+
+---
+
+### Task 3: Preserve Software-Unit Ownership Through `BlockAddress` And `BlockTargetResolver`
+
+**Files:**
+- Modify: `TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs`
+- Modify: `TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs`
+- Create: `TiaMcpServer.OpennessWorker/Openness/ProjectTreeSafetySnapshotReader.cs`
+- Create: `TiaMcpServer.Tests/Project/ProjectTreeSafetySourceContractTests.cs`
+- Modify: `TiaMcpServer.Tests/Batch/ProjectTreeCurrentStateReadTests.cs`
+- Modify: `TiaMcpServer.Tests/Block/BlockAddressTests.cs`
+
+**Interfaces:**
+- Add in `BlockTargetResolver.cs`: `internal static ResolvedBlockOwner ResolveOwnerForDeterministicPath(PlcSoftware plcSoftware, BlockAddress address)`
+- Add in `BlockTargetResolver.cs`: `internal sealed class ResolvedBlockOwner`
+- Add in `ProjectTreeSafetySnapshotReader.cs`:
+  - `public static CreateBlockSafetySnapshotInfo ReadCreateBlockSnapshot(Project project, string blockPath, string blockType, string? language, string? obEventClass)`
+  - `public static CreateBlockGroupSafetySnapshotInfo ReadCreateBlockGroupSnapshot(Project project, string blockPath)`
+  - `public static DeleteBlockGroupSafetySnapshotInfo ReadDeleteBlockGroupSnapshot(Project project, string blockPath)`
+
+- [ ] **Step 1: Write the software-unit canonical-path tests**
+
+Add to `ProjectTreeCurrentStateReadTests.cs`:
+
+```csharp
+[Fact]
+public async Task CreateBlock_CurrentStateRead_CanonicalizesSoftwareUnitRootParentPath()
+{
+    using var client = new OpennessWorkerClient(new ProjectSessionBinding(null), logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+    var result = await BatchWorkerInvoker.ReadCurrentStateAsync(client, new BatchOperationRequest
+    {
+        OperationId = "create-root-unit",
+        Operation = "create_block",
+        BlockPath = "PLC_1/Units/Line1/Blocks/Main",
+        BlockType = "FB",
+        Language = "SCL",
+        ProjectPath = "tree-safety-unit-root"
+    });
+
+    Assert.True(result.Success, result.Error);
+    Assert.Contains("\"softwareUnitName\":\"Line1\"", result.Payload, StringComparison.Ordinal);
+    Assert.Contains("\"rootBlocksPath\":\"PLC_1/Units/Line1/Blocks\"", result.Payload, StringComparison.Ordinal);
+    Assert.Contains("\"parentPath\":\"PLC_1/Units/Line1/Blocks\"", result.Payload, StringComparison.Ordinal);
+}
+
+[Fact]
+public async Task DeleteBlockGroup_CurrentStateRead_CanonicalizesNestedSoftwareUnitAncestorPath()
+{
+    using var client = new OpennessWorkerClient(new ProjectSessionBinding(null), logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+    var result = await BatchWorkerInvoker.ReadCurrentStateAsync(client, new BatchOperationRequest
+    {
+        OperationId = "delete-nested-unit",
+        Operation = "delete_block_group",
+        BlockPath = "PLC_1/Units/Line1/Blocks/Motion/AreaA",
+        ProjectPath = "tree-safety-unit-nested"
+    });
+
+    Assert.True(result.Success, result.Error);
+    Assert.Contains("\"parentPath\":\"PLC_1/Units/Line1/Blocks/Motion\"", result.Payload, StringComparison.Ordinal);
+    Assert.Contains("\"path\":\"PLC_1/Units/Line1/Blocks/Motion/AreaA\"", result.Payload, StringComparison.Ordinal);
+}
+```
+
+Add to `ProjectTreeSafetySourceContractTests.cs`:
+
+```csharp
+[Fact]
+public void ProjectTreeSafetySnapshotReader_UsesBlockTargetResolverForDeterministicOwnership()
+{
+    var source = File.ReadAllText(Path.Combine(GetRepositoryRoot(), "TiaMcpServer.OpennessWorker", "Openness", "ProjectTreeSafetySnapshotReader.cs"));
+
+    Assert.Contains("BlockTargetResolver.ResolveOwnerForDeterministicPath", source, StringComparison.Ordinal);
+    Assert.DoesNotContain("SoftwareUnitName = null", source, StringComparison.Ordinal);
+}
+```
+
+Add to `BlockAddressTests.cs`:
+
+```csharp
+[Fact]
+public void ParseSupportsSoftwareUnitRootBlockPath()
+{
+    var address = BlockAddress.Parse("PLC_1/Units/Line1/Blocks/Main");
+
+    Assert.Equal("PLC_1", address.PlcName);
+    Assert.Equal("Line1", address.UnitName);
+    Assert.Empty(address.FolderPath);
+    Assert.Equal("Main", address.BlockName);
+    Assert.True(address.UsesSoftwareUnit);
+}
+```
+
+- [ ] **Step 2: Run the software-unit tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~CreateBlock_CurrentStateRead_CanonicalizesSoftwareUnitRootParentPath|FullyQualifiedName~DeleteBlockGroup_CurrentStateRead_CanonicalizesNestedSoftwareUnitAncestorPath|FullyQualifiedName~ParseSupportsSoftwareUnitRootBlockPath|FullyQualifiedName~ProjectTreeSafetySnapshotReader_UsesBlockTargetResolverForDeterministicOwnership"
+```
+
+Expected RED: the current plan baseline cannot yet emit unit-scoped owner metadata and canonical unit paths through the exact current-state read.
+
+- [ ] **Step 3: Extend `BlockTargetResolver` instead of introducing a parallel resolver**
+
+Add an owner model inside `BlockTargetResolver.cs`:
+
+```csharp
+internal sealed class ResolvedBlockOwner
+{
+    public ResolvedBlockOwner(
+        string scopeKind,
+        string plcName,
+        string? softwareUnitName,
+        string rootBlocksPath,
+        PlcBlockGroup rootBlockGroup,
+        PlcExternalSourceSystemGroup externalSourceGroup)
+    {
+        ScopeKind = scopeKind;
+        PlcName = plcName;
+        SoftwareUnitName = softwareUnitName;
+        RootBlocksPath = rootBlocksPath;
+        RootBlockGroup = rootBlockGroup;
+        ExternalSourceGroup = externalSourceGroup;
+    }
+
+    public string ScopeKind { get; }
+    public string PlcName { get; }
+    public string? SoftwareUnitName { get; }
+    public string RootBlocksPath { get; }
+    public PlcBlockGroup RootBlockGroup { get; }
+    public PlcExternalSourceSystemGroup ExternalSourceGroup { get; }
+}
+```
+
+Then add:
+
+```csharp
+internal static ResolvedBlockOwner ResolveOwnerForDeterministicPath(PlcSoftware plcSoftware, BlockAddress address)
+{
+    if (!address.UsesSoftwareUnit)
+    {
+        return new ResolvedBlockOwner(
+            "Plc",
+            plcSoftware.Name,
+            address.UnitName,
+            $"{plcSoftware.Name}/Blocks",
+            plcSoftware.BlockGroup,
+            plcSoftware.ExternalSourceGroup);
+    }
+
+    var unit = FindSoftwareUnit(plcSoftware, address.UnitName!);
+    var resolvedSoftwareUnitName = unit.Name;
+    return new ResolvedBlockOwner(
+        "SoftwareUnit",
+        plcSoftware.Name,
+        resolvedSoftwareUnitName,
+        $"{plcSoftware.Name}/Units/{unit.Name}/Blocks",
+        unit.BlockGroup,
+        unit.ExternalSourceGroup);
+}
+```
+
+`BlockMutationService.CreateBlock`, `CreateBlockGroup`, and `DeleteBlockGroup` must continue to resolve through the same owner/resolution seam instead of reimplementing unit detection locally.
+
+- [ ] **Step 4: Implement the worker snapshot reader with exact owner-aware canonical paths**
+
+Implement `ProjectTreeSafetySnapshotReader.cs` so it:
+
+- parses the path with `BlockAddress.Parse(...)`,
+- resolves the owning PLC or software unit with `BlockTargetResolver.ResolveOwnerForDeterministicPath(...)`,
+- derives `ParentPath` from `owner.RootBlocksPath` plus `address.FolderPath`,
+- emits ancestor paths under the same root,
+- uses `BlockExporter` for deterministic XML exports of occupied blocks and descendant blocks,
+- never hard-codes `SoftwareUnitName = null` for unit-scoped paths.
+
+For example:
+
+```csharp
+var address = BlockAddress.Parse(blockPath);
+var plcSoftware = PlcSoftwareLocator.Find(project, address.PlcName);
+var owner = address.IsDeterministic
+    ? BlockTargetResolver.ResolveOwnerForDeterministicPath(plcSoftware, address)
+    : throw new InvalidOperationException("Project-tree safety snapshots require deterministic block paths.");
+var parentPath = address.FolderPath.Count == 0
+    ? owner.RootBlocksPath
+    : $"{owner.RootBlocksPath}/{string.Join("/", address.FolderPath)}";
+```
+
+- [ ] **Step 5: Run the software-unit tests and the supplemental source-contract tests and verify GREEN**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTreeCurrentStateReadTests|FullyQualifiedName~ProjectTreeSafetySourceContractTests|FullyQualifiedName~BlockAddressTests.ParseSupportsSoftwareUnitBlockPath|FullyQualifiedName~BlockAddressTests.ParseSupportsSoftwareUnitRootBlockPath"
+```
+
+Expected GREEN: root and nested unit-scoped paths retain the owning software unit and canonical `PLC/Units/<unit>/Blocks/...` paths end to end.
+
+- [ ] **Step 6: Review checkpoint**
+
+Confirm there is no new `BlockPathResolver` file, no unit path is flattened back to PLC scope, and `BlockTargetResolver` remains the single authority for deterministic owner resolution. Suggested commit if separately authorized: `feat: preserve software-unit ownership in tree safety snapshots`
+
+---
+
+### Task 4: Route Exact Snapshot Reads Through The Registered Write Path And Close The Original RED
+
+**Files:**
+- Modify: `TiaMcpServer.Contracts/OperationPolicyCatalog.cs`
+- Modify: `TiaMcpServer/Worker/OpennessWorkerClient.cs`
+- Modify: `TiaMcpServer/Batch/BatchWorkerInvoker.cs`
+- Modify: `TiaMcpServer.OpennessWorker/Program.cs`
+- Modify: `TiaMcpServer.FakeWorker/Program.cs`
+- Modify: `TiaMcpServer.Tests/Batch/ProjectTreeSafetyBehaviorTests.cs`
+- Modify: `TiaMcpServer.Tests/Batch/ProjectTreeCurrentStateReadTests.cs`
+- Modify: `TiaMcpServer.Tests/Project/ProjectTreeSafetySourceContractTests.cs`
+- Create: `TiaMcpServer.Tests/Worker/ProjectTreeSafetyIdentityEnforcementTests.cs`
+
+**Interfaces:**
+- Add:
+  - `public Task<WorkerCallResult> ReadCreateBlockSafetySnapshotAsync(string blockPath, string blockType, string? language, string? obEventClass, string? projectPath)`
+  - `public Task<WorkerCallResult> ReadCreateBlockGroupSafetySnapshotAsync(string blockPath, string? projectPath)`
+  - `public Task<WorkerCallResult> ReadDeleteBlockGroupSafetySnapshotAsync(string blockPath, string? projectPath)`
+- Classify all three internal method names with PR 3's `OperationCapability.SafetyRead`; `OperationPolicyCatalog.RequiresExpectedSessionIdentity(...)` must return `true` for each.
+- Add in `BatchWorkerInvoker.cs`: `private static async Task<WorkerCallResult> DecodeProjectTreeSnapshotAsync(Task<WorkerCallResult> pending, Func<string, string> decode)`
+
+- [ ] **Step 1: Write the exact routing tests**
+
+Add to `ProjectTreeCurrentStateReadTests.cs`:
+
+```csharp
+[Fact]
+public async Task CreateBlock_CurrentStateRead_UsesExactInternalSnapshotMethod()
+{
+    const string scenario = "tree-safety-route-create-block";
+    var binding = new ProjectSessionBinding(null);
+    using var client = new OpennessWorkerClient(binding, logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+    await FakeWorkerBinding.BindVerifiedAsync(client, binding, scenario);
+    var result = await BatchWorkerInvoker.ReadCurrentStateAsync(client, new BatchOperationRequest
+    {
+        OperationId = "create",
+        Operation = "create_block",
+        BlockPath = "PLC_1/Blocks/Main/Mixer",
+        BlockType = "FB",
+        Language = "SCL",
+        ProjectPath = scenario
+    });
+
+    Assert.True(result.Success, result.Error);
+    Assert.Contains("\"parentPath\":\"PLC_1/Blocks/Main\"", result.Payload, StringComparison.Ordinal);
+}
+
+[Fact]
+public async Task DeleteBlockGroup_CurrentStateRead_DoesNotUseBrowseProjectTree()
+{
+    const string scenario = "tree-safety-route-delete-block-group";
+    var binding = new ProjectSessionBinding(null);
+    using var client = new OpennessWorkerClient(binding, logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+    await FakeWorkerBinding.BindVerifiedAsync(client, binding, scenario);
+    var result = await BatchWorkerInvoker.ReadCurrentStateAsync(client, new BatchOperationRequest
+    {
+        OperationId = "delete",
+        Operation = "delete_block_group",
+        BlockPath = "PLC_1/Blocks/Main/AreaA",
+        ProjectPath = scenario
+    });
+
+    Assert.True(result.Success, result.Error);
+    Assert.Contains("\"groupPath\":\"PLC_1/Blocks/Main/AreaA\"", result.Payload, StringComparison.Ordinal);
+}
+```
+
+Add the equivalent `create_block_group` case using scenario `tree-safety-route-create-block-group`, operation path `PLC_1/Blocks/Main/AreaA`, and an assertion for canonical `parentPath:"PLC_1/Blocks/Main"`. After allowing the initial `get_project_status` binding probe, each route scenario must fail unless the FakeWorker receives its one expected internal snapshot method, then return a valid typed payload; therefore `BatchWorkerInvoker.ReadCurrentStateAsync` success is runtime evidence that it did not fall back to `browse_project_tree`.
+
+Add an identity-carrying request regression after establishing a verified FakeWorker binding. The `echo` scenario returns the serialized `WorkerRequest`, so the assertion proves the production client seam—not a hand-built request—sent the complete identity:
+
+```csharp
+[Fact]
+public async Task CreateBlock_CurrentStateRead_SendsExpectedSessionIdentity()
+{
+    var binding = new ProjectSessionBinding(null);
+    using var client = new OpennessWorkerClient(binding, logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+    await FakeWorkerBinding.BindVerifiedAsync(client, binding, "echo");
+
+    var result = await client.ReadCreateBlockSafetySnapshotAsync(
+        blockPath: "PLC_1/Blocks/Main/Mixer",
+        blockType: "FB",
+        language: "SCL",
+        obEventClass: null,
+        projectPath: "echo");
+
+    Assert.True(result.Success, result.Error);
+    using var request = JsonDocument.Parse(result.Payload);
+    var identity = request.RootElement.GetProperty("expectedSessionIdentity");
+    Assert.False(string.IsNullOrWhiteSpace(identity.GetProperty("workerSessionId").GetString()));
+    Assert.True(string.Equals(
+        binding.CaptureSnapshot().ProjectPath,
+        identity.GetProperty("projectPath").GetString(),
+        StringComparison.OrdinalIgnoreCase));
+}
+```
+
+Add executable worker-guard coverage in `ProjectTreeSafetyIdentityEnforcementTests.cs` so the same identity-required policy is proven beyond source inspection:
+
+```csharp
+[Theory]
+[InlineData("read_create_block_safety_snapshot")]
+[InlineData("read_create_block_group_safety_snapshot")]
+[InlineData("read_delete_block_group_safety_snapshot")]
+public async Task InternalTreeSafetyRead_RejectsMissingExpectedSessionIdentity(string method)
+{
+    using var transport = new PersistentWorkerTransport(FakeWorkerLocator.Locate(), TimeSpan.FromSeconds(5));
+    var observed = await transport.SendAsync(new WorkerRequest
+    {
+        Method = "read_hardware_config",
+        ProjectPath = "tree-safety-request-echo"
+    });
+
+    Assert.True(observed.Success, observed.Error);
+
+    var response = await transport.SendAsync(new WorkerRequest
+    {
+        Method = method,
+        ProjectPath = "tree-safety-request-echo"
+    });
+
+    Assert.False(response.Success);
+    Assert.Equal(WorkerFailureCategories.BindingConflict, response.FailureCategory);
+}
+```
+
+Add to `ProjectTreeSafetySourceContractTests.cs` a table-driven policy/worker-guard regression for all three internal method names:
+
+```csharp
+[Theory]
+[InlineData("read_create_block_safety_snapshot")]
+[InlineData("read_create_block_group_safety_snapshot")]
+[InlineData("read_delete_block_group_safety_snapshot")]
+public void InternalTreeSafetyRead_IsIdentityRequiredSafetyRead(string method)
+{
+    Assert.Equal(OperationCapability.SafetyRead, OperationPolicyCatalog.GetCapability(method));
+    Assert.True(OperationPolicyCatalog.RequiresExpectedSessionIdentity(method));
+}
+
+[Fact]
+public void WorkerGuard_RejectsMissingExpectedSessionIdentity_ForSafetyReads()
+{
+    var program = ReadRepositoryFile("TiaMcpServer.OpennessWorker", "Program.cs");
+    var policy = ReadRepositoryFile("TiaMcpServer.Contracts", "OperationPolicyCatalog.cs");
+
+    Assert.Contains("AllowsMissingExpectedSessionIdentity(request.Method)", program, StringComparison.Ordinal);
+    Assert.Contains("!OperationPolicyCatalog.RequiresExpectedSessionIdentity(method)", program, StringComparison.Ordinal);
+    Assert.Contains("OperationCapability.SafetyRead", policy, StringComparison.Ordinal);
+    foreach (var method in new[]
+    {
+        "read_create_block_safety_snapshot",
+        "read_create_block_group_safety_snapshot",
+        "read_delete_block_group_safety_snapshot"
+    })
+    {
+        Assert.True(OperationPolicyCatalog.RequiresExpectedSessionIdentity(method));
+    }
+}
+```
+
+The executable transport test proves the worker actually rejects a missing `ExpectedSessionIdentity` with `binding_conflict`; the source-contract test pins why that happens by keeping each method on the shared `SafetyRead` guard path. Do not weaken `RequiresExpectedSessionIdentity(...)` or classify these methods as ordinary `Observe` merely because they are non-mutating.
+
+- [ ] **Step 2: Run the focused routing, identity, and registered-behavior tests and confirm RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTreeCurrentStateReadTests|FullyQualifiedName~ProjectTreeSafetyIdentityEnforcementTests|FullyQualifiedName~ProjectTreeSafetySourceContractTests|FullyQualifiedName~ProjectTreeSafetyBehaviorTests"
+```
+
+Expected RED: the Task 1 registered behavioral failures are already captured; this slice additionally fails because the exact client methods are absent, because all three methods are not yet guarded `SafetyRead` operations, and because the worker still permits missing identity for reads that have not yet been reclassified onto that shared guard. Do not write production code before recording this focused RED.
+
+- [ ] **Step 3: Add worker-client methods and route `BatchWorkerInvoker.ReadCurrentStateAsync` to them**
+
+Implement:
+
+```csharp
+public Task<WorkerCallResult> ReadCreateBlockSafetySnapshotAsync(
+    string blockPath,
+    string blockType,
+    string? language,
+    string? obEventClass,
+    string? projectPath)
+{
+    return SendBoundProjectRequestAsync(
+        "read_create_block_safety_snapshot",
+        projectPath,
+        request =>
+        {
+            request.BlockPath = blockPath;
+            request.BlockType = blockType;
+            request.Language = language;
+            request.OBEventClass = obEventClass;
+        },
+        "{}");
+}
+```
+
+Register the three method names as `OperationCapability.SafetyRead` using the capability and worker guard delivered by PR 3. Do not add a parallel identity exception or transport path. `SendBoundProjectRequestAsync(...)` must remain the only client path so `ExpectedSessionIdentity = bindingBeforeCall.ToWorkerIdentity()` is populated by the existing core request builder, and the worker must evaluate the same catalog before dispatch.
+
+Implement the decode shim:
+
+```csharp
+private static async Task<WorkerCallResult> DecodeProjectTreeSnapshotAsync(
+    Task<WorkerCallResult> pending,
+    Func<string, string> decode)
+{
+    var result = await pending.ConfigureAwait(false);
+    if (!result.Success)
+    {
+        return result;
+    }
+
+    try
+    {
+        return WorkerCallResult.Ok(decode(result.Payload), result.Warnings);
+    }
+    catch (JsonException)
+    {
+        return WorkerCallResult.Fail(
+            WorkerFailureCategories.ProtocolError,
+            "The project-tree safety snapshot payload did not match its declared contract.",
+            result.Warnings);
+    }
+}
+```
+
+Then route:
+
+```csharp
+"create_block" => DecodeProjectTreeSnapshotAsync(
+    client.ReadCreateBlockSafetySnapshotAsync(
+        op.BlockPath!, op.BlockType!, op.Language, op.ObEventClass, op.ProjectPath),
+    ProjectTreeSafetyPayloadContract.DecodeCreateBlockAndCanonicalize),
+"create_block_group" => DecodeProjectTreeSnapshotAsync(
+    client.ReadCreateBlockGroupSafetySnapshotAsync(op.BlockPath!, op.ProjectPath),
+    ProjectTreeSafetyPayloadContract.DecodeCreateBlockGroupAndCanonicalize),
+"delete_block_group" => DecodeProjectTreeSnapshotAsync(
+    client.ReadDeleteBlockGroupSafetySnapshotAsync(op.BlockPath!, op.ProjectPath),
+    ProjectTreeSafetyPayloadContract.DecodeDeleteBlockGroupAndCanonicalize),
+```
+
+- [ ] **Step 4: Expand the FakeWorker scenarios to reflect exact-scope behavior**
+
+Update the scenarios introduced in Task 1 and add:
+
+- `tree-safety-route-create-block`
+- `tree-safety-route-create-block-group`
+- `tree-safety-route-delete-block-group`
+- `tree-safety-create-group-collision-drift`
+- `tree-safety-delete-group-descendant-drift`
+- `tree-safety-malformed-payload`
+
+Green behavior must be:
+
+- after its required `get_project_status` binding probe, each `tree-safety-route-*` scenario rejects every worker method except its exact `read_*_safety_snapshot` method and returns a valid typed snapshot only for that method,
+- `create_block` stale token is rejected when only occupied target content changes,
+- `create_block_group` stale token is rejected when only same-parent name occupancy changes,
+- `delete_block_group` stale token is rejected when only one descendant block’s content changes,
+- unit-scoped unrelated sibling drift no longer invalidates the target write,
+- malformed exact snapshot payload becomes `protocol_error`.
+
+- [ ] **Step 5: Run the registered behavioral suite and verify GREEN**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTreeSafetyBehaviorTests|FullyQualifiedName~ProjectTreeCurrentStateReadTests|FullyQualifiedName~ProjectTreeSafetySourceContractTests"
+```
+
+Expected GREEN:
+
+- the Task 1 REDs are now closed through registered `WriteBatchTools`,
+- exact internal worker methods are used,
+- every internal snapshot request carries `ExpectedSessionIdentity`, and the worker guard rejects a missing identity,
+- `delete_block_group` now binds descendant block content,
+- malformed payloads fail as `protocol_error`.
+
+- [ ] **Step 6: Review checkpoint**
+
+Confirm the broad `BrowseProjectTreeAsync(op.ProjectPath)` binding path is gone only for these three operations, all three internal reads are guarded `SafetyRead` operations rather than `Observe`, the production bound request seam is the only transport path, and the tests still execute `WriteBatchTools`, not compatibility `BatchTools`. Suggested commit if separately authorized: `feat: route structural block writes through exact tree snapshots`
+
+---
+
+### Task 5: Add Exact Per-Phase Dedup Assertions And Ordered State Expansion Checks
+
+**Files:**
+- Modify: `TiaMcpServer/Batch/WriteBatchTools.cs`
+- Modify: `TiaMcpServer.FakeWorker/Program.cs`
+- Create: `TiaMcpServer.Tests/Batch/ProjectTreeSafetyDedupTests.cs`
+
+**Interfaces:**
+- Add in `WriteBatchTools.cs`:
+  - `private readonly record struct ProjectTreeSelectorKey(string Operation, string? ProjectPath, string BlockPath, string? BlockType, string? Language, string? ObEventClass);`
+  - `internal static async Task<(IReadOnlyList<OperationBatchCurrentState> States, string CombinedState, string? Error)> ReadCurrentStatesForTestingAsync(OpennessWorkerClient workerClient, BatchOperationRequest[] operations)`
+- Preserve private caller surface:
+  - `PreviewWriteBatch(...)`
+  - `ApplyWriteBatch(...)`
+
+- [ ] **Step 1: Write the exact dedup tests**
+
+Create `ProjectTreeSafetyDedupTests.cs`:
+
+```csharp
+using System.Linq;
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using TiaMcpServer.OperationBatches;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tests.Worker;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class ProjectTreeSafetyDedupTests
+{
+    [Fact]
+    public async Task ReadCurrentStatesForTestingAsync_ExpandsTwoIdenticalSelectorsBackIntoOrderedOperationStates()
+    {
+        var binding = new ProjectSessionBinding(null);
+        using var client = new OpennessWorkerClient(binding, logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, "tree-safety-dedup");
+
+        var operations = new[]
+        {
+            new BatchOperationRequest { OperationId = "first", Operation = "create_block_group", BlockPath = "PLC_1/Blocks/Main/AreaA", ProjectPath = "tree-safety-dedup" },
+            new BatchOperationRequest { OperationId = "second", Operation = "create_block_group", BlockPath = "PLC_1/Blocks/Main/AreaA", ProjectPath = "tree-safety-dedup" }
+        };
+
+        var snapshot = await WriteBatchTools.ReadCurrentStatesForTestingAsync(client, operations);
+
+        Assert.Null(snapshot.Error);
+        Assert.Equal(new[] { "first", "second" }, snapshot.States.Select(state => state.OperationId).ToArray());
+        Assert.Equal(new[] { "create_block_group", "create_block_group" }, snapshot.States.Select(state => state.Operation).ToArray());
+        Assert.Equal(snapshot.States[0].CurrentState, snapshot.States[1].CurrentState);
+    }
+
+    [Fact]
+    public async Task WriteBatchTools_DeduplicatesOnePreviewReadButPerformsAFreshApplyRead()
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        using var client = new OpennessWorkerClient(binding, logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+        var safety = new WriteSafetyService(binding, () => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, audit.Path);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, "tree-safety-dedup");
+
+        var operations = new[]
+        {
+            new BatchOperationRequest { OperationId = "first", Operation = "create_block_group", BlockPath = "PLC_1/Blocks/Main/AreaA", ProjectPath = "tree-safety-dedup" },
+            new BatchOperationRequest { OperationId = "second", Operation = "create_block_group", BlockPath = "PLC_1/Blocks/Main/AreaA", ProjectPath = "tree-safety-dedup" }
+        };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+        using var previewDoc = JsonDocument.Parse(preview);
+        var token = previewDoc.RootElement.GetProperty("safetyToken").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(token));
+
+        var apply = await WriteBatchTools.ApplyWriteBatch(client, safety, operations, confirm: true, safetyToken: token);
+        using var applyDoc = JsonDocument.Parse(apply);
+        Assert.True(applyDoc.RootElement.GetProperty("success").GetBoolean(), apply);
+
+        var counters = FakeWorkerCounterProbe.Read("tree-safety-dedup");
+        Assert.Equal(1, counters["read_create_block_group_safety_snapshot.preview"]);
+        Assert.Equal(1, counters["read_create_block_group_safety_snapshot.apply"]);
+    }
+}
+```
+
+- [ ] **Step 2: Run the dedup tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTreeSafetyDedupTests"
+```
+
+Expected RED:
+
+- identical selectors still trigger two internal reads during preview,
+- there is no exact per-phase request count yet,
+- ordered expansion cannot yet be asserted through an exposed helper.
+
+- [ ] **Step 3: Implement phase-local deduplication and exact count observability**
+
+Change `WriteBatchTools.cs` so the current-state read helper becomes:
+
+```csharp
+internal static async Task<(IReadOnlyList<OperationBatchCurrentState> States, string CombinedState, string? Error)>
+    ReadCurrentStatesForTestingAsync(OpennessWorkerClient workerClient, BatchOperationRequest[] operations)
+{
+    var states = new List<OperationBatchCurrentState>(operations.Length);
+    var cache = new Dictionary<ProjectTreeSelectorKey, string>();
+
+    foreach (var op in operations)
+    {
+        if (TryBuildProjectTreeSelectorKey(op, out var key))
+        {
+            if (!cache.TryGetValue(key, out var currentState))
+            {
+                var workerResult = await BatchWorkerInvoker.ReadCurrentStateAsync(workerClient, op).ConfigureAwait(false);
+                if (!workerResult.Success)
+                {
+                    return (Array.Empty<OperationBatchCurrentState>(), string.Empty, $"Could not read current state for operationId '{op.OperationId}' ({op.Operation}). Error: {workerResult.Error}");
+                }
+
+                currentState = workerResult.Payload;
+                cache.Add(key, currentState);
+            }
+
+            states.Add(new OperationBatchCurrentState(op.OperationId, op.Operation, currentState));
+            continue;
+        }
+
+        var fallback = await BatchWorkerInvoker.ReadCurrentStateAsync(workerClient, op).ConfigureAwait(false);
+        if (!fallback.Success)
+        {
+            return (Array.Empty<OperationBatchCurrentState>(), string.Empty, $"Could not read current state for operationId '{op.OperationId}' ({op.Operation}). Error: {fallback.Error}");
+        }
+
+        states.Add(new OperationBatchCurrentState(op.OperationId, op.Operation, fallback.Payload));
+    }
+
+    return (states, BatchSafetySnapshot.CombineCurrentState(states), null);
+}
+```
+
+Make `PreviewWriteBatch` and `ApplyWriteBatch` call that helper internally. Add FakeWorker phase-specific counters keyed by method plus `preview` or `apply`.
+
+- [ ] **Step 4: Run the exact dedup tests and neighbouring registered behavior tests and verify GREEN**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTreeSafetyDedupTests|FullyQualifiedName~ProjectTreeSafetyBehaviorTests"
+```
+
+Expected GREEN:
+
+- preview issues exactly one internal snapshot read for two identical selector keys,
+- apply issues one fresh internal snapshot read rather than reusing the preview cache,
+- `OperationBatchCurrentState` expansion preserves original operation IDs and order.
+
+- [ ] **Step 5: Review checkpoint**
+
+Confirm the dedup cache lives only inside one helper invocation, the per-phase counters distinguish preview from apply, and no dedup path changes ordered state composition. Suggested commit if separately authorized: `feat: deduplicate identical tree safety reads per phase`
+
+---
+
+### Task 6: Add The Guarded Live Harness With Exact Startup Binding Verification
+
+**Files:**
+- Create: `scripts/live-test-project-tree-safety-scopes.ps1`
+- Create: `TiaMcpServer.Tests/Batch/ProjectTreeSafetyLiveHarnessScriptTests.cs`
+
+**Interfaces:**
+- Harness modes: `Inventory`, `Preview`, `Apply`
+- Default host launch arguments: `@('run', '--project', 'TiaMcpServer', '--', '--project', $ProjectPath)`
+- Public MCP route only: `initialize`, `notifications/initialized`, `tools/list`, `tools/call`, `get_project_status`, `preview_write_batch`, `apply_write_batch`, `compile_check`
+- Exact mutation gate: `-AllowMutation` and `-Acknowledgement 'OVERRIDE BLOCKS AND DELETE GROUPS'`
+
+- [ ] **Step 1: Write the static harness contract tests first**
+
+Create `ProjectTreeSafetyLiveHarnessScriptTests.cs`:
+
+```csharp
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class ProjectTreeSafetyLiveHarnessScriptTests
+{
+    [Fact]
+    public void Script_DefaultsToInventoryAndExactStartupProjectBinding()
+    {
+        var text = ReadScript();
+        Assert.Matches(new Regex(@"\[ValidateSet\('Inventory', 'Preview', 'Apply'\)\]"), text);
+        Assert.Matches(new Regex(@"\[string\]\s+\$Mode\s*=\s*'Inventory'"), text);
+        Assert.Contains("@('run', '--project', 'TiaMcpServer', '--', '--project', $ProjectPath)", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_VerifiesStartupBindingBeforePreviewApplyOrCompile()
+    {
+        var text = ReadScript();
+        Assert.Contains("function Assert-VerifiedStartupBinding", text, StringComparison.Ordinal);
+        Assert.Contains("get_project_status", text, StringComparison.Ordinal);
+        Assert.Contains("$status.success", text, StringComparison.Ordinal);
+        Assert.Contains("$statusPayload.isOpen", text, StringComparison.Ordinal);
+        Assert.Contains("$statusPayload.path", text, StringComparison.Ordinal);
+        Assert.Contains("$status.sessionIdentity.projectPath", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("bindingState", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("connectionState", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_UsesOnlyPublicRoutesAndNeverLifecycleMutation()
+    {
+        var text = ReadScript();
+        Assert.Contains("preview_write_batch", text, StringComparison.Ordinal);
+        Assert.Contains("apply_write_batch", text, StringComparison.Ordinal);
+        Assert.Contains("compile_check", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("open_project", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("save_project", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("close_project", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("OpennessWorker.exe", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_ApplyRequiresAllowMutationAndExactAcknowledgement()
+    {
+        var text = ReadScript();
+        Assert.Contains("[switch] $AllowMutation", text, StringComparison.Ordinal);
+        Assert.Contains("$script:RequiredAcknowledgement = 'OVERRIDE BLOCKS AND DELETE GROUPS'", text, StringComparison.Ordinal);
+        Assert.Contains("-cne $script:RequiredAcknowledgement", text, StringComparison.Ordinal);
+        Assert.Equal(1, Regex.Matches(text, @"confirm\s*=\s*\$true").Count);
+    }
+
+    [Fact]
+    public void Script_RestoresAndProvesByteEquivalentContentBeforeFinalCompile()
+    {
+        var text = ReadScript();
+        Assert.Contains("function Restore-ByteEquivalentProjectContent", text, StringComparison.Ordinal);
+        Assert.Contains("function Assert-ByteEquivalentProjectContent", text, StringComparison.Ordinal);
+        Assert.Contains("preApplyContentSha256", text, StringComparison.Ordinal);
+        Assert.Contains("restoredContentSha256", text, StringComparison.Ordinal);
+        Assert.Contains("$script:MutationStarted", text, StringComparison.Ordinal);
+        Assert.Contains("finally", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("discard", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Matches(
+            new Regex(@"Assert-ByteEquivalentProjectContent[\s\S]*Invoke-CompileCheck", RegexOptions.CultureInvariant),
+            text);
+    }
+}
+```
+
+- [ ] **Step 2: Run the static harness tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTreeSafetyLiveHarnessScriptTests"
+```
+
+Expected RED: the script does not exist yet.
+
+- [ ] **Step 3: Implement the live harness**
+
+Create `scripts/live-test-project-tree-safety-scopes.ps1` with these fixed startup semantics:
+
+```powershell
+#Requires -Version 7
+[CmdletBinding()]
+param(
+    [ValidateSet('Inventory', 'Preview', 'Apply')]
+    [string] $Mode = 'Inventory',
+    [Parameter(Mandatory)] [string] $ProjectPath,
+    [switch] $AllowMutation,
+    [string] $Acknowledgement,
+    [string] $HostExecutable = 'dotnet',
+    [string[]] $HostArguments,
+    [int] $StartupTimeoutSeconds = 120
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$script:RequiredAcknowledgement = 'OVERRIDE BLOCKS AND DELETE GROUPS'
+if (-not $HostArguments -or $HostArguments.Count -eq 0) {
+    $HostArguments = @('run', '--project', 'TiaMcpServer', '--', '--project', $ProjectPath)
+}
+```
+
+The script must:
+
+- call `get_project_status` immediately after MCP initialize,
+- decode the public tool envelope and its JSON `payload`, then stop unless `success == true`, `payload.isOpen == true`, `payload.path` canonically equals the intended disposable project, and `sessionIdentity.projectPath` canonically equals that same path,
+- canonicalize all three paths with resolved full-path semantics and compare them with `OrdinalIgnoreCase`; a basename or raw input-string comparison is insufficient,
+- record the successful status call, `payload.isOpen`, `payload.path`, and `sessionIdentity.projectPath` before any preview/apply/compile; never invent or assert unavailable `bindingState` or `connectionState` fields,
+- keep `Inventory` and `Preview` non-mutating,
+- use only public `preview_write_batch` / `apply_write_batch` / `compile_check` routes for write acceptance,
+- redact every persisted safety token from the JSON artifact,
+- before Apply, capture the exact deterministic exported bytes and SHA-256 values needed to reconstruct and verify every affected object,
+- set a mutation-started guard before the first confirmed apply and wrap the mutation sequence in `try`/`finally`; after any mutation attempt, the `finally` path must restore the affected disposable-project content through the same public preview/apply path, re-export it, and byte-compare it to the pre-Apply baseline even when a later probe fails,
+- stop on any restoration mismatch and do not call final `compile_check` until byte-equivalent restoration has been proven,
+- call `get_project_status` again and require the same successful `isOpen`/payload-path/session-identity-path proof immediately before final `compile_check`.
+
+- [ ] **Step 4: Run the static harness tests and verify GREEN**
+
+Run the Step 2 command.
+
+Expected GREEN: the harness uses only public observable status evidence for exact startup binding, verifies it before any preview/apply/compile, does not add a lifecycle mutation, keeps Apply hard-gated, and cannot compile or report success before byte-equivalent restoration.
+
+- [ ] **Step 5: Review checkpoint**
+
+Confirm the script records only successful `get_project_status` evidence (`isOpen`, payload path, and `sessionIdentity.projectPath`) before any guarded write preview, never mutates lifecycle state merely to establish binding, uses the single `confirm:$true` apply call site for both the authorized mutation and deterministic restoration, and refuses final compile on a content-byte mismatch. Suggested commit if separately authorized: `test: add exact-startup-bound live tree safety harness`
+
+---
+
+### Task 7: Run Live V21 Acceptance, Restore The Disposable Project, And Update Current Docs
+
+**Files:**
+- Create: `docs/superpowers/acceptance/reports/2026-09-01-pr6-project-tree-safety-scopes-live.md`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md`
+- Modify: `docs/IMPROVEMENT_LOG.md`
+- Modify: `docs/README.md`
+- Modify: `docs/superpowers/README.md`
+
+**Interfaces:**
+- Acceptance report sections:
+  - branch and commit
+  - exact startup host command
+  - disposable project path
+  - successful `get_project_status`, payload `isOpen`/`path`, and envelope `sessionIdentity.projectPath` before preview
+  - occupied-target content-drift rejection evidence
+  - descendant block-content-drift rejection evidence
+  - relevant collision rejection evidence
+  - unrelated drift non-false-invalidation evidence
+  - reversible apply plus pre/post export hashes and byte-equivalent restoration evidence
+  - final `compile_check` evidence
+  - explicit deferred items
+
+- [ ] **Step 1: Run the full offline suite before touching live TIA**
+
+Run:
+
+```powershell
+dotnet build TiaMcpServer.sln --no-restore -m:1 --disable-build-servers -p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers
+```
+
+Expected GREEN: the repository passes before live acceptance begins.
+
+- [ ] **Step 2: Run the non-mutating live inventory and preview passes**
+
+Run:
+
+```powershell
+pwsh -NoProfile -File scripts/live-test-project-tree-safety-scopes.ps1 -ProjectPath C:\Sandbox\Pr6TreeScopes.ap21
+pwsh -NoProfile -File scripts/live-test-project-tree-safety-scopes.ps1 -ProjectPath C:\Sandbox\Pr6TreeScopes.ap21 -Mode Preview
+```
+
+Expected GREEN:
+
+- `get_project_status` succeeds before preview,
+- its decoded payload reports `isOpen:true` and a canonical `path` equal to the exact startup `--project` path,
+- the response envelope's `sessionIdentity.projectPath` canonically matches that same disposable project,
+- inventory identifies the disposable occupied block target, collision target, and delete subtree.
+
+- [ ] **Step 3: Run the separately authorized reversible apply pass**
+
+Run:
+
+```powershell
+pwsh -NoProfile -File scripts/live-test-project-tree-safety-scopes.ps1 `
+  -ProjectPath C:\Sandbox\Pr6TreeScopes.ap21 `
+  -Mode Apply `
+  -AllowMutation `
+  -Acknowledgement 'OVERRIDE BLOCKS AND DELETE GROUPS'
+```
+
+Expected GREEN:
+
+- stale `create_block` token is rejected after only occupied-target content drift,
+- stale `delete_block_group` token is rejected after only descendant block-content drift,
+- stale `create_block_group` token is rejected after only relevant same-parent occupancy drift,
+- unrelated sibling-tree drift does not invalidate the target write,
+- the authorized target-mutation apply sequence succeeds and the separately previewed restoration apply sequence succeeds through the same guarded call site,
+- the script restores the affected disposable-project content and proves the restored deterministic export bytes match the pre-Apply baseline exactly,
+- the repeated public status proof still reports the same open disposable project immediately before compile,
+- a final `compile_check` succeeds against the restored disposable project.
+
+- [ ] **Step 4: Write the dated acceptance report and update the current documentation authorities**
+
+Write `docs/superpowers/acceptance/reports/2026-09-01-pr6-project-tree-safety-scopes-live.md` with these exact sections, populated from the actual run:
+
+```markdown
+# Acceptance Test Report — PR 6 Project-Tree Safety Scopes
+
+## Environment
+- Branch:
+- Commit:
+- Startup host command:
+- Disposable project:
+- TIA Portal version:
+- `get_project_status` success before preview:
+- Payload `isOpen` before preview:
+- Payload `path` before preview:
+- Envelope `sessionIdentity.projectPath` before preview:
+- Repeated `get_project_status` success before final compile:
+- Repeated payload `isOpen` before final compile:
+- Repeated payload `path` before final compile:
+- Repeated envelope `sessionIdentity.projectPath` before final compile:
+
+## Restoration
+- Pre-Apply deterministic export SHA-256:
+- Restored deterministic export SHA-256:
+- Byte comparison result:
+
+## Evidence
+1. Occupied-target content drift invalidated `create_block` before mutation.
+2. Descendant block-content drift invalidated `delete_block_group` before mutation.
+3. Relevant collision drift invalidated `create_block_group`.
+4. Unrelated sibling-tree drift did not invalidate the token.
+5. The authorized target-mutation and restoration apply sequences both succeeded through the guarded public flow.
+6. Pre-Apply and restored deterministic export SHA-256 values matched, proving byte-equivalent content restoration.
+7. Public status evidence still identified the same open disposable project after restoration.
+8. Final `compile_check` passed on the restored disposable project.
+
+## Deferred Items
+- Broader snapshot narrowing: unchanged and out of scope.
+- `start_plc` / `stop_plc`: unchanged and out of scope.
+```
+
+Then update:
+
+- `docs/ARCHITECTURE.md` with the exact narrowed project-tree selector architecture,
+- `docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md` with the exact current-state binding behavior for the three structural operations,
+- `docs/IMPROVEMENT_LOG.md` with the completed PR 6 scope and remaining deferrals,
+- `docs/README.md` and `docs/superpowers/README.md` so the new report is indexed.
+
+- [ ] **Step 5: Review checkpoint**
+
+Confirm the report distinguishes repository-auditable artifacts from live-only observations, records only the successful public status evidence (`isOpen`, payload path, and `sessionIdentity.projectPath`) for project binding, records the restoration hash comparison before compile, and repeats both deferrals verbatim. Suggested commit if separately authorized: `docs: record live acceptance for project tree safety scopes`
+
+---
+
+### Task 8: Final Verification And Scope Review
+
+**Files:**
+- Review: every file changed in Tasks 1-7 only
+
+**Verification boundary:**
+- Establishes: registered `WriteBatchTools` behavioral RED closure, explicit typed payload validation, software-unit ownership preservation, exact routing to identity-required `SafetyRead` snapshots, client-sent and worker-enforced `ExpectedSessionIdentity`, deterministic occupied-block and descendant exports, phase-local dedup with exact per-phase request counts, public-status-proven live startup binding, byte-equivalent restoration, and final compile success.
+- Does not establish: broader snapshot narrowing beyond these three operations, any tag-scope change, PLC start/stop behavior, plant acceptance, or physical-hardware commissioning.
+
+- [ ] **Step 1: Run the focused PR 6 regression slice**
+
+Run:
+
+```powershell
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj --no-restore -m:1 --disable-build-servers --filter "FullyQualifiedName~ProjectTreeSafetyBehaviorTests|FullyQualifiedName~ProjectTreeSafetyPayloadContractTests|FullyQualifiedName~ProjectTreeCurrentStateReadTests|FullyQualifiedName~ProjectTreeSafetyDedupTests|FullyQualifiedName~ProjectTreeSafetySourceContractTests|FullyQualifiedName~ProjectTreeSafetyLiveHarnessScriptTests"
+```
+
+Expected GREEN: every new PR 6 regression passes.
+
+- [ ] **Step 2: Run the full serial repository verification**
+
+Run:
+
+```powershell
+dotnet build TiaMcpServer.sln --no-restore -m:1 --disable-build-servers -p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers
+git diff --check
+git status --short
+```
+
+Expected GREEN: clean whitespace, passing suite, and a diff limited to the planned files.
+
+- [ ] **Step 3: Perform the final scope audit**
+
+Check the diff against this list:
+
+```text
+Must exist:
+- TiaMcpServer.Contracts/ProjectTreeSafetySnapshotInfo.cs
+- TiaMcpServer/Batch/ProjectTreeSafetyPayloadContract.cs
+- TiaMcpServer.OpennessWorker/Openness/ProjectTreeSafetySnapshotReader.cs
+- TiaMcpServer.Tests/Batch/ProjectTreeSafetyBehaviorTests.cs
+- TiaMcpServer.Tests/Batch/ProjectTreeSafetyPayloadContractTests.cs
+- TiaMcpServer.Tests/Batch/ProjectTreeCurrentStateReadTests.cs
+- TiaMcpServer.Tests/Batch/ProjectTreeSafetyDedupTests.cs
+- TiaMcpServer.Tests/Project/ProjectTreeSafetySourceContractTests.cs
+- TiaMcpServer.Tests/Batch/ProjectTreeSafetyLiveHarnessScriptTests.cs
+- scripts/live-test-project-tree-safety-scopes.ps1
+- docs/superpowers/acceptance/reports/2026-09-01-pr6-project-tree-safety-scopes-live.md
+
+Must be modified:
+- TiaMcpServer.Contracts/OperationPolicyCatalog.cs
+- TiaMcpServer.OpennessWorker/Openness/BlockTargetResolver.cs
+- TiaMcpServer.OpennessWorker/Openness/BlockMutationService.cs
+- TiaMcpServer.OpennessWorker/Openness/BlockExporter.cs
+- TiaMcpServer.OpennessWorker/Program.cs
+- TiaMcpServer/Worker/OpennessWorkerClient.cs
+- TiaMcpServer/Batch/BatchWorkerInvoker.cs
+- TiaMcpServer/Batch/WriteBatchTools.cs
+- TiaMcpServer.FakeWorker/Program.cs
+
+Must remain out of scope:
+- Any public tool rename or batch request DTO field addition
+- Any compatibility-path-only test as primary evidence
+- Any new parallel block ownership resolver outside `BlockTargetResolver`
+- Any change to `start_plc` or `stop_plc`
+- Broader tag or project-tree snapshot narrowing outside these three operations
+```
+
+- [ ] **Step 4: Final report**
+
+Report:
+
+- the first registered `WriteBatchTools` RED and how it was closed,
+- the exact new snapshot contract and validation seams,
+- the software-unit ownership preservation evidence,
+- the guarded `SafetyRead` classification plus client-send and worker-rejection identity evidence,
+- the exact per-phase dedup counts and ordered-state expansion evidence,
+- the public `get_project_status` startup-binding evidence, byte-equivalent restoration evidence, and final compile evidence,
+- the explicit remaining deferrals.
+
+Stop before merge, push, or PR comment unless separately authorized.

--- a/docs/superpowers/specs/2026-09-01-write-safety-hardening-design.md
+++ b/docs/superpowers/specs/2026-09-01-write-safety-hardening-design.md
@@ -1,0 +1,489 @@
+# Write-Safety Preview and Registered-Surface Hardening Design
+
+**Date:** 2026-09-01
+
+**Status:** Architecture approved; awaiting written-spec review
+**Source:** `priv/CLAUDE_THOUGHTS_VERIFICATION.md` and the follow-up repository and live-TIA investigation
+**Delivery:** Six active milestones, each delivered as a separate pull request
+
+## Goal
+
+Improve the reviewability, MCP metadata, test fidelity, and state-snapshot precision of the
+existing write-safety system without weakening its server-enforced guarantees or changing the
+public write-tool names and input schemas.
+
+Every pull request in this design must pass both repository verification and scope-specific
+live TIA Portal V21 acceptance. Offline, stub, and FakeWorker evidence is necessary but never
+sufficient for completion.
+
+## Scope
+
+The active work is:
+
+1. Add explicit MCP annotations and verify the emitted `tools/list` metadata.
+2. Put behavioral coverage on the registered write classes and make compatibility wrappers
+   delegate instead of duplicate behavior.
+3. Complete the `update_tag` mutable-state snapshot with the three external-access flags.
+4. Add bounded, structured preview evidence for block and type content replacements.
+5. Narrow and deduplicate tag-related current-state reads without weakening conflict detection.
+6. Narrow project-tree current-state reads operation by operation.
+
+PLC start/stop investigation was originally the fourth milestone. It is explicitly deferred and
+does not become a quarantine or removal change under this design.
+
+## Non-goals
+
+- Replacing `preview_write_batch` and `apply_write_batch` with one self-previewing tool.
+- Removing `BatchTools` or `ProjectLifecycleTools`.
+- Removing `confirm` from any write tool.
+- Changing the safety-token format, ten-minute lifetime, single-use behavior, or audit format.
+- Weakening exact project/session binding or the pinned apply lease.
+- Predicting Siemens post-write state in the host.
+- Generalizing text diffs to lifecycle, network, creation, deletion, or tree operations.
+- Changing the canonical structured-JSON network contract.
+- Implementing, removing, or quarantining `start_plc` or `stop_plc`.
+- Claiming a particular MCP client's warning or approval user experience.
+- Treating PLCSIM acceptance as physical-PLC or plant acceptance.
+
+## Current evidence
+
+The existing architecture already provides the strongest safety properties identified in the
+verification note:
+
+- the token binds the exact requested input and freshly read current state;
+- the token retains the complete verified project/session binding;
+- tokens are single-use, including after an uncertain apply attempt;
+- apply re-reads state and consumes the token under a pinned binding lease; and
+- successful writes are audited.
+
+The confirmed hardening gaps are:
+
+- registered batch and lifecycle tools omit explicit MCP behavior annotations;
+- most behavioral tests exercise compatibility wrappers rather than the registered classes;
+- `update_tag` can change `ExternalAccessible`, `ExternalVisible`, and `ExternalWritable`, while
+  the current tag snapshot omits all three values;
+- the public tag reader can skip an unreadable tag or constant and return a partial payload, which
+  is not acceptable as a fail-closed write-safety snapshot;
+- block and type replacement previews contain target and hash evidence but no bounded content
+  comparison;
+- tag operations repeatedly read the selected PLC's complete tag-table state;
+- three structural block operations bind to the complete project tree; and
+- the current PLC start/stop token binds project metadata rather than CPU operating state.
+
+Two guarded, read-only V21 probes were performed while planning. An offline provider and a
+PLCSIM-connected provider both exposed only connection state, with no public `Start`, `Stop`,
+CPU operating-mode, or RUN/STOP-state read. The connected provider reported `State=Online`, but
+its public CLR and self-description surfaces did not expand. This evidence is the reason PLC
+control work is deferred rather than guessed from undocumented APIs.
+
+## Architecture invariants
+
+Every milestone must preserve these invariants:
+
+1. Siemens Openness calls remain in the net48 worker. The net8 host performs validation,
+   orchestration, hashing, token handling, response construction, and audit only.
+2. The public tools remain `preview_write_batch`, `apply_write_batch`, the six lifecycle write
+   tools, and `network_write`. No active milestone renames, combines, or removes a tool.
+3. Preview remains non-mutating. Apply still requires the unchanged request, `confirm=true`, and
+   the matching single-use safety token.
+4. Tokens continue to bind tool name, normalized project path, ordered targets, exact requested
+   input, exact current state, and the complete verified project/session binding.
+5. Apply continues to perform cheap envelope rejection before expensive reads, then fresh-state
+   read, token consumption, mutation, and audit under the pinned binding lease.
+6. Display evidence and its truncation policy never participate in target, input, or current-state
+   hashing. Changing display formatting must not invalidate or validate a token.
+7. New worker success payloads are typed shared contracts. Missing, malformed, ambiguous, or
+   unsupported state fails closed before token issuance.
+8. Batch order and per-operation identity remain significant. Read deduplication may reuse one
+   payload internally, but it must expand back to one ordered state entry per operation before
+   `OperationBatchStateComposer` hashes it.
+9. No milestone introduces undocumented Siemens calls. Runtime behavior that cannot be proven
+   from the installed API and live acceptance remains deferred.
+10. Each milestone is independently reviewable and shippable. It receives its own branch, pull
+    request, implementation plan, documentation updates, verification output, and live acceptance
+    report.
+
+## Delivery sequence
+
+The pull requests are intentionally serial. Later work may depend on coverage or contracts added
+by earlier work, but no pull request may absorb the next milestone merely because the files
+overlap.
+
+| Pull request | Scope | Dependency |
+| --- | --- | --- |
+| PR 1 | Registered MCP annotations | Existing baseline |
+| PR 2 | Registered-class coverage and wrapper delegation | PR 1 |
+| PR 3 | Complete `update_tag` mutable-state snapshot | PR 2 |
+| PR 4 | Bounded block/type preview evidence | PR 2 |
+| PR 5 | Narrow and deduplicate tag scopes | PRs 2 and 3 |
+| PR 6 | Narrow project-tree scopes | PR 2; reuse only proven internal patterns from PR 5 |
+
+The PLC start/stop investigation is a deferred work item, not an active pull request.
+
+PRs 4 and 5 remain separate even though both touch batch preview state. PR 4 changes human review
+evidence; PR 5 changes the safety snapshot selectors themselves.
+
+## Milestone 1: registered MCP annotations
+
+### Design
+
+Add explicit annotations to the registered methods in `WriteBatchTools` and
+`ProjectWriteTools`.
+
+| Tool | `ReadOnly` | `Destructive` | `OpenWorld` | Reason |
+| --- | ---: | ---: | ---: | --- |
+| `preview_write_batch` | `true` | `false` | `false` | The tool only reads current state and issues a token. |
+| `apply_write_batch` | `false` | `true` | `false` | The tool can mutate the bound TIA project. |
+| Six lifecycle write tools | `false` | `true` | `false` | Each public tool can mutate on its apply call, so tool-level metadata is conservative even though its first call is a preview. |
+
+`network_write` already uses the conservative mutating classification and remains a regression
+reference. Annotations are untrusted client hints and must not be described as stronger than the
+token flow.
+
+### Verification boundary
+
+- Add protocol-level tests that call `ListToolsAsync`, not reflection-only tests.
+- Assert exact annotations, names, and availability in read-only and read-write server modes.
+- Preserve existing input schemas and tool counts.
+- Run a live V21 host, complete MCP initialization, call `tools/list`, and record the emitted
+  annotations. The same run must make one benign project read so the report proves that the host
+  is connected to a real TIA session rather than only testing an in-memory SDK server.
+- No project mutation is required for this milestone.
+
+## Milestone 2: registered-class coverage and wrapper delegation
+
+### Design
+
+Make the registered classes the behavioral authority:
+
+- `BatchTools` delegates reads to `ReadBatchTools` and writes to `WriteBatchTools`.
+- `ProjectLifecycleTools` delegates status reads to `ProjectReadTools` and writes to
+  `ProjectWriteTools`.
+- Delegation flows toward the registered classes, never from registered production classes into
+  legacy wrappers.
+- The wrappers remain compiled compatibility/test seams. Deletion is deferred.
+
+Before delegation, add direct tests for the registered methods covering schema, read-only gates,
+binding gates, preview issuance, token validation and replay, pinned lease behavior, ordered batch
+execution, audit isolation, and worker/protocol error propagation. Existing wrapper-oriented tests
+may then be migrated or retained as delegation tests, but they may not remain the sole evidence for
+registered behavior.
+
+### Verification boundary
+
+- Demonstrate a behavioral RED on a registered method before changing delegation or production
+  mechanics; a reflection-only failure is insufficient for a runtime behavior claim.
+- Run the full registered path against FakeWorker and the actual MCP protocol surface.
+- In live V21, execute a registered generic-batch preview and a self-previewing lifecycle call
+  without its token. Verify both are non-mutating and retain the expected binding and token data.
+- No apply is required because this milestone changes test/runtime alignment rather than write
+  semantics.
+
+## Milestone 3: complete `update_tag` mutable-state snapshot
+
+### Design
+
+Introduce a typed exact-target `TagUpdateSafetySnapshot` in `TiaMcpServer.Contracts` and a
+dedicated strict worker reader for `update_tag`. The snapshot binds deterministic PLC, folder,
+table, and tag identity plus every property the current mutator can change: name, data type,
+logical address, `ExternalAccessible`, `ExternalVisible`, and `ExternalWritable`.
+
+The three external values are nullable so an actual `false` differs from a property that the
+selected PLC/tag does not expose. If the request intends to change a flag whose current value
+cannot be read, preview fails before issuing a token.
+
+For this milestone, `update_tag` composes the strict exact-target snapshot with the existing broad
+`ListTagTablesAsync` state instead of replacing it. This adds the missing mutable fields without
+discarding current collision/context coverage or making an unrelated unreadable tag a new global
+failure. Milestone 5 replaces that composition with proven scoped collision selectors.
+
+The exact-target reader must not skip or partially serialize the target. The existing public
+`list_tag_tables` response, its best-effort behavior, and the other tag operation selectors remain
+unchanged. `IsSafety` is not added because the current write path rejects it before mutation.
+
+### Verification boundary
+
+- Add contract, strict-reader, serialization, FakeWorker, and registered preview/apply tests for
+  all three flag values, including `false` versus unavailable and an exact-target read failure.
+- Prove the legacy broad state is still composed for `update_tag` until milestone 5 and that an
+  unrelated best-effort omission does not newly fail the preview.
+- Prove that changing only one external flag changes the current-state hash and causes an old token
+  to fail with `state_changed` before mutation.
+- Prove ordinary tag updates that do not request an unavailable external flag remain supported.
+- In live V21, read real tag flags, preview an `update_tag`, change exactly one flag through an
+  explicitly authorized action on a disposable project, and verify that the stale token is
+  rejected. Restore or discard the disposable project change and record the final state.
+
+## Deferred item: PLC start/stop investigation
+
+No pull request is created for this deferred item.
+
+### Current behavior preserved
+
+- `start_plc` and `stop_plc` remain advertised and implemented as they are today.
+- Their current project-status snapshot remains unchanged.
+- The reflected worker control calls are neither replaced nor quarantined.
+
+### Reason for deferral
+
+The installed and live V21 public `OnlineProvider` surface did not expose the assumed `Start` and
+`Stop` methods or an authoritative CPU RUN/STOP read. The user will investigate the Siemens API
+surface more deeply before choosing compatibility, quarantine, removal, or a supported control
+implementation.
+
+### Known risk while deferred
+
+- The reflected control calls are contradicted by the inspected V21 runtime and may fail when
+  invoked.
+- The safety token does not bind CPU operating state, so it cannot detect an intervening RUN/STOP
+  transition.
+- No milestone in this design may cite generic project status as proof of CPU operating state.
+
+### Re-entry conditions
+
+Work may resume only when all of the following exist:
+
+1. A documented, installed V21 public API for the intended control action.
+2. A documented, authoritative CPU operating-state read.
+3. Deterministic binding to the exact project, PLC, CPU device item, and online target.
+4. A fail-closed design for unavailable, transitional, protected, and incompatible states.
+5. Successful live qualification against the intended PLCSIM and, if the feature claims physical
+   hardware support, separately authorized hardware acceptance.
+
+## Milestone 4: bounded block/type preview evidence
+
+### Design
+
+Reuse the existing top-level `diff` field in the text preview envelope. Widen the text-preview
+helper from `string?` to a structured response-only value and populate it only for
+`update_block_logic` and `update_type_content`.
+
+The canonical `network_write` preview remains unchanged. Lifecycle and non-content batch
+operations continue to emit `diff: null`.
+
+The structured batch diff contains one entry per eligible operation in request order:
+
+- operation ID, operation name, and normalized write format;
+- raw current/requested SHA-256, character count, and line count;
+- whether raw text is equal, normalized lines are equal, or the difference is line-ending-only;
+- unchanged prefix and suffix line counts;
+- current and requested changed-span line counts;
+- bounded current and requested excerpts; and
+- explicit omitted-line, omitted-character, and exhausted-batch-budget metadata.
+
+Evidence compares the exact-format state already read for token binding with the submitted
+replacement text. It is a current-versus-requested comparison, not a prediction of compiled or
+post-import Siemens state. It performs no additional worker read.
+
+### Deterministic bounds
+
+- At most 40 excerpt lines and 8,192 excerpt characters are retained from each side of one
+  operation.
+- When a changed span exceeds 40 lines, retain its first 20 and last 20 lines and report the exact
+  omitted-line count.
+- A single displayed line is capped at 512 characters and reports omitted characters.
+- Across the complete batch, excerpts are capped at 32,768 characters and 320 lines, allocated in
+  request order.
+- Every eligible operation retains hashes and counts even after the batch excerpt budget is
+  exhausted.
+- Raw hashes and equality use the original text. Line-window comparison normalizes CRLF and CR to
+  LF and explicitly reports a line-ending-only difference.
+
+Changing these display limits later is a presentation change only. The `diff` value and all
+truncation decisions remain outside token issuance and validation.
+
+### Verification boundary
+
+- Add registered-class tests for source and XML block content, type content, mixed batches,
+  identical content, line-ending-only changes, long lines, per-entry truncation, and whole-batch
+  truncation.
+- Prove non-content operations keep `diff: null`.
+- Prove changing or omitting display evidence has no effect on token validation when target,
+  request, state, and binding are unchanged.
+- Preserve the existing exact-format current-state tests.
+- In live V21, use host-level MCP calls against a disposable project to preview source-format block
+  and type replacements, verify bounded evidence, apply unchanged input with the issued token,
+  restore byte-equivalent content, compile, and record the clean final state. Apply and restore
+  require explicit authorization for the exact disposable target.
+
+## Milestone 5: narrow and deduplicate tag scopes
+
+### Design
+
+Replace the blanket `ListTagTablesAsync` safety selector with typed, operation-specific worker
+snapshots. The worker resolves Siemens objects; the host never reconstructs object identity from
+partial text.
+
+The selector shapes are:
+
+- `create_tag_table`: exact PLC and parent-folder identity plus occupancy for the requested table
+  name;
+- `delete_tag_table`: parent membership plus a deterministic Simatic ML export of the complete
+  target table using timestamp-free export options;
+- `create_tag`: target table identity plus collision results for the requested effective tag name
+  and logical address;
+- `update_tag`: complete current target-tag state, target table identity, and collision results for
+  the requested effective new name/address;
+- `delete_tag`: current target-tag identity and every safety field introduced for `update_tag` in
+  milestone 3, plus target table identity;
+- create/update/delete user constant: target table identity, complete target-constant state when it
+  exists, and collision results for the requested effective name.
+
+Collision probes are scoped to exact requested names/addresses across the selected PLC. They do
+not hash unrelated tag content. Results use deterministic canonical paths and ordering.
+
+Within one preview or apply state-read phase, identical selectors may execute once. The cache key
+must include normalized project path, verified PLC identity, folder path, table name, object name,
+effective requested name/address where relevant, and selector kind. Reused payloads are expanded
+back into the original operation order before combined-state hashing.
+
+No snapshot cache survives the current preview or apply phase. Apply always performs fresh reads.
+
+### Verification boundary
+
+- Add selector-contract tests for every tag/table/constant operation and malformed worker payload.
+- Prove same-object and relevant-collision changes invalidate the token.
+- Prove unrelated sibling-table changes no longer invalidate operations whose proven preconditions
+  do not include that sibling.
+- Prove identical selector calls are deduplicated while combined state remains ordered and
+  operation-specific.
+- Prove apply still re-reads after preview and does not use a cross-phase cache.
+- In live V21 on a disposable project, exercise same-object drift, relevant name/address collision,
+  unrelated sibling-table drift, and a successful explicitly authorized apply followed by restore
+  or discard. Record both rejection and non-false-invalidation evidence.
+
+## Milestone 6: narrow project-tree scopes
+
+### Design
+
+Replace complete-project tree snapshots only for the three structural operations that currently
+use them:
+
+- `create_block`: bind the exact PLC/software-unit and ancestor group chain, target parent-group
+  identity, and requested block/group-name occupancy in that parent. Because the current worker
+  imports with `ImportOptions.Override`, an occupied target additionally binds the exact existing
+  block export rather than only its name;
+- `create_block_group`: bind the exact PLC/software-unit and ancestor group chain, target
+  parent-group identity, and both block and group occupancy for the requested name;
+- `delete_block_group`: bind the exact target group, its parent membership, and the complete target
+  subtree because that subtree is the destructive effect under review. The subtree snapshot
+  includes deterministic content exports for contained blocks, not only their names.
+
+The worker returns typed, deterministically ordered snapshots. An unresolved or ambiguous path,
+unsupported software-unit selector, duplicate candidate, or malformed snapshot fails before token
+issuance.
+
+Deduplication follows the milestone 5 rule: reuse only identical reads within one phase, then
+expand them back into per-operation order. No generic tree-pruning heuristic is introduced.
+
+### Verification boundary
+
+- Add selector tests for root groups, nested groups, software units, missing targets, ambiguous
+  targets, occupied names, occupied-target content, and complete content-bearing delete subtrees.
+- Prove a relevant parent, occupancy, rename, move, deletion, or descendant change invalidates the
+  token when it changes the intended operation or destructive effect.
+- Prove unrelated device, tag, type, or sibling-tree changes do not invalidate a narrowly scoped
+  operation.
+- In live V21 on a disposable project, determine and record the actual name-collision behavior for
+  sibling blocks/groups, exercise relevant and unrelated drift, perform one explicitly authorized
+  reversible apply, and restore or discard the project. The same run must prove that an
+  occupied-target content change invalidates `create_block` and that a descendant block-content
+  change invalidates `delete_block_group`. The live result is part of acceptance, not an optional
+  follow-up.
+
+## Error handling
+
+- A missing, unreadable, malformed, ambiguous, or unsupported safety snapshot fails before token
+  issuance; there is no fallback to a broader stale payload or empty state.
+- A stale token continues to fail as `state_changed`; binding mismatches remain
+  `binding_conflict`.
+- An unsupported tag flag requested for mutation fails before token issuance rather than being
+  omitted from the state hash.
+- Oversized preview evidence uses the deterministic truncation contract. Unexpected evidence
+  generation or serialization failure fails the preview and issues no usable token.
+- Rejected worker payloads are not echoed to clients.
+- A failed or unavailable live-TIA gate leaves the pull request incomplete. It is not converted
+  into an offline-only acceptance claim.
+
+## Testing and verification policy
+
+Each implementation plan must use behavioral TDD:
+
+1. Add a focused test against the registered runtime path.
+2. Observe a meaningful failure caused by missing production behavior.
+3. Implement the smallest production change.
+4. Run the focused test and relevant integration slice.
+5. Run the complete serial stub build and test suite.
+6. Run the milestone's live V21 harness and write its acceptance report.
+7. Review the diff, documentation, and deferred-work register before the pull request is complete.
+
+The common repository commands are:
+
+```powershell
+dotnet build TiaMcpServer.sln -m:1 /p:UseTiaPortalReferenceStubs=true
+dotnet test TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Debug --no-restore -m:1 --disable-build-servers
+git diff --check
+git status --short
+```
+
+Each pull request adds or updates a scope-specific PowerShell 7 live harness with a safe
+non-mutating default, an explicit mode for any authorized mutation, static harness-contract tests,
+and a dated report under `docs/superpowers/acceptance/reports/`. Reuse is acceptable only when an
+existing harness already exercises the exact milestone surface and records the milestone-specific
+evidence. The report records the exact TIA version, project copy, PLC/CPU identity where
+relevant, connection state, calls performed, mutations performed, restoration or discard result,
+and evidence boundary.
+
+Live acceptance uses a disposable project copy for every mutation. It does not save, close,
+reconnect, start/stop a CPU, or change a project unless the exact action and target have been
+authorized for that run.
+
+## Deferred-work register
+
+| Deferred item | Current behavior preserved | Reason and risk | Re-entry condition |
+| --- | --- | --- | --- |
+| PLC `start_plc` / `stop_plc` state binding and implementation | Tools remain advertised; current snapshot and reflected calls remain | Installed/live V21 evidence did not expose the assumed methods or authoritative state; calls may fail and tokens do not detect mode drift | Documented control and state APIs, exact target design, and mandatory live qualification |
+| One self-previewing batch tool | Separate preview/apply tools remain | Public tool-name and client workflow migration is larger than the safety hardening | Separate compatibility design and protocol migration evidence |
+| Compatibility-wrapper deletion | Wrappers remain and delegate | Their test/compatibility purpose must be resolved after registered coverage is established | Proven no consumers plus migrated coverage and separate approval |
+| Dropping `confirm` | All current confirmation parameters remain | It is still the lifecycle/network phase selector and removing it changes public inputs | Separate per-tool contract analysis and migration approval |
+| Generalized or predicted post-state diff | Only exact text replacements receive bounded current-versus-requested evidence | Host-side prediction would duplicate worker/Siemens semantics and can mislead | Operation-specific authoritative post-state model and separate design |
+| Lifecycle and network preview diffs | Existing `diff: null` behavior remains | Not required to solve the confirmed block/type reviewability gap | Independent value case and operation-specific evidence design |
+| Broader snapshot narrowing | Only the operation scopes named in milestones 5 and 6 change | Blanket narrowing risks omitted preconditions and silent overwrites | Per-operation conflict model, tests, and live evidence |
+| Public `list_tag_tables` completeness semantics | Existing best-effort read behavior remains; `update_tag` safety adds a separate strict exact-target reader | Changing public partial-read behavior is a separate compatibility decision | Dedicated read-contract design, schema tests, and live compatibility evidence |
+| Per-tag multilingual comment binding for `delete_tag` | Current omission remains; table deletion is separately bound to a complete table export | The current mutator does not edit comments, and a stable multilingual per-tag safety contract is not yet implemented; a concurrent comment-only edit can remain undetected before tag deletion | Documented comment extraction contract, exact-target serialization tests, and live comment-drift rejection evidence |
+| Client-specific warning/prompt behavior | Server emits standards metadata only | MCP annotations are untrusted hints; UI behavior is outside this repository | Named client, reproducible version, and client-level acceptance scope |
+| Physical PLC and plant acceptance | PLCSIM/live TIA is the minimum gate | These milestones do not claim production hardware behavior | Separately authorized target, commissioning plan, and plant acceptance |
+
+Every pull request repeats the deferred entries relevant to its scope in its description and
+documentation. Completing one milestone does not silently authorize a deferred item.
+
+## Documentation impact
+
+Each pull request updates the current authorities affected by its behavior:
+
+- `docs/ARCHITECTURE.md` for write-safety or selector architecture;
+- the relevant supported-operation reference for additive outputs or behavior;
+- `docs/IMPROVEMENT_LOG.md` for completed and still-open work;
+- `README.md` only when landing-page behavior materially changes; and
+- both documentation indexes for each new plan or acceptance report.
+
+Historical specs, plans, and acceptance reports remain evidence of their date. They do not replace
+the current architecture or supported-operation documents.
+
+## Acceptance criteria
+
+- The six active milestones are delivered as six separate pull requests.
+- Every pull request has a separately approved implementation plan and passes its mandatory live
+  TIA Portal V21 acceptance gate before completion.
+- Registered tools emit explicit, verified MCP annotations.
+- Registered classes, not only compatibility wrappers, carry the behavioral safety evidence.
+- Tag state includes every mutable external-access flag used by `update_tag`.
+- Block/type previews provide deterministic bounded current-versus-requested evidence without
+  changing token semantics.
+- Narrow tag and tree selectors detect every proven relevant conflict while eliminating the
+  specifically tested unrelated invalidations.
+- Read deduplication never changes ordered per-operation state composition or crosses preview/apply
+  phases.
+- Existing binding, token, lease, confirmation, audit, access-mode, and canonical-network
+  guarantees remain intact.
+- PLC start/stop work and every other deferred item remain explicitly out of implementation scope.

--- a/scripts/live-test-write-tool-metadata.ps1
+++ b/scripts/live-test-write-tool-metadata.ps1
@@ -393,8 +393,16 @@ function Get-ProjectStatusEvidence {
     }
 
     $resolvedExpectedProjectPath = [System.IO.Path]::GetFullPath($ExpectedProjectPath)
-    Get-RequiredBooleanProperty -Object $statusPayload -Name 'isOpen' -ExpectedValue $true | Out-Null
-    $payloadPath = Get-RequiredNormalizedPathProperty -Object $statusPayload -Name 'path' -ExpectedPath $resolvedExpectedProjectPath
+    Get-RequiredBooleanProperty -Object $statusPayload -Name 'success' -ExpectedValue $true | Out-Null
+    Get-RequiredNormalizedPathProperty -Object $statusPayload -Name 'projectPath' -ExpectedPath $resolvedExpectedProjectPath | Out-Null
+
+    $project = Get-PropertyValue -Object $statusPayload -Name 'project'
+    if ($null -eq $project) {
+        throw 'get_project_status payload did not return a project.'
+    }
+
+    Get-RequiredBooleanProperty -Object $project -Name 'isOpen' -ExpectedValue $true | Out-Null
+    $projectPath = Get-RequiredNormalizedPathProperty -Object $project -Name 'path' -ExpectedPath $resolvedExpectedProjectPath
 
     $sessionIdentity = Get-PropertyValue -Object $statusEnvelope -Name 'sessionIdentity'
     if ($null -eq $sessionIdentity) {
@@ -414,7 +422,7 @@ function Get-ProjectStatusEvidence {
     return [pscustomobject] [ordered]@{
         success         = $true
         isOpen          = $true
-        path            = $payloadPath
+        path            = $projectPath
         sessionIdentity = [pscustomobject] [ordered]@{
             projectPath     = $identityProjectPath
             portalProcessId = $normalizedPortalProcessId

--- a/scripts/live-test-write-tool-metadata.ps1
+++ b/scripts/live-test-write-tool-metadata.ps1
@@ -1,0 +1,408 @@
+#Requires -Version 7
+<#
+.SYNOPSIS
+    Separately authorized, non-mutating TIA Portal V21 acceptance harness for PR 1 explicit MCP
+    tool annotations.
+
+.DESCRIPTION
+    Launches the real TiaMcpServer host twice over stdio: once in --read-only mode and once in
+    --read-write mode. Each host receives initialize, notifications/initialized, tools/list, and
+    the one benign tools/call request get_project_status. The harness neither talks to the net48
+    worker directly nor invokes any write, preview, or apply tool.
+
+    This script is not an ordinary test or CI action. Run it only with separate authorization,
+    while the supplied disposable .ap21 project is already open in TIA Portal V21. The generated
+    report proves only the live host/project/session combination it records; static, stub, and
+    FakeWorker evidence remain separate evidence classes.
+
+.PARAMETER ProjectPath
+    Absolute path to the already-open, disposable TIA Portal V21 .ap21 project to verify.
+
+.PARAMETER ReportPath
+    Required explicit destination. It must be the dated PR 1 report under
+    docs/superpowers/acceptance/reports so a live run replaces the pending evidence template.
+
+.EXAMPLE
+    pwsh -NoProfile -File scripts/live-test-write-tool-metadata.ps1 `
+        -ProjectPath 'C:\Sandbox\ExplicitToolAnnotations.ap21' `
+        -ReportPath 'docs\superpowers\acceptance\reports\2026-09-01-pr1-explicit-mcp-tool-annotations-live.md'
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $ProjectPath,
+
+    [Parameter(Mandatory)]
+    [string] $ReportPath,
+
+    [int] $StartupTimeoutSeconds = 30
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:NextRequestId = 0
+$script:HostProcess = $null
+$script:ExpectedReadOnlyToolCount = 4
+$script:ExpectedReadWriteToolCount = 14
+$script:ExpectedReadOnlyToolNames = @(
+    'browse_project_tree',
+    'execute_read_batch',
+    'get_project_status',
+    'network_read'
+)
+$script:ExpectedReadWriteToolNames = @(
+    'apply_write_batch',
+    'archive_project',
+    'browse_project_tree',
+    'close_project',
+    'compile_check',
+    'create_project',
+    'execute_read_batch',
+    'get_project_status',
+    'network_read',
+    'network_write',
+    'open_project',
+    'preview_write_batch',
+    'save_project',
+    'save_project_as'
+)
+$script:AnnotatedWriteToolNames = @(
+    'preview_write_batch',
+    'apply_write_batch',
+    'open_project',
+    'create_project',
+    'save_project',
+    'save_project_as',
+    'archive_project',
+    'close_project'
+)
+
+$repositoryRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$expectedReportPath = Join-Path $repositoryRoot 'docs\superpowers\acceptance\reports\2026-09-01-pr1-explicit-mcp-tool-annotations-live.md'
+$resolvedReportPath = [System.IO.Path]::GetFullPath($ReportPath, (Get-Location).Path)
+$resolvedProjectPath = [System.IO.Path]::GetFullPath($ProjectPath, (Get-Location).Path)
+
+if (-not [string]::Equals($resolvedReportPath, $expectedReportPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "-ReportPath must be '$expectedReportPath' so this run records the intended dated acceptance evidence."
+}
+
+if (-not $resolvedProjectPath.EndsWith('.ap21', [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "-ProjectPath must name a .ap21 project, not '$resolvedProjectPath'."
+}
+
+if (-not (Test-Path -LiteralPath $resolvedProjectPath -PathType Leaf)) {
+    throw "-ProjectPath does not exist: '$resolvedProjectPath'."
+}
+
+function Start-McpHost {
+    param([string] $AccessModeArgument)
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = 'dotnet'
+    foreach ($argument in @('run', '--project', 'TiaMcpServer', '--', '--project', $resolvedProjectPath, $AccessModeArgument)) {
+        [void] $psi.ArgumentList.Add($argument)
+    }
+    $psi.WorkingDirectory = $repositoryRoot
+    $psi.RedirectStandardInput = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $false
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow = $true
+
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $psi
+    [void] $process.Start()
+    $script:HostProcess = $process
+}
+
+function Stop-McpHost {
+    if ($null -ne $script:HostProcess -and -not $script:HostProcess.HasExited) {
+        try { $script:HostProcess.StandardInput.Close() } catch { }
+        if (-not $script:HostProcess.WaitForExit(5000)) {
+            $script:HostProcess.Kill($true)
+        }
+    }
+
+    $script:HostProcess = $null
+}
+
+function Send-McpMessage {
+    param([hashtable] $Message)
+
+    $json = $Message | ConvertTo-Json -Compress -Depth 30
+    $script:HostProcess.StandardInput.WriteLine($json)
+    $script:HostProcess.StandardInput.Flush()
+}
+
+function Read-McpResponse {
+    param([int] $Id)
+
+    $deadline = (Get-Date).AddSeconds($StartupTimeoutSeconds)
+    $pendingReadTask = $null
+    while ((Get-Date) -lt $deadline) {
+        if ($script:HostProcess.HasExited) {
+            throw "The MCP host exited with code $($script:HostProcess.ExitCode) before responding to request id $Id."
+        }
+
+        if ($null -eq $pendingReadTask) {
+            $pendingReadTask = $script:HostProcess.StandardOutput.ReadLineAsync()
+        }
+
+        $remainingMilliseconds = [int] [Math]::Max(0, ($deadline - (Get-Date)).TotalMilliseconds)
+        if (-not $pendingReadTask.Wait($remainingMilliseconds)) {
+            continue
+        }
+
+        $line = $pendingReadTask.Result
+        $pendingReadTask = $null
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        try { $response = $line | ConvertFrom-Json -Depth 80 } catch { continue }
+        if ($null -ne $response.PSObject.Properties['id'] -and $response.id -eq $Id) {
+            return $response
+        }
+    }
+
+    throw "Timed out after $StartupTimeoutSeconds second(s) waiting for MCP request id $Id."
+}
+
+function Invoke-McpRequest {
+    param([string] $Method, [hashtable] $Params = @{})
+
+    $id = ++$script:NextRequestId
+    Send-McpMessage -Message @{ jsonrpc = '2.0'; id = $id; method = $Method; params = $Params }
+    $response = Read-McpResponse -Id $id
+    if ($null -ne $response.PSObject.Properties['error'] -and $null -ne $response.error) {
+        throw "MCP request '$Method' returned: $($response.error | ConvertTo-Json -Compress -Depth 20)"
+    }
+
+    return $response.result
+}
+
+function Invoke-McpNotification {
+    param([string] $Method)
+
+    Send-McpMessage -Message @{ jsonrpc = '2.0'; method = $Method; params = @{} }
+}
+
+function Invoke-McpToolCall {
+    param([string] $Name, [hashtable] $Arguments)
+
+    $result = Invoke-McpRequest -Method 'tools/call' -Params @{ name = $Name; arguments = $Arguments }
+    $isError = $result.PSObject.Properties['isError']
+    if ($null -ne $isError -and [bool] $isError.Value) {
+        throw "Tool '$Name' returned isError:true: $($result | ConvertTo-Json -Compress -Depth 40)"
+    }
+
+    return $result
+}
+
+function Get-PropertyValue {
+    param([object] $Object, [string] $Name)
+
+    if ($null -eq $Object) {
+        return $null
+    }
+
+    $property = $Object.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $null
+    }
+
+    return $property.Value
+}
+
+function Assert-ToolSurface {
+    param(
+        [string] $Mode,
+        [object[]] $ActualNames,
+        [string[]] $ExpectedNames,
+        [int] $ExpectedCount
+    )
+
+    $actual = @($ActualNames | Sort-Object)
+    if ($actual.Count -ne $ExpectedCount) {
+        throw "$Mode tools/list returned $($actual.Count) tools; expected exactly ${ExpectedCount}: $($actual -join ', ')."
+    }
+
+    $difference = Compare-Object -ReferenceObject $ExpectedNames -DifferenceObject $actual
+    if ($null -ne $difference) {
+        throw "$Mode tools/list did not match the approved surface: $($difference | Out-String)."
+    }
+
+    return $actual
+}
+
+function Get-ToolAnnotationEvidence {
+    param([object[]] $Tools)
+
+    $byName = @{}
+    foreach ($tool in $Tools) {
+        $byName[$tool.name] = $tool
+    }
+
+    $records = @()
+    foreach ($toolName in $script:AnnotatedWriteToolNames) {
+        if (-not $byName.ContainsKey($toolName)) {
+            throw "Read-write tools/list did not advertise required annotated tool '$toolName'."
+        }
+
+        $annotations = Get-PropertyValue -Object $byName[$toolName] -Name 'annotations'
+        if ($null -eq $annotations) {
+            throw "Read-write tools/list omitted annotations for '$toolName'."
+        }
+
+        $records += [pscustomobject] [ordered]@{
+            name            = $toolName
+            readOnlyHint    = Get-PropertyValue -Object $annotations -Name 'readOnlyHint'
+            destructiveHint = Get-PropertyValue -Object $annotations -Name 'destructiveHint'
+            openWorldHint   = Get-PropertyValue -Object $annotations -Name 'openWorldHint'
+        }
+    }
+
+    return $records
+}
+
+function Get-ToolResultText {
+    param([object] $ToolResult)
+
+    $content = @(Get-PropertyValue -Object $ToolResult -Name 'content')
+    if ($content.Count -eq 0) {
+        throw 'get_project_status returned no content blocks.'
+    }
+
+    $text = Get-PropertyValue -Object $content[0] -Name 'text'
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        throw 'get_project_status returned no text content.'
+    }
+
+    return $text
+}
+
+function Get-TiaPortalVersion {
+    param([string] $ProjectStatusText)
+
+    try { $payload = $ProjectStatusText | ConvertFrom-Json -Depth 80 } catch {
+        throw "Could not parse the benign get_project_status result as JSON: $($_.Exception.Message)"
+    }
+
+    $identity = Get-PropertyValue -Object $payload -Name 'sessionIdentity'
+    $portalProcessId = Get-PropertyValue -Object $identity -Name 'portalProcessId'
+    if ($null -eq $portalProcessId) {
+        throw 'get_project_status did not return a portalProcessId from which to record the attached TIA Portal version.'
+    }
+
+    $portalProcess = Get-Process -Id ([int] $portalProcessId) -ErrorAction Stop
+    $version = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($portalProcess.Path).ProductVersion
+    if ([string]::IsNullOrWhiteSpace($version)) {
+        throw "The attached TIA Portal process '$($portalProcess.ProcessName)' did not expose a ProductVersion."
+    }
+
+    return $version
+}
+
+function Invoke-LiveSession {
+    param(
+        [string] $Mode,
+        [string] $AccessModeArgument,
+        [string[]] $ExpectedNames,
+        [int] $ExpectedCount
+    )
+
+    try {
+        Start-McpHost -AccessModeArgument $AccessModeArgument
+        $initializeResult = Invoke-McpRequest -Method 'initialize' -Params @{
+            protocolVersion = '2025-06-18'
+            capabilities    = @{}
+            clientInfo      = @{ name = 'live-test-write-tool-metadata'; version = '1.0.0' }
+        }
+        Invoke-McpNotification -Method 'notifications/initialized'
+
+        $toolsResult = Invoke-McpRequest -Method 'tools/list'
+        $tools = @($toolsResult.tools)
+        $toolNames = Assert-ToolSurface -Mode $Mode -ActualNames @($tools | ForEach-Object { $_.name }) -ExpectedNames $ExpectedNames -ExpectedCount $ExpectedCount
+
+        $projectStatus = Invoke-McpToolCall -Name 'get_project_status' -Arguments @{ projectPath = $resolvedProjectPath }
+        $projectStatusText = Get-ToolResultText -ToolResult $projectStatus
+
+        return [pscustomobject] [ordered]@{
+            mode                = $Mode
+            serverName          = Get-PropertyValue -Object (Get-PropertyValue -Object $initializeResult -Name 'serverInfo') -Name 'name'
+            serverVersion       = Get-PropertyValue -Object (Get-PropertyValue -Object $initializeResult -Name 'serverInfo') -Name 'version'
+            toolCount           = $toolNames.Count
+            toolNames           = $toolNames
+            writeToolAnnotations = if ($Mode -eq 'read-write') { Get-ToolAnnotationEvidence -Tools $tools } else { @() }
+            projectStatusResult = $projectStatusText
+            tiaPortalVersion    = Get-TiaPortalVersion -ProjectStatusText $projectStatusText
+        }
+    }
+    finally {
+        Stop-McpHost
+    }
+}
+
+function Convert-ToMarkdownCodeBlock {
+    param([object] $Value)
+
+    return ('```json' + [Environment]::NewLine + ($Value | ConvertTo-Json -Depth 80) + [Environment]::NewLine + '```')
+}
+
+$readOnlySession = Invoke-LiveSession -Mode 'read-only' -AccessModeArgument '--read-only' -ExpectedNames $script:ExpectedReadOnlyToolNames -ExpectedCount $script:ExpectedReadOnlyToolCount
+$readWriteSession = Invoke-LiveSession -Mode 'read-write' -AccessModeArgument '--read-write' -ExpectedNames $script:ExpectedReadWriteToolNames -ExpectedCount $script:ExpectedReadWriteToolCount
+
+if (-not [string]::Equals($readOnlySession.tiaPortalVersion, $readWriteSession.tiaPortalVersion, [System.StringComparison]::Ordinal)) {
+    throw "The two host sessions resolved different TIA Portal product versions ('$($readOnlySession.tiaPortalVersion)' and '$($readWriteSession.tiaPortalVersion)')."
+}
+
+$reportLines = @(
+    '# PR 1 Explicit MCP Tool Annotations — Live TIA Portal V21 Acceptance',
+    '',
+    '## Evidence status',
+    '',
+    'Live acceptance completed by this separately authorized, non-mutating run. This evidence proves only the exact live TiaMcpServer host, attached TIA Portal session, and disposable project path recorded below. It does not replace offline, stub, or FakeWorker evidence, and those evidence classes do not replace this live run.',
+    '',
+    '## Tested environment',
+    '',
+    "- TIA Portal product version: $($readOnlySession.tiaPortalVersion)",
+    ('- Project copy path: `' + $resolvedProjectPath + '`'),
+    ('- Harness report path: `' + $resolvedReportPath + '`'),
+    "- Read-only server: $($readOnlySession.serverName) $($readOnlySession.serverVersion)",
+    "- Read-write server: $($readWriteSession.serverName) $($readWriteSession.serverVersion)",
+    '',
+    '## Read-only MCP surface',
+    '',
+    "Expected and observed exactly $($readOnlySession.toolCount) tools:",
+    '',
+    (Convert-ToMarkdownCodeBlock -Value $readOnlySession.toolNames),
+    '',
+    'Benign call: `tools/call` for `get_project_status` with the project copy path. Result summary:',
+    '',
+    (Convert-ToMarkdownCodeBlock -Value ($readOnlySession.projectStatusResult | ConvertFrom-Json -Depth 80)),
+    '',
+    '## Read-write MCP surface',
+    '',
+    "Expected and observed exactly $($readWriteSession.toolCount) tools:",
+    '',
+    (Convert-ToMarkdownCodeBlock -Value $readWriteSession.toolNames),
+    '',
+    'Emitted annotations for the approved write-tool matrix:',
+    '',
+    (Convert-ToMarkdownCodeBlock -Value $readWriteSession.writeToolAnnotations),
+    '',
+    'Benign call: `tools/call` for `get_project_status` with the project copy path. Result summary:',
+    '',
+    (Convert-ToMarkdownCodeBlock -Value ($readWriteSession.projectStatusResult | ConvertFrom-Json -Depth 80)),
+    '',
+    '## Non-mutation and evidence boundary',
+    '',
+    'The harness sent only `initialize`, `notifications/initialized`, `tools/list`, and one `get_project_status` `tools/call` per access mode. It did not call any lifecycle, preview, apply, compilation, network-write, or PLC-control operation; no project mutation was performed. PLC `start_plc` and `stop_plc` remain deferred.',
+    '',
+    'The explicit MCP annotations are client-facing, untrusted metadata. Server-enforced access policy, preview/token/apply validation, binding checks, and auditing remain the write-safety authority.'
+)
+
+[System.IO.Directory]::CreateDirectory((Split-Path -Parent $resolvedReportPath)) | Out-Null
+[System.IO.File]::WriteAllText($resolvedReportPath, ($reportLines -join [Environment]::NewLine) + [Environment]::NewLine, [System.Text.UTF8Encoding]::new($false))
+Write-Host "Live acceptance evidence written to $resolvedReportPath"

--- a/scripts/live-test-write-tool-metadata.ps1
+++ b/scripts/live-test-write-tool-metadata.ps1
@@ -339,20 +339,93 @@ function Get-ToolResultText {
     return $text
 }
 
-function Get-TiaPortalVersion {
-    param([string] $ProjectStatusText)
+function Get-RequiredBooleanProperty {
+    param([object] $Object, [string] $Name, [bool] $ExpectedValue)
 
-    try { $payload = $ProjectStatusText | ConvertFrom-Json -Depth 80 } catch {
+    $value = Get-PropertyValue -Object $Object -Name $Name
+    if ($value -isnot [bool] -or $value -ne $ExpectedValue) {
+        throw "get_project_status public field '$Name' must be boolean '$ExpectedValue'; actual '$value'."
+    }
+
+    return $value
+}
+
+function Get-RequiredNormalizedPathProperty {
+    param([object] $Object, [string] $Name, [string] $ExpectedPath)
+
+    $value = Get-PropertyValue -Object $Object -Name $Name
+    if ([string]::IsNullOrWhiteSpace([string] $value)) {
+        throw "get_project_status public field '$Name' must contain the requested project path."
+    }
+
+    try {
+        $normalizedActualPath = [System.IO.Path]::GetFullPath([string] $value)
+    }
+    catch {
+        throw "get_project_status public field '$Name' is not a valid path: $($_.Exception.Message)"
+    }
+
+    if (-not [string]::Equals($normalizedActualPath, $ExpectedPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "get_project_status public field '$Name' did not match the requested project path. Expected '$ExpectedPath', actual '$normalizedActualPath'."
+    }
+
+    return $normalizedActualPath
+}
+
+function Get-ProjectStatusEvidence {
+    param([object] $ToolResult, [string] $ExpectedProjectPath)
+
+    $projectStatusText = Get-ToolResultText -ToolResult $ToolResult
+
+    try { $statusEnvelope = $projectStatusText | ConvertFrom-Json -Depth 80 } catch {
         throw "Could not parse the benign get_project_status result as JSON: $($_.Exception.Message)"
     }
 
-    $identity = Get-PropertyValue -Object $payload -Name 'sessionIdentity'
-    $portalProcessId = Get-PropertyValue -Object $identity -Name 'portalProcessId'
-    if ($null -eq $portalProcessId) {
-        throw 'get_project_status did not return a portalProcessId from which to record the attached TIA Portal version.'
+    Get-RequiredBooleanProperty -Object $statusEnvelope -Name 'success' -ExpectedValue $true | Out-Null
+
+    $payloadText = Get-PropertyValue -Object $statusEnvelope -Name 'payload'
+    if ([string]::IsNullOrWhiteSpace([string] $payloadText)) {
+        throw 'get_project_status did not return a payload JSON document.'
     }
 
-    $portalProcess = Get-Process -Id ([int] $portalProcessId) -ErrorAction Stop
+    try { $statusPayload = $payloadText | ConvertFrom-Json -Depth 80 } catch {
+        throw "Could not parse the get_project_status payload as JSON: $($_.Exception.Message)"
+    }
+
+    $resolvedExpectedProjectPath = [System.IO.Path]::GetFullPath($ExpectedProjectPath)
+    Get-RequiredBooleanProperty -Object $statusPayload -Name 'isOpen' -ExpectedValue $true | Out-Null
+    $payloadPath = Get-RequiredNormalizedPathProperty -Object $statusPayload -Name 'path' -ExpectedPath $resolvedExpectedProjectPath
+
+    $sessionIdentity = Get-PropertyValue -Object $statusEnvelope -Name 'sessionIdentity'
+    if ($null -eq $sessionIdentity) {
+        throw 'get_project_status did not return a sessionIdentity.'
+    }
+
+    $identityProjectPath = Get-RequiredNormalizedPathProperty -Object $sessionIdentity -Name 'projectPath' -ExpectedPath $resolvedExpectedProjectPath
+    $portalProcessId = Get-PropertyValue -Object $sessionIdentity -Name 'portalProcessId'
+    try { [int] $normalizedPortalProcessId = $portalProcessId } catch {
+        throw 'get_project_status did not return a valid portalProcessId.'
+    }
+
+    if ($normalizedPortalProcessId -le 0) {
+        throw 'get_project_status did not return a positive portalProcessId.'
+    }
+
+    return [pscustomobject] [ordered]@{
+        success         = $true
+        isOpen          = $true
+        path            = $payloadPath
+        sessionIdentity = [pscustomobject] [ordered]@{
+            projectPath     = $identityProjectPath
+            portalProcessId = $normalizedPortalProcessId
+        }
+    }
+}
+
+function Get-TiaPortalVersion {
+    param([int] $PortalProcessId)
+
+    $portalProcess = Get-Process -Id $PortalProcessId -ErrorAction Stop
     $version = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($portalProcess.Path).ProductVersion
     if ([string]::IsNullOrWhiteSpace($version)) {
         throw "The attached TIA Portal process '$($portalProcess.ProcessName)' did not expose a ProductVersion."
@@ -383,7 +456,7 @@ function Invoke-LiveSession {
         $toolNames = Assert-ToolSurface -Mode $Mode -ActualNames @($tools | ForEach-Object { $_.name }) -ExpectedNames $ExpectedNames -ExpectedCount $ExpectedCount
 
         $projectStatus = Invoke-McpToolCall -Name 'get_project_status' -Arguments @{ projectPath = $resolvedProjectPath }
-        $projectStatusText = Get-ToolResultText -ToolResult $projectStatus
+        $projectStatusSummary = Get-ProjectStatusEvidence -ToolResult $projectStatus -ExpectedProjectPath $resolvedProjectPath
 
         return [pscustomobject] [ordered]@{
             mode                = $Mode
@@ -392,8 +465,8 @@ function Invoke-LiveSession {
             toolCount           = $toolNames.Count
             toolNames           = $toolNames
             writeToolAnnotations = if ($Mode -eq 'read-write') { Get-ToolAnnotationEvidence -Tools $tools } else { @() }
-            projectStatusResult = $projectStatusText
-            tiaPortalVersion    = Get-TiaPortalVersion -ProjectStatusText $projectStatusText
+            projectStatusSummary = $projectStatusSummary
+            tiaPortalVersion      = Get-TiaPortalVersion -PortalProcessId $projectStatusSummary.sessionIdentity.portalProcessId
         }
     }
     finally {
@@ -412,6 +485,10 @@ $readWriteSession = Invoke-LiveSession -Mode 'read-write' -AccessModeArgument '-
 
 if (-not [string]::Equals($readOnlySession.tiaPortalVersion, $readWriteSession.tiaPortalVersion, [System.StringComparison]::Ordinal)) {
     throw "The two host sessions resolved different TIA Portal product versions ('$($readOnlySession.tiaPortalVersion)' and '$($readWriteSession.tiaPortalVersion)')."
+}
+
+if ($readOnlySession.projectStatusSummary.sessionIdentity.portalProcessId -ne $readWriteSession.projectStatusSummary.sessionIdentity.portalProcessId) {
+    throw "The two host sessions resolved different TIA Portal process ids ('$($readOnlySession.projectStatusSummary.sessionIdentity.portalProcessId)' and '$($readWriteSession.projectStatusSummary.sessionIdentity.portalProcessId)')."
 }
 
 $reportLines = @(
@@ -437,7 +514,7 @@ $reportLines = @(
     '',
     'Benign call: `tools/call` for `get_project_status` with the project copy path. Result summary:',
     '',
-    (Convert-ToMarkdownCodeBlock -Value ($readOnlySession.projectStatusResult | ConvertFrom-Json -Depth 80)),
+    (Convert-ToMarkdownCodeBlock -Value $readOnlySession.projectStatusSummary),
     '',
     '## Read-write MCP surface',
     '',
@@ -451,7 +528,7 @@ $reportLines = @(
     '',
     'Benign call: `tools/call` for `get_project_status` with the project copy path. Result summary:',
     '',
-    (Convert-ToMarkdownCodeBlock -Value ($readWriteSession.projectStatusResult | ConvertFrom-Json -Depth 80)),
+    (Convert-ToMarkdownCodeBlock -Value $readWriteSession.projectStatusSummary),
     '',
     '## Non-mutation and evidence boundary',
     '',

--- a/scripts/live-test-write-tool-metadata.ps1
+++ b/scripts/live-test-write-tool-metadata.ps1
@@ -77,6 +77,48 @@ $script:AnnotatedWriteToolNames = @(
     'archive_project',
     'close_project'
 )
+$script:ExpectedWriteToolAnnotations = @{
+    'preview_write_batch' = @{
+        readOnlyHint    = $true
+        destructiveHint = $false
+        openWorldHint   = $false
+    }
+    'apply_write_batch' = @{
+        readOnlyHint    = $false
+        destructiveHint = $true
+        openWorldHint   = $false
+    }
+    'open_project' = @{
+        readOnlyHint    = $false
+        destructiveHint = $true
+        openWorldHint   = $false
+    }
+    'create_project' = @{
+        readOnlyHint    = $false
+        destructiveHint = $true
+        openWorldHint   = $false
+    }
+    'save_project' = @{
+        readOnlyHint    = $false
+        destructiveHint = $true
+        openWorldHint   = $false
+    }
+    'save_project_as' = @{
+        readOnlyHint    = $false
+        destructiveHint = $true
+        openWorldHint   = $false
+    }
+    'archive_project' = @{
+        readOnlyHint    = $false
+        destructiveHint = $true
+        openWorldHint   = $false
+    }
+    'close_project' = @{
+        readOnlyHint    = $false
+        destructiveHint = $true
+        openWorldHint   = $false
+    }
+}
 
 $repositoryRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
 $expectedReportPath = Join-Path $repositoryRoot 'docs\superpowers\acceptance\reports\2026-09-01-pr1-explicit-mcp-tool-annotations-live.md'
@@ -250,20 +292,35 @@ function Get-ToolAnnotationEvidence {
             throw "Read-write tools/list did not advertise required annotated tool '$toolName'."
         }
 
-        $annotations = Get-PropertyValue -Object $byName[$toolName] -Name 'annotations'
-        if ($null -eq $annotations) {
-            throw "Read-write tools/list omitted annotations for '$toolName'."
-        }
-
-        $records += [pscustomobject] [ordered]@{
-            name            = $toolName
-            readOnlyHint    = Get-PropertyValue -Object $annotations -Name 'readOnlyHint'
-            destructiveHint = Get-PropertyValue -Object $annotations -Name 'destructiveHint'
-            openWorldHint   = Get-PropertyValue -Object $annotations -Name 'openWorldHint'
-        }
+        $records += Assert-ToolAnnotationEvidence -ToolName $toolName -Annotations (Get-PropertyValue -Object $byName[$toolName] -Name 'annotations')
     }
 
     return $records
+}
+
+function Assert-ToolAnnotationEvidence {
+    param([string] $ToolName, [object] $Annotations)
+
+    if ($null -eq $Annotations) {
+        throw "Read-write tools/list omitted annotations for '$ToolName'."
+    }
+
+    if (-not $script:ExpectedWriteToolAnnotations.ContainsKey($ToolName)) {
+        throw "No approved annotation matrix entry exists for '$ToolName'."
+    }
+
+    $expected = $script:ExpectedWriteToolAnnotations[$ToolName]
+    $actual = [ordered]@{ name = $ToolName }
+    foreach ($hintName in @('readOnlyHint', 'destructiveHint', 'openWorldHint')) {
+        $actualValue = Get-PropertyValue -Object $Annotations -Name $hintName
+        if ($actualValue -isnot [bool] -or $actualValue -ne $expected[$hintName]) {
+            throw "Read-write tools/list annotation mismatch for '$ToolName.$hintName': expected '$($expected[$hintName])', actual '$actualValue'."
+        }
+
+        $actual[$hintName] = $actualValue
+    }
+
+    return [pscustomobject] $actual
 }
 
 function Get-ToolResultText {


### PR DESCRIPTION
## Summary

- add explicit client-facing MCP annotation hints for `preview_write_batch`, `apply_write_batch`, and all six registered project lifecycle write tools
- add production-equivalent `ListToolsAsync()` coverage for the exact read-only/read-write surfaces and complete eight-tool annotation matrix
- add a separately authorized, non-mutating TIA Portal V21 live acceptance harness, durable evidence report, and current documentation updates

## Safety and scope

- no public tool names, counts, input schemas, write behavior, safety-token semantics, binding rules, auditing, or access-mode policies changed
- annotation hints remain untrusted client metadata; server-enforced preview/token/apply validation remains authoritative
- the live harness called only `initialize`, `notifications/initialized`, `tools/list`, and benign `get_project_status`
- PLC `start_plc` / `stop_plc` remains deferred and out of scope

## Verification

- Siemens reference-stub build: 0 warnings, 0 errors
- full serial offline/FakeWorker suite: 2,535 passed, 0 failed, 0 skipped
- focused live-harness contracts: 11/11 passed
- live TIA Portal acceptance: exit 0 against product version `2100.0.121.1`
- live surfaces: exact 4-tool read-only and 14-tool read-write sets
- live annotations: all eight approved tuples matched
- both live modes resolved the same project path and Portal PID; post-run project status reported `isModified:false`
- final whole-branch review: approved with no Critical, Important, or Minor findings

## Live evidence

[PR 1 explicit MCP tool annotations — live TIA Portal V21 acceptance](https://github.com/Czarnak/tia-portal-mcp/blob/feat/explicit-tool-annotations/docs/superpowers/acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md)
