### PR TITLE
feat: bind update_tag safety snapshots

### DIFF
--- a/TiaMcpServer.Contracts/OperationCapability.cs
+++ b/TiaMcpServer.Contracts/OperationCapability.cs
@@ -14,6 +14,10 @@ public enum OperationCapability
     /// output. Allowed in read-only mode when cleanup is guaranteed.</summary>
     TemporaryExport,
 
+    /// <summary>Side-effect-free internal safety-state read. Allowed in read-only mode but
+    /// bound to the verified worker/Portal/project identity.</summary>
+    SafetyRead,
+
     /// <summary>Invokes the Siemens compilation API. Not allowed in read-only mode because
     /// compilation may modify internal project state.</summary>
     Compile,

--- a/TiaMcpServer.Contracts/OperationPolicyCatalog.cs
+++ b/TiaMcpServer.Contracts/OperationPolicyCatalog.cs
@@ -23,7 +23,7 @@ public static class OperationPolicyCatalog
 
     /// <summary>
     /// True when <paramref name="operation"/> is allowed under the given access mode.
-    /// Read-only mode allows only Observe and TemporaryExport.
+    /// Read-only mode allows Observe, TemporaryExport, and side-effect-free SafetyRead.
     /// </summary>
     public static bool IsAllowed(McpAccessMode mode, string operation)
     {
@@ -38,7 +38,9 @@ public static class OperationPolicyCatalog
             return false;
         }
 
-        return cap.Value is OperationCapability.Observe or OperationCapability.TemporaryExport;
+        return cap.Value is OperationCapability.Observe
+            or OperationCapability.TemporaryExport
+            or OperationCapability.SafetyRead;
     }
 
     /// <summary>
@@ -58,9 +60,13 @@ public static class OperationPolicyCatalog
             return false;
         }
 
-        var capability = GetCapability(operation);
-        return capability != OperationCapability.Observe &&
-               capability != OperationCapability.TemporaryExport;
+        return GetCapability(operation) switch
+        {
+            OperationCapability.Observe => false,
+            OperationCapability.TemporaryExport => false,
+            OperationCapability.SafetyRead => true,
+            _ => true
+        };
     }
 
     /// <summary>
@@ -83,6 +89,9 @@ public static class OperationPolicyCatalog
             ["list_network_objects"] = OperationCapability.Observe,
             ["inspect_network_object"] = OperationCapability.Observe,
             ["probe_network_object_attributes"] = OperationCapability.Observe,
+
+            // SafetyRead (read-only safe, but requires a verified expected identity)
+            ["read_update_tag_safety_snapshot"] = OperationCapability.SafetyRead,
 
             // TemporaryExport (read-only safe, temporary files with cleanup)
             ["get_block_content"] = OperationCapability.TemporaryExport,

--- a/TiaMcpServer.Contracts/TagUpdateSafetySnapshot.cs
+++ b/TiaMcpServer.Contracts/TagUpdateSafetySnapshot.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace TiaMcpServer.Contracts;
+
+/// <summary>Exact current state that an <c>update_tag</c> safety token must bind to.</summary>
+public sealed record TagUpdateSafetySnapshot(
+    [property: JsonPropertyName("plcName")] string PlcName,
+    [property: JsonPropertyName("folderPath")] string FolderPath,
+    [property: JsonPropertyName("tableName")] string TableName,
+    [property: JsonPropertyName("tagName")] string TagName,
+    [property: JsonPropertyName("dataType")] string DataType,
+    [property: JsonPropertyName("logicalAddress")] string LogicalAddress,
+    [property: JsonPropertyName("externalAccessible")] bool? ExternalAccessible,
+    [property: JsonPropertyName("externalVisible")] bool? ExternalVisible,
+    [property: JsonPropertyName("externalWritable")] bool? ExternalWritable);

--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -60,6 +60,8 @@ var updateBlockPostconditionAttempt = 0;
 var createBlockPostconditionAttempt = 0;
 var orderedTypeWriteCount = 0;
 var tagUpdateFlagDriftSnapshotReadCount = 0;
+var tagUpdateBroadDriftReadCount = 0;
+var tagUpdateBroadDriftMutationCount = 0;
 var tagUpdateStrictSnapshotFailureBroadReadCount = 0;
 var tagUpdateInvalidSnapshotBroadReadCount = 0;
 var hardwarePaginationScenarioCalls = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -282,6 +284,16 @@ while ((line = Console.In.ReadLine()) is not null)
                 _ => $$"""{"success":false,"error":"unexpected update-tag safety fixture method '{{ReadMethod(line)}}'"}"""
             });
             break;
+        case "tag-update-snapshot-unavailable-all":
+            Respond(ReadMethod(line) switch
+            {
+                "get_project_status" => """{"success":true,"payload":"{\"isOpen\":true}"}""",
+                "list_tag_tables" => """{"success":true,"payload":"{\"tables\":[]}"}""",
+                "update_tag" => """{"success":true,"payload":"{}"}""",
+                "read_update_tag_safety_snapshot" => """{"success":true,"payload":"{\"plcName\":\"ResolvedPLC\",\"folderPath\":\"/\",\"tableName\":\"Default tag table\",\"tagName\":\"MotorReady\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I0.0\",\"externalAccessible\":null,\"externalVisible\":null,\"externalWritable\":null}"}""",
+                _ => $$"""{"success":false,"error":"unexpected all-unavailable update-tag fixture method '{{ReadMethod(line)}}'"}"""
+            });
+            break;
         case "tag-update-flag-drift":
             Respond(ReadMethod(line) switch
             {
@@ -291,6 +303,27 @@ while ((line = Console.In.ReadLine()) is not null)
                 "read_update_tag_safety_snapshot" => TagUpdateDriftSnapshotResponse(++tagUpdateFlagDriftSnapshotReadCount),
                 _ => $$"""{"success":false,"error":"unexpected update-tag safety fixture method '{{ReadMethod(line)}}'"}"""
             });
+            break;
+        case "tag-update-broad-drift":
+            switch (ReadMethod(line))
+            {
+                case "get_project_status":
+                    Respond($$"""{"success":true,"payload":"{\"isOpen\":true,\"broadDriftMutationCount\":{{tagUpdateBroadDriftMutationCount}}}"}""");
+                    break;
+                case "read_update_tag_safety_snapshot":
+                    Respond("""{"success":true,"payload":"{\"plcName\":\"ResolvedPLC\",\"folderPath\":\"/\",\"tableName\":\"Default tag table\",\"tagName\":\"MotorReady\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I0.0\",\"externalAccessible\":false,\"externalVisible\":true,\"externalWritable\":false}"}""");
+                    break;
+                case "list_tag_tables":
+                    Respond(TagUpdateBroadDriftResponse(++tagUpdateBroadDriftReadCount));
+                    break;
+                case "update_tag":
+                    tagUpdateBroadDriftMutationCount++;
+                    Respond("""{"success":true,"payload":"{}"}""");
+                    break;
+                default:
+                    Respond("""{"success":false,"error":"unexpected broad-drift update-tag fixture method"}""");
+                    break;
+            }
             break;
         case "tag-update-snapshot-read-fails":
             switch (ReadMethod(line))
@@ -2018,6 +2051,14 @@ string TagUpdateDriftSnapshotResponse(int readCount)
 {
     var externalAccessible = readCount == 1 ? "false" : "true";
     return $$"""{"success":true,"payload":"{\"plcName\":\"ResolvedPLC\",\"folderPath\":\"/\",\"tableName\":\"Default tag table\",\"tagName\":\"MotorReady\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I0.0\",\"externalAccessible\":{{externalAccessible}},\"externalVisible\":true,\"externalWritable\":false}"}""";
+}
+
+string TagUpdateBroadDriftResponse(int readCount)
+{
+    var payload = readCount == 1
+        ? """{"tables":[]}"""
+        : """{"tables":[{"name":"Unrelated","folderPath":"/","tags":[],"userConstants":[]}]}""";
+    return Success(payload);
 }
 
 string InvalidTagUpdateSnapshotResponse(string requestLine)

--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -61,6 +61,7 @@ var createBlockPostconditionAttempt = 0;
 var orderedTypeWriteCount = 0;
 var tagUpdateFlagDriftSnapshotReadCount = 0;
 var tagUpdateStrictSnapshotFailureBroadReadCount = 0;
+var tagUpdateInvalidSnapshotBroadReadCount = 0;
 var hardwarePaginationScenarioCalls = new Dictionary<string, int>(StringComparer.Ordinal);
 var hardwarePaginationIdentityDrift = false;
 
@@ -306,6 +307,24 @@ while ((line = Console.In.ReadLine()) is not null)
                     break;
                 default:
                     Respond("""{"success":false,"error":"unexpected update-tag snapshot-failure fixture method"}""");
+                    break;
+            }
+            break;
+        case "tag-update-snapshot-invalid-payload":
+            switch (ReadMethod(line))
+            {
+                case "read_update_tag_safety_snapshot":
+                    Respond(InvalidTagUpdateSnapshotResponse(line));
+                    break;
+                case "list_tag_tables":
+                    tagUpdateInvalidSnapshotBroadReadCount++;
+                    Respond("""{"success":true,"payload":"{\"tables\":[]}"}""");
+                    break;
+                case "get_project_status":
+                    Respond($$"""{"success":true,"payload":"{\"isOpen\":true,\"invalidSnapshotBroadReadCount\":{{tagUpdateInvalidSnapshotBroadReadCount}}}"}""");
+                    break;
+                default:
+                    Respond("""{"success":false,"error":"unexpected update-tag invalid-snapshot fixture method"}""");
                     break;
             }
             break;
@@ -1999,6 +2018,57 @@ string TagUpdateDriftSnapshotResponse(int readCount)
 {
     var externalAccessible = readCount == 1 ? "false" : "true";
     return $$"""{"success":true,"payload":"{\"plcName\":\"ResolvedPLC\",\"folderPath\":\"/\",\"tableName\":\"Default tag table\",\"tagName\":\"MotorReady\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I0.0\",\"externalAccessible\":{{externalAccessible}},\"externalVisible\":true,\"externalWritable\":false}"}""";
+}
+
+string InvalidTagUpdateSnapshotResponse(string requestLine)
+{
+    var variant = ReadField(requestLine, "name") ?? "empty";
+    if (variant == "malformed")
+    {
+        return Success("{not valid json");
+    }
+    if (variant == "root-array")
+    {
+        return Success("[]");
+    }
+
+    var snapshot = new Dictionary<string, object?>(StringComparer.Ordinal)
+    {
+        ["plcName"] = "ResolvedPLC",
+        ["folderPath"] = "/",
+        ["tableName"] = "Default tag table",
+        ["tagName"] = "MotorReady",
+        ["dataType"] = "Bool",
+        ["logicalAddress"] = "%I0.0",
+        ["externalAccessible"] = false,
+        ["externalVisible"] = true,
+        ["externalWritable"] = false,
+    };
+
+    if (variant == "empty")
+    {
+        snapshot.Clear();
+    }
+    else if (variant.StartsWith("missing-", StringComparison.Ordinal))
+    {
+        snapshot.Remove(variant["missing-".Length..]);
+    }
+    else if (variant.StartsWith("wrong-", StringComparison.Ordinal))
+    {
+        snapshot[variant["wrong-".Length..]] = new { unsupported = true };
+    }
+
+    if (variant == "unknown-member")
+    {
+        snapshot["unexpected"] = true;
+    }
+
+    var payload = JsonSerializer.Serialize(snapshot);
+    if (variant == "duplicate-member")
+    {
+        payload = payload.Insert(1, "\"plcName\":\"Duplicate\",");
+    }
+    return Success(payload);
 }
 
 int? ReadIntField(string requestLine, string propertyName)

--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -60,6 +60,7 @@ var updateBlockPostconditionAttempt = 0;
 var createBlockPostconditionAttempt = 0;
 var orderedTypeWriteCount = 0;
 var tagUpdateFlagDriftSnapshotReadCount = 0;
+var tagUpdateStrictSnapshotFailureBroadReadCount = 0;
 var hardwarePaginationScenarioCalls = new Dictionary<string, int>(StringComparer.Ordinal);
 var hardwarePaginationIdentityDrift = false;
 
@@ -291,11 +292,22 @@ while ((line = Console.In.ReadLine()) is not null)
             });
             break;
         case "tag-update-snapshot-read-fails":
-            Respond(ReadMethod(line) == "read_update_tag_safety_snapshot"
-                ? """{"success":false,"failureCategory":"worker_operation_failed","error":"strict update-tag snapshot read failed"}"""
-                : ReadMethod(line) == "get_project_status"
-                    ? """{"success":true,"payload":"{\"isOpen\":true}"}"""
-                    : """{"success":false,"error":"unexpected update-tag snapshot-failure fixture method"}""");
+            switch (ReadMethod(line))
+            {
+                case "read_update_tag_safety_snapshot":
+                    Respond("""{"success":false,"failureCategory":"worker_operation_failed","error":"strict update-tag snapshot read failed"}""");
+                    break;
+                case "list_tag_tables":
+                    tagUpdateStrictSnapshotFailureBroadReadCount++;
+                    Respond("""{"success":true,"payload":"{\"tables\":[]}"}""");
+                    break;
+                case "get_project_status":
+                    Respond($$"""{"success":true,"payload":"{\"isOpen\":true,\"strictSnapshotFailureBroadReadCount\":{{tagUpdateStrictSnapshotFailureBroadReadCount}}}"}""");
+                    break;
+                default:
+                    Respond("""{"success":false,"error":"unexpected update-tag snapshot-failure fixture method"}""");
+                    break;
+            }
             break;
         case "tag-update-broad-best-effort-omission":
             Respond(ReadMethod(line) switch

--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -59,6 +59,7 @@ var subnetLifecycleStateDriftReadCount = 0;
 var updateBlockPostconditionAttempt = 0;
 var createBlockPostconditionAttempt = 0;
 var orderedTypeWriteCount = 0;
+var tagUpdateFlagDriftSnapshotReadCount = 0;
 var hardwarePaginationScenarioCalls = new Dictionary<string, int>(StringComparer.Ordinal);
 var hardwarePaginationIdentityDrift = false;
 
@@ -268,6 +269,43 @@ while ((line = Console.In.ReadLine()) is not null)
             // Returns the received request verbatim so tests can assert which fields survived
             // the BatchOperationRequest -> WorkerRequest hop.
             Respond(JsonSerializer.Serialize(new { success = true, payload = line }));
+            break;
+        case "tag-update-snapshot-unavailable-visible":
+            Respond(ReadMethod(line) switch
+            {
+                "get_project_status" => """{"success":true,"payload":"{\"isOpen\":true}"}""",
+                "list_tag_tables" => """{"success":true,"payload":"{\"tables\":[]}"}""",
+                "update_tag" => """{"success":true,"payload":"{}"}""",
+                "read_update_tag_safety_snapshot" => """{"success":true,"payload":"{\"plcName\":\"ResolvedPLC\",\"folderPath\":\"/\",\"tableName\":\"Default tag table\",\"tagName\":\"MotorReady\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I0.0\",\"externalAccessible\":false,\"externalVisible\":null,\"externalWritable\":false}"}""",
+                _ => $$"""{"success":false,"error":"unexpected update-tag safety fixture method '{{ReadMethod(line)}}'"}"""
+            });
+            break;
+        case "tag-update-flag-drift":
+            Respond(ReadMethod(line) switch
+            {
+                "get_project_status" => """{"success":true,"payload":"{\"isOpen\":true}"}""",
+                "list_tag_tables" => """{"success":true,"payload":"{\"tables\":[]}"}""",
+                "update_tag" => """{"success":true,"payload":"{}"}""",
+                "read_update_tag_safety_snapshot" => TagUpdateDriftSnapshotResponse(++tagUpdateFlagDriftSnapshotReadCount),
+                _ => $$"""{"success":false,"error":"unexpected update-tag safety fixture method '{{ReadMethod(line)}}'"}"""
+            });
+            break;
+        case "tag-update-snapshot-read-fails":
+            Respond(ReadMethod(line) == "read_update_tag_safety_snapshot"
+                ? """{"success":false,"failureCategory":"worker_operation_failed","error":"strict update-tag snapshot read failed"}"""
+                : ReadMethod(line) == "get_project_status"
+                    ? """{"success":true,"payload":"{\"isOpen\":true}"}"""
+                    : """{"success":false,"error":"unexpected update-tag snapshot-failure fixture method"}""");
+            break;
+        case "tag-update-broad-best-effort-omission":
+            Respond(ReadMethod(line) switch
+            {
+                "get_project_status" => """{"success":true,"payload":"{\"isOpen\":true}"}""",
+                "read_update_tag_safety_snapshot" => """{"success":true,"payload":"{\"plcName\":\"ResolvedPLC\",\"folderPath\":\"/\",\"tableName\":\"Default tag table\",\"tagName\":\"MotorReady\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I0.0\",\"externalAccessible\":false,\"externalVisible\":true,\"externalWritable\":false}"}""",
+                "list_tag_tables" => """{"success":true,"payload":"{\"tables\":[]}","warnings":["Skipping unrelated tag table: access denied."]}""",
+                "update_tag" => """{"success":true,"payload":"{}"}""",
+                _ => """{"success":false,"error":"unexpected update-tag broad-omission fixture method"}"""
+            });
             break;
         case "network-read-warnings":
             // A contract-valid hardware payload carried alongside worker warnings, so the network
@@ -1934,6 +1972,12 @@ string HandleSecondItemFailureWrite(string requestLine, List<SubnetLifecycleSubn
     return subnetLifecycleSecondFailureWriteCount == 1
         ? DispatchSubnetLifecycleWrite(requestLine, subnets)
         : $$"""{"success":false,"error":"deliberate second-item failure for network-subnet-lifecycle-second-item-failure"}""";
+}
+
+string TagUpdateDriftSnapshotResponse(int readCount)
+{
+    var externalAccessible = readCount == 1 ? "false" : "true";
+    return $$"""{"success":true,"payload":"{\"plcName\":\"ResolvedPLC\",\"folderPath\":\"/\",\"tableName\":\"Default tag table\",\"tagName\":\"MotorReady\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I0.0\",\"externalAccessible\":{{externalAccessible}},\"externalVisible\":true,\"externalWritable\":false}"}""";
 }
 
 int? ReadIntField(string requestLine, string propertyName)

--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -307,6 +307,15 @@ while ((line = Console.In.ReadLine()) is not null)
                 _ => """{"success":false,"error":"unexpected update-tag broad-omission fixture method"}"""
             });
             break;
+        case "tag-update-broad-malformed-payload":
+            Respond(ReadMethod(line) switch
+            {
+                "get_project_status" => """{"success":true,"payload":"{\"isOpen\":true}"}""",
+                "read_update_tag_safety_snapshot" => """{"success":true,"payload":"{\"plcName\":\"ResolvedPLC\",\"folderPath\":\"/\",\"tableName\":\"Default tag table\",\"tagName\":\"MotorReady\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I0.0\",\"externalAccessible\":false,\"externalVisible\":true,\"externalWritable\":false}"}""",
+                "list_tag_tables" => """{"success":true,"payload":"{not valid json"}""",
+                _ => """{"success":false,"error":"unexpected update-tag malformed-broad fixture method"}"""
+            });
+            break;
         case "network-read-warnings":
             // A contract-valid hardware payload carried alongside worker warnings, so the network
             // read path can be proven to copy warnings onto the item it decoded successfully.

--- a/TiaMcpServer.OpennessWorker/IsExternalInit.cs
+++ b/TiaMcpServer.OpennessWorker/IsExternalInit.cs
@@ -1,0 +1,6 @@
+namespace System.Runtime.CompilerServices;
+
+/// <summary>Compiler marker required for C# records under this net48 target.</summary>
+internal static class IsExternalInit
+{
+}

--- a/TiaMcpServer.OpennessWorker/Openness/TagMutationService.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/TagMutationService.cs
@@ -84,9 +84,9 @@ public static class TagMutationService
             throw new InvalidOperationException("Updating IsSafety is not supported by the available TIA Openness API.");
         }
 
-        var table = ResolveTable(project, plcName, tableName, folderPath);
-        var tag = table.Tags.Find(name) ??
-            throw new InvalidOperationException($"Tag '{name}' was not found in tag table '{tableName}'.");
+        var resolved = TagTargetResolver.Resolve(project, plcName, tableName, folderPath, name);
+        var table = resolved.Table;
+        var tag = resolved.Tag;
 
         if (!string.IsNullOrWhiteSpace(newName) &&
             !string.Equals(name, newName, StringComparison.OrdinalIgnoreCase) &&
@@ -125,7 +125,7 @@ public static class TagMutationService
             tag.ExternalWritable = externalWritable.Value;
         }
 
-        return Result("update_tag", project, plcName, table.Name, NormalizeFolderPath(folderPath), tag.Name, null);
+        return Result("update_tag", project, resolved.PlcName, table.Name, resolved.FolderPath, tag.Name, null);
     }
 
     public static TagMutationResultInfo DeleteTag(

--- a/TiaMcpServer.OpennessWorker/Openness/TagTargetResolver.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/TagTargetResolver.cs
@@ -1,0 +1,65 @@
+using Siemens.Engineering;
+using Siemens.Engineering.SW.Tags;
+
+namespace TiaMcpServer.OpennessWorker.Openness;
+
+internal sealed record ResolvedTagTarget(
+    string PlcName,
+    string FolderPath,
+    PlcTagTable Table,
+    PlcTag Tag);
+
+internal static class TagTargetResolver
+{
+    internal static ResolvedTagTarget Resolve(
+        Project project,
+        string? plcName,
+        string tableName,
+        string? folderPath,
+        string name)
+    {
+        RequireName(tableName, "TableName");
+        RequireName(name, "Name");
+
+        var normalizedFolderPath = NormalizeFolderPath(folderPath);
+        var plcSoftware = PlcSoftwareLocator.Find(project, plcName);
+        PlcTagTableGroup group = plcSoftware.TagTableGroup;
+        foreach (var segment in SplitFolderPath(folderPath))
+        {
+            group = group.Groups.Find(segment)
+                ?? throw new InvalidOperationException($"Tag table folder '{normalizedFolderPath}' was not found.");
+        }
+
+        var table = group.TagTables.Find(tableName)
+            ?? throw new InvalidOperationException($"Tag table '{tableName}' was not found in '{normalizedFolderPath}'.");
+        var tag = table.Tags.Find(name)
+            ?? throw new InvalidOperationException($"Tag '{name}' was not found in tag table '{tableName}'.");
+
+        return new ResolvedTagTarget(plcSoftware.Name, normalizedFolderPath, table, tag);
+    }
+
+    internal static string NormalizeFolderPath(string? folderPath)
+    {
+        var segments = SplitFolderPath(folderPath);
+        return segments.Length == 0 ? "/" : "/" + string.Join("/", segments);
+    }
+
+    private static string[] SplitFolderPath(string? folderPath)
+    {
+        var trimmed = folderPath?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed) || trimmed == "/")
+        {
+            return Array.Empty<string>();
+        }
+
+        return trimmed!.Trim('/').Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static void RequireName(string? value, string fieldName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"{fieldName} is required.");
+        }
+    }
+}

--- a/TiaMcpServer.OpennessWorker/Openness/TagUpdateSafetySnapshotReader.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/TagUpdateSafetySnapshotReader.cs
@@ -1,0 +1,39 @@
+using Siemens.Engineering;
+using TiaMcpServer.Contracts;
+
+namespace TiaMcpServer.OpennessWorker.Openness;
+
+internal static class TagUpdateSafetySnapshotReader
+{
+    internal static TagUpdateSafetySnapshot Read(
+        Project project,
+        string? plcName,
+        string tableName,
+        string? folderPath,
+        string name)
+    {
+        var resolved = TagTargetResolver.Resolve(project, plcName, tableName, folderPath, name);
+        return new TagUpdateSafetySnapshot(
+            resolved.PlcName,
+            resolved.FolderPath,
+            resolved.Table.Name,
+            resolved.Tag.Name,
+            resolved.Tag.DataTypeName,
+            resolved.Tag.LogicalAddress,
+            ReadOptionalFlag(() => resolved.Tag.ExternalAccessible),
+            ReadOptionalFlag(() => resolved.Tag.ExternalVisible),
+            ReadOptionalFlag(() => resolved.Tag.ExternalWritable));
+    }
+
+    private static bool? ReadOptionalFlag(Func<bool> read)
+    {
+        try
+        {
+            return read();
+        }
+        catch (NotSupportedException)
+        {
+            return null;
+        }
+    }
+}

--- a/TiaMcpServer.OpennessWorker/Program.cs
+++ b/TiaMcpServer.OpennessWorker/Program.cs
@@ -163,6 +163,7 @@ internal static class Program
                 "get_type_content"    => GetTypeContent(request),
                 "update_type_content" => UpdateTypeContent(request),
                 "list_tag_tables"     => ListTagTables(request),
+                "read_update_tag_safety_snapshot" => ReadUpdateTagSafetySnapshot(request),
                 "compile_check"       => CompileCheck(request),
                 "create_tag_table"    => CreateTagTable(request),
                 "delete_tag_table"    => DeleteTagTable(request),
@@ -856,6 +857,17 @@ internal static class Program
     private static WorkerResponse ListTagTables(WorkerRequest request)
     {
         return WithProject(request, project => Success(TagTableReader.ReadAll(project, request.PlcName)));
+    }
+
+    private static WorkerResponse ReadUpdateTagSafetySnapshot(WorkerRequest request)
+    {
+        return WithProject(request, project => Success(
+            TagUpdateSafetySnapshotReader.Read(
+                project,
+                request.PlcName,
+                request.TableName!,
+                request.FolderPath,
+                request.Name!)));
     }
 
     private static WorkerResponse CompileCheck(WorkerRequest request)

--- a/TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs
@@ -84,9 +84,13 @@ public class TagUpdateCurrentStateFakeWorkerTests
         await FakeWorkerBinding.BindVerifiedAsync(client, binding, scenario);
 
         var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, new[] { UpdateTagOp(scenario) });
+        var observedState = await client.GetProjectStatusAsync(scenario);
 
         Assert.Contains("strict update-tag snapshot read failed", preview, StringComparison.Ordinal);
         Assert.DoesNotContain("\"safetyToken\":", preview, StringComparison.Ordinal);
+        Assert.True(observedState.Success, observedState.Error);
+        using var document = JsonDocument.Parse(observedState.Payload);
+        Assert.Equal(0, document.RootElement.GetProperty("strictSnapshotFailureBroadReadCount").GetInt32());
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs
@@ -21,6 +21,7 @@ public class TagUpdateCurrentStateFakeWorkerTests
 
     private static BatchOperationRequest UpdateTagOp(
         string projectPath,
+        string name = TagName,
         bool? externalAccessible = null,
         bool? externalVisible = null,
         bool? externalWritable = null) => new()
@@ -30,7 +31,7 @@ public class TagUpdateCurrentStateFakeWorkerTests
         PlcName = "PLC_1",
         TableName = TableName,
         FolderPath = "/",
-        Name = TagName,
+        Name = name,
         ExternalAccessible = externalAccessible,
         ExternalVisible = externalVisible,
         ExternalWritable = externalWritable,
@@ -52,6 +53,63 @@ public class TagUpdateCurrentStateFakeWorkerTests
 
         Assert.Contains("externalVisible", preview, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("\"safetyToken\":", preview, StringComparison.Ordinal);
+    }
+
+    public static TheoryData<string> InvalidStrictSnapshotPayloads()
+    {
+        var cases = new TheoryData<string>
+        {
+            "empty",
+            "malformed",
+            "root-array",
+            "unknown-member",
+            "duplicate-member",
+        };
+        foreach (var member in new[]
+        {
+            "plcName",
+            "folderPath",
+            "tableName",
+            "tagName",
+            "dataType",
+            "logicalAddress",
+            "externalAccessible",
+            "externalVisible",
+            "externalWritable",
+        })
+        {
+            cases.Add($"missing-{member}");
+            cases.Add($"wrong-{member}");
+        }
+        return cases;
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidStrictSnapshotPayloads))]
+    public async Task PreviewWriteBatch_UpdateTagInvalidStrictSnapshotFailsClosedBeforeBroadRead(string payloadVariant)
+    {
+        const string scenario = "tag-update-snapshot-invalid-payload";
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        var safety = CreateSafety(audit, binding);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, scenario);
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(
+            client,
+            safety,
+            new[] { UpdateTagOp(scenario, name: payloadVariant) });
+        var observedState = await client.GetProjectStatusAsync(scenario);
+
+        using var previewDocument = JsonDocument.Parse(preview);
+        Assert.False(previewDocument.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal(
+            WorkerFailureCategories.ProtocolError,
+            previewDocument.RootElement.GetProperty("failureCategory").GetString());
+        Assert.False(previewDocument.RootElement.TryGetProperty("safetyToken", out _));
+        Assert.True(observedState.Success, observedState.Error);
+        using var stateDocument = JsonDocument.Parse(observedState.Payload);
+        Assert.Equal(0, stateDocument.RootElement.GetProperty("invalidSnapshotBroadReadCount").GetInt32());
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tests.Worker;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public class TagUpdateCurrentStateFakeWorkerTests
+{
+    private const string TableName = "Default tag table";
+    private const string TagName = "MotorReady";
+
+    private static OpennessWorkerClient CreateClient(ProjectSessionBinding binding)
+        => new(binding, logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+
+    private static WriteSafetyService CreateSafety(TempAuditDirectory audit, ProjectSessionBinding binding)
+        => new(binding, () => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, audit.Path);
+
+    private static BatchOperationRequest UpdateTagOp(
+        string projectPath,
+        bool? externalAccessible = null,
+        bool? externalVisible = null,
+        bool? externalWritable = null) => new()
+    {
+        OperationId = "update-motor-ready",
+        Operation = "update_tag",
+        PlcName = "PLC_1",
+        TableName = TableName,
+        FolderPath = "/",
+        Name = TagName,
+        ExternalAccessible = externalAccessible,
+        ExternalVisible = externalVisible,
+        ExternalWritable = externalWritable,
+        ProjectPath = projectPath,
+    };
+
+    [Fact]
+    public async Task PreviewWriteBatch_UpdateTagRejectsRequestedUnavailableFlagBeforeTokenIssuance()
+    {
+        const string scenario = "tag-update-snapshot-unavailable-visible";
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        var safety = CreateSafety(audit, binding);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, scenario);
+        var operations = new[] { UpdateTagOp(scenario, externalVisible: true) };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+
+        Assert.Contains("externalVisible", preview, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("\"safetyToken\":", preview, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyWriteBatch_UpdateTagFlagOnlyDriftFailsWithStateChanged()
+    {
+        const string scenario = "tag-update-flag-drift";
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        var safety = CreateSafety(audit, binding);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, scenario);
+        var operations = new[] { UpdateTagOp(scenario, externalAccessible: true) };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+        var token = JsonDocument.Parse(preview).RootElement.GetProperty("safetyToken").GetString();
+
+        var apply = await WriteBatchTools.ApplyWriteBatch(client, safety, operations, confirm: true, safetyToken: token);
+
+        Assert.Contains("\"failureCategory\":\"state_changed\"", apply, StringComparison.Ordinal);
+    }
+}

--- a/TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs
@@ -72,4 +72,53 @@ public class TagUpdateCurrentStateFakeWorkerTests
 
         Assert.Contains("\"failureCategory\":\"state_changed\"", apply, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public async Task PreviewWriteBatch_UpdateTagStrictSnapshotFailurePreventsBroadReadAndTokenIssuance()
+    {
+        const string scenario = "tag-update-snapshot-read-fails";
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        var safety = CreateSafety(audit, binding);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, scenario);
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, new[] { UpdateTagOp(scenario) });
+
+        Assert.Contains("strict update-tag snapshot read failed", preview, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"safetyToken\":", preview, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_UpdateTagAllowsBroadBestEffortWarningAfterStrictSnapshotSucceeds()
+    {
+        const string scenario = "tag-update-broad-best-effort-omission";
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        var safety = CreateSafety(audit, binding);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, scenario);
+        var operations = new[] { UpdateTagOp(scenario, externalVisible: false) };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+
+        Assert.Contains("\"safetyToken\":", preview, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_UpdateTagMalformedBroadPayloadFailsClosedWithProtocolError()
+    {
+        const string scenario = "tag-update-broad-malformed-payload";
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        var safety = CreateSafety(audit, binding);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, scenario);
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, new[] { UpdateTagOp(scenario) });
+
+        Assert.Contains("\"success\":false", preview, StringComparison.Ordinal);
+        Assert.Contains("\"failureCategory\":\"protocol_error\"", preview, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"safetyToken\":", preview, StringComparison.Ordinal);
+    }
 }

--- a/TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs
@@ -22,6 +22,7 @@ public class TagUpdateCurrentStateFakeWorkerTests
     private static BatchOperationRequest UpdateTagOp(
         string projectPath,
         string name = TagName,
+        string? dataType = null,
         bool? externalAccessible = null,
         bool? externalVisible = null,
         bool? externalWritable = null) => new()
@@ -32,6 +33,7 @@ public class TagUpdateCurrentStateFakeWorkerTests
         TableName = TableName,
         FolderPath = "/",
         Name = name,
+        DataType = dataType,
         ExternalAccessible = externalAccessible,
         ExternalVisible = externalVisible,
         ExternalWritable = externalWritable,
@@ -53,6 +55,62 @@ public class TagUpdateCurrentStateFakeWorkerTests
 
         Assert.Contains("externalVisible", preview, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("\"safetyToken\":", preview, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("externalAccessible", true, null, null)]
+    [InlineData("externalVisible", null, true, null)]
+    [InlineData("externalWritable", null, null, true)]
+    public async Task PreviewWriteBatch_UpdateTagRejectsEachRequestedUnavailableFlagBeforeTokenIssuance(
+        string expectedFlag,
+        bool? externalAccessible,
+        bool? externalVisible,
+        bool? externalWritable)
+    {
+        const string scenario = "tag-update-snapshot-unavailable-all";
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        var safety = CreateSafety(audit, binding);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, scenario);
+        var operations = new[]
+        {
+            UpdateTagOp(
+                scenario,
+                externalAccessible: externalAccessible,
+                externalVisible: externalVisible,
+                externalWritable: externalWritable)
+        };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+
+        using var document = JsonDocument.Parse(preview);
+        Assert.False(document.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal(
+            WorkerFailureCategories.ValidationError,
+            document.RootElement.GetProperty("failureCategory").GetString());
+        Assert.Contains(expectedFlag, document.RootElement.GetProperty("error").GetString(), StringComparison.Ordinal);
+        Assert.False(document.RootElement.TryGetProperty("safetyToken", out _));
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_UpdateTagWithoutUnavailableFlagRequestStillIssuesToken()
+    {
+        const string scenario = "tag-update-snapshot-unavailable-all";
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        var safety = CreateSafety(audit, binding);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, scenario);
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(
+            client,
+            safety,
+            new[] { UpdateTagOp(scenario, dataType: "DInt") });
+
+        using var document = JsonDocument.Parse(preview);
+        Assert.True(document.RootElement.TryGetProperty("safetyToken", out var safetyToken), preview);
+        Assert.False(string.IsNullOrWhiteSpace(safetyToken.GetString()));
     }
 
     public static TheoryData<string> InvalidStrictSnapshotPayloads()
@@ -129,6 +187,39 @@ public class TagUpdateCurrentStateFakeWorkerTests
         var apply = await WriteBatchTools.ApplyWriteBatch(client, safety, operations, confirm: true, safetyToken: token);
 
         Assert.Contains("\"failureCategory\":\"state_changed\"", apply, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyWriteBatch_UpdateTagBroadOnlyDriftFailsWithStateChangedBeforeMutation()
+    {
+        const string scenario = "tag-update-broad-drift";
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        var safety = CreateSafety(audit, binding);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, scenario);
+        var operations = new[] { UpdateTagOp(scenario, externalVisible: false) };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+        using var previewDocument = JsonDocument.Parse(preview);
+        var token = previewDocument.RootElement.GetProperty("safetyToken").GetString();
+
+        var apply = await WriteBatchTools.ApplyWriteBatch(
+            client,
+            safety,
+            operations,
+            confirm: true,
+            safetyToken: token);
+        var observedState = await client.GetProjectStatusAsync(scenario);
+
+        using var applyDocument = JsonDocument.Parse(apply);
+        Assert.False(applyDocument.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal(
+            WorkerFailureCategories.StateChanged,
+            applyDocument.RootElement.GetProperty("failureCategory").GetString());
+        Assert.True(observedState.Success, observedState.Error);
+        using var stateDocument = JsonDocument.Parse(observedState.Payload);
+        Assert.Equal(0, stateDocument.RootElement.GetProperty("broadDriftMutationCount").GetInt32());
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Xunit;
 
@@ -23,10 +24,11 @@ public class TagUpdateSafetyLiveHarnessContractTests
     public void Script_ApplyDriftRequiresExplicitAuthorizationAndPreflightedReadableFlag()
     {
         var text = ReadScript();
-        var applyGuard = text.IndexOf(
+        var main = ExtractTopLevelFunction(text, "Invoke-Main");
+        var applyGuard = main.IndexOf(
             "if ($Mode -eq 'ApplyDrift' -and -not $AllowApply)",
             StringComparison.Ordinal);
-        var mainTry = text.IndexOf("try {\n    $script:WorkerProcess", StringComparison.Ordinal);
+        var mainTry = main.IndexOf("try {\n        $script:WorkerProcess", StringComparison.Ordinal);
 
         Assert.True(applyGuard >= 0, "Expected an explicit ApplyDrift AllowApply guard.");
         Assert.True(mainTry > applyGuard, "AllowApply must be checked before the harness starts a child process.");
@@ -38,9 +40,10 @@ public class TagUpdateSafetyLiveHarnessContractTests
         var text = ReadScript();
         var identityReader = ExtractTopLevelFunction(text, "Get-CompleteSessionIdentity");
         var safetyReader = ExtractTopLevelFunction(text, "Read-UpdateTagSafetySnapshot");
-        var mainTry = text.IndexOf("try {\n    $script:WorkerProcess", StringComparison.Ordinal);
-        var statusCall = text.IndexOf("Get-CompleteSessionIdentity", mainTry, StringComparison.Ordinal);
-        var firstSafetyRead = text.IndexOf("Read-UpdateTagSafetySnapshot", statusCall + 1, StringComparison.Ordinal);
+        var main = ExtractTopLevelFunction(text, "Invoke-Main");
+        var mainTry = main.IndexOf("try {\n        $script:WorkerProcess", StringComparison.Ordinal);
+        var statusCall = main.IndexOf("Get-CompleteSessionIdentity", mainTry, StringComparison.Ordinal);
+        var firstSafetyRead = main.IndexOf("Read-UpdateTagSafetySnapshot", statusCall + 1, StringComparison.Ordinal);
 
         Assert.Contains("get_project_status", identityReader, StringComparison.Ordinal);
         Assert.Contains("$script:WorkerSessionIdentity = $identity", identityReader, StringComparison.Ordinal);
@@ -55,8 +58,9 @@ public class TagUpdateSafetyLiveHarnessContractTests
     {
         var text = ReadScript();
         var probeGuard = ExtractTopLevelFunction(text, "Assert-OptionalProbeTargetIsDistinct");
-        var entryPoint = text.IndexOf("if ($Mode -eq 'ProbeUnavailable')", StringComparison.Ordinal);
-        var guardCall = text.IndexOf("Assert-OptionalProbeTargetIsDistinct", entryPoint, StringComparison.Ordinal);
+        var main = ExtractTopLevelFunction(text, "Invoke-Main");
+        var entryPoint = main.IndexOf("if ($Mode -eq 'ProbeUnavailable')", StringComparison.Ordinal);
+        var guardCall = main.IndexOf("Assert-OptionalProbeTargetIsDistinct", entryPoint, StringComparison.Ordinal);
 
         Assert.Contains("$ProbeTableName", probeGuard, StringComparison.Ordinal);
         Assert.Contains("$ProbeTagName", probeGuard, StringComparison.Ordinal);
@@ -70,6 +74,28 @@ public class TagUpdateSafetyLiveHarnessContractTests
         var mcpTool = ExtractTopLevelFunction(text, "Invoke-McpTool");
         Assert.Contains("[switch]$AllowApplicationError", mcpTool, StringComparison.Ordinal);
         Assert.Contains("-AllowApplicationError", probeCase, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_DefinesOptionalProbeGuardBeforeTheEntrypointCanCallIt()
+    {
+        var text = ReadScript();
+        var guardDefinition = text.IndexOf(
+            "function Assert-OptionalProbeTargetIsDistinct {",
+            StringComparison.Ordinal);
+        var mainDefinition = text.IndexOf("function Invoke-Main {", StringComparison.Ordinal);
+        var guardCall = text.IndexOf(
+            "\n        Assert-OptionalProbeTargetIsDistinct",
+            mainDefinition,
+            StringComparison.Ordinal);
+        var finalMainCall = text.LastIndexOf("\nInvoke-Main", StringComparison.Ordinal);
+
+        Assert.True(guardDefinition >= 0 && guardDefinition < mainDefinition,
+            "The optional-probe guard must be defined before the entrypoint function.");
+        Assert.True(mainDefinition >= 0 && mainDefinition < guardCall,
+            "The entrypoint must call the already-defined optional-probe guard.");
+        Assert.True(finalMainCall > mainDefinition,
+            "The script must invoke Main only after every function has been defined.");
     }
 
     [Fact]
@@ -92,15 +118,12 @@ public class TagUpdateSafetyLiveHarnessContractTests
     }
 
     [Fact]
-    public void Script_ReadRejectsApplicationErrorsAndComparesThePublicTagRow()
+    public void Script_ReadComparesThePublicTagRow()
     {
         var text = ReadScript();
-        var mcpTool = ExtractTopLevelFunction(text, "Invoke-McpTool");
         var publicComparison = ExtractTopLevelFunction(text, "Assert-PublicTagRowMatchesSnapshot");
         var readCase = ExtractSwitchCase(text, "Read", "PreviewDrift");
 
-        Assert.Contains("$result.isError", mcpTool, StringComparison.Ordinal);
-        Assert.Contains("$ToolCall.Result.isError", publicComparison, StringComparison.Ordinal);
         Assert.Contains("$Snapshot", publicComparison, StringComparison.Ordinal);
         Assert.Contains("Invoke-McpTool -Name 'execute_read_batch'", readCase, StringComparison.Ordinal);
         Assert.Contains("operation = 'list_tag_tables'", readCase, StringComparison.Ordinal);
@@ -109,6 +132,56 @@ public class TagUpdateSafetyLiveHarnessContractTests
             readCase.IndexOf("Assert-PublicTagRowMatchesSnapshot", StringComparison.Ordinal)
             > readCase.IndexOf("Invoke-McpTool -Name 'execute_read_batch'", StringComparison.Ordinal),
             "Read must compare the public list_tag_tables row after its call succeeds.");
+    }
+
+    [Fact]
+    public async Task Script_InvokeMcpToolAcceptsOmittedIsErrorAndHonorsExplicitApplicationErrors()
+    {
+        var text = ReadScript();
+        Assert.DoesNotMatch(new Regex(@"\.\s*isError\b", RegexOptions.IgnoreCase), text);
+        var resultErrorReader = ExtractTopLevelFunction(text, "Test-McpToolResultIsError");
+        var invokeMcpTool = ExtractTopLevelFunction(text, "Invoke-McpTool");
+        var fixture = $$"""
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            function Invoke-McpRequest {
+                param([string]$Method, [hashtable]$Params)
+                return $script:NextResult
+            }
+            {{resultErrorReader}}
+            {{invokeMcpTool}}
+            $script:NextResult = [pscustomobject]@{
+                content = @([pscustomobject]@{ text = '{"success":true}' })
+            }
+            $success = Invoke-McpTool -Name 'fixture' -Arguments @{}
+            if ($null -eq $success.Document -or -not $success.Document.success) {
+                throw 'A legal result without isError was not decoded.'
+            }
+            $script:NextResult = [pscustomobject]@{
+                isError = $true
+                content = @([pscustomobject]@{ text = '{"success":false}' })
+            }
+            $rejected = $false
+            try {
+                $null = Invoke-McpTool -Name 'fixture' -Arguments @{}
+            }
+            catch {
+                if ($_.Exception.Message -notlike '*application error*') { throw }
+                $rejected = $true
+            }
+            if (-not $rejected) { throw 'An explicit isError:true result was not rejected.' }
+            $observed = Invoke-McpTool -Name 'fixture' -Arguments @{} -AllowApplicationError
+            if ($null -eq $observed.Document -or $observed.Document.success) {
+                throw 'AllowApplicationError did not preserve the application-error document.'
+            }
+            Write-Output 'fixture-ok'
+            """;
+
+        var result = await RunPowerShellFixtureAsync(fixture);
+
+        Assert.True(result.ExitCode == 0,
+            $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
+        Assert.Contains("fixture-ok", result.StandardOutput, StringComparison.Ordinal);
     }
 
     private static string ReadScript()
@@ -131,7 +204,7 @@ public class TagUpdateSafetyLiveHarnessContractTests
         Assert.True(start >= 0, $"Expected '{name}' switch case.");
         if (nextName == "}")
         {
-            var finallyStart = text.IndexOf("\n}\nfinally", start, StringComparison.Ordinal);
+            var finallyStart = text.IndexOf("\n        }\n    }\n    finally", start, StringComparison.Ordinal);
             Assert.True(finallyStart > start, $"Expected switch closing boundary after '{name}'.");
             return text[start..finallyStart];
         }
@@ -139,6 +212,40 @@ public class TagUpdateSafetyLiveHarnessContractTests
         Assert.True(end > start, $"Expected '{nextName}' after '{name}'.");
         return text[start..end];
     }
+
+    private static async Task<PowerShellResult> RunPowerShellFixtureAsync(string fixture)
+    {
+        var fixturePath = Path.Combine(Path.GetTempPath(), $"tag-update-harness-{Guid.NewGuid():N}.ps1");
+        await File.WriteAllTextAsync(fixturePath, fixture + Environment.NewLine);
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-NonInteractive");
+        startInfo.ArgumentList.Add("-File");
+        startInfo.ArgumentList.Add(fixturePath);
+
+        try
+        {
+            using var process = new Process { StartInfo = startInfo };
+            Assert.True(process.Start(), "Expected the PowerShell fixture process to start.");
+            var standardOutput = await process.StandardOutput.ReadToEndAsync();
+            var standardError = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+            return new PowerShellResult(process.ExitCode, standardOutput, standardError);
+        }
+        finally
+        {
+            File.Delete(fixturePath);
+        }
+    }
+
+    private sealed record PowerShellResult(int ExitCode, string StandardOutput, string StandardError);
 
     private static string GetRepositoryRoot()
         => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));

--- a/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
@@ -226,6 +226,64 @@ public class TagUpdateSafetyLiveHarnessContractTests
         Assert.Contains("empty-arguments-started", result.StandardOutput, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task Script_InvokeWorkerRequest_IncludesProtocolVersionOnNonHelloRequests()
+    {
+        var text = ReadScript();
+        var launcher = ExtractTopLevelFunction(text, "Start-JsonLineProcess");
+        var stopper = ExtractTopLevelFunction(text, "Stop-JsonLineProcess");
+        var sender = ExtractTopLevelFunction(text, "Send-JsonLine");
+        var reader = ExtractTopLevelFunction(text, "Read-JsonLine");
+        var successAssertion = ExtractTopLevelFunction(text, "Assert-WorkerSuccess");
+        var requestInvoker = ExtractTopLevelFunction(text, "Invoke-WorkerRequest");
+        var fixture = $$"""
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            $TimeoutSeconds = 10
+            {{launcher}}
+            {{stopper}}
+            {{sender}}
+            {{reader}}
+            {{successAssertion}}
+            {{requestInvoker}}
+            $workerFixture = @'
+            $line = [Console]::In.ReadLine()
+            if ($null -eq $line) { exit 1 }
+            $request = $line | ConvertFrom-Json -Depth 10
+            if ($request.method -ne 'get_project_status') {
+                Write-Output (@{ success = $false; failureCategory = 'validation_error'; error = 'controlled child received an unexpected method' } | ConvertTo-Json -Compress)
+                exit 0
+            }
+            if ($request.PSObject.Properties['protocolVersion'] -eq $null -or $request.protocolVersion -ne 'project-binding-v1') {
+                Write-Output (@{ success = $false; failureCategory = 'validation_error'; error = 'controlled child: request did not carry protocolVersion project-binding-v1' } | ConvertTo-Json -Compress)
+                exit 0
+            }
+            Write-Output (@{ success = $true; protocolVersion = $request.protocolVersion } | ConvertTo-Json -Compress)
+            '@
+            $workerPath = Join-Path ([System.IO.Path]::GetTempPath()) ("tag-update-worker-{{Guid.NewGuid():N}}.ps1")
+            $script:WorkerProcess = $null
+            try {
+                [System.IO.File]::WriteAllText($workerPath, $workerFixture, [System.Text.UTF8Encoding]::new($false))
+                $script:WorkerProcess = Start-JsonLineProcess -Executable (Join-Path $PSHOME 'pwsh.exe') -Arguments @('-NoProfile', '-NonInteractive', '-File', $workerPath) -Label 'controlled worker protocol fixture'
+                $response = Invoke-WorkerRequest -Method 'get_project_status' -Arguments @{ projectPath = 'C:\\fixture\\project.ap21' }
+                if ($response.protocolVersion -ne 'project-binding-v1') {
+                    throw 'The controlled child did not receive project-binding-v1 on the non-hello request.'
+                }
+                Write-Output 'worker-protocol-version-forwarded'
+            }
+            finally {
+                Stop-JsonLineProcess -Process $script:WorkerProcess
+                Remove-Item -LiteralPath $workerPath -Force -ErrorAction SilentlyContinue
+            }
+            """;
+
+        var result = await RunPowerShellFixtureAsync(fixture);
+
+        Assert.True(result.ExitCode == 0,
+            $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
+        Assert.Contains("worker-protocol-version-forwarded", result.StandardOutput, StringComparison.Ordinal);
+    }
+
     private static string ReadScript()
     {
         Assert.True(File.Exists(ScriptPath), $"Expected live harness at {ScriptPath}.");

--- a/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
@@ -184,6 +184,48 @@ public class TagUpdateSafetyLiveHarnessContractTests
         Assert.Contains("fixture-ok", result.StandardOutput, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task Script_StartJsonLineProcess_DoesNotRejectTheWorkerStyleEmptyArgumentArrayAtParameterBinding()
+    {
+        var launcher = ExtractTopLevelFunction(ReadScript(), "Start-JsonLineProcess");
+        var fixture = $$"""
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            {{launcher}}
+            $child = $null
+            try {
+                $childExecutable = Join-Path $PSHOME 'pwsh.exe'
+                if (-not (Test-Path -LiteralPath $childExecutable -PathType Leaf)) {
+                    throw "Expected a harmless local child executable at $childExecutable."
+                }
+                $child = Start-JsonLineProcess -Executable $childExecutable -Arguments @() -Label 'empty-arguments regression fixture'
+                if ($null -eq $child -or $child.HasExited) {
+                    throw 'The local child did not start with an empty argument array.'
+                }
+                Write-Output 'empty-arguments-started'
+            }
+            finally {
+                if ($null -ne $child) {
+                    try {
+                        if (-not $child.HasExited) {
+                            $child.Kill($true)
+                            $child.WaitForExit()
+                        }
+                    }
+                    finally {
+                        $child.Dispose()
+                    }
+                }
+            }
+            """;
+
+        var result = await RunPowerShellFixtureAsync(fixture);
+
+        Assert.True(result.ExitCode == 0,
+            $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
+        Assert.Contains("empty-arguments-started", result.StandardOutput, StringComparison.Ordinal);
+    }
+
     private static string ReadScript()
     {
         Assert.True(File.Exists(ScriptPath), $"Expected live harness at {ScriptPath}.");

--- a/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
@@ -23,35 +23,121 @@ public class TagUpdateSafetyLiveHarnessContractTests
     public void Script_ApplyDriftRequiresExplicitAuthorizationAndPreflightedReadableFlag()
     {
         var text = ReadScript();
-        Assert.Matches(new Regex(@"\[switch\]\s*\$AllowApply"), text);
-        Assert.Contains("$DriftFlagName", text, StringComparison.Ordinal);
-        Assert.Contains("read_update_tag_safety_snapshot", text, StringComparison.Ordinal);
-        Assert.Contains("state_changed", text, StringComparison.Ordinal);
+        var applyGuard = text.IndexOf(
+            "if ($Mode -eq 'ApplyDrift' -and -not $AllowApply)",
+            StringComparison.Ordinal);
+        var mainTry = text.IndexOf("try {\n    $script:WorkerProcess", StringComparison.Ordinal);
+
+        Assert.True(applyGuard >= 0, "Expected an explicit ApplyDrift AllowApply guard.");
+        Assert.True(mainTry > applyGuard, "AllowApply must be checked before the harness starts a child process.");
     }
 
     [Fact]
     public void Script_InternalSafetyReadCarriesObservedSessionIdentity()
     {
         var text = ReadScript();
-        Assert.Contains("get_project_status", text, StringComparison.Ordinal);
-        Assert.Contains("sessionIdentity", text, StringComparison.Ordinal);
-        Assert.Contains("expectedSessionIdentity", text, StringComparison.Ordinal);
-        Assert.Contains("read_update_tag_safety_snapshot", text, StringComparison.Ordinal);
+        var identityReader = ExtractTopLevelFunction(text, "Get-CompleteSessionIdentity");
+        var safetyReader = ExtractTopLevelFunction(text, "Read-UpdateTagSafetySnapshot");
+        var mainTry = text.IndexOf("try {\n    $script:WorkerProcess", StringComparison.Ordinal);
+        var statusCall = text.IndexOf("Get-CompleteSessionIdentity", mainTry, StringComparison.Ordinal);
+        var firstSafetyRead = text.IndexOf("Read-UpdateTagSafetySnapshot", statusCall + 1, StringComparison.Ordinal);
+
+        Assert.Contains("get_project_status", identityReader, StringComparison.Ordinal);
+        Assert.Contains("$script:WorkerSessionIdentity = $identity", identityReader, StringComparison.Ordinal);
+        Assert.Contains("expectedSessionIdentity = $script:WorkerSessionIdentity", safetyReader, StringComparison.Ordinal);
+        Assert.DoesNotContain("expectedSessionIdentity = @{", safetyReader, StringComparison.Ordinal);
+        Assert.True(statusCall >= 0 && firstSafetyRead > statusCall,
+            "The entry point must establish the observed identity before any safety read.");
     }
 
     [Fact]
     public void Script_OptionalUnavailableProbeUsesSeparateTargetInputs()
     {
         var text = ReadScript();
-        Assert.Contains("$ProbeTagName", text, StringComparison.Ordinal);
-        Assert.Contains("$ProbeFlagName", text, StringComparison.Ordinal);
-        Assert.Contains("'ProbeUnavailable'", text, StringComparison.Ordinal);
+        var probeGuard = ExtractTopLevelFunction(text, "Assert-OptionalProbeTargetIsDistinct");
+        var entryPoint = text.IndexOf("if ($Mode -eq 'ProbeUnavailable')", StringComparison.Ordinal);
+        var guardCall = text.IndexOf("Assert-OptionalProbeTargetIsDistinct", entryPoint, StringComparison.Ordinal);
+
+        Assert.Contains("$ProbeTableName", probeGuard, StringComparison.Ordinal);
+        Assert.Contains("$ProbeTagName", probeGuard, StringComparison.Ordinal);
+        Assert.Contains("$TableName", probeGuard, StringComparison.Ordinal);
+        Assert.Contains("$TagName", probeGuard, StringComparison.Ordinal);
+        Assert.Contains("$PlcName", probeGuard, StringComparison.Ordinal);
+        Assert.True(guardCall > entryPoint,
+            "ProbeUnavailable must reject a target identical to the mandatory drift target before startup.");
+
+        var probeCase = ExtractSwitchCase(text, "ProbeUnavailable", "}" );
+        var mcpTool = ExtractTopLevelFunction(text, "Invoke-McpTool");
+        Assert.Contains("[switch]$AllowApplicationError", mcpTool, StringComparison.Ordinal);
+        Assert.Contains("-AllowApplicationError", probeCase, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_ApplyDriftPreplansReconciliationAndVerifiesFinalSnapshot()
+    {
+        var text = ReadScript();
+        var applyCase = ExtractSwitchCase(text, "ApplyDrift", "ProbeUnavailable");
+        var firstMutatingApply = applyCase.IndexOf(
+            "Invoke-Apply -Operation $originalOperation -SafetyToken $intermediateToken",
+            StringComparison.Ordinal);
+        var reconciliationPlan = applyCase.IndexOf(
+            "New-UpdateTagOperation -Snapshot $snapshot -FlagName $DriftFlagName -Value $currentValue -OperationId 'update-tag-restore-original-flag'",
+            StringComparison.Ordinal);
+
+        Assert.True(reconciliationPlan >= 0 && reconciliationPlan < firstMutatingApply,
+            "ApplyDrift must prepare reconciliation before its intermediate mutation can be issued.");
+        Assert.DoesNotContain("if ($intermediateApplied)", applyCase, StringComparison.Ordinal);
+        Assert.Contains("Assert-SnapshotFlagEquals", applyCase, StringComparison.Ordinal);
+        Assert.Contains("-ExpectedValue $currentValue", applyCase, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_ReadRejectsApplicationErrorsAndComparesThePublicTagRow()
+    {
+        var text = ReadScript();
+        var mcpTool = ExtractTopLevelFunction(text, "Invoke-McpTool");
+        var publicComparison = ExtractTopLevelFunction(text, "Assert-PublicTagRowMatchesSnapshot");
+        var readCase = ExtractSwitchCase(text, "Read", "PreviewDrift");
+
+        Assert.Contains("$result.isError", mcpTool, StringComparison.Ordinal);
+        Assert.Contains("$ToolCall.Result.isError", publicComparison, StringComparison.Ordinal);
+        Assert.Contains("$Snapshot", publicComparison, StringComparison.Ordinal);
+        Assert.Contains("Invoke-McpTool -Name 'execute_read_batch'", readCase, StringComparison.Ordinal);
+        Assert.Contains("operation = 'list_tag_tables'", readCase, StringComparison.Ordinal);
+        Assert.Contains("Assert-PublicTagRowMatchesSnapshot", readCase, StringComparison.Ordinal);
+        Assert.True(
+            readCase.IndexOf("Assert-PublicTagRowMatchesSnapshot", StringComparison.Ordinal)
+            > readCase.IndexOf("Invoke-McpTool -Name 'execute_read_batch'", StringComparison.Ordinal),
+            "Read must compare the public list_tag_tables row after its call succeeds.");
     }
 
     private static string ReadScript()
     {
         Assert.True(File.Exists(ScriptPath), $"Expected live harness at {ScriptPath}.");
         return File.ReadAllText(ScriptPath).ReplaceLineEndings("\n");
+    }
+
+    private static string ExtractTopLevelFunction(string text, string name)
+    {
+        var start = text.IndexOf($"function {name} {{", StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Expected function '{name}'.");
+        var next = text.IndexOf("\nfunction ", start + 1, StringComparison.Ordinal);
+        return next >= 0 ? text[start..next] : text[start..];
+    }
+
+    private static string ExtractSwitchCase(string text, string name, string nextName)
+    {
+        var start = text.IndexOf($"'{name}' {{", StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Expected '{name}' switch case.");
+        if (nextName == "}")
+        {
+            var finallyStart = text.IndexOf("\n}\nfinally", start, StringComparison.Ordinal);
+            Assert.True(finallyStart > start, $"Expected switch closing boundary after '{name}'.");
+            return text[start..finallyStart];
+        }
+        var end = text.IndexOf($"'{nextName}' {{", start + 1, StringComparison.Ordinal);
+        Assert.True(end > start, $"Expected '{nextName}' after '{name}'.");
+        return text[start..end];
     }
 
     private static string GetRepositoryRoot()

--- a/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
@@ -1,0 +1,59 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public class TagUpdateSafetyLiveHarnessContractTests
+{
+    private static readonly string RepositoryRoot = GetRepositoryRoot();
+    private static readonly string ScriptPath = Path.Combine(
+        RepositoryRoot,
+        "scripts",
+        "live-test-update-tag-safety.ps1");
+
+    [Fact]
+    public void Script_DefaultModeIsReadOnly()
+    {
+        var text = ReadScript();
+        Assert.Matches(new Regex(@"\[ValidateSet\(\s*'Read'\s*,\s*'PreviewDrift'\s*,\s*'ApplyDrift'\s*,\s*'ProbeUnavailable'\s*\)\]"), text);
+        Assert.Matches(new Regex(@"\[string\]\s*\$Mode\s*=\s*'Read'"), text);
+    }
+
+    [Fact]
+    public void Script_ApplyDriftRequiresExplicitAuthorizationAndPreflightedReadableFlag()
+    {
+        var text = ReadScript();
+        Assert.Matches(new Regex(@"\[switch\]\s*\$AllowApply"), text);
+        Assert.Contains("$DriftFlagName", text, StringComparison.Ordinal);
+        Assert.Contains("read_update_tag_safety_snapshot", text, StringComparison.Ordinal);
+        Assert.Contains("state_changed", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_InternalSafetyReadCarriesObservedSessionIdentity()
+    {
+        var text = ReadScript();
+        Assert.Contains("get_project_status", text, StringComparison.Ordinal);
+        Assert.Contains("sessionIdentity", text, StringComparison.Ordinal);
+        Assert.Contains("expectedSessionIdentity", text, StringComparison.Ordinal);
+        Assert.Contains("read_update_tag_safety_snapshot", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_OptionalUnavailableProbeUsesSeparateTargetInputs()
+    {
+        var text = ReadScript();
+        Assert.Contains("$ProbeTagName", text, StringComparison.Ordinal);
+        Assert.Contains("$ProbeFlagName", text, StringComparison.Ordinal);
+        Assert.Contains("'ProbeUnavailable'", text, StringComparison.Ordinal);
+    }
+
+    private static string ReadScript()
+    {
+        Assert.True(File.Exists(ScriptPath), $"Expected live harness at {ScriptPath}.");
+        return File.ReadAllText(ScriptPath).ReplaceLineEndings("\n");
+    }
+
+    private static string GetRepositoryRoot()
+        => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+}

--- a/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
@@ -135,6 +135,64 @@ public class TagUpdateSafetyLiveHarnessContractTests
     }
 
     [Fact]
+    public async Task Script_PublicTagComparison_AcceptsDirectArrayResultAndRejectsSnapshotValueMismatches()
+    {
+        // Catches treating list_tag_tables' JSON array string as a { tables: ... } wrapper,
+        // or accepting a selected tag whose data type or logical address differs from the snapshot.
+        var text = ReadScript();
+        var errorReader = ExtractTopLevelFunction(text, "Test-McpToolResultIsError");
+        var comparison = ExtractTopLevelFunction(text, "Assert-PublicTagRowMatchesSnapshot");
+        var fixture = $$"""
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            {{errorReader}}
+            {{comparison}}
+            $responseText = @'
+            {
+              "success": true,
+              "operations": [{
+                "operationId": "public-list",
+                "operation": "list_tag_tables",
+                "status": "succeeded",
+                "result": "[{\"name\":\"Outputs\",\"folderPath\":\"\",\"isDefault\":false,\"tags\":[],\"userConstants\":[]},{\"name\":\"Inputs\",\"folderPath\":\"Other\",\"isDefault\":false,\"tags\":[],\"userConstants\":[]},{\"name\":\"Inputs\",\"folderPath\":\"\",\"isDefault\":false,\"tags\":[{\"name\":\"OtherTag\",\"dataType\":\"Int\",\"logicalAddress\":\"%IW2\"},{\"name\":\"DI_Reserve_1_7\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I1.7\"}],\"userConstants\":[]}]"
+              }]
+            }
+            '@
+            $toolCall = [pscustomobject]@{
+                Result = [pscustomobject]@{ content = @([pscustomobject]@{ type = 'text'; text = $responseText }) }
+                Text = $responseText
+                Document = $responseText | ConvertFrom-Json -Depth 100
+            }
+            $snapshot = [pscustomobject]@{
+                tableName = 'Inputs'; folderPath = ''; tagName = 'DI_Reserve_1_7'
+                dataType = 'Bool'; logicalAddress = '%I1.7'
+            }
+            Assert-PublicTagRowMatchesSnapshot -ToolCall $toolCall -Snapshot $snapshot
+            foreach ($mismatch in @(
+                [pscustomobject]@{ tableName = 'Inputs'; folderPath = ''; tagName = 'DI_Reserve_1_7'; dataType = 'Int'; logicalAddress = '%I1.7' },
+                [pscustomobject]@{ tableName = 'Inputs'; folderPath = ''; tagName = 'DI_Reserve_1_7'; dataType = 'Bool'; logicalAddress = '%I1.6' }
+            )) {
+                $rejected = $false
+                try {
+                    Assert-PublicTagRowMatchesSnapshot -ToolCall $toolCall -Snapshot $mismatch
+                }
+                catch {
+                    if ($_.Exception.Message -notlike '*tag values differ from the strict snapshot*') { throw }
+                    $rejected = $true
+                }
+                if (-not $rejected) { throw 'A public tag value mismatch was accepted.' }
+            }
+            Write-Output 'public-tag-array-compared'
+            """;
+
+        var result = await RunPowerShellFixtureAsync(fixture);
+
+        Assert.True(result.ExitCode == 0,
+            $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
+        Assert.Contains("public-tag-array-compared", result.StandardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Script_InvokeMcpToolAcceptsOmittedIsErrorAndHonorsExplicitApplicationErrors()
     {
         var text = ReadScript();

--- a/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
@@ -243,6 +243,187 @@ public class TagUpdateSafetyLiveHarnessContractTests
     }
 
     [Fact]
+    public async Task Script_InvokeMain_DefaultHostArgumentsBindTheExactProjectPath()
+    {
+        // Catches starting the host without --project or binding a path other than the harness target.
+        var main = ExtractTopLevelFunction(ReadScript(), "Invoke-Main");
+        var fixture = $$"""
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            $Mode = 'Fixture'
+            $AllowApply = $false
+            $ProjectPath = 'C:\fixture projects\bound target.ap21'
+            $TableName = 'Inputs'
+            $TagName = 'TargetTag'
+            $PlcName = 'PLC_1'
+            $HostArguments = $null
+            $WorkerExecutable = 'fixture-worker'
+            $script:RepositoryRoot = 'C:\fixture repo'
+            $script:HostProcess = $null
+            $script:WorkerProcess = $null
+            function Start-JsonLineProcess { return [pscustomobject]@{ Label = 'worker' } }
+            function Connect-Worker {}
+            function Get-CompleteSessionIdentity {}
+            function Start-McpHost {
+                $expectedHost = Join-Path $script:RepositoryRoot 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll'
+                if ($HostArguments.Count -ne 3 -or
+                    $HostArguments[0] -ne $expectedHost -or
+                    $HostArguments[1] -ne '--project' -or
+                    $HostArguments[2] -ne $ProjectPath) {
+                    throw "Default host arguments did not bind the exact project: $($HostArguments | ConvertTo-Json -Compress)"
+                }
+                Write-Output 'default-host-project-bound'
+            }
+            function Stop-JsonLineProcess {}
+            {{main}}
+            Invoke-Main
+            """;
+
+        var result = await RunPowerShellFixtureAsync(fixture);
+
+        Assert.True(result.ExitCode == 0,
+            $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
+        Assert.Contains("default-host-project-bound", result.StandardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Script_ProbeUnavailable_AcceptsOnlyDocumentLevelValidationRejectionWithoutToken()
+    {
+        // Catches requiring MCP isError for the registered validation result, accepting the wrong
+        // document shape/category, or dereferencing absent properties under StrictMode.
+        var text = ReadScript();
+        var resultErrorReader = ExtractTopLevelFunction(text, "Test-McpToolResultIsError");
+        var main = ExtractTopLevelFunction(text, "Invoke-Main");
+        var fixture = $$"""
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            $Mode = 'ProbeUnavailable'
+            $AllowApply = $false
+            $ProjectPath = 'C:\fixture\bound.ap21'
+            $TableName = 'Inputs'
+            $TagName = 'TargetTag'
+            $PlcName = 'PLC_1'
+            $ProbeTableName = 'ProbeInputs'
+            $ProbeTagName = 'UnavailableTag'
+            $ProbeFlagName = 'ExternalVisible'
+            $HostArguments = @('fixture-host', '--project', $ProjectPath)
+            $WorkerExecutable = 'fixture-worker'
+            $script:RepositoryRoot = 'C:\fixture'
+            $script:HostProcess = $null
+            $script:WorkerProcess = $null
+            function Assert-OptionalProbeTargetIsDistinct {}
+            function Start-JsonLineProcess { return [pscustomobject]@{ Label = 'worker' } }
+            function Connect-Worker {}
+            function Get-CompleteSessionIdentity {}
+            function Start-McpHost {}
+            function Stop-JsonLineProcess {}
+            function Read-UpdateTagSafetySnapshot {
+                return [pscustomobject]@{
+                    plcName = 'PLC_1'; folderPath = '/'; tableName = 'ProbeInputs'; tagName = 'UnavailableTag'
+                    dataType = 'Bool'; logicalAddress = '%I0.0'; ExternalVisible = $null
+                }
+            }
+            function New-UpdateTagOperation { return [ordered]@{ operation = 'update_tag' } }
+            function Invoke-McpTool { return $script:NextToolCall }
+            {{resultErrorReader}}
+            {{main}}
+            $cases = @(
+                [pscustomobject]@{
+                    Name = 'expected validation rejection'; Accept = $true
+                    Call = [pscustomobject]@{
+                        Result = [pscustomobject]@{}
+                        Text = '{"success":false,"failureCategory":"validation_error","error":"requested flag is unavailable"}'
+                        Document = [pscustomobject]@{ success = $false; failureCategory = 'validation_error'; error = 'requested flag is unavailable' }
+                    }
+                },
+                [pscustomobject]@{
+                    Name = 'successful preview'; Accept = $false
+                    Call = [pscustomobject]@{ Result = [pscustomobject]@{}; Text = '{"success":true}'; Document = [pscustomobject]@{ success = $true } }
+                },
+                [pscustomobject]@{
+                    Name = 'wrong failure category'; Accept = $false
+                    Call = [pscustomobject]@{ Result = [pscustomobject]@{}; Text = '{"success":false,"failureCategory":"protocol_error"}'; Document = [pscustomobject]@{ success = $false; failureCategory = 'protocol_error' } }
+                },
+                [pscustomobject]@{
+                    Name = 'missing document'; Accept = $false
+                    Call = [pscustomobject]@{ Result = [pscustomobject]@{}; Text = ''; Document = $null }
+                },
+                [pscustomobject]@{
+                    Name = 'missing success property'; Accept = $false
+                    Call = [pscustomobject]@{ Result = [pscustomobject]@{}; Text = '{"failureCategory":"validation_error"}'; Document = [pscustomobject]@{ failureCategory = 'validation_error' } }
+                },
+                [pscustomobject]@{
+                    Name = 'rejection carrying a token'; Accept = $false
+                    Call = [pscustomobject]@{
+                        Result = [pscustomobject]@{}
+                        Text = '{"success":false,"failureCategory":"validation_error","safetyToken":"unsafe"}'
+                        Document = [pscustomobject]@{ success = $false; failureCategory = 'validation_error'; safetyToken = 'unsafe' }
+                    }
+                }
+            )
+            foreach ($case in $cases) {
+                $script:NextToolCall = $case.Call
+                $accepted = $true
+                try { Invoke-Main } catch { $accepted = $false }
+                if ($accepted -ne $case.Accept) {
+                    throw "ProbeUnavailable case '$($case.Name)' acceptance was '$accepted', expected '$($case.Accept)'."
+                }
+            }
+            Write-Output 'probe-result-matrix-enforced'
+            """;
+
+        var result = await RunPowerShellFixtureAsync(fixture);
+
+        Assert.True(result.ExitCode == 0,
+            $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
+        Assert.Contains("probe-result-matrix-enforced", result.StandardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Script_GetPreviewToken_PreservesTokenlessFailureDiagnosticUnderStrictMode()
+    {
+        // Catches reading Document.safetyToken before proving success and property presence.
+        var text = ReadScript();
+        var resultErrorReader = ExtractTopLevelFunction(text, "Test-McpToolResultIsError");
+        var tokenReader = ExtractTopLevelFunction(text, "Get-PreviewToken");
+        var fixture = $$"""
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            {{resultErrorReader}}
+            {{tokenReader}}
+            $diagnostic = '{"success":false,"failureCategory":"validation_error","error":"controlled tokenless preview"}'
+            $failedCall = [pscustomobject]@{
+                Result = [pscustomobject]@{}
+                Text = $diagnostic
+                Document = $diagnostic | ConvertFrom-Json -Depth 10
+            }
+            $rejected = $false
+            try { $null = Get-PreviewToken -ToolCall $failedCall }
+            catch {
+                if ($_.Exception.Message -notlike "*$diagnostic*") { throw }
+                if ($_.Exception.Message -like "*property 'safetyToken' cannot be found*") { throw }
+                $rejected = $true
+            }
+            if (-not $rejected) { throw 'The tokenless failed preview was accepted.' }
+            $successfulCall = [pscustomobject]@{
+                Result = [pscustomobject]@{}
+                Text = '{"success":true,"safetyToken":"fixture-token"}'
+                Document = [pscustomobject]@{ success = $true; safetyToken = 'fixture-token' }
+            }
+            if ((Get-PreviewToken -ToolCall $successfulCall) -ne 'fixture-token') {
+                throw 'The successful preview token was not returned.'
+            }
+            Write-Output 'tokenless-preview-diagnostic-preserved'
+            """;
+
+        var result = await RunPowerShellFixtureAsync(fixture);
+
+        Assert.True(result.ExitCode == 0,
+            $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
+        Assert.Contains("tokenless-preview-diagnostic-preserved", result.StandardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Script_StartJsonLineProcess_DoesNotRejectTheWorkerStyleEmptyArgumentArrayAtParameterBinding()
     {
         var launcher = ExtractTopLevelFunction(ReadScript(), "Start-JsonLineProcess");
@@ -431,7 +612,12 @@ public class TagUpdateSafetyLiveHarnessContractTests
         var start = text.IndexOf($"function {name} {{", StringComparison.Ordinal);
         Assert.True(start >= 0, $"Expected function '{name}'.");
         var next = text.IndexOf("\nfunction ", start + 1, StringComparison.Ordinal);
-        return next >= 0 ? text[start..next] : text[start..];
+        if (next >= 0)
+        {
+            return text[start..next];
+        }
+        var entryPoint = text.IndexOf("\n\nInvoke-Main", start + 1, StringComparison.Ordinal);
+        return entryPoint >= 0 ? text[start..entryPoint] : text[start..];
     }
 
     private static string ExtractSwitchCase(string text, string name, string nextName)

--- a/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
@@ -243,6 +243,51 @@ public class TagUpdateSafetyLiveHarnessContractTests
     }
 
     [Fact]
+    public async Task Script_InvokeMcpTool_ApplicationErrorDoesNotLeakReturnedSafetyToken()
+    {
+        // Catches composing arbitrary application-error content into the default exception path.
+        var text = ReadScript();
+        var resultErrorReader = ExtractTopLevelFunction(text, "Test-McpToolResultIsError");
+        var invokeMcpTool = ExtractTopLevelFunction(text, "Invoke-McpTool");
+        var fixture = $$"""
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            $secret = 'fixture-application-error-secret-token'
+            function Invoke-McpRequest {
+                param([string]$Method, [hashtable]$Params)
+                return [pscustomobject]@{
+                    isError = $true
+                    content = @([pscustomobject]@{
+                        text = '{"success":false,"failureCategory":"validation_error","safetyToken":"fixture-application-error-secret-token"}'
+                    })
+                }
+            }
+            {{resultErrorReader}}
+            {{invokeMcpTool}}
+            $rejected = $false
+            try {
+                $null = Invoke-McpTool -Name 'preview_write_batch' -Arguments @{}
+            }
+            catch {
+                $message = $_.Exception.Message
+                if ($message -notlike '*application error*') { throw }
+                if ($message -like "*$secret*") {
+                    throw 'Invoke-McpTool leaked the returned safety token.'
+                }
+                $rejected = $true
+            }
+            if (-not $rejected) { throw 'An explicit isError:true result was not rejected.' }
+            Write-Output 'application-error-token-redacted'
+            """;
+
+        var result = await RunPowerShellFixtureAsync(fixture);
+
+        Assert.True(result.ExitCode == 0,
+            $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
+        Assert.Contains("application-error-token-redacted", result.StandardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Script_InvokeMain_DefaultHostArgumentsBindTheExactProjectPath()
     {
         // Catches starting the host without --project or binding a path other than the harness target.
@@ -377,6 +422,75 @@ public class TagUpdateSafetyLiveHarnessContractTests
         Assert.True(result.ExitCode == 0,
             $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
         Assert.Contains("probe-result-matrix-enforced", result.StandardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Script_ProbeUnavailable_UnexpectedDocumentDoesNotLeakReturnedSafetyToken()
+    {
+        // Catches composing the raw preview document into optional-probe shape diagnostics.
+        var text = ReadScript();
+        var resultErrorReader = ExtractTopLevelFunction(text, "Test-McpToolResultIsError");
+        var main = ExtractTopLevelFunction(text, "Invoke-Main");
+        var fixture = $$"""
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            $secret = 'fixture-probe-secret-token'
+            $Mode = 'ProbeUnavailable'
+            $AllowApply = $false
+            $ProjectPath = 'C:\fixture\bound.ap21'
+            $TableName = 'Inputs'
+            $TagName = 'TargetTag'
+            $PlcName = 'PLC_1'
+            $ProbeTableName = 'ProbeInputs'
+            $ProbeTagName = 'UnavailableTag'
+            $ProbeFlagName = 'ExternalVisible'
+            $HostArguments = @('fixture-host', '--project', $ProjectPath)
+            $WorkerExecutable = 'fixture-worker'
+            $script:RepositoryRoot = 'C:\fixture'
+            $script:HostProcess = $null
+            $script:WorkerProcess = $null
+            function Assert-OptionalProbeTargetIsDistinct {}
+            function Start-JsonLineProcess { return [pscustomobject]@{ Label = 'worker' } }
+            function Connect-Worker {}
+            function Get-CompleteSessionIdentity {}
+            function Start-McpHost {}
+            function Stop-JsonLineProcess {}
+            function Read-UpdateTagSafetySnapshot {
+                return [pscustomobject]@{
+                    plcName = 'PLC_1'; folderPath = '/'; tableName = 'ProbeInputs'; tagName = 'UnavailableTag'
+                    dataType = 'Bool'; logicalAddress = '%I0.0'; ExternalVisible = $null
+                }
+            }
+            function New-UpdateTagOperation { return [ordered]@{ operation = 'update_tag' } }
+            function Invoke-McpTool {
+                return [pscustomobject]@{
+                    Result = [pscustomobject]@{}
+                    Text = '{"failureCategory":"validation_error","safetyToken":"fixture-probe-secret-token"}'
+                    Document = [pscustomobject]@{ failureCategory = 'validation_error'; safetyToken = $secret }
+                }
+            }
+            {{resultErrorReader}}
+            {{main}}
+            $rejected = $false
+            try { Invoke-Main }
+            catch {
+                $message = $_.Exception.Message
+                if ($message -notlike '*expected validation document*' -and
+                    $message -notlike '*success:false*') { throw }
+                if ($message -like "*$secret*") {
+                    throw 'ProbeUnavailable leaked the returned safety token.'
+                }
+                $rejected = $true
+            }
+            if (-not $rejected) { throw 'The malformed optional-probe document was accepted.' }
+            Write-Output 'probe-error-token-redacted'
+            """;
+
+        var result = await RunPowerShellFixtureAsync(fixture);
+
+        Assert.True(result.ExitCode == 0,
+            $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
+        Assert.Contains("probe-error-token-redacted", result.StandardOutput, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
@@ -400,7 +400,7 @@ public class TagUpdateSafetyLiveHarnessContractTests
             $rejected = $false
             try { $null = Get-PreviewToken -ToolCall $failedCall }
             catch {
-                if ($_.Exception.Message -notlike "*$diagnostic*") { throw }
+                if ($_.Exception.Message -notlike '*validation_error*' -or $_.Exception.Message -notlike '*controlled tokenless preview*') { throw }
                 if ($_.Exception.Message -like "*property 'safetyToken' cannot be found*") { throw }
                 $rejected = $true
             }
@@ -421,6 +421,118 @@ public class TagUpdateSafetyLiveHarnessContractTests
         Assert.True(result.ExitCode == 0,
             $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
         Assert.Contains("tokenless-preview-diagnostic-preserved", result.StandardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Script_GetPreviewToken_AcceptsRegisteredSuccessShapeWithoutOptionalSuccessMember()
+    {
+        // Catches treating the optional success member as mandatory when the registered preview
+        // has already proved success by returning a nonblank top-level safetyToken.
+        var text = ReadScript();
+        var resultErrorReader = ExtractTopLevelFunction(text, "Test-McpToolResultIsError");
+        var tokenReader = ExtractTopLevelFunction(text, "Get-PreviewToken");
+        var fixture = $$"""
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            {{resultErrorReader}}
+            {{tokenReader}}
+            $registeredPreviewText = '{"safetyToken":"registered-preview-token","expiresAt":"2026-09-05T12:00:00Z","summary":"Preview only"}'
+            $registeredPreview = [pscustomobject]@{
+                Result = [pscustomobject]@{}
+                Text = $registeredPreviewText
+                Document = $registeredPreviewText | ConvertFrom-Json -Depth 10
+            }
+            if ((Get-PreviewToken -ToolCall $registeredPreview) -ne 'registered-preview-token') {
+                throw 'The registered successful preview token was not returned.'
+            }
+            Write-Output 'registered-preview-token-accepted'
+            """;
+
+        var result = await RunPowerShellFixtureAsync(fixture);
+
+        Assert.True(result.ExitCode == 0,
+            $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
+        Assert.Contains("registered-preview-token-accepted", result.StandardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Script_GetPreviewToken_FailsClosedForInvalidShapesWithoutLeakingToken()
+    {
+        // Catches accepting application errors, invalid optional success members, or missing/blank
+        // tokens, and catches copying a returned token into an exception message.
+        var text = ReadScript();
+        var resultErrorReader = ExtractTopLevelFunction(text, "Test-McpToolResultIsError");
+        var tokenReader = ExtractTopLevelFunction(text, "Get-PreviewToken");
+        var fixture = $$"""
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            {{resultErrorReader}}
+            {{tokenReader}}
+            $secret = 'fixture-secret-token'
+            $cases = @(
+                [pscustomobject]@{
+                    Name = 'MCP application error'; ExpectedDiagnostic = $null
+                    Call = [pscustomobject]@{
+                        Result = [pscustomobject]@{ isError = $true }
+                        Text = '{"safetyToken":"fixture-secret-token"}'
+                        Document = [pscustomobject]@{ safetyToken = $secret }
+                    }
+                },
+                [pscustomobject]@{
+                    Name = 'null document'; ExpectedDiagnostic = $null
+                    Call = [pscustomobject]@{ Result = [pscustomobject]@{}; Text = $null; Document = $null }
+                },
+                [pscustomobject]@{
+                    Name = 'malformed document'; ExpectedDiagnostic = $null
+                    Call = [pscustomobject]@{ Result = [pscustomobject]@{}; Text = '{not-json fixture-secret-token'; Document = $null }
+                },
+                [pscustomobject]@{
+                    Name = 'explicit failure'; ExpectedDiagnostic = 'validation_error'
+                    Call = [pscustomobject]@{
+                        Result = [pscustomobject]@{}
+                        Text = '{"success":false,"failureCategory":"validation_error","error":"controlled failure","safetyToken":"fixture-secret-token"}'
+                        Document = [pscustomobject]@{ success = $false; failureCategory = 'validation_error'; error = 'controlled failure'; safetyToken = $secret }
+                    }
+                },
+                [pscustomobject]@{
+                    Name = 'non-boolean success'; ExpectedDiagnostic = $null
+                    Call = [pscustomobject]@{
+                        Result = [pscustomobject]@{}
+                        Text = '{"success":"true","safetyToken":"fixture-secret-token"}'
+                        Document = [pscustomobject]@{ success = 'true'; safetyToken = $secret }
+                    }
+                },
+                [pscustomobject]@{
+                    Name = 'missing token'; ExpectedDiagnostic = $null
+                    Call = [pscustomobject]@{ Result = [pscustomobject]@{}; Text = '{"summary":"preview"}'; Document = [pscustomobject]@{ summary = 'preview' } }
+                },
+                [pscustomobject]@{
+                    Name = 'blank token'; ExpectedDiagnostic = $null
+                    Call = [pscustomobject]@{ Result = [pscustomobject]@{}; Text = '{"safetyToken":"   "}'; Document = [pscustomobject]@{ safetyToken = '   ' } }
+                }
+            )
+            foreach ($case in $cases) {
+                $rejected = $false
+                try { $null = Get-PreviewToken -ToolCall $case.Call }
+                catch {
+                    $message = $_.Exception.Message
+                    if ($message -notlike '*preview_write_batch*') { throw }
+                    if ($message -like "*$secret*") { throw "Case '$($case.Name)' leaked a safety token." }
+                    if ($null -ne $case.ExpectedDiagnostic -and $message -notlike "*$($case.ExpectedDiagnostic)*") {
+                        throw "Case '$($case.Name)' lost its useful diagnostic."
+                    }
+                    $rejected = $true
+                }
+                if (-not $rejected) { throw "Case '$($case.Name)' was accepted." }
+            }
+            Write-Output 'invalid-preview-token-shapes-rejected'
+            """;
+
+        var result = await RunPowerShellFixtureAsync(fixture);
+
+        Assert.True(result.ExitCode == 0,
+            $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
+        Assert.Contains("invalid-preview-token-shapes-rejected", result.StandardOutput, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateSafetyLiveHarnessContractTests.cs
@@ -284,6 +284,84 @@ public class TagUpdateSafetyLiveHarnessContractTests
         Assert.Contains("worker-protocol-version-forwarded", result.StandardOutput, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Script_InvokeMcpRequest_AcceptsOmittedErrorAndRejectsExplicitJsonRpcError(bool returnError)
+    {
+        var text = ReadScript();
+        var launcher = ExtractTopLevelFunction(text, "Start-JsonLineProcess");
+        var stopper = ExtractTopLevelFunction(text, "Stop-JsonLineProcess");
+        var sender = ExtractTopLevelFunction(text, "Send-JsonLine");
+        var reader = ExtractTopLevelFunction(text, "Read-JsonLine");
+        var requestInvoker = ExtractTopLevelFunction(text, "Invoke-McpRequest");
+        var fixture = $$"""
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            $TimeoutSeconds = 10
+            $script:NextRequestId = 0
+            {{launcher}}
+            {{stopper}}
+            {{sender}}
+            {{reader}}
+            {{requestInvoker}}
+            $hostFixture = @'
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            $request = [Console]::In.ReadLine() | ConvertFrom-Json -Depth 10
+            if ($request.jsonrpc -ne '2.0' -or $request.method -ne 'fixture/read' -or $request.params.target -ne 'fixture-tag') {
+                throw 'The controlled child received an unexpected request.'
+            }
+            Write-Output (@{ jsonrpc = '2.0'; id = ($request.id + 100); result = @{ value = 'uncorrelated' } } | ConvertTo-Json -Compress)
+            if (${{returnError.ToString().ToLowerInvariant()}}) {
+                Write-Output (@{ jsonrpc = '2.0'; id = $request.id; error = @{ code = -32602; message = 'controlled invalid params'; data = @{ target = 'fixture-tag' } } } | ConvertTo-Json -Compress -Depth 10)
+            }
+            else {
+                Write-Output (@{ jsonrpc = '2.0'; id = $request.id; result = @{ value = 'correlated-success' } } | ConvertTo-Json -Compress)
+            }
+            $null = [Console]::In.ReadLine()
+            '@
+            $encodedHost = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($hostFixture))
+            $script:HostProcess = $null
+            try {
+                $script:HostProcess = Start-JsonLineProcess -Executable (Join-Path $PSHOME 'pwsh.exe') -Arguments @('-NoProfile', '-NonInteractive', '-EncodedCommand', $encodedHost) -Label 'controlled JSON-RPC fixture'
+                $rejected = $false
+                try {
+                    $result = Invoke-McpRequest -Method 'fixture/read' -Params @{ target = 'fixture-tag' }
+                    if (${{returnError.ToString().ToLowerInvariant()}}) {
+                        throw 'An explicit JSON-RPC error was accepted.'
+                    }
+                    if ($result.value -ne 'correlated-success') {
+                        throw 'The legal success result was not returned with response-ID correlation.'
+                    }
+                }
+                catch {
+                    if (-not ${{returnError.ToString().ToLowerInvariant()}}) { throw }
+                    $prefix = "MCP request 'fixture/read' failed: "
+                    if (-not $_.Exception.Message.StartsWith($prefix)) { throw }
+                    $errorDocument = $_.Exception.Message.Substring($prefix.Length) | ConvertFrom-Json -Depth 10
+                    if ($errorDocument.code -ne -32602 -or $errorDocument.message -ne 'controlled invalid params' -or $errorDocument.data.target -ne 'fixture-tag') {
+                        throw 'JSON-RPC error serialization did not preserve the error document.'
+                    }
+                    $rejected = $true
+                }
+                if (${{returnError.ToString().ToLowerInvariant()}} -and -not $rejected) {
+                    throw 'The explicit JSON-RPC error was not rejected.'
+                }
+                Write-Output 'json-rpc-response-handled'
+            }
+            finally {
+                Stop-JsonLineProcess -Process $script:HostProcess
+            }
+            """;
+
+        var result = await RunPowerShellFixtureAsync(fixture);
+
+        Assert.True(result.ExitCode == 0,
+            $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
+        Assert.Contains("json-rpc-response-handled", result.StandardOutput, StringComparison.Ordinal);
+    }
+
     private static string ReadScript()
     {
         Assert.True(File.Exists(ScriptPath), $"Expected live harness at {ScriptPath}.");

--- a/TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotContractTests.cs
@@ -20,6 +20,25 @@ public sealed class TagUpdateSafetySnapshotContractTests
     }
 
     [Fact]
+    public void Snapshot_SerializesTheCompleteResolvedExactTarget()
+    {
+        var json = JsonSerializer.Serialize(new TagUpdateSafetySnapshot(
+            "ResolvedPLC", "/Safety", "Default tag table", "MotorReady", "Bool", "%I0.0", false, null, true));
+
+        using var document = JsonDocument.Parse(json);
+        var target = document.RootElement;
+        Assert.Equal("ResolvedPLC", target.GetProperty("plcName").GetString());
+        Assert.Equal("/Safety", target.GetProperty("folderPath").GetString());
+        Assert.Equal("Default tag table", target.GetProperty("tableName").GetString());
+        Assert.Equal("MotorReady", target.GetProperty("tagName").GetString());
+        Assert.Equal("Bool", target.GetProperty("dataType").GetString());
+        Assert.Equal("%I0.0", target.GetProperty("logicalAddress").GetString());
+        Assert.False(target.GetProperty("externalAccessible").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, target.GetProperty("externalVisible").ValueKind);
+        Assert.True(target.GetProperty("externalWritable").GetBoolean());
+    }
+
+    [Fact]
     public void SnapshotRead_IsAReusableIdentityRequiredSafetyRead()
     {
         const string method = "read_update_tag_safety_snapshot";

--- a/TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotContractTests.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagUpdateSafetySnapshotContractTests
+{
+    [Fact]
+    public void Snapshot_SerializesFalseDifferentlyFromUnavailable()
+    {
+        var concrete = JsonSerializer.Serialize(new TagUpdateSafetySnapshot(
+            "ResolvedPLC", "/", "Default tag table", "MotorReady", "Bool", "%I0.0", false, true, false));
+        var unavailable = JsonSerializer.Serialize(new TagUpdateSafetySnapshot(
+            "ResolvedPLC", "/", "Default tag table", "MotorReady", "Bool", "%I0.0", null, null, null));
+
+        Assert.Contains("\"externalAccessible\":false", concrete, StringComparison.Ordinal);
+        Assert.Contains("\"externalAccessible\":null", unavailable, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SnapshotRead_IsAReusableIdentityRequiredSafetyRead()
+    {
+        const string method = "read_update_tag_safety_snapshot";
+
+        Assert.Equal(OperationCapability.SafetyRead, OperationPolicyCatalog.GetCapability(method));
+        Assert.True(OperationPolicyCatalog.IsAllowed(McpAccessMode.ReadOnly, method));
+        Assert.True(OperationPolicyCatalog.RequiresExpectedSessionIdentity(method));
+    }
+}

--- a/TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotSourceContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotSourceContractTests.cs
@@ -1,0 +1,50 @@
+using TiaMcpServer.Batch;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagUpdateSafetySnapshotSourceContractTests
+{
+    [Fact]
+    public void WorkerProgram_DispatchesSnapshotReadThroughWithProjectAndSharedPolicy()
+    {
+        var source = ReadRepositorySource("TiaMcpServer.OpennessWorker", "Program.cs");
+
+        Assert.Contains("\"read_update_tag_safety_snapshot\" => ReadUpdateTagSafetySnapshot(request)", source, StringComparison.Ordinal);
+        Assert.Contains("return WithProject(request, project => Success(", source, StringComparison.Ordinal);
+        Assert.Contains("=> !OperationPolicyCatalog.RequiresExpectedSessionIdentity(method)", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Reader_UsesResolvedPlcNameFromLocator()
+    {
+        var source = ReadRepositorySource("TiaMcpServer.OpennessWorker", "Openness", "TagUpdateSafetySnapshotReader.cs");
+
+        Assert.Contains("resolved.PlcName", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("plcName ?? string.Empty", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InternalSnapshotRead_IsAbsentFromPublicBatchAndNetworkCatalogs()
+    {
+        const string method = "read_update_tag_safety_snapshot";
+        Assert.DoesNotContain(method, ReadRepositorySource("TiaMcpServer", "Batch", "BatchOperationCatalog.cs"), StringComparison.Ordinal);
+        Assert.DoesNotContain(method, ReadRepositorySource("TiaMcpServer", "Network", "NetworkOperationCatalog.cs"), StringComparison.Ordinal);
+    }
+
+    private static string ReadRepositorySource(params string[] pathSegments)
+    {
+        var root = new DirectoryInfo(AppContext.BaseDirectory);
+        while (root is not null && !File.Exists(Path.Combine(root.FullName, "TiaMcpServer.sln")))
+        {
+            root = root.Parent;
+        }
+
+        if (root is null)
+        {
+            throw new DirectoryNotFoundException("Could not locate the repository root.");
+        }
+
+        return File.ReadAllText(Path.Combine(new[] { root.FullName }.Concat(pathSegments).ToArray()));
+    }
+}

--- a/TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotSourceContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateSafetySnapshotSourceContractTests.cs
@@ -9,9 +9,10 @@ public sealed class TagUpdateSafetySnapshotSourceContractTests
     public void WorkerProgram_DispatchesSnapshotReadThroughWithProjectAndSharedPolicy()
     {
         var source = ReadRepositorySource("TiaMcpServer.OpennessWorker", "Program.cs");
+        var handler = ReadWorkerHandler(source, "ReadUpdateTagSafetySnapshot");
 
         Assert.Contains("\"read_update_tag_safety_snapshot\" => ReadUpdateTagSafetySnapshot(request)", source, StringComparison.Ordinal);
-        Assert.Contains("return WithProject(request, project => Success(", source, StringComparison.Ordinal);
+        Assert.Contains("return WithProject(request, project => Success(", handler, StringComparison.Ordinal);
         Assert.Contains("=> !OperationPolicyCatalog.RequiresExpectedSessionIdentity(method)", source, StringComparison.Ordinal);
     }
 
@@ -22,6 +23,24 @@ public sealed class TagUpdateSafetySnapshotSourceContractTests
 
         Assert.Contains("resolved.PlcName", source, StringComparison.Ordinal);
         Assert.DoesNotContain("plcName ?? string.Empty", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Reader_SerializesEveryExactTargetFieldAndPreservesUnavailableFlags()
+    {
+        var source = ReadRepositorySource("TiaMcpServer.OpennessWorker", "Openness", "TagUpdateSafetySnapshotReader.cs");
+
+        Assert.Contains("resolved.PlcName", source, StringComparison.Ordinal);
+        Assert.Contains("resolved.FolderPath", source, StringComparison.Ordinal);
+        Assert.Contains("resolved.Table.Name", source, StringComparison.Ordinal);
+        Assert.Contains("resolved.Tag.Name", source, StringComparison.Ordinal);
+        Assert.Contains("resolved.Tag.DataTypeName", source, StringComparison.Ordinal);
+        Assert.Contains("resolved.Tag.LogicalAddress", source, StringComparison.Ordinal);
+        Assert.Contains("ReadOptionalFlag(() => resolved.Tag.ExternalAccessible)", source, StringComparison.Ordinal);
+        Assert.Contains("ReadOptionalFlag(() => resolved.Tag.ExternalVisible)", source, StringComparison.Ordinal);
+        Assert.Contains("ReadOptionalFlag(() => resolved.Tag.ExternalWritable)", source, StringComparison.Ordinal);
+        Assert.Contains("catch (NotSupportedException)", source, StringComparison.Ordinal);
+        Assert.Contains("return null;", source, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -46,5 +65,16 @@ public sealed class TagUpdateSafetySnapshotSourceContractTests
         }
 
         return File.ReadAllText(Path.Combine(new[] { root.FullName }.Concat(pathSegments).ToArray()));
+    }
+
+    private static string ReadWorkerHandler(string source, string methodName)
+    {
+        var marker = $"    private static WorkerResponse {methodName}(WorkerRequest request)";
+        var start = source.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Could not find worker handler '{methodName}'.");
+
+        var next = source.IndexOf("\n    private static WorkerResponse ", start + marker.Length, StringComparison.Ordinal);
+        Assert.True(next >= 0, $"Could not find the end of worker handler '{methodName}'.");
+        return source[start..next];
     }
 }

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -84,6 +84,8 @@
     <Compile Include="..\TiaMcpServer\OperationBatches\StructuredOperationBatchPayloadBudget.cs" Link="Host\OperationBatches\StructuredOperationBatchPayloadBudget.cs" />
     <Compile Include="..\TiaMcpServer\Batch\BatchWorkerInvoker.cs"
       Link="Host\Batch\BatchWorkerInvoker.cs" />
+    <Compile Include="..\TiaMcpServer\Batch\TagUpdateSafetyCurrentState.cs"
+      Link="Host\Batch\TagUpdateSafetyCurrentState.cs" />
     <Compile Include="..\TiaMcpServer\Batch\BatchTools.cs" Link="Host\Batch\BatchTools.cs" />
     <Compile Include="..\TiaMcpServer\Batch\ReadBatchTools.cs" Link="Host\Batch\ReadBatchTools.cs" />
     <Compile Include="..\TiaMcpServer\Batch\WriteBatchTools.cs" Link="Host\Batch\WriteBatchTools.cs" />

--- a/TiaMcpServer.Tests/Worker/TagUpdateSafetySnapshotIdentityEnforcementTests.cs
+++ b/TiaMcpServer.Tests/Worker/TagUpdateSafetySnapshotIdentityEnforcementTests.cs
@@ -24,6 +24,7 @@ public sealed class TagUpdateSafetySnapshotIdentityEnforcementTests
 
         Assert.False(response.Success);
         Assert.Equal(WorkerFailureCategories.BindingConflict, response.FailureCategory);
+        Assert.Null(response.SessionIdentity);
     }
 
     [Theory]
@@ -48,6 +49,7 @@ public sealed class TagUpdateSafetySnapshotIdentityEnforcementTests
 
         Assert.False(response.Success);
         Assert.Equal(WorkerFailureCategories.BindingConflict, response.FailureCategory);
+        Assert.Null(response.SessionIdentity);
     }
 
     private static PersistentWorkerTransport CreateFakeWorkerTransport()

--- a/TiaMcpServer.Tests/Worker/TagUpdateSafetySnapshotIdentityEnforcementTests.cs
+++ b/TiaMcpServer.Tests/Worker/TagUpdateSafetySnapshotIdentityEnforcementTests.cs
@@ -1,0 +1,76 @@
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Worker;
+
+public sealed class TagUpdateSafetySnapshotIdentityEnforcementTests
+{
+    [Fact]
+    public async Task WorkerRejectsSnapshotReadWithMissingIdentity()
+    {
+        using var transport = CreateFakeWorkerTransport();
+        var observed = await PrimeAndReadIdentityAsync(transport);
+        var response = await transport.SendAsync(new WorkerRequest
+        {
+            Method = "read_update_tag_safety_snapshot",
+            ProjectPath = observed.ProjectPath,
+            PlcName = "PLC_1",
+            TableName = "Default tag table",
+            FolderPath = "/",
+            Name = "MotorReady",
+            ExpectedSessionIdentity = null,
+        });
+
+        Assert.False(response.Success);
+        Assert.Equal(WorkerFailureCategories.BindingConflict, response.FailureCategory);
+    }
+
+    [Theory]
+    [InlineData("workerSessionId")]
+    [InlineData("sessionGeneration")]
+    [InlineData("portalProcessId")]
+    [InlineData("projectPath")]
+    public async Task WorkerRejectsEveryMismatchedSnapshotIdentityField(string field)
+    {
+        using var transport = CreateFakeWorkerTransport();
+        var observed = await PrimeAndReadIdentityAsync(transport);
+        var response = await transport.SendAsync(new WorkerRequest
+        {
+            Method = "read_update_tag_safety_snapshot",
+            ProjectPath = observed.ProjectPath,
+            PlcName = "PLC_1",
+            TableName = "Default tag table",
+            FolderPath = "/",
+            Name = "MotorReady",
+            ExpectedSessionIdentity = CopyWithChangedField(observed, field),
+        });
+
+        Assert.False(response.Success);
+        Assert.Equal(WorkerFailureCategories.BindingConflict, response.FailureCategory);
+    }
+
+    private static PersistentWorkerTransport CreateFakeWorkerTransport()
+        => new(FakeWorkerLocator.Locate(), TimeSpan.FromSeconds(5));
+
+    private static async Task<WorkerSessionIdentity> PrimeAndReadIdentityAsync(PersistentWorkerTransport transport)
+    {
+        var response = await transport.SendAsync(new WorkerRequest
+        {
+            Method = "get_project_status",
+            ProjectPath = "tag-update-flag-drift",
+        });
+
+        Assert.True(response.Success, response.Error);
+        return Assert.IsType<WorkerSessionIdentity>(response.SessionIdentity);
+    }
+
+    private static WorkerSessionIdentity CopyWithChangedField(WorkerSessionIdentity source, string field)
+        => new()
+        {
+            WorkerSessionId = field == "workerSessionId" ? source.WorkerSessionId + "-different" : source.WorkerSessionId,
+            SessionGeneration = field == "sessionGeneration" ? source.SessionGeneration + 1 : source.SessionGeneration,
+            PortalProcessId = field == "portalProcessId" ? source.PortalProcessId + 1 : source.PortalProcessId,
+            ProjectPath = field == "projectPath" ? source.ProjectPath + ".different" : source.ProjectPath,
+        };
+}

--- a/TiaMcpServer.Tests/Worker/TagUpdateSafetySnapshotWorkerClientTests.cs
+++ b/TiaMcpServer.Tests/Worker/TagUpdateSafetySnapshotWorkerClientTests.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Tests.Worker;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Worker;
+
+public sealed class TagUpdateSafetySnapshotWorkerClientTests
+{
+    [Fact]
+    public async Task BoundSnapshotRead_RequestJsonStillCarriesExpectedSessionIdentity()
+    {
+        var binding = new ProjectSessionBinding(null);
+        using var client = new OpennessWorkerClient(binding, logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, "echo");
+
+        var call = await client.ReadUpdateTagSafetySnapshotAsync(
+            plcName: null,
+            tableName: "Default tag table",
+            folderPath: "/",
+            name: "MotorReady",
+            projectPath: "echo");
+
+        Assert.True(call.Success, call.Error);
+        using var echoed = JsonDocument.Parse(call.Payload);
+        var expected = echoed.RootElement.GetProperty("expectedSessionIdentity");
+        Assert.Equal(JsonValueKind.Object, expected.ValueKind);
+        Assert.False(string.IsNullOrWhiteSpace(expected.GetProperty("workerSessionId").GetString()));
+        Assert.True(expected.GetProperty("sessionGeneration").GetInt64() >= 0);
+        Assert.True(expected.GetProperty("portalProcessId").GetInt32() > 0);
+        Assert.False(string.IsNullOrWhiteSpace(expected.GetProperty("projectPath").GetString()));
+    }
+}

--- a/TiaMcpServer/Batch/BatchWorkerInvoker.cs
+++ b/TiaMcpServer/Batch/BatchWorkerInvoker.cs
@@ -65,21 +65,10 @@ public static class BatchWorkerInvoker
             return strict;
         }
 
-        TagUpdateSafetySnapshot? snapshot;
-        try
-        {
-            snapshot = JsonSerializer.Deserialize<TagUpdateSafetySnapshot>(strict.Payload);
-        }
-        catch (JsonException ex)
+        if (!TryDecodeUpdateTagSafetySnapshot(strict.Payload, out var snapshot, out var decodeError))
         {
             return WorkerCallResult.Fail(WorkerFailureCategories.ProtocolError,
-                $"Could not decode the update_tag safety snapshot. {ex.Message}");
-        }
-
-        if (snapshot is null)
-        {
-            return WorkerCallResult.Fail(WorkerFailureCategories.ProtocolError,
-                "Could not decode the update_tag safety snapshot.");
+                $"Could not decode the update_tag safety snapshot. {decodeError}");
         }
 
         var unavailableFlag = TagUpdateSafetyCurrentState.ValidateRequestedExternalFlags(op, snapshot);
@@ -115,6 +104,83 @@ public static class BatchWorkerInvoker
             ResolvedProjectPath = broad.ResolvedProjectPath,
             SessionIdentity = broad.SessionIdentity,
         };
+    }
+
+    private static bool TryDecodeUpdateTagSafetySnapshot(
+        string payload,
+        out TagUpdateSafetySnapshot snapshot,
+        out string error)
+    {
+        snapshot = null!;
+        error = string.Empty;
+        try
+        {
+            using var document = JsonDocument.Parse(payload);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                error = "Expected one JSON object.";
+                return false;
+            }
+
+            var expectedKinds = new Dictionary<string, JsonValueKind>(StringComparer.Ordinal)
+            {
+                ["plcName"] = JsonValueKind.String,
+                ["folderPath"] = JsonValueKind.String,
+                ["tableName"] = JsonValueKind.String,
+                ["tagName"] = JsonValueKind.String,
+                ["dataType"] = JsonValueKind.String,
+                ["logicalAddress"] = JsonValueKind.String,
+                ["externalAccessible"] = JsonValueKind.True,
+                ["externalVisible"] = JsonValueKind.True,
+                ["externalWritable"] = JsonValueKind.True,
+            };
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var property in document.RootElement.EnumerateObject())
+            {
+                if (!expectedKinds.TryGetValue(property.Name, out var expectedKind))
+                {
+                    error = $"Unsupported member '{property.Name}'.";
+                    return false;
+                }
+                if (!seen.Add(property.Name))
+                {
+                    error = $"Duplicate member '{property.Name}'.";
+                    return false;
+                }
+
+                var actualKind = property.Value.ValueKind;
+                var validKind = expectedKind == JsonValueKind.String
+                    ? actualKind == JsonValueKind.String
+                    : actualKind is JsonValueKind.True or JsonValueKind.False or JsonValueKind.Null;
+                if (!validKind)
+                {
+                    error = $"Member '{property.Name}' has an unsupported JSON type.";
+                    return false;
+                }
+            }
+
+            foreach (var member in expectedKinds.Keys)
+            {
+                if (!seen.Contains(member))
+                {
+                    error = $"Required member '{member}' is missing.";
+                    return false;
+                }
+            }
+
+            snapshot = document.RootElement.Deserialize<TagUpdateSafetySnapshot>()!;
+            if (snapshot is null)
+            {
+                error = "The snapshot object decoded to null.";
+                return false;
+            }
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            error = ex.Message;
+            return false;
+        }
     }
 
     /// <summary>Executes a single read or write item against the worker.</summary>

--- a/TiaMcpServer/Batch/BatchWorkerInvoker.cs
+++ b/TiaMcpServer/Batch/BatchWorkerInvoker.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using TiaMcpServer.Contracts;
 using TiaMcpServer.Worker;
 
@@ -31,8 +32,9 @@ public static class BatchWorkerInvoker
         "update_type_content" => WithValidatedFormat(
             () => NormalizeFormat(op),
             format => client.GetTypeContentAsync(op.TypePath!, format, op.ProjectPath)),
+        "update_tag" => ReadUpdateTagCurrentStateAsync(client, op),
         "create_tag_table" or "delete_tag_table"
-            or "create_tag" or "update_tag" or "delete_tag"
+            or "create_tag" or "delete_tag"
             or "create_user_constant" or "update_user_constant" or "delete_user_constant"
             => client.ListTagTablesAsync(op.PlcName, op.ProjectPath),
         "create_block" or "create_block_group" or "delete_block_group"
@@ -47,6 +49,60 @@ public static class BatchWorkerInvoker
             WorkerFailureCategories.ValidationError,
             $"Unsupported batch write operation '{op.Operation}'.")),
     };
+
+    private static async Task<WorkerCallResult> ReadUpdateTagCurrentStateAsync(
+        OpennessWorkerClient client,
+        BatchOperationRequest op)
+    {
+        var strict = await client.ReadUpdateTagSafetySnapshotAsync(
+            op.PlcName,
+            op.TableName!,
+            op.FolderPath,
+            op.Name!,
+            op.ProjectPath).ConfigureAwait(false);
+        if (!strict.Success)
+        {
+            return strict;
+        }
+
+        TagUpdateSafetySnapshot? snapshot;
+        try
+        {
+            snapshot = JsonSerializer.Deserialize<TagUpdateSafetySnapshot>(strict.Payload);
+        }
+        catch (JsonException ex)
+        {
+            return WorkerCallResult.Fail(WorkerFailureCategories.ProtocolError,
+                $"Could not decode the update_tag safety snapshot. {ex.Message}");
+        }
+
+        if (snapshot is null)
+        {
+            return WorkerCallResult.Fail(WorkerFailureCategories.ProtocolError,
+                "Could not decode the update_tag safety snapshot.");
+        }
+
+        var unavailableFlag = TagUpdateSafetyCurrentState.ValidateRequestedExternalFlags(op, snapshot);
+        if (unavailableFlag is not null)
+        {
+            return WorkerCallResult.Fail(WorkerFailureCategories.ValidationError,
+                $"The current tag does not expose requested flag '{unavailableFlag}'.");
+        }
+
+        var broad = await client.ListTagTablesAsync(op.PlcName, op.ProjectPath).ConfigureAwait(false);
+        if (!broad.Success)
+        {
+            return broad;
+        }
+
+        return WorkerCallResult.Ok(
+            TagUpdateSafetyCurrentState.Compose(snapshot, broad.Payload),
+            broad.Warnings) with
+        {
+            ResolvedProjectPath = broad.ResolvedProjectPath,
+            SessionIdentity = broad.SessionIdentity,
+        };
+    }
 
     /// <summary>Executes a single read or write item against the worker.</summary>
     public static Task<WorkerCallResult> InvokeAsync(OpennessWorkerClient client, BatchOperationRequest op) => op.Operation switch

--- a/TiaMcpServer/Batch/BatchWorkerInvoker.cs
+++ b/TiaMcpServer/Batch/BatchWorkerInvoker.cs
@@ -95,8 +95,21 @@ public static class BatchWorkerInvoker
             return broad;
         }
 
+        string currentState;
+        try
+        {
+            currentState = TagUpdateSafetyCurrentState.Compose(snapshot, broad.Payload);
+        }
+        catch (JsonException ex)
+        {
+            return WorkerCallResult.Fail(
+                WorkerFailureCategories.ProtocolError,
+                $"Could not decode the update_tag broad tag-table safety state. {ex.Message}",
+                broad.Warnings);
+        }
+
         return WorkerCallResult.Ok(
-            TagUpdateSafetyCurrentState.Compose(snapshot, broad.Payload),
+            currentState,
             broad.Warnings) with
         {
             ResolvedProjectPath = broad.ResolvedProjectPath,

--- a/TiaMcpServer/Batch/TagUpdateSafetyCurrentState.cs
+++ b/TiaMcpServer/Batch/TagUpdateSafetyCurrentState.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using TiaMcpServer.Contracts;
+
+namespace TiaMcpServer.Batch;
+
+internal static class TagUpdateSafetyCurrentState
+{
+    internal static string? ValidateRequestedExternalFlags(BatchOperationRequest op, TagUpdateSafetySnapshot snapshot)
+    {
+        if (op.ExternalAccessible.HasValue && snapshot.ExternalAccessible is null) return "externalAccessible";
+        if (op.ExternalVisible.HasValue && snapshot.ExternalVisible is null) return "externalVisible";
+        if (op.ExternalWritable.HasValue && snapshot.ExternalWritable is null) return "externalWritable";
+        return null;
+    }
+
+    internal static string Compose(TagUpdateSafetySnapshot snapshot, string broadTagTablesPayload)
+    {
+        using var broadTagTables = JsonDocument.Parse(broadTagTablesPayload);
+        return JsonSerializer.Serialize(new
+        {
+            exactTarget = snapshot,
+            broadTagTables = broadTagTables.RootElement
+        });
+    }
+}

--- a/TiaMcpServer/Batch/WriteBatchTools.cs
+++ b/TiaMcpServer/Batch/WriteBatchTools.cs
@@ -56,7 +56,7 @@ public class WriteBatchTools
                 var snapshot = await ReadCombinedCurrentStateAsync(workerClient, operations).ConfigureAwait(false);
                 if (snapshot.Error is not null)
                 {
-                    return OperationBatchResultFormatter.Error(PreviewToolName, snapshot.Error);
+                    return OperationBatchResultFormatter.Error(PreviewToolName, snapshot.Error, snapshot.FailureCategory);
                 }
 
                 var targets = BatchSafetySnapshot.BuildTargets(operations);
@@ -151,7 +151,10 @@ public class WriteBatchTools
                 var snapshot = await ReadCombinedCurrentStateAsync(workerClient, operations).ConfigureAwait(false);
                 if (snapshot.Error is not null)
                 {
-                    return OperationBatchResultFormatter.Error(ApplyToolName, $"Could not read current state before write. {snapshot.Error}");
+                    return OperationBatchResultFormatter.Error(
+                        ApplyToolName,
+                        $"Could not read current state before write. {snapshot.Error}",
+                        snapshot.FailureCategory);
                 }
 
                 var tokenValidation = safety.ValidateAndConsume(
@@ -186,7 +189,7 @@ public class WriteBatchTools
         return execution.Value!;
     }
 
-    private static async Task<(string CombinedState, string? Error)> ReadCombinedCurrentStateAsync(
+    private static async Task<(string CombinedState, string? Error, string? FailureCategory)> ReadCombinedCurrentStateAsync(
         OpennessWorkerClient workerClient,
         BatchOperationRequest[] operations)
     {
@@ -196,12 +199,15 @@ public class WriteBatchTools
             var state = await BatchWorkerInvoker.ReadCurrentStateAsync(workerClient, op).ConfigureAwait(false);
             if (!state.Success)
             {
-                return (string.Empty, $"Could not read current state for operationId '{op.OperationId}' ({op.Operation}). Error: {state.Error}");
+                return (
+                    string.Empty,
+                    $"Could not read current state for operationId '{op.OperationId}' ({op.Operation}). Error: {state.Error}",
+                    state.FailureCategory);
             }
 
             states.Add(new OperationBatchCurrentState(op.OperationId, op.Operation, state.Payload));
         }
 
-        return (BatchSafetySnapshot.CombineCurrentState(states), null);
+        return (BatchSafetySnapshot.CombineCurrentState(states), null, null);
     }
 }

--- a/TiaMcpServer/Batch/WriteBatchTools.cs
+++ b/TiaMcpServer/Batch/WriteBatchTools.cs
@@ -164,7 +164,10 @@ public class WriteBatchTools
                     PreviewToolName);
                 if (!tokenValidation.IsValid)
                 {
-                    return OperationBatchResultFormatter.Error(ApplyToolName, tokenValidation.Error);
+                    return OperationBatchResultFormatter.Error(
+                        ApplyToolName,
+                        tokenValidation.Error,
+                        tokenValidation.FailureCategory);
                 }
 
                 var results = await OperationBatchExecutionEngine.ApplyWritesAsync(

--- a/TiaMcpServer/OperationBatches/OperationBatchResultFormatter.cs
+++ b/TiaMcpServer/OperationBatches/OperationBatchResultFormatter.cs
@@ -8,6 +8,11 @@ public static class OperationBatchResultFormatter
     public static string Error(string toolName, string error)
         => JsonSerializer.Serialize(new { tool = toolName, success = false, error }, TiaJson.Presentation);
 
+    public static string Error(string toolName, string error, string? failureCategory)
+        => failureCategory is null
+            ? Error(toolName, error)
+            : JsonSerializer.Serialize(new { tool = toolName, success = false, failureCategory, error }, TiaJson.Presentation);
+
     public static string Read(string toolName, IReadOnlyList<OperationBatchResult> results)
     {
         var failed = Count(results, OperationBatchStatus.Failed);

--- a/TiaMcpServer/Worker/OpennessWorkerClient.cs
+++ b/TiaMcpServer/Worker/OpennessWorkerClient.cs
@@ -729,6 +729,26 @@ public class OpennessWorkerClient : IDisposable
             "[]");
     }
 
+    public Task<WorkerCallResult> ReadUpdateTagSafetySnapshotAsync(
+        string? plcName,
+        string tableName,
+        string? folderPath,
+        string name,
+        string? projectPath)
+    {
+        return SendBoundProjectRequestAsync(
+            "read_update_tag_safety_snapshot",
+            projectPath,
+            request =>
+            {
+                request.PlcName = plcName;
+                request.TableName = tableName;
+                request.FolderPath = folderPath;
+                request.Name = name;
+            },
+            "{}");
+    }
+
     public Task<WorkerCallResult> CompileCheckAsync(string? blockPath, string? plcName, string? projectPath)
     {
         return SendBoundProjectRequestAsync(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -523,6 +523,19 @@ reuse causes rejection. Completed writes are appended to the audit log under
 Read-only mode is categorically stronger than this token flow: confirmation and
 a valid token cannot override the access policy.
 
+For `update_tag`, the preview state currently composes two complementary reads: one strict,
+exact-target `TagUpdateSafetySnapshot` and the legacy broad tag-table payload retained until PR 5
+narrows the remaining tag-operation scopes. The strict snapshot records the resolved PLC name
+(rather than a caller-supplied selector), folder, table, tag, and every property the mutator can
+change. In particular, a requested external flag whose current value is unreadable causes preview
+to fail before token issuance. The public `list_tag_tables` read remains best-effort and unchanged.
+
+Internal exact-target selectors use the shared `SafetyRead` capability. A `SafetyRead` is
+side-effect-free and allowed in read-only mode, but it is not an ordinary observe: every request
+must carry the complete, exact worker/Portal/project session identity previously observed from the
+worker. This prevents an internal safety read from silently moving to a different same-path
+session while a preview is assembled.
+
 ## 9. Diagnostics
 
 `tia-mcp doctor` runs the environment diagnostic pipeline without starting the

--- a/docs/IMPROVEMENT_LOG.md
+++ b/docs/IMPROVEMENT_LOG.md
@@ -413,7 +413,7 @@ equivalence. The separately authorized read-only harness
 `scripts/live-test-hardware-pagination.ps1` is contract-tested but has not been executed against
 live TIA Portal V21; live pagination acceptance remains unverified.
 
-## PR 3 update_tag exact safety snapshot — offline implementation verified; live acceptance pending (2026-09-01)
+## PR 3 update_tag exact safety snapshot — mandatory live acceptance completed (2026-09-05)
 
 The missing external-flag safety-state gap for `update_tag` is closed in the offline contract,
 worker, FakeWorker, and registered write path: a strict exact-target snapshot captures resolved
@@ -421,11 +421,14 @@ PLC/table/tag identity and mutable values, requires the observed worker session 
 rejects a requested unreadable external flag before a preview token can be issued. The legacy
 best-effort public `list_tag_tables` response is intentionally unchanged until PR 5.
 
-The guarded disposable-copy harness and its durable report are prepared at
+The guarded disposable-copy harness and its durable report are at
 [`scripts/live-test-update-tag-safety.ps1`](../scripts/live-test-update-tag-safety.ps1) and
 [`PR 3 update_tag safety snapshot acceptance report`](superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md).
-They have not been run against live TIA Portal V21. PR 3 remains incomplete until separately
-authorized real-V21 flag-only drift and stale-token (`state_changed`) acceptance is recorded.
+The mandatory live V21 read, preview, authorized `ExternalVisible` flag-only drift, stale-token
+`state_changed` rejection, and restoration all passed. The optional unavailable-target probe was
+`NOT RUN` because no distinct target exposing an unavailable flag was established. The flag was
+restored to its original value, but TIA retained `isModified = true`; no save, close, or discard
+was performed.
 PR 5 selector narrowing, multilingual per-tag comment binding, and PLC `start_plc`/`stop_plc`
 work remain deferred.
 

--- a/docs/IMPROVEMENT_LOG.md
+++ b/docs/IMPROVEMENT_LOG.md
@@ -413,6 +413,22 @@ equivalence. The separately authorized read-only harness
 `scripts/live-test-hardware-pagination.ps1` is contract-tested but has not been executed against
 live TIA Portal V21; live pagination acceptance remains unverified.
 
+## PR 3 update_tag exact safety snapshot — offline implementation verified; live acceptance pending (2026-09-01)
+
+The missing external-flag safety-state gap for `update_tag` is closed in the offline contract,
+worker, FakeWorker, and registered write path: a strict exact-target snapshot captures resolved
+PLC/table/tag identity and mutable values, requires the observed worker session identity, and
+rejects a requested unreadable external flag before a preview token can be issued. The legacy
+best-effort public `list_tag_tables` response is intentionally unchanged until PR 5.
+
+The guarded disposable-copy harness and its durable report are prepared at
+[`scripts/live-test-update-tag-safety.ps1`](../scripts/live-test-update-tag-safety.ps1) and
+[`PR 3 update_tag safety snapshot acceptance report`](superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md).
+They have not been run against live TIA Portal V21. PR 3 remains incomplete until separately
+authorized real-V21 flag-only drift and stale-token (`state_changed`) acceptance is recorded.
+PR 5 selector narrowing, multilingual per-tag comment binding, and PLC `start_plc`/`stop_plc`
+work remain deferred.
+
 ## PR 1 explicit MCP tool annotations — live acceptance completed (2026-09-01)
 
 The registered 4-tool read-only and 14-tool read-write MCP surfaces now expose the approved

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@ with separate plans for [PR 1 explicit MCP tool annotations](superpowers/plans/2
 [PR 2 registered-tool delegation](superpowers/plans/2026-09-01-pr2-registered-tool-delegation.md),
 [its completed live acceptance report](superpowers/acceptance/reports/2026-09-01-pr2-registered-tool-delegation-live.md),
 [PR 3 exact `update_tag` safety snapshots](superpowers/plans/2026-09-01-pr3-update-tag-safety-snapshot.md),
-[its pending live acceptance report](superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md),
+[its completed mandatory live acceptance report](superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md),
 [PR 4 bounded structured preview diffs](superpowers/plans/2026-09-01-pr4-structured-preview-diff.md),
 [PR 5 tag-operation safety scopes](superpowers/plans/2026-09-01-pr5-tag-operation-safety-scopes.md),
 and [PR 6 project-tree safety scopes](superpowers/plans/2026-09-01-pr6-project-tree-safety-scopes.md);

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ with separate plans for [PR 1 explicit MCP tool annotations](superpowers/plans/2
 [PR 2 registered-tool delegation](superpowers/plans/2026-09-01-pr2-registered-tool-delegation.md),
 [its completed live acceptance report](superpowers/acceptance/reports/2026-09-01-pr2-registered-tool-delegation-live.md),
 [PR 3 exact `update_tag` safety snapshots](superpowers/plans/2026-09-01-pr3-update-tag-safety-snapshot.md),
+[its pending live acceptance report](superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md),
 [PR 4 bounded structured preview diffs](superpowers/plans/2026-09-01-pr4-structured-preview-diff.md),
 [PR 5 tag-operation safety scopes](superpowers/plans/2026-09-01-pr5-tag-operation-safety-scopes.md),
 and [PR 6 project-tree safety scopes](superpowers/plans/2026-09-01-pr6-project-tree-safety-scopes.md);

--- a/docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md
+++ b/docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md
@@ -42,6 +42,11 @@ The operations below run through `preview_write_batch` and `apply_write_batch`.
 - Import/update operations modify existing objects only. They do not create, rename, delete, or upsert the addressed object.
 - Deletes and PLC start/stop operations use the same confirmed write flow as other data writes.
 - A write batch is applied in order and stops on the first failure. Completed mutations are not rolled back.
+- `update_tag` preview combines its existing broad tag-table state with a strict exact-target
+  snapshot. If an update requests `externalAccessible`, `externalVisible`, or
+  `externalWritable` and that selected flag cannot be read for the exact tag, preview fails before
+  token issuance. This safety condition does not change the public `list_tag_tables` contract:
+  that read remains best-effort and may retain its existing skipped-read behavior.
 
 ## Current limits
 

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -64,7 +64,7 @@ explicitly pending.
 
 | Date | Document |
 | --- | --- |
-| 2026-09-01 | [PR 3 — exact `update_tag` safety snapshot — live PENDING](acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md) |
+| 2026-09-05 | [PR 3 — exact `update_tag` safety snapshot — mandatory live PASS](acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md) |
 | 2026-09-01 | [PR 2 — registered-tool delegation — live](acceptance/reports/2026-09-01-pr2-registered-tool-delegation-live.md) |
 | 2026-09-01 | [PR 1 — explicit MCP tool annotations — live](acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md) |
 | 2026-08-14 | [Structured I/O map defect fixes — live](acceptance/reports/2026-08-14-io-map-defect-fixes-live.md) |

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -59,10 +59,12 @@ Task-level implementation plans derived from the specs above.
 
 ## Acceptance reports
 
-Evidence from completed live runs against TIA Portal V21.
+Evidence from completed live runs against TIA Portal V21, plus prepared reports whose live gate is
+explicitly pending.
 
 | Date | Document |
 | --- | --- |
+| 2026-09-01 | [PR 3 — exact `update_tag` safety snapshot — live PENDING](acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md) |
 | 2026-09-01 | [PR 2 — registered-tool delegation — live](acceptance/reports/2026-09-01-pr2-registered-tool-delegation-live.md) |
 | 2026-09-01 | [PR 1 — explicit MCP tool annotations — live](acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md) |
 | 2026-08-14 | [Structured I/O map defect fixes — live](acceptance/reports/2026-08-14-io-map-defect-fixes-live.md) |

--- a/docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
+++ b/docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
@@ -39,7 +39,7 @@ supports the required offline/registered rows below; it does not replace the liv
 - `preview_write_batch` - PASS; `PreviewDrift` observed `ExternalVisible = True` and issued a safety token; no mutation was made and the token was discarded
 - one authorized intermediate flag-only drift write on the disposable copy - PASS; `ApplyDrift -AllowApply` changed only `ExternalVisible` from `True` to `False`
 - stale-token `apply_write_batch` - PASS; applying the original stale token failed with `failureCategory = state_changed`
-- restoration or discard step - PASS; the harness `finally` reconciliation restored `ExternalVisible = True`; no save, close, or discard was performed
+- restoration step - PASS; the harness `finally` reconciliation restored `ExternalVisible = True`; no save, close, or discard was performed
 
 ## Mandatory Live Results
 

--- a/docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
+++ b/docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
@@ -9,26 +9,30 @@
 probe was not run because no distinct second target was established to expose a truly unavailable
 external flag.
 
-**Source and live-tested revision:** `952f66f3627486e9d5ef0cb2d48bfcbd93a71c2e`.
+**Final reviewed source revision:** `475090a4248c2afc1c34784ad14e8ce5387a3889`.
+**Live-tested revision:** `952f66f3627486e9d5ef0cb2d48bfcbd93a71c2e`.
 **Production safety implementation revision:** `3c7e8b29ca0b923877cf310cfd6d3a4e1fc5a0e1`
 (`fix: validate update tag safety snapshot`). The live harness repairs after that production
 revision, including `5510e40`, `0feadf3`, and `952f66f`, were separately TDD-tested and scoped
-re-reviewed. The live runtime was TIA Portal V21 with portal PID `44176`.
+re-reviewed. Revision `475090a` is a post-live diagnostic-only harness fix that removes
+token-bearing raw text from failure messages and adds composed-path tests. It does not change
+production mutation or snapshot semantics, and no live TIA action was rerun for it. The live
+runtime was TIA Portal V21 with portal PID `44176`.
 
-**Offline-tested evidence:** Fresh final evidence at `952f66f` passed the serial reference-stub
+**Offline-tested evidence:** Fresh final evidence at `475090a` passed the serial reference-stub
 build with 0 warnings/0 errors, the focused `TagUpdateSafetyLiveHarnessContractTests` suite with
-18/18 tests, and the complete suite with 2,632/2,632 tests and 0 skipped. The complete passing run
+20/20 tests, and the complete suite with 2,634/2,634 tests and 0 skipped. The complete passing run
 used:
 
 ```powershell
-dotnet test TiaMcpServer.Tests --no-build --no-restore --nologo --verbosity minimal -- xunit.parallelizeTestCollections=false xunit.maxParallelThreads=1
+dotnet test TiaMcpServer.Tests --no-build --no-restore --nologo --verbosity minimal -- xUnit.ParallelizeTestCollections=false xUnit.MaxParallelThreads=1
 ```
 
 This supports the required offline/registered rows below; it does not replace the live
-acceptance. Before that sequential pass, two default-parallel attempts exposed unrelated existing
-timing failures outside PR 3: the first had a network smoke-test timeout plus fake-worker restart
-timing failures, and the second had only the network smoke-test timeout. The exact failing groups
-then passed in isolation (2/2 and 4/4).
+acceptance. xUnit inline RunSettings keys are case-sensitive. A lowercase-key attempt did not
+serialize the test collections and exposed the same unrelated timing-sensitive process-start and
+restart tests. The correctly cased command serialized the collections and passed the complete
+suite.
 
 ## Mandatory Live Target
 
@@ -78,10 +82,10 @@ and the token was discarded.
 
 | Criterion | Evidence source | Observed |
 |---|---|---|
-| Bound client sends a complete expected identity; worker rejects missing and mismatched identity as `binding_conflict` | `TagUpdateSafetySnapshotWorkerClientTests` plus `TagUpdateSafetySnapshotIdentityEnforcementTests` | PASS - revision `952f66f`; fresh final complete suite (2,632/2,632, 0 skipped) |
-| Requested unavailable flag fails before token issuance | `TagUpdateCurrentStateFakeWorkerTests` plus contract/worker tests | PASS - revision `952f66f`; registered matrix coverage includes `0feadf3`; fresh final complete suite (2,632/2,632, 0 skipped) |
-| Strict snapshot payload rejects `{}`, malformed/unsupported shapes, every omitted member, and wrong member types before broad fallback or token issuance | `TagUpdateCurrentStateFakeWorkerTests` | PASS - revision `952f66f`; fresh final complete suite (2,632/2,632, 0 skipped) |
-| Harness accepts legal registered token-only preview results, preserves explicit application-error handling, rejects invalid shapes without leaking tokens, and defines the optional-probe guard before its entrypoint call | `TagUpdateSafetyLiveHarnessContractTests` | PASS - revision `952f66f`; focused harness suite 18/18 and fresh final complete suite (2,632/2,632, 0 skipped) |
+| Bound client sends a complete expected identity; worker rejects missing and mismatched identity as `binding_conflict` | `TagUpdateSafetySnapshotWorkerClientTests` plus `TagUpdateSafetySnapshotIdentityEnforcementTests` | PASS - final source revision `475090a`; fresh final complete suite (2,634/2,634, 0 skipped) |
+| Requested unavailable flag fails before token issuance | `TagUpdateCurrentStateFakeWorkerTests` plus contract/worker tests | PASS - final source revision `475090a`; registered matrix coverage includes `0feadf3`; fresh final complete suite (2,634/2,634, 0 skipped) |
+| Strict snapshot payload rejects `{}`, malformed/unsupported shapes, every omitted member, and wrong member types before broad fallback or token issuance | `TagUpdateCurrentStateFakeWorkerTests` | PASS - final source revision `475090a`; fresh final complete suite (2,634/2,634, 0 skipped) |
+| Harness accepts legal registered token-only preview results, preserves explicit application-error handling, rejects invalid shapes without leaking tokens, and defines the optional-probe guard before its entrypoint call | `TagUpdateSafetyLiveHarnessContractTests` | PASS - final source revision `475090a`; focused harness suite 20/20 and fresh final complete suite (2,634/2,634, 0 skipped) |
 
 ## Optional Live Unavailable Probe
 
@@ -109,6 +113,10 @@ required offline/registered evidence.
   (registered token-only preview acceptance with fail-closed invalid-shape handling). The successful
   mandatory read preceded any preview/write; only the authorized `ApplyDrift -AllowApply` mutated
   TIA.
+- Post-live revision `475090a` removed token-bearing raw text from harness failure messages and
+  added composed-path tests. It was reviewed and offline-tested at the final source revision, but
+  it did not change production mutation or snapshot semantics and was not live-tested; no live TIA
+  action was rerun for it.
 - `ApplyDrift -AllowApply` changed only `ExternalVisible` from `True` to `False`; the original token
   was rejected with `failureCategory = state_changed`, and `finally` restored the flag to `True`.
   A separate final `Read` then passed the strict snapshot and public-row assertions with

--- a/docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
+++ b/docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
@@ -9,15 +9,26 @@
 probe was not run because no distinct second target was established to expose a truly unavailable
 external flag.
 
-**Live-tested branch revision:** `845824b0903743220c82084610891b4ab4f4dceb`.
+**Source and live-tested revision:** `952f66f3627486e9d5ef0cb2d48bfcbd93a71c2e`.
 **Production safety implementation revision:** `3c7e8b29ca0b923877cf310cfd6d3a4e1fc5a0e1`
 (`fix: validate update tag safety snapshot`). The live harness repairs after that production
-revision were separately TDD-tested and scoped re-reviewed. The live runtime was TIA Portal V21
-with portal PID `44176`.
+revision, including `5510e40`, `0feadf3`, and `952f66f`, were separately TDD-tested and scoped
+re-reviewed. The live runtime was TIA Portal V21 with portal PID `44176`.
 
-**Offline-tested evidence:** Fresh final evidence at `845824b` passed the serial reference-stub
-build with 0 warnings/0 errors and the full suite with 2,622/2,622 tests and 0 skipped. This
-supports the required offline/registered rows below; it does not replace the live acceptance.
+**Offline-tested evidence:** Fresh final evidence at `952f66f` passed the serial reference-stub
+build with 0 warnings/0 errors, the focused `TagUpdateSafetyLiveHarnessContractTests` suite with
+18/18 tests, and the complete suite with 2,632/2,632 tests and 0 skipped. The complete passing run
+used:
+
+```powershell
+dotnet test TiaMcpServer.Tests --no-build --no-restore --nologo --verbosity minimal -- xunit.parallelizeTestCollections=false xunit.maxParallelThreads=1
+```
+
+This supports the required offline/registered rows below; it does not replace the live
+acceptance. Before that sequential pass, two default-parallel attempts exposed unrelated existing
+timing failures outside PR 3: the first had a network smoke-test timeout plus fake-worker restart
+timing failures, and the second had only the network smoke-test timeout. The exact failing groups
+then passed in isolation (2/2 and 4/4).
 
 ## Mandatory Live Target
 
@@ -36,10 +47,12 @@ supports the required offline/registered rows below; it does not replace the liv
 - `get_project_status` identity establishment for the worker-level preflight - PASS; direct worker hello/status established a complete worker-stamped session identity, with portal PID `44176`
 - `read_update_tag_safety_snapshot` preflight on the drift target - PASS; strict snapshot resolved `PLC_LAD` / `/` / `Inputs` / `DI_Reserve_1_7`, and observed `ExternalVisible = True`
 - `list_tag_tables` comparison read - PASS; registered `execute_read_batch/list_tag_tables` returned one successful operation whose row matched `Bool` / `%I1.7`
-- `preview_write_batch` - PASS; `PreviewDrift` observed `ExternalVisible = True` and issued a safety token; no mutation was made and the token was discarded
+- `preview_write_batch` - PASS; exact default-bound `PreviewDrift` accepted the registered token-only preview shape, observed `ExternalVisible = True`, and issued a safety token; no mutation was made and the token was discarded
 - one authorized intermediate flag-only drift write on the disposable copy - PASS; `ApplyDrift -AllowApply` changed only `ExternalVisible` from `True` to `False`
 - stale-token `apply_write_batch` - PASS; applying the original stale token failed with `failureCategory = state_changed`
 - restoration step - PASS; the harness `finally` reconciliation restored `ExternalVisible = True`; no save, close, or discard was performed
+- separate final `Read` - PASS; strict snapshot and public-row assertions passed with `ExternalVisible = True`
+- direct final `get_project_status` - PASS; `SimpleProject.ap21` remained open with `isModified = true`; no save, close, or discard was performed
 
 ## Mandatory Live Results
 
@@ -57,17 +70,18 @@ $projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\Sim
 pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode PreviewDrift
 ```
 
-`PreviewDrift` observed `ExternalVisible = True` and issued a safety token. No mutation was made
-by this mode, and the token was discarded.
+The exact default-bound `PreviewDrift` accepted the registered preview's token-only result shape,
+observed `ExternalVisible = True`, and issued a safety token. No mutation was made by this mode,
+and the token was discarded.
 
 ## Required Offline and Registered Evidence
 
 | Criterion | Evidence source | Observed |
 |---|---|---|
-| Bound client sends a complete expected identity; worker rejects missing and mismatched identity as `binding_conflict` | `TagUpdateSafetySnapshotWorkerClientTests` plus `TagUpdateSafetySnapshotIdentityEnforcementTests` | PASS - revision `845824b0903743220c82084610891b4ab4f4dceb`; fresh final full offline suite (2,622/2,622, 0 skipped) |
-| Requested unavailable flag fails before token issuance | `TagUpdateCurrentStateFakeWorkerTests` plus contract/worker tests | PASS - revision `845824b0903743220c82084610891b4ab4f4dceb`; fresh final full offline suite (2,622/2,622, 0 skipped) |
-| Strict snapshot payload rejects `{}`, malformed/unsupported shapes, every omitted member, and wrong member types before broad fallback or token issuance | `TagUpdateCurrentStateFakeWorkerTests` | PASS - revision `845824b0903743220c82084610891b4ab4f4dceb`; fresh final full offline suite (2,622/2,622, 0 skipped) |
-| Harness accepts a legal tool result with omitted `isError`, preserves explicit application-error handling, and defines the optional-probe guard before its entrypoint call | `TagUpdateSafetyLiveHarnessContractTests` | PASS - revision `845824b0903743220c82084610891b4ab4f4dceb`; focused harness suite 13/13 and fresh final full offline suite (2,622/2,622, 0 skipped) |
+| Bound client sends a complete expected identity; worker rejects missing and mismatched identity as `binding_conflict` | `TagUpdateSafetySnapshotWorkerClientTests` plus `TagUpdateSafetySnapshotIdentityEnforcementTests` | PASS - revision `952f66f`; fresh final complete suite (2,632/2,632, 0 skipped) |
+| Requested unavailable flag fails before token issuance | `TagUpdateCurrentStateFakeWorkerTests` plus contract/worker tests | PASS - revision `952f66f`; registered matrix coverage includes `0feadf3`; fresh final complete suite (2,632/2,632, 0 skipped) |
+| Strict snapshot payload rejects `{}`, malformed/unsupported shapes, every omitted member, and wrong member types before broad fallback or token issuance | `TagUpdateCurrentStateFakeWorkerTests` | PASS - revision `952f66f`; fresh final complete suite (2,632/2,632, 0 skipped) |
+| Harness accepts legal registered token-only preview results, preserves explicit application-error handling, rejects invalid shapes without leaking tokens, and defines the optional-probe guard before its entrypoint call | `TagUpdateSafetyLiveHarnessContractTests` | PASS - revision `952f66f`; focused harness suite 18/18 and fresh final complete suite (2,632/2,632, 0 skipped) |
 
 ## Optional Live Unavailable Probe
 
@@ -89,10 +103,16 @@ required offline/registered evidence.
 - Earlier attempts all stopped before mutation: empty-array binder; missing worker protocol marker;
   Openness permission timeout; optional JSON-RPC error access; and wrong public payload wrapper. The
   corresponding harness repairs were `c07a624` (empty worker arguments), `594e304` (per-request
-  worker protocol marker), `d000fb5` (optional JSON-RPC `error`), and `845824b` (direct public
-  tag-table array). Each was TDD-tested and scoped re-reviewed. The successful mandatory read
-  preceded any preview/write; only the final authorized `ApplyDrift -AllowApply` mutated TIA.
-- The exact flag value was restored in memory to `ExternalVisible = True`, but direct final
-  `get_project_status` observed the unchanged project path with `isModified = true`. No save, close,
-  or discard was performed; TIA retains an unsaved modification marker from the transient
-  change/restore round trip.
+  worker protocol marker), `d000fb5` (optional JSON-RPC `error`), and the direct public tag-table
+  array repair. Later reviewed commits were `5510e40` (exact default project binding and hardened
+  validation handling), `0feadf3` (registered update-tag safety matrix coverage), and `952f66f`
+  (registered token-only preview acceptance with fail-closed invalid-shape handling). The successful
+  mandatory read preceded any preview/write; only the authorized `ApplyDrift -AllowApply` mutated
+  TIA.
+- `ApplyDrift -AllowApply` changed only `ExternalVisible` from `True` to `False`; the original token
+  was rejected with `failureCategory = state_changed`, and `finally` restored the flag to `True`.
+  A separate final `Read` then passed the strict snapshot and public-row assertions with
+  `ExternalVisible = True`.
+- Direct final `get_project_status` showed `SimpleProject.ap21` still open with `isModified = true`.
+  No save, close, or discard was performed; TIA retains an unsaved modification marker from the
+  transient change/restore round trip.

--- a/docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
+++ b/docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
@@ -1,67 +1,98 @@
 # Acceptance Test Report - PR 3 update_tag safety snapshot (live TIA Portal V21)
 
-**Date:** 2026-09-01
+**Date:** 2026-09-05
 **Runtime:** Real TIA Portal V21
 **Harness:** `scripts/live-test-update-tag-safety.ps1`
 **Boundary:** Disposable project copy; the mandatory live gate is exact-target read plus one authorized flag-only drift and stale-token rejection.
 
-**Status:** PENDING / NOT RUN. This report prepares the required live evidence, but no live
-TIA Portal V21 harness mode has been authorized or run. PR 3 remains incomplete until the
-mandatory live acceptance is separately authorized and observed.
+**Status:** PASS. PR 3's mandatory live acceptance is complete. The optional unavailable-flag
+probe was not run because no distinct second target was established to expose a truly unavailable
+external flag.
 
-**Offline-tested code-fix revision:** `3c7e8b29ca0b923877cf310cfd6d3a4e1fc5a0e1`
-(`fix: validate update tag safety snapshot`). The exact committed revision passed the full offline
-suite on 2026-09-02. This does not replace or satisfy any live acceptance row below.
+**Live-tested branch revision:** `845824b0903743220c82084610891b4ab4f4dceb`.
+**Production safety implementation revision:** `3c7e8b29ca0b923877cf310cfd6d3a4e1fc5a0e1`
+(`fix: validate update tag safety snapshot`). The live harness repairs after that production
+revision were separately TDD-tested and scoped re-reviewed. The live runtime was TIA Portal V21
+with portal PID `44176`.
+
+**Offline-tested evidence:** Fresh final evidence at `845824b` passed the serial reference-stub
+build with 0 warnings/0 errors and the full suite with 2,622/2,622 tests and 0 skipped. This
+supports the required offline/registered rows below; it does not replace the live acceptance.
 
 ## Mandatory Live Target
 
-- Project copy path: PENDING
-- Requested `plcName` input: PENDING
-- Resolved PLC name from `read_update_tag_safety_snapshot`: PENDING
-- Tag table name: PENDING
-- Tag name: PENDING
-- Drift flag proved: PENDING
+- Project copy path (authorized test project): `C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21`
+- Requested `plcName` input: `PLC_LAD`
+- Resolved PLC name from `read_update_tag_safety_snapshot`: `PLC_LAD`
+- Root folder: `/`
+- Tag table name: `Inputs`
+- Tag name: `DI_Reserve_1_7`
+- Data type: `Bool`
+- Logical address: `%I1.7`
+- Drift flag proved: `ExternalVisible`, observed as `True`
 
 ## Mandatory Calls Performed
 
-- `get_project_status` identity establishment for the worker-level preflight - NOT RUN
-- `read_update_tag_safety_snapshot` preflight on the drift target - NOT RUN
-- `list_tag_tables` comparison read - NOT RUN
-- `preview_write_batch` - NOT RUN
-- one authorized intermediate flag-only drift write on the disposable copy - NOT RUN
-- stale-token `apply_write_batch` - NOT RUN
-- restoration or discard step - NOT RUN
+- `get_project_status` identity establishment for the worker-level preflight - PASS; direct worker hello/status established a complete worker-stamped session identity, with portal PID `44176`
+- `read_update_tag_safety_snapshot` preflight on the drift target - PASS; strict snapshot resolved `PLC_LAD` / `/` / `Inputs` / `DI_Reserve_1_7`, and observed `ExternalVisible = True`
+- `list_tag_tables` comparison read - PASS; registered `execute_read_batch/list_tag_tables` returned one successful operation whose row matched `Bool` / `%I1.7`
+- `preview_write_batch` - PASS; `PreviewDrift` observed `ExternalVisible = True` and issued a safety token; no mutation was made and the token was discarded
+- one authorized intermediate flag-only drift write on the disposable copy - PASS; `ApplyDrift -AllowApply` changed only `ExternalVisible` from `True` to `False`
+- stale-token `apply_write_batch` - PASS; applying the original stale token failed with `failureCategory = state_changed`
+- restoration or discard step - PASS; the harness `finally` reconciliation restored `ExternalVisible = True`; no save, close, or discard was performed
 
 ## Mandatory Live Results
 
 | Criterion | Command | Observed |
 |---|---|---|
-| Identity-bound internal safety read succeeds with the worker-stamped identity | `pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -DriftFlagName ExternalVisible -Mode Read` | NOT RUN |
-| Exact-target snapshot resolves PLC identity and the chosen drift flag is readable | `pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -DriftFlagName ExternalVisible -Mode Read` | NOT RUN |
-| Flag-only drift causes stale-token `state_changed` before mutation | `pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -DriftFlagName ExternalVisible -Mode ApplyDrift -AllowApply` | NOT RUN |
-| Public `list_tag_tables` semantics remain unchanged | `pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -DriftFlagName ExternalVisible -Mode Read` | NOT RUN |
+| Identity-bound internal safety read succeeds with the worker-stamped identity | `$projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21'; $hostDll = (Resolve-Path 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll').Path; pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode Read -HostArguments @($hostDll, '--project', $projectPath)` | PASS - direct worker hello/status established the complete worker-stamped session identity; the strict safety snapshot resolved the exact target and observed `ExternalVisible = True` |
+| Exact-target snapshot resolves PLC identity and the chosen drift flag is readable | `$projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21'; $hostDll = (Resolve-Path 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll').Path; pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode Read -HostArguments @($hostDll, '--project', $projectPath)` | PASS - resolved PLC `PLC_LAD`, root `/`, table `Inputs`, tag `DI_Reserve_1_7`; `ExternalVisible = True` |
+| Flag-only drift causes stale-token `state_changed` before mutation | `$projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21'; $hostDll = (Resolve-Path 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll').Path; pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode ApplyDrift -AllowApply -HostArguments @($hostDll, '--project', $projectPath)` | PASS - the authorized intermediate update changed only `ExternalVisible` `True` -> `False`; the original stale token was rejected with `failureCategory = state_changed`; reconciliation restored `True` |
+| Public `list_tag_tables` semantics remain unchanged | `$projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21'; $hostDll = (Resolve-Path 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll').Path; pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode Read -HostArguments @($hostDll, '--project', $projectPath)` | PASS - registered `execute_read_batch/list_tag_tables` returned one successful operation matching `Bool` / `%I1.7`; an independent final `Read` again observed `ExternalVisible = True` |
 
-The mandatory non-mutating preview command is also prepared, but has not been run:
+The mandatory non-mutating preview command passed without mutation:
 
 ```powershell
-pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -DriftFlagName ExternalVisible -Mode PreviewDrift
+$projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21'
+$hostDll = (Resolve-Path 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll').Path
+pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode PreviewDrift -HostArguments @($hostDll, '--project', $projectPath)
 ```
+
+`PreviewDrift` observed `ExternalVisible = True` and issued a safety token. No mutation was made
+by this mode, and the token was discarded.
 
 ## Required Offline and Registered Evidence
 
 | Criterion | Evidence source | Observed |
 |---|---|---|
-| Bound client sends a complete expected identity; worker rejects missing and mismatched identity as `binding_conflict` | `TagUpdateSafetySnapshotWorkerClientTests` plus `TagUpdateSafetySnapshotIdentityEnforcementTests` | PASS - revision `3c7e8b29ca0b923877cf310cfd6d3a4e1fc5a0e1`; fresh 2026-09-02 full offline suite (2,617/2,617) |
-| Requested unavailable flag fails before token issuance | `TagUpdateCurrentStateFakeWorkerTests` plus contract/worker tests | PASS - revision `3c7e8b29ca0b923877cf310cfd6d3a4e1fc5a0e1`; fresh 2026-09-02 full offline suite (2,617/2,617) |
-| Strict snapshot payload rejects `{}`, malformed/unsupported shapes, every omitted member, and wrong member types before broad fallback or token issuance | `TagUpdateCurrentStateFakeWorkerTests` | PASS - revision `3c7e8b29ca0b923877cf310cfd6d3a4e1fc5a0e1`; fresh 2026-09-02 full offline suite (2,617/2,617) |
-| Harness accepts a legal tool result with omitted `isError`, preserves explicit application-error handling, and defines the optional-probe guard before its entrypoint call | `TagUpdateSafetyLiveHarnessContractTests` | PASS - revision `3c7e8b29ca0b923877cf310cfd6d3a4e1fc5a0e1`; fresh 2026-09-02 full offline suite (2,617/2,617) |
+| Bound client sends a complete expected identity; worker rejects missing and mismatched identity as `binding_conflict` | `TagUpdateSafetySnapshotWorkerClientTests` plus `TagUpdateSafetySnapshotIdentityEnforcementTests` | PASS - revision `845824b0903743220c82084610891b4ab4f4dceb`; fresh final full offline suite (2,622/2,622, 0 skipped) |
+| Requested unavailable flag fails before token issuance | `TagUpdateCurrentStateFakeWorkerTests` plus contract/worker tests | PASS - revision `845824b0903743220c82084610891b4ab4f4dceb`; fresh final full offline suite (2,622/2,622, 0 skipped) |
+| Strict snapshot payload rejects `{}`, malformed/unsupported shapes, every omitted member, and wrong member types before broad fallback or token issuance | `TagUpdateCurrentStateFakeWorkerTests` | PASS - revision `845824b0903743220c82084610891b4ab4f4dceb`; fresh final full offline suite (2,622/2,622, 0 skipped) |
+| Harness accepts a legal tool result with omitted `isError`, preserves explicit application-error handling, and defines the optional-probe guard before its entrypoint call | `TagUpdateSafetyLiveHarnessContractTests` | PASS - revision `845824b0903743220c82084610891b4ab4f4dceb`; focused harness suite 13/13 and fresh final full offline suite (2,622/2,622, 0 skipped) |
 
 ## Optional Live Unavailable Probe
 
 | Criterion | Command | Observed |
 |---|---|---|
-| Second target exposes an unavailable flag and preview rejects it before token issuance | `pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -ProbeTableName 'Legacy table' -ProbeTagName 'LegacyTag' -ProbeFlagName ExternalWritable -Mode ProbeUnavailable` | NOT RUN |
+| Second target exposes an unavailable flag and preview rejects it before token issuance | Not run; no distinct second target was established to expose a truly unavailable external flag. | NOT RUN |
 
 If the authorized disposable target does not expose an unavailable flag for the chosen second target,
 record `NOT RUN` here and keep the acceptance gate anchored to the mandatory live rows plus the
 required offline/registered evidence.
+
+## Execution notes
+
+- The successful commands used the harness `HostArguments` extension point to bind the local host
+  exactly: `$hostDll = (Resolve-Path 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll').Path` and
+  `-HostArguments @($hostDll, '--project', $projectPath)`. Earlier abbreviated unbound commands are
+  not the accepted evidence.
+- Earlier attempts all stopped before mutation: empty-array binder; missing worker protocol marker;
+  Openness permission timeout; optional JSON-RPC error access; and wrong public payload wrapper. The
+  corresponding harness repairs were `c07a624` (empty worker arguments), `594e304` (per-request
+  worker protocol marker), `d000fb5` (optional JSON-RPC `error`), and `845824b` (direct public
+  tag-table array). Each was TDD-tested and scoped re-reviewed. The successful mandatory read
+  preceded any preview/write; only the final authorized `ApplyDrift -AllowApply` mutated TIA.
+- The exact flag value was restored in memory to `ExternalVisible = True`, but direct final
+  `get_project_status` observed the unchanged project path with `isModified = true`. No save, close,
+  or discard was performed; TIA retains an unsaved modification marker from the transient
+  change/restore round trip.

--- a/docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
+++ b/docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
@@ -45,17 +45,16 @@ supports the required offline/registered rows below; it does not replace the liv
 
 | Criterion | Command | Observed |
 |---|---|---|
-| Identity-bound internal safety read succeeds with the worker-stamped identity | `$projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21'; $hostDll = (Resolve-Path 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll').Path; pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode Read -HostArguments @($hostDll, '--project', $projectPath)` | PASS - direct worker hello/status established the complete worker-stamped session identity; the strict safety snapshot resolved the exact target and observed `ExternalVisible = True` |
-| Exact-target snapshot resolves PLC identity and the chosen drift flag is readable | `$projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21'; $hostDll = (Resolve-Path 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll').Path; pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode Read -HostArguments @($hostDll, '--project', $projectPath)` | PASS - resolved PLC `PLC_LAD`, root `/`, table `Inputs`, tag `DI_Reserve_1_7`; `ExternalVisible = True` |
-| Flag-only drift causes stale-token `state_changed` before mutation | `$projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21'; $hostDll = (Resolve-Path 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll').Path; pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode ApplyDrift -AllowApply -HostArguments @($hostDll, '--project', $projectPath)` | PASS - the authorized intermediate update changed only `ExternalVisible` `True` -> `False`; the original stale token was rejected with `failureCategory = state_changed`; reconciliation restored `True` |
-| Public `list_tag_tables` semantics remain unchanged | `$projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21'; $hostDll = (Resolve-Path 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll').Path; pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode Read -HostArguments @($hostDll, '--project', $projectPath)` | PASS - registered `execute_read_batch/list_tag_tables` returned one successful operation matching `Bool` / `%I1.7`; an independent final `Read` again observed `ExternalVisible = True` |
+| Identity-bound internal safety read succeeds with the worker-stamped identity | `$projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21'; pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode Read` | PASS - direct worker hello/status established the complete worker-stamped session identity; the strict safety snapshot resolved the exact target and observed `ExternalVisible = True` |
+| Exact-target snapshot resolves PLC identity and the chosen drift flag is readable | `$projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21'; pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode Read` | PASS - resolved PLC `PLC_LAD`, root `/`, table `Inputs`, tag `DI_Reserve_1_7`; `ExternalVisible = True` |
+| Flag-only drift causes stale-token `state_changed` before mutation | `$projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21'; pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode ApplyDrift -AllowApply` | PASS - the authorized intermediate update changed only `ExternalVisible` `True` -> `False`; the original stale token was rejected with `failureCategory = state_changed`; reconciliation restored `True` |
+| Public `list_tag_tables` semantics remain unchanged | `$projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21'; pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode Read` | PASS - registered `execute_read_batch/list_tag_tables` returned one successful operation matching `Bool` / `%I1.7`; an independent final `Read` again observed `ExternalVisible = True` |
 
 The mandatory non-mutating preview command passed without mutation:
 
 ```powershell
 $projectPath = 'C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21'
-$hostDll = (Resolve-Path 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll').Path
-pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode PreviewDrift -HostArguments @($hostDll, '--project', $projectPath)
+pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath $projectPath -PlcName 'PLC_LAD' -TableName 'Inputs' -TagName 'DI_Reserve_1_7' -DriftFlagName ExternalVisible -Mode PreviewDrift
 ```
 
 `PreviewDrift` observed `ExternalVisible = True` and issued a safety token. No mutation was made
@@ -82,10 +81,11 @@ required offline/registered evidence.
 
 ## Execution notes
 
-- The successful commands used the harness `HostArguments` extension point to bind the local host
-  exactly: `$hostDll = (Resolve-Path 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll').Path` and
-  `-HostArguments @($hostDll, '--project', $projectPath)`. Earlier abbreviated unbound commands are
-  not the accepted evidence.
+- The reproducible commands above use the harness default, which starts the local host DLL with the
+  exact `--project $ProjectPath` binding. The previously recorded native `pwsh -File` form with an
+  array-valued `-HostArguments` override was removed because native parameter binding consumed its
+  embedded `--project` as another harness argument. Earlier abbreviated unbound commands are not
+  the accepted evidence.
 - Earlier attempts all stopped before mutation: empty-array binder; missing worker protocol marker;
   Openness permission timeout; optional JSON-RPC error access; and wrong public payload wrapper. The
   corresponding harness repairs were `c07a624` (empty worker arguments), `594e304` (per-request

--- a/docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
+++ b/docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
@@ -9,6 +9,10 @@
 TIA Portal V21 harness mode has been authorized or run. PR 3 remains incomplete until the
 mandatory live acceptance is separately authorized and observed.
 
+**Offline-tested code-fix revision:** `3c7e8b29ca0b923877cf310cfd6d3a4e1fc5a0e1`
+(`fix: validate update tag safety snapshot`). The exact committed revision passed the full offline
+suite on 2026-09-02. This does not replace or satisfy any live acceptance row below.
+
 ## Mandatory Live Target
 
 - Project copy path: PENDING
@@ -47,8 +51,10 @@ pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\P
 
 | Criterion | Evidence source | Observed |
 |---|---|---|
-| Bound client sends a complete expected identity; worker rejects missing and mismatched identity as `binding_conflict` | `TagUpdateSafetySnapshotWorkerClientTests` plus `TagUpdateSafetySnapshotIdentityEnforcementTests` | PASS - fresh 2026-09-02 full offline suite (2,590/2,590) |
-| Requested unavailable flag fails before token issuance | `TagUpdateCurrentStateFakeWorkerTests` plus contract/worker tests | PASS - fresh 2026-09-02 full offline suite (2,590/2,590) |
+| Bound client sends a complete expected identity; worker rejects missing and mismatched identity as `binding_conflict` | `TagUpdateSafetySnapshotWorkerClientTests` plus `TagUpdateSafetySnapshotIdentityEnforcementTests` | PASS - revision `3c7e8b29ca0b923877cf310cfd6d3a4e1fc5a0e1`; fresh 2026-09-02 full offline suite (2,617/2,617) |
+| Requested unavailable flag fails before token issuance | `TagUpdateCurrentStateFakeWorkerTests` plus contract/worker tests | PASS - revision `3c7e8b29ca0b923877cf310cfd6d3a4e1fc5a0e1`; fresh 2026-09-02 full offline suite (2,617/2,617) |
+| Strict snapshot payload rejects `{}`, malformed/unsupported shapes, every omitted member, and wrong member types before broad fallback or token issuance | `TagUpdateCurrentStateFakeWorkerTests` | PASS - revision `3c7e8b29ca0b923877cf310cfd6d3a4e1fc5a0e1`; fresh 2026-09-02 full offline suite (2,617/2,617) |
+| Harness accepts a legal tool result with omitted `isError`, preserves explicit application-error handling, and defines the optional-probe guard before its entrypoint call | `TagUpdateSafetyLiveHarnessContractTests` | PASS - revision `3c7e8b29ca0b923877cf310cfd6d3a4e1fc5a0e1`; fresh 2026-09-02 full offline suite (2,617/2,617) |
 
 ## Optional Live Unavailable Probe
 

--- a/docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
+++ b/docs/superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md
@@ -1,0 +1,61 @@
+# Acceptance Test Report - PR 3 update_tag safety snapshot (live TIA Portal V21)
+
+**Date:** 2026-09-01
+**Runtime:** Real TIA Portal V21
+**Harness:** `scripts/live-test-update-tag-safety.ps1`
+**Boundary:** Disposable project copy; the mandatory live gate is exact-target read plus one authorized flag-only drift and stale-token rejection.
+
+**Status:** PENDING / NOT RUN. This report prepares the required live evidence, but no live
+TIA Portal V21 harness mode has been authorized or run. PR 3 remains incomplete until the
+mandatory live acceptance is separately authorized and observed.
+
+## Mandatory Live Target
+
+- Project copy path: PENDING
+- Requested `plcName` input: PENDING
+- Resolved PLC name from `read_update_tag_safety_snapshot`: PENDING
+- Tag table name: PENDING
+- Tag name: PENDING
+- Drift flag proved: PENDING
+
+## Mandatory Calls Performed
+
+- `get_project_status` identity establishment for the worker-level preflight - NOT RUN
+- `read_update_tag_safety_snapshot` preflight on the drift target - NOT RUN
+- `list_tag_tables` comparison read - NOT RUN
+- `preview_write_batch` - NOT RUN
+- one authorized intermediate flag-only drift write on the disposable copy - NOT RUN
+- stale-token `apply_write_batch` - NOT RUN
+- restoration or discard step - NOT RUN
+
+## Mandatory Live Results
+
+| Criterion | Command | Observed |
+|---|---|---|
+| Identity-bound internal safety read succeeds with the worker-stamped identity | `pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -DriftFlagName ExternalVisible -Mode Read` | NOT RUN |
+| Exact-target snapshot resolves PLC identity and the chosen drift flag is readable | `pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -DriftFlagName ExternalVisible -Mode Read` | NOT RUN |
+| Flag-only drift causes stale-token `state_changed` before mutation | `pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -DriftFlagName ExternalVisible -Mode ApplyDrift -AllowApply` | NOT RUN |
+| Public `list_tag_tables` semantics remain unchanged | `pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -DriftFlagName ExternalVisible -Mode Read` | NOT RUN |
+
+The mandatory non-mutating preview command is also prepared, but has not been run:
+
+```powershell
+pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -DriftFlagName ExternalVisible -Mode PreviewDrift
+```
+
+## Required Offline and Registered Evidence
+
+| Criterion | Evidence source | Observed |
+|---|---|---|
+| Bound client sends a complete expected identity; worker rejects missing and mismatched identity as `binding_conflict` | `TagUpdateSafetySnapshotWorkerClientTests` plus `TagUpdateSafetySnapshotIdentityEnforcementTests` | PASS - fresh 2026-09-02 full offline suite (2,590/2,590) |
+| Requested unavailable flag fails before token issuance | `TagUpdateCurrentStateFakeWorkerTests` plus contract/worker tests | PASS - fresh 2026-09-02 full offline suite (2,590/2,590) |
+
+## Optional Live Unavailable Probe
+
+| Criterion | Command | Observed |
+|---|---|---|
+| Second target exposes an unavailable flag and preview rejects it before token issuance | `pwsh -File scripts/live-test-update-tag-safety.ps1 -ProjectPath 'C:\Disposable\ProjectCopy.ap21' -PlcName 'PLC_1' -TableName 'Default tag table' -TagName 'MotorReady' -ProbeTableName 'Legacy table' -ProbeTagName 'LegacyTag' -ProbeFlagName ExternalWritable -Mode ProbeUnavailable` | NOT RUN |
+
+If the authorized disposable target does not expose an unavailable flag for the chosen second target,
+record `NOT RUN` here and keep the acceptance gate anchored to the mandatory live rows plus the
+required offline/registered evidence.

--- a/scripts/live-test-update-tag-safety.ps1
+++ b/scripts/live-test-update-tag-safety.ps1
@@ -1,0 +1,467 @@
+#Requires -Version 7
+<#
+.SYNOPSIS
+    Separately authorized live TIA Portal V21 acceptance harness for the PR 3 update_tag safety snapshot.
+
+.DESCRIPTION
+    Read is non-mutating. PreviewDrift obtains a preview token for one flag-only update. ApplyDrift
+    is the separately authorized disposable-copy acceptance: it makes one intermediate flag-only
+    change, proves the original token rejects with state_changed, and restores the original value.
+    ProbeUnavailable is optional and only applies to a separately supplied target whose chosen flag
+    is actually unavailable. Ordinary tests inspect this script; they never invoke it.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$ProjectPath,
+    [Parameter(Mandatory)][string]$TableName,
+    [Parameter(Mandatory)][string]$TagName,
+    [string]$PlcName,
+    [ValidateSet('ExternalAccessible','ExternalVisible','ExternalWritable')][string]$DriftFlagName = 'ExternalVisible',
+    [string]$ProbeTableName,
+    [string]$ProbeTagName,
+    [ValidateSet('ExternalAccessible','ExternalVisible','ExternalWritable')][string]$ProbeFlagName = 'ExternalVisible',
+    [ValidateSet('Read','PreviewDrift','ApplyDrift','ProbeUnavailable')][string]$Mode = 'Read',
+    [switch]$AllowApply,
+    [string]$HostExecutable = 'dotnet',
+    [string[]]$HostArguments,
+    [string]$WorkerExecutable,
+    [ValidateRange(10, 600)][int]$TimeoutSeconds = 120
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:RepositoryRoot = Split-Path -Parent $PSScriptRoot
+$script:HostProcess = $null
+$script:WorkerProcess = $null
+$script:NextRequestId = 0
+$script:WorkerSessionIdentity = $null
+
+if ($Mode -eq 'ApplyDrift' -and -not $AllowApply) {
+    throw "Mode 'ApplyDrift' requires -AllowApply. It changes one flag on a disposable project copy."
+}
+
+if ($Mode -eq 'ProbeUnavailable') {
+    foreach ($required in @('ProbeTableName', 'ProbeTagName', 'ProbeFlagName')) {
+        if ([string]::IsNullOrWhiteSpace([string](Get-Variable -Name $required -ValueOnly))) {
+            throw "Mode 'ProbeUnavailable' requires -$required. This optional probe uses a separate target."
+        }
+    }
+}
+
+if ($null -eq $HostArguments -or $HostArguments.Count -eq 0) {
+    $hostDll = Join-Path $script:RepositoryRoot 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll'
+    $HostArguments = @($hostDll)
+}
+
+if ([string]::IsNullOrWhiteSpace($WorkerExecutable)) {
+    $WorkerExecutable = Join-Path $script:RepositoryRoot 'TiaMcpServer\bin\Debug\net8.0\openness-worker\TiaMcpServer.OpennessWorker.exe'
+}
+
+function Start-JsonLineProcess {
+    param(
+        [Parameter(Mandatory)][string]$Executable,
+        [Parameter(Mandatory)][string[]]$Arguments,
+        [Parameter(Mandatory)][string]$Label
+    )
+
+    if (-not (Test-Path -LiteralPath $Executable -PathType Leaf) -and $Executable -ne 'dotnet') {
+        throw "$Label executable was not found: $Executable"
+    }
+
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $Executable
+    foreach ($argument in $Arguments) {
+        [void]$startInfo.ArgumentList.Add($argument)
+    }
+    $startInfo.RedirectStandardInput = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $false
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    if (-not $process.Start()) {
+        throw "Failed to start $Label."
+    }
+    return $process
+}
+
+function Stop-JsonLineProcess {
+    param([System.Diagnostics.Process]$Process)
+
+    if ($null -eq $Process) {
+        return
+    }
+
+    try {
+        if (-not $Process.HasExited) {
+            try { $Process.StandardInput.Close() } catch { [Console]::Error.WriteLine($_.Exception.Message) }
+            if (-not $Process.WaitForExit(5000)) {
+                $Process.Kill($true)
+                if (-not $Process.WaitForExit(5000)) {
+                    throw 'The child process tree did not exit within 5 seconds after forced termination.'
+                }
+            }
+        }
+    }
+    finally {
+        $Process.Dispose()
+    }
+}
+
+function Send-JsonLine {
+    param(
+        [Parameter(Mandatory)][System.Diagnostics.Process]$Process,
+        [Parameter(Mandatory)][object]$Message
+    )
+
+    $json = $Message | ConvertTo-Json -Compress -Depth 100
+    $Process.StandardInput.WriteLine($json)
+    $Process.StandardInput.Flush()
+}
+
+function Read-JsonLine {
+    param(
+        [Parameter(Mandatory)][System.Diagnostics.Process]$Process,
+        [int]$ExpectedId = -1
+    )
+
+    $deadline = [DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ([DateTimeOffset]::UtcNow -lt $deadline) {
+        if ($Process.HasExited) {
+            throw "The child process exited with code $($Process.ExitCode)."
+        }
+
+        $readTask = $Process.StandardOutput.ReadLineAsync()
+        $remaining = $deadline - [DateTimeOffset]::UtcNow
+        if ($remaining -le [TimeSpan]::Zero -or -not $readTask.Wait($remaining)) {
+            break
+        }
+
+        $line = $readTask.Result
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+        try { $candidate = $line | ConvertFrom-Json -Depth 100 } catch { continue }
+        if ($null -eq $candidate) {
+            continue
+        }
+        if ($ExpectedId -lt 0) {
+            return $candidate
+        }
+        $idProperty = $candidate.PSObject.Properties['id']
+        if ($null -ne $idProperty -and $candidate.id -eq $ExpectedId) {
+            return $candidate
+        }
+    }
+    throw "Timed out after $TimeoutSeconds second(s) waiting for a JSON response."
+}
+
+function Assert-WorkerSuccess {
+    param(
+        [Parameter(Mandatory)][object]$Response,
+        [Parameter(Mandatory)][string]$Method
+    )
+
+    if ($null -eq $Response -or -not $Response.success) {
+        $category = if ($null -ne $Response -and $null -ne $Response.failureCategory) { $Response.failureCategory } else { 'unknown' }
+        $error = if ($null -ne $Response -and $null -ne $Response.error) { $Response.error } else { 'no response' }
+        throw "Worker method '$Method' failed ($category): $error"
+    }
+}
+
+function Invoke-WorkerRequest {
+    param(
+        [Parameter(Mandatory)][string]$Method,
+        [Parameter(Mandatory)][hashtable]$Arguments
+    )
+
+    $request = @{ method = $Method }
+    foreach ($key in $Arguments.Keys) { $request[$key] = $Arguments[$key] }
+    Send-JsonLine -Process $script:WorkerProcess -Message $request
+    $response = Read-JsonLine -Process $script:WorkerProcess
+    Assert-WorkerSuccess -Response $response -Method $Method
+    return $response
+}
+
+function Convert-WorkerPayload {
+    param([Parameter(Mandatory)][object]$Response)
+
+    if ($null -eq $Response.payload -or [string]::IsNullOrWhiteSpace([string]$Response.payload)) {
+        throw 'The worker returned no payload.'
+    }
+    $payload = $Response.payload | ConvertFrom-Json -Depth 100
+    if ($null -eq $payload) {
+        throw 'The worker returned a null payload.'
+    }
+    return $payload
+}
+
+function Connect-Worker {
+    Send-JsonLine -Process $script:WorkerProcess -Message @{
+        method = 'hello'
+        protocolVersion = 'project-binding-v1'
+    }
+    $hello = Read-JsonLine -Process $script:WorkerProcess
+    Assert-WorkerSuccess -Response $hello -Method 'hello'
+    if ($hello.protocolVersion -ne 'project-binding-v1') {
+        throw "Worker hello returned incompatible protocolVersion '$($hello.protocolVersion)'."
+    }
+    $capabilities = @($hello.capabilities)
+    foreach ($required in @('expected-session-identity', 'response-session-identity', 'deterministic-project-selection')) {
+        if ($capabilities -notcontains $required) {
+            throw "Worker hello did not advertise required capability '$required'."
+        }
+    }
+}
+
+function Get-CompleteSessionIdentity {
+    $statusResponse = Invoke-WorkerRequest -Method 'get_project_status' -Arguments @{ projectPath = $ProjectPath }
+    $identity = $statusResponse.sessionIdentity
+    if ($null -eq $identity `
+        -or [string]::IsNullOrWhiteSpace([string]$identity.workerSessionId) `
+        -or $identity.sessionGeneration -lt 1 `
+        -or $null -eq $identity.portalProcessId -or $identity.portalProcessId -lt 1 `
+        -or [string]::IsNullOrWhiteSpace([string]$identity.projectPath)) {
+        throw 'get_project_status did not return a complete worker sessionIdentity.'
+    }
+    $script:WorkerSessionIdentity = $identity
+}
+
+function Read-UpdateTagSafetySnapshot {
+    param(
+        [Parameter(Mandatory)][string]$RequestedTableName,
+        [Parameter(Mandatory)][string]$RequestedTagName,
+        [string]$RequestedPlcName
+    )
+
+    if ($null -eq $script:WorkerSessionIdentity) {
+        throw 'A worker-stamped sessionIdentity is required before an internal safety read.'
+    }
+    $response = Invoke-WorkerRequest -Method 'read_update_tag_safety_snapshot' -Arguments @{
+        projectPath = $ProjectPath
+        plcName = $RequestedPlcName
+        tableName = $RequestedTableName
+        folderPath = '/'
+        name = $RequestedTagName
+        expectedSessionIdentity = $script:WorkerSessionIdentity
+    }
+    $snapshot = Convert-WorkerPayload -Response $response
+    if ([string]::IsNullOrWhiteSpace([string]$snapshot.plcName)) {
+        throw 'The strict update_tag snapshot did not resolve a PLC name.'
+    }
+    return $snapshot
+}
+
+function Get-ReadableSnapshotFlag {
+    param(
+        [Parameter(Mandatory)][object]$Snapshot,
+        [Parameter(Mandatory)][string]$FlagName
+    )
+
+    $property = $Snapshot.PSObject.Properties[$FlagName]
+    if ($null -eq $property -or $null -eq $property.Value) {
+        throw "The mandatory drift flag '$FlagName' is unreadable on the exact target. This is a live-gate failure."
+    }
+    return [bool]$property.Value
+}
+
+function Start-McpHost {
+    $script:HostProcess = Start-JsonLineProcess -Executable $HostExecutable -Arguments $HostArguments -Label 'MCP host'
+    $null = Invoke-McpRequest -Method 'initialize' -Params @{
+        protocolVersion = '2025-06-18'
+        capabilities = @{}
+        clientInfo = @{ name = 'live-test-update-tag-safety'; version = '1.0.0' }
+    }
+    Invoke-McpNotification -Method 'notifications/initialized'
+    $tools = Invoke-McpRequest -Method 'tools/list'
+    $toolNames = @($tools.tools | ForEach-Object { $_.name })
+    foreach ($required in @('list_tag_tables', 'preview_write_batch', 'apply_write_batch')) {
+        if ($toolNames -notcontains $required) {
+            throw "The MCP host does not advertise '$required'."
+        }
+    }
+}
+
+function Invoke-McpRequest {
+    param([Parameter(Mandatory)][string]$Method, [hashtable]$Params = @{})
+
+    $id = ++$script:NextRequestId
+    Send-JsonLine -Process $script:HostProcess -Message @{ jsonrpc = '2.0'; id = $id; method = $Method; params = $Params }
+    $response = Read-JsonLine -Process $script:HostProcess -ExpectedId $id
+    if ($null -ne $response.error) {
+        throw "MCP request '$Method' failed: $($response.error | ConvertTo-Json -Compress -Depth 20)"
+    }
+    return $response.result
+}
+
+function Invoke-McpNotification {
+    param([Parameter(Mandatory)][string]$Method, [hashtable]$Params = @{})
+    Send-JsonLine -Process $script:HostProcess -Message @{ jsonrpc = '2.0'; method = $Method; params = $Params }
+}
+
+function Invoke-McpTool {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][hashtable]$Arguments
+    )
+
+    $result = Invoke-McpRequest -Method 'tools/call' -Params @{ name = $Name; arguments = $Arguments }
+    if ($null -eq $result) {
+        throw "MCP tool '$Name' returned no result."
+    }
+    $text = if ($null -ne $result.content -and @($result.content).Count -gt 0) { [string]$result.content[0].text } else { $null }
+    $document = if ([string]::IsNullOrWhiteSpace($text)) { $null } else { $text | ConvertFrom-Json -Depth 100 }
+    return [pscustomobject]@{ Result = $result; Text = $text; Document = $document }
+}
+
+function New-UpdateTagOperation {
+    param(
+        [Parameter(Mandatory)][object]$Snapshot,
+        [Parameter(Mandatory)][string]$FlagName,
+        [Parameter(Mandatory)][bool]$Value,
+        [Parameter(Mandatory)][string]$OperationId
+    )
+
+    $operation = [ordered]@{
+        operationId = $OperationId
+        operation = 'update_tag'
+        projectPath = $ProjectPath
+        plcName = [string]$Snapshot.plcName
+        tableName = [string]$Snapshot.tableName
+        folderPath = [string]$Snapshot.folderPath
+        name = [string]$Snapshot.tagName
+    }
+    $operation[$FlagName] = $Value
+    return $operation
+}
+
+function Get-PreviewToken {
+    param([Parameter(Mandatory)][object]$ToolCall)
+
+    if ($ToolCall.Result.isError -or $null -eq $ToolCall.Document) {
+        throw "preview_write_batch failed before issuing a token: $($ToolCall.Text)"
+    }
+    $token = $ToolCall.Document.safetyToken
+    if ([string]::IsNullOrWhiteSpace([string]$token)) {
+        throw 'preview_write_batch succeeded without a safetyToken.'
+    }
+    return [string]$token
+}
+
+function Invoke-Preview {
+    param([Parameter(Mandatory)][object]$Operation)
+    return Invoke-McpTool -Name 'preview_write_batch' -Arguments @{ operations = @($Operation) }
+}
+
+function Invoke-Apply {
+    param(
+        [Parameter(Mandatory)][object]$Operation,
+        [Parameter(Mandatory)][string]$SafetyToken
+    )
+    return Invoke-McpTool -Name 'apply_write_batch' -Arguments @{
+        confirm = $true
+        safetyToken = $SafetyToken
+        operations = @($Operation)
+    }
+}
+
+function Write-SnapshotEvidence {
+    param(
+        [Parameter(Mandatory)][object]$Snapshot,
+        [Parameter(Mandatory)][string]$FlagName
+    )
+    $flag = $Snapshot.PSObject.Properties[$FlagName].Value
+    Write-Output "resolvedPlcName: $($Snapshot.plcName)"
+    Write-Output "tableName: $($Snapshot.tableName)"
+    Write-Output "tagName: $($Snapshot.tagName)"
+    Write-Output "${FlagName}: $flag"
+}
+
+try {
+    $script:WorkerProcess = Start-JsonLineProcess -Executable $WorkerExecutable -Arguments @() -Label 'Openness worker'
+    Connect-Worker
+    Get-CompleteSessionIdentity
+    Start-McpHost
+
+    switch ($Mode) {
+        'Read' {
+            $snapshot = Read-UpdateTagSafetySnapshot -RequestedTableName $TableName -RequestedTagName $TagName -RequestedPlcName $PlcName
+            $null = Get-ReadableSnapshotFlag -Snapshot $snapshot -FlagName $DriftFlagName
+            Write-SnapshotEvidence -Snapshot $snapshot -FlagName $DriftFlagName
+            $listResult = Invoke-McpTool -Name 'list_tag_tables' -Arguments @{ projectPath = $ProjectPath; plcName = $PlcName }
+            Write-Output 'list_tag_tables public response:'
+            Write-Output $listResult.Text
+        }
+        'PreviewDrift' {
+            $snapshot = Read-UpdateTagSafetySnapshot -RequestedTableName $TableName -RequestedTagName $TagName -RequestedPlcName $PlcName
+            $currentValue = Get-ReadableSnapshotFlag -Snapshot $snapshot -FlagName $DriftFlagName
+            $operation = New-UpdateTagOperation -Snapshot $snapshot -FlagName $DriftFlagName -Value (-not $currentValue) -OperationId 'update-tag-preview-drift'
+            $preview = Invoke-Preview -Operation $operation
+            $token = Get-PreviewToken -ToolCall $preview
+            Write-SnapshotEvidence -Snapshot $snapshot -FlagName $DriftFlagName
+            Write-Output "safetyToken: $token"
+        }
+        'ApplyDrift' {
+            $snapshot = Read-UpdateTagSafetySnapshot -RequestedTableName $TableName -RequestedTagName $TagName -RequestedPlcName $PlcName
+            $currentValue = Get-ReadableSnapshotFlag -Snapshot $snapshot -FlagName $DriftFlagName
+            $originalOperation = New-UpdateTagOperation -Snapshot $snapshot -FlagName $DriftFlagName -Value (-not $currentValue) -OperationId 'update-tag-stale-token'
+            $originalPreview = Invoke-Preview -Operation $originalOperation
+            $originalToken = Get-PreviewToken -ToolCall $originalPreview
+            $intermediateApplied = $false
+            try {
+                $intermediatePreview = Invoke-Preview -Operation $originalOperation
+                $intermediateToken = Get-PreviewToken -ToolCall $intermediatePreview
+                $intermediateApply = Invoke-Apply -Operation $originalOperation -SafetyToken $intermediateToken
+                if ($intermediateApply.Result.isError) {
+                    throw "The authorized intermediate update_tag drift failed: $($intermediateApply.Text)"
+                }
+                $intermediateApplied = $true
+
+                $staleApply = Invoke-Apply -Operation $originalOperation -SafetyToken $originalToken
+                $failureCategory = if ($null -ne $staleApply.Document) { [string]$staleApply.Document.failureCategory } else { '' }
+                if ($failureCategory -ne 'state_changed') {
+                    throw "The stale-token apply did not reject with state_changed: $($staleApply.Text)"
+                }
+                Write-Output 'stale apply failureCategory: state_changed'
+                Write-SnapshotEvidence -Snapshot (Read-UpdateTagSafetySnapshot -RequestedTableName $TableName -RequestedTagName $TagName -RequestedPlcName $PlcName) -FlagName $DriftFlagName
+            }
+            finally {
+                if ($intermediateApplied) {
+                    $restoreSnapshot = Read-UpdateTagSafetySnapshot -RequestedTableName $TableName -RequestedTagName $TagName -RequestedPlcName $PlcName
+                    $restoreOperation = New-UpdateTagOperation -Snapshot $restoreSnapshot -FlagName $DriftFlagName -Value $currentValue -OperationId 'update-tag-restore-original-flag'
+                    $restorePreview = Invoke-Preview -Operation $restoreOperation
+                    $restoreToken = Get-PreviewToken -ToolCall $restorePreview
+                    $restoreApply = Invoke-Apply -Operation $restoreOperation -SafetyToken $restoreToken
+                    if ($restoreApply.Result.isError) {
+                        throw "The restoration update_tag failed: $($restoreApply.Text)"
+                    }
+                    Write-Output 'Restored the original flag value on the disposable copy.'
+                    Write-SnapshotEvidence -Snapshot (Read-UpdateTagSafetySnapshot -RequestedTableName $TableName -RequestedTagName $TagName -RequestedPlcName $PlcName) -FlagName $DriftFlagName
+                }
+            }
+        }
+        'ProbeUnavailable' {
+            $probeSnapshot = Read-UpdateTagSafetySnapshot -RequestedTableName $ProbeTableName -RequestedTagName $ProbeTagName -RequestedPlcName $PlcName
+            $probeProperty = $probeSnapshot.PSObject.Properties[$ProbeFlagName]
+            if ($null -eq $probeProperty -or $null -ne $probeProperty.Value) {
+                throw "Optional unavailable probe is NOT RUN: '$ProbeFlagName' is readable on the supplied second target."
+            }
+            $probeOperation = New-UpdateTagOperation -Snapshot $probeSnapshot -FlagName $ProbeFlagName -Value $true -OperationId 'update-tag-unavailable-flag-probe'
+            $probePreview = Invoke-Preview -Operation $probeOperation
+            if (-not $probePreview.Result.isError) {
+                throw "Optional unavailable probe unexpectedly issued a preview result: $($probePreview.Text)"
+            }
+            if ($null -ne $probePreview.Document -and -not [string]::IsNullOrWhiteSpace([string]$probePreview.Document.safetyToken)) {
+                throw 'Optional unavailable probe unexpectedly issued a safety token.'
+            }
+            Write-Output 'Optional unavailable flag preview rejected before token issuance.'
+        }
+    }
+}
+finally {
+    Stop-JsonLineProcess -Process $script:HostProcess
+    Stop-JsonLineProcess -Process $script:WorkerProcess
+}

--- a/scripts/live-test-update-tag-safety.ps1
+++ b/scripts/live-test-update-tag-safety.ps1
@@ -40,7 +40,7 @@ $script:WorkerSessionIdentity = $null
 function Start-JsonLineProcess {
     param(
         [Parameter(Mandatory)][string]$Executable,
-        [Parameter(Mandatory)][string[]]$Arguments,
+        [string[]]$Arguments,
         [Parameter(Mandatory)][string]$Label
     )
 

--- a/scripts/live-test-update-tag-safety.ps1
+++ b/scripts/live-test-update-tag-safety.ps1
@@ -157,7 +157,7 @@ function Invoke-WorkerRequest {
         [Parameter(Mandatory)][hashtable]$Arguments
     )
 
-    $request = @{ method = $Method }
+    $request = @{ method = $Method; protocolVersion = 'project-binding-v1' }
     foreach ($key in $Arguments.Keys) { $request[$key] = $Arguments[$key] }
     Send-JsonLine -Process $script:WorkerProcess -Message $request
     $response = Read-JsonLine -Process $script:WorkerProcess

--- a/scripts/live-test-update-tag-safety.ps1
+++ b/scripts/live-test-update-tag-safety.ps1
@@ -351,11 +351,15 @@ function Get-PreviewToken {
     if ((Test-McpToolResultIsError -Result $ToolCall.Result) -or $null -eq $ToolCall.Document) {
         throw "preview_write_batch failed before issuing a token: $($ToolCall.Text)"
     }
-    $token = $ToolCall.Document.safetyToken
-    if ([string]::IsNullOrWhiteSpace([string]$token)) {
+    $successProperty = $ToolCall.Document.PSObject.Properties['success']
+    if ($null -eq $successProperty -or $successProperty.Value -isnot [bool] -or -not [bool]$successProperty.Value) {
+        throw "preview_write_batch failed before issuing a token: $($ToolCall.Text)"
+    }
+    $tokenProperty = $ToolCall.Document.PSObject.Properties['safetyToken']
+    if ($null -eq $tokenProperty -or [string]::IsNullOrWhiteSpace([string]$tokenProperty.Value)) {
         throw 'preview_write_batch succeeded without a safetyToken.'
     }
-    return [string]$token
+    return [string]$tokenProperty.Value
 }
 
 function Invoke-Preview {
@@ -452,7 +456,7 @@ function Invoke-Main {
 
     if ($null -eq $HostArguments -or $HostArguments.Count -eq 0) {
         $hostDll = Join-Path $script:RepositoryRoot 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll'
-        $HostArguments = @($hostDll)
+        $HostArguments = @($hostDll, '--project', $ProjectPath)
     }
 
     if ([string]::IsNullOrWhiteSpace($WorkerExecutable)) {
@@ -545,11 +549,16 @@ function Invoke-Main {
             }
             $probeOperation = New-UpdateTagOperation -Snapshot $probeSnapshot -FlagName $ProbeFlagName -Value $true -OperationId 'update-tag-unavailable-flag-probe'
             $probePreview = Invoke-McpTool -Name 'preview_write_batch' -Arguments @{ operations = @($probeOperation) } -AllowApplicationError
-            if (-not (Test-McpToolResultIsError -Result $probePreview.Result)) {
-                throw "Optional unavailable probe unexpectedly issued a preview result: $($probePreview.Text)"
+            if ((Test-McpToolResultIsError -Result $probePreview.Result) -or $null -eq $probePreview.Document) {
+                throw "Optional unavailable probe did not return the expected validation document: $($probePreview.Text)"
             }
-            if ($null -ne $probePreview.Document -and -not [string]::IsNullOrWhiteSpace([string]$probePreview.Document.safetyToken)) {
-                throw 'Optional unavailable probe unexpectedly issued a safety token.'
+            $probeSuccess = $probePreview.Document.PSObject.Properties['success']
+            $probeFailureCategory = $probePreview.Document.PSObject.Properties['failureCategory']
+            $probeToken = $probePreview.Document.PSObject.Properties['safetyToken']
+            if ($null -eq $probeSuccess -or $probeSuccess.Value -isnot [bool] -or [bool]$probeSuccess.Value -or
+                $null -eq $probeFailureCategory -or [string]$probeFailureCategory.Value -ne 'validation_error' -or
+                $null -ne $probeToken) {
+                throw "Optional unavailable probe did not return success:false, failureCategory validation_error, and no safety token: $($probePreview.Text)"
             }
             Write-Output 'Optional unavailable flag preview rejected before token issuance.'
         }

--- a/scripts/live-test-update-tag-safety.ps1
+++ b/scripts/live-test-update-tag-safety.ps1
@@ -348,16 +348,36 @@ function New-UpdateTagOperation {
 function Get-PreviewToken {
     param([Parameter(Mandatory)][object]$ToolCall)
 
-    if ((Test-McpToolResultIsError -Result $ToolCall.Result) -or $null -eq $ToolCall.Document) {
-        throw "preview_write_batch failed before issuing a token: $($ToolCall.Text)"
+    if (Test-McpToolResultIsError -Result $ToolCall.Result) {
+        throw 'preview_write_batch failed before issuing a token: MCP application error.'
+    }
+    if ($null -eq $ToolCall.Document) {
+        throw 'preview_write_batch failed before issuing a token: no valid result document.'
     }
     $successProperty = $ToolCall.Document.PSObject.Properties['success']
-    if ($null -eq $successProperty -or $successProperty.Value -isnot [bool] -or -not [bool]$successProperty.Value) {
-        throw "preview_write_batch failed before issuing a token: $($ToolCall.Text)"
+    if ($null -ne $successProperty -and $successProperty.Value -isnot [bool]) {
+        throw 'preview_write_batch failed before issuing a token: malformed success member.'
+    }
+    if ($null -ne $successProperty -and -not [bool]$successProperty.Value) {
+        $categoryProperty = $ToolCall.Document.PSObject.Properties['failureCategory']
+        $errorProperty = $ToolCall.Document.PSObject.Properties['error']
+        $category = if ($null -ne $categoryProperty -and -not [string]::IsNullOrWhiteSpace([string]$categoryProperty.Value)) {
+            [string]$categoryProperty.Value
+        }
+        else {
+            'unknown failure category'
+        }
+        $errorText = if ($null -ne $errorProperty -and -not [string]::IsNullOrWhiteSpace([string]$errorProperty.Value)) {
+            [string]$errorProperty.Value
+        }
+        else {
+            'no server diagnostic'
+        }
+        throw "preview_write_batch failed before issuing a token ($category): $errorText"
     }
     $tokenProperty = $ToolCall.Document.PSObject.Properties['safetyToken']
     if ($null -eq $tokenProperty -or [string]::IsNullOrWhiteSpace([string]$tokenProperty.Value)) {
-        throw 'preview_write_batch succeeded without a safetyToken.'
+        throw 'preview_write_batch failed before issuing a token: no nonblank safetyToken was returned.'
     }
     return [string]$tokenProperty.Value
 }

--- a/scripts/live-test-update-tag-safety.ps1
+++ b/scripts/live-test-update-tag-safety.ps1
@@ -405,10 +405,10 @@ function Assert-PublicTagRowMatchesSnapshot {
     if ($payload -is [string]) {
         $payload = $payload | ConvertFrom-Json -Depth 100
     }
-    if ($null -eq $payload -or $null -eq $payload.tables) {
+    if ($null -eq $payload) {
         throw "list_tag_tables returned no tables payload: $($ToolCall.Text)"
     }
-    $tables = @($payload.tables)
+    $tables = @($payload)
     $tables = @($tables | Where-Object {
         $_.name -eq $Snapshot.tableName -and $_.folderPath -eq $Snapshot.folderPath
     })

--- a/scripts/live-test-update-tag-safety.ps1
+++ b/scripts/live-test-update-tag-safety.ps1
@@ -47,6 +47,7 @@ if ($Mode -eq 'ProbeUnavailable') {
             throw "Mode 'ProbeUnavailable' requires -$required. This optional probe uses a separate target."
         }
     }
+    Assert-OptionalProbeTargetIsDistinct
 }
 
 if ($null -eq $HostArguments -or $HostArguments.Count -eq 0) {
@@ -278,7 +279,7 @@ function Start-McpHost {
     Invoke-McpNotification -Method 'notifications/initialized'
     $tools = Invoke-McpRequest -Method 'tools/list'
     $toolNames = @($tools.tools | ForEach-Object { $_.name })
-    foreach ($required in @('list_tag_tables', 'preview_write_batch', 'apply_write_batch')) {
+    foreach ($required in @('execute_read_batch', 'preview_write_batch', 'apply_write_batch')) {
         if ($toolNames -notcontains $required) {
             throw "The MCP host does not advertise '$required'."
         }
@@ -305,16 +306,33 @@ function Invoke-McpNotification {
 function Invoke-McpTool {
     param(
         [Parameter(Mandatory)][string]$Name,
-        [Parameter(Mandatory)][hashtable]$Arguments
+        [Parameter(Mandatory)][hashtable]$Arguments,
+        [switch]$AllowApplicationError
     )
 
     $result = Invoke-McpRequest -Method 'tools/call' -Params @{ name = $Name; arguments = $Arguments }
     if ($null -eq $result) {
         throw "MCP tool '$Name' returned no result."
     }
+    if ($result.isError -and -not $AllowApplicationError) {
+        $errorText = if ($null -ne $result.content -and @($result.content).Count -gt 0) { [string]$result.content[0].text } else { 'no error content' }
+        throw "MCP tool '$Name' returned an application error: $errorText"
+    }
     $text = if ($null -ne $result.content -and @($result.content).Count -gt 0) { [string]$result.content[0].text } else { $null }
     $document = if ([string]::IsNullOrWhiteSpace($text)) { $null } else { $text | ConvertFrom-Json -Depth 100 }
     return [pscustomobject]@{ Result = $result; Text = $text; Document = $document }
+}
+
+function Assert-OptionalProbeTargetIsDistinct {
+    # ProbeUnavailable has no independent PLC/folder selector. Its target therefore shares the
+    # mandatory target's $PlcName and root folder scope; table/tag must identify a second target.
+    $samePlcScope = $true
+    $sameFolderScope = $true
+    $sameTable = [string]::Equals($ProbeTableName, $TableName, [System.StringComparison]::Ordinal)
+    $sameTag = [string]::Equals($ProbeTagName, $TagName, [System.StringComparison]::Ordinal)
+    if ($samePlcScope -and $sameFolderScope -and $sameTable -and $sameTag) {
+        throw 'Mode ProbeUnavailable requires a second table/tag target distinct from the mandatory drift target.'
+    }
 }
 
 function New-UpdateTagOperation {
@@ -368,6 +386,55 @@ function Invoke-Apply {
     }
 }
 
+function Assert-SnapshotFlagEquals {
+    param(
+        [Parameter(Mandatory)][object]$Snapshot,
+        [Parameter(Mandatory)][string]$FlagName,
+        [Parameter(Mandatory)][bool]$ExpectedValue
+    )
+
+    $actualValue = Get-ReadableSnapshotFlag -Snapshot $Snapshot -FlagName $FlagName
+    if ($actualValue -ne $ExpectedValue) {
+        throw "Strict snapshot '$FlagName' was '$actualValue', expected original value '$ExpectedValue'."
+    }
+}
+
+function Assert-PublicTagRowMatchesSnapshot {
+    param(
+        [Parameter(Mandatory)][object]$ToolCall,
+        [Parameter(Mandatory)][object]$Snapshot
+    )
+
+    if ($ToolCall.Result.isError -or $null -eq $ToolCall.Document -or -not $ToolCall.Document.success) {
+        throw "list_tag_tables returned an application error: $($ToolCall.Text)"
+    }
+    $operations = @($ToolCall.Document.operations)
+    if ($operations.Count -ne 1 -or $operations[0].operation -ne 'list_tag_tables' -or $operations[0].status -ne 'succeeded') {
+        throw "list_tag_tables did not return exactly one successful operation: $($ToolCall.Text)"
+    }
+    $payload = $operations[0].result
+    if ($payload -is [string]) {
+        $payload = $payload | ConvertFrom-Json -Depth 100
+    }
+    if ($null -eq $payload -or $null -eq $payload.tables) {
+        throw "list_tag_tables returned no tables payload: $($ToolCall.Text)"
+    }
+    $tables = @($payload.tables)
+    $tables = @($tables | Where-Object {
+        $_.name -eq $Snapshot.tableName -and $_.folderPath -eq $Snapshot.folderPath
+    })
+    if ($tables.Count -ne 1) {
+        throw "list_tag_tables did not return exactly one matching table '$($Snapshot.tableName)'."
+    }
+    $tags = @($tables[0].tags | Where-Object { $_.name -eq $Snapshot.tagName })
+    if ($tags.Count -ne 1) {
+        throw "list_tag_tables did not return exactly one matching tag '$($Snapshot.tagName)'."
+    }
+    if ($tags[0].dataType -ne $Snapshot.dataType -or $tags[0].logicalAddress -ne $Snapshot.logicalAddress) {
+        throw "list_tag_tables tag values differ from the strict snapshot for '$($Snapshot.tagName)'."
+    }
+}
+
 function Write-SnapshotEvidence {
     param(
         [Parameter(Mandatory)][object]$Snapshot,
@@ -391,7 +458,13 @@ try {
             $snapshot = Read-UpdateTagSafetySnapshot -RequestedTableName $TableName -RequestedTagName $TagName -RequestedPlcName $PlcName
             $null = Get-ReadableSnapshotFlag -Snapshot $snapshot -FlagName $DriftFlagName
             Write-SnapshotEvidence -Snapshot $snapshot -FlagName $DriftFlagName
-            $listResult = Invoke-McpTool -Name 'list_tag_tables' -Arguments @{ projectPath = $ProjectPath; plcName = $PlcName }
+            $listResult = Invoke-McpTool -Name 'execute_read_batch' -Arguments @{ operations = @(@{
+                operationId = 'public-list-tag-tables'
+                operation = 'list_tag_tables'
+                projectPath = $ProjectPath
+                plcName = $PlcName
+            }) }
+            Assert-PublicTagRowMatchesSnapshot -ToolCall $listResult -Snapshot $snapshot
             Write-Output 'list_tag_tables public response:'
             Write-Output $listResult.Text
         }
@@ -410,7 +483,8 @@ try {
             $originalOperation = New-UpdateTagOperation -Snapshot $snapshot -FlagName $DriftFlagName -Value (-not $currentValue) -OperationId 'update-tag-stale-token'
             $originalPreview = Invoke-Preview -Operation $originalOperation
             $originalToken = Get-PreviewToken -ToolCall $originalPreview
-            $intermediateApplied = $false
+            $reconciliationIntent = New-UpdateTagOperation -Snapshot $snapshot -FlagName $DriftFlagName -Value $currentValue -OperationId 'update-tag-restore-original-flag'
+            $reconciliationRequired = $true
             try {
                 $intermediatePreview = Invoke-Preview -Operation $originalOperation
                 $intermediateToken = Get-PreviewToken -ToolCall $intermediatePreview
@@ -418,7 +492,6 @@ try {
                 if ($intermediateApply.Result.isError) {
                     throw "The authorized intermediate update_tag drift failed: $($intermediateApply.Text)"
                 }
-                $intermediateApplied = $true
 
                 $staleApply = Invoke-Apply -Operation $originalOperation -SafetyToken $originalToken
                 $failureCategory = if ($null -ne $staleApply.Document) { [string]$staleApply.Document.failureCategory } else { '' }
@@ -429,9 +502,16 @@ try {
                 Write-SnapshotEvidence -Snapshot (Read-UpdateTagSafetySnapshot -RequestedTableName $TableName -RequestedTagName $TagName -RequestedPlcName $PlcName) -FlagName $DriftFlagName
             }
             finally {
-                if ($intermediateApplied) {
-                    $restoreSnapshot = Read-UpdateTagSafetySnapshot -RequestedTableName $TableName -RequestedTagName $TagName -RequestedPlcName $PlcName
+                if (-not $reconciliationRequired) {
+                    throw 'ApplyDrift lost its required reconciliation plan before the intermediate mutation completed.'
+                }
+                $restoreSnapshot = Read-UpdateTagSafetySnapshot -RequestedTableName $TableName -RequestedTagName $TagName -RequestedPlcName $PlcName
+                $restoreValue = Get-ReadableSnapshotFlag -Snapshot $restoreSnapshot -FlagName $DriftFlagName
+                if ($restoreValue -ne $currentValue) {
                     $restoreOperation = New-UpdateTagOperation -Snapshot $restoreSnapshot -FlagName $DriftFlagName -Value $currentValue -OperationId 'update-tag-restore-original-flag'
+                    if ($restoreOperation.tableName -ne $reconciliationIntent.tableName -or $restoreOperation.folderPath -ne $reconciliationIntent.folderPath -or $restoreOperation.name -ne $reconciliationIntent.name) {
+                        throw 'The fresh reconciliation snapshot no longer identifies the originally planned tag target.'
+                    }
                     $restorePreview = Invoke-Preview -Operation $restoreOperation
                     $restoreToken = Get-PreviewToken -ToolCall $restorePreview
                     $restoreApply = Invoke-Apply -Operation $restoreOperation -SafetyToken $restoreToken
@@ -439,8 +519,10 @@ try {
                         throw "The restoration update_tag failed: $($restoreApply.Text)"
                     }
                     Write-Output 'Restored the original flag value on the disposable copy.'
-                    Write-SnapshotEvidence -Snapshot (Read-UpdateTagSafetySnapshot -RequestedTableName $TableName -RequestedTagName $TagName -RequestedPlcName $PlcName) -FlagName $DriftFlagName
                 }
+                $finalSnapshot = Read-UpdateTagSafetySnapshot -RequestedTableName $TableName -RequestedTagName $TagName -RequestedPlcName $PlcName
+                Assert-SnapshotFlagEquals -Snapshot $finalSnapshot -FlagName $DriftFlagName -ExpectedValue $currentValue
+                Write-SnapshotEvidence -Snapshot $finalSnapshot -FlagName $DriftFlagName
             }
         }
         'ProbeUnavailable' {
@@ -450,7 +532,7 @@ try {
                 throw "Optional unavailable probe is NOT RUN: '$ProbeFlagName' is readable on the supplied second target."
             }
             $probeOperation = New-UpdateTagOperation -Snapshot $probeSnapshot -FlagName $ProbeFlagName -Value $true -OperationId 'update-tag-unavailable-flag-probe'
-            $probePreview = Invoke-Preview -Operation $probeOperation
+            $probePreview = Invoke-McpTool -Name 'preview_write_batch' -Arguments @{ operations = @($probeOperation) } -AllowApplicationError
             if (-not $probePreview.Result.isError) {
                 throw "Optional unavailable probe unexpectedly issued a preview result: $($probePreview.Text)"
             }

--- a/scripts/live-test-update-tag-safety.ps1
+++ b/scripts/live-test-update-tag-safety.ps1
@@ -37,28 +37,6 @@ $script:WorkerProcess = $null
 $script:NextRequestId = 0
 $script:WorkerSessionIdentity = $null
 
-if ($Mode -eq 'ApplyDrift' -and -not $AllowApply) {
-    throw "Mode 'ApplyDrift' requires -AllowApply. It changes one flag on a disposable project copy."
-}
-
-if ($Mode -eq 'ProbeUnavailable') {
-    foreach ($required in @('ProbeTableName', 'ProbeTagName', 'ProbeFlagName')) {
-        if ([string]::IsNullOrWhiteSpace([string](Get-Variable -Name $required -ValueOnly))) {
-            throw "Mode 'ProbeUnavailable' requires -$required. This optional probe uses a separate target."
-        }
-    }
-    Assert-OptionalProbeTargetIsDistinct
-}
-
-if ($null -eq $HostArguments -or $HostArguments.Count -eq 0) {
-    $hostDll = Join-Path $script:RepositoryRoot 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll'
-    $HostArguments = @($hostDll)
-}
-
-if ([string]::IsNullOrWhiteSpace($WorkerExecutable)) {
-    $WorkerExecutable = Join-Path $script:RepositoryRoot 'TiaMcpServer\bin\Debug\net8.0\openness-worker\TiaMcpServer.OpennessWorker.exe'
-}
-
 function Start-JsonLineProcess {
     param(
         [Parameter(Mandatory)][string]$Executable,
@@ -303,6 +281,16 @@ function Invoke-McpNotification {
     Send-JsonLine -Process $script:HostProcess -Message @{ jsonrpc = '2.0'; method = $Method; params = $Params }
 }
 
+function Test-McpToolResultIsError {
+    param([Parameter(Mandatory)][object]$Result)
+
+    $property = $Result.PSObject.Properties['isError']
+    if ($null -eq $property) {
+        return $false
+    }
+    return [bool]$property.Value
+}
+
 function Invoke-McpTool {
     param(
         [Parameter(Mandatory)][string]$Name,
@@ -314,7 +302,7 @@ function Invoke-McpTool {
     if ($null -eq $result) {
         throw "MCP tool '$Name' returned no result."
     }
-    if ($result.isError -and -not $AllowApplicationError) {
+    if ((Test-McpToolResultIsError -Result $result) -and -not $AllowApplicationError) {
         $errorText = if ($null -ne $result.content -and @($result.content).Count -gt 0) { [string]$result.content[0].text } else { 'no error content' }
         throw "MCP tool '$Name' returned an application error: $errorText"
     }
@@ -359,7 +347,7 @@ function New-UpdateTagOperation {
 function Get-PreviewToken {
     param([Parameter(Mandatory)][object]$ToolCall)
 
-    if ($ToolCall.Result.isError -or $null -eq $ToolCall.Document) {
+    if ((Test-McpToolResultIsError -Result $ToolCall.Result) -or $null -eq $ToolCall.Document) {
         throw "preview_write_batch failed before issuing a token: $($ToolCall.Text)"
     }
     $token = $ToolCall.Document.safetyToken
@@ -405,7 +393,7 @@ function Assert-PublicTagRowMatchesSnapshot {
         [Parameter(Mandatory)][object]$Snapshot
     )
 
-    if ($ToolCall.Result.isError -or $null -eq $ToolCall.Document -or -not $ToolCall.Document.success) {
+    if ((Test-McpToolResultIsError -Result $ToolCall.Result) -or $null -eq $ToolCall.Document -or -not $ToolCall.Document.success) {
         throw "list_tag_tables returned an application error: $($ToolCall.Text)"
     }
     $operations = @($ToolCall.Document.operations)
@@ -447,13 +435,36 @@ function Write-SnapshotEvidence {
     Write-Output "${FlagName}: $flag"
 }
 
-try {
-    $script:WorkerProcess = Start-JsonLineProcess -Executable $WorkerExecutable -Arguments @() -Label 'Openness worker'
-    Connect-Worker
-    Get-CompleteSessionIdentity
-    Start-McpHost
+function Invoke-Main {
+    if ($Mode -eq 'ApplyDrift' -and -not $AllowApply) {
+        throw "Mode 'ApplyDrift' requires -AllowApply. It changes one flag on a disposable project copy."
+    }
 
-    switch ($Mode) {
+    if ($Mode -eq 'ProbeUnavailable') {
+        foreach ($required in @('ProbeTableName', 'ProbeTagName', 'ProbeFlagName')) {
+            if ([string]::IsNullOrWhiteSpace([string](Get-Variable -Name $required -ValueOnly))) {
+                throw "Mode 'ProbeUnavailable' requires -$required. This optional probe uses a separate target."
+            }
+        }
+        Assert-OptionalProbeTargetIsDistinct
+    }
+
+    if ($null -eq $HostArguments -or $HostArguments.Count -eq 0) {
+        $hostDll = Join-Path $script:RepositoryRoot 'TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll'
+        $HostArguments = @($hostDll)
+    }
+
+    if ([string]::IsNullOrWhiteSpace($WorkerExecutable)) {
+        $WorkerExecutable = Join-Path $script:RepositoryRoot 'TiaMcpServer\bin\Debug\net8.0\openness-worker\TiaMcpServer.OpennessWorker.exe'
+    }
+
+    try {
+        $script:WorkerProcess = Start-JsonLineProcess -Executable $WorkerExecutable -Arguments @() -Label 'Openness worker'
+        Connect-Worker
+        Get-CompleteSessionIdentity
+        Start-McpHost
+
+        switch ($Mode) {
         'Read' {
             $snapshot = Read-UpdateTagSafetySnapshot -RequestedTableName $TableName -RequestedTagName $TagName -RequestedPlcName $PlcName
             $null = Get-ReadableSnapshotFlag -Snapshot $snapshot -FlagName $DriftFlagName
@@ -489,7 +500,7 @@ try {
                 $intermediatePreview = Invoke-Preview -Operation $originalOperation
                 $intermediateToken = Get-PreviewToken -ToolCall $intermediatePreview
                 $intermediateApply = Invoke-Apply -Operation $originalOperation -SafetyToken $intermediateToken
-                if ($intermediateApply.Result.isError) {
+                if (Test-McpToolResultIsError -Result $intermediateApply.Result) {
                     throw "The authorized intermediate update_tag drift failed: $($intermediateApply.Text)"
                 }
 
@@ -515,7 +526,7 @@ try {
                     $restorePreview = Invoke-Preview -Operation $restoreOperation
                     $restoreToken = Get-PreviewToken -ToolCall $restorePreview
                     $restoreApply = Invoke-Apply -Operation $restoreOperation -SafetyToken $restoreToken
-                    if ($restoreApply.Result.isError) {
+                    if (Test-McpToolResultIsError -Result $restoreApply.Result) {
                         throw "The restoration update_tag failed: $($restoreApply.Text)"
                     }
                     Write-Output 'Restored the original flag value on the disposable copy.'
@@ -533,7 +544,7 @@ try {
             }
             $probeOperation = New-UpdateTagOperation -Snapshot $probeSnapshot -FlagName $ProbeFlagName -Value $true -OperationId 'update-tag-unavailable-flag-probe'
             $probePreview = Invoke-McpTool -Name 'preview_write_batch' -Arguments @{ operations = @($probeOperation) } -AllowApplicationError
-            if (-not $probePreview.Result.isError) {
+            if (-not (Test-McpToolResultIsError -Result $probePreview.Result)) {
                 throw "Optional unavailable probe unexpectedly issued a preview result: $($probePreview.Text)"
             }
             if ($null -ne $probePreview.Document -and -not [string]::IsNullOrWhiteSpace([string]$probePreview.Document.safetyToken)) {
@@ -541,9 +552,12 @@ try {
             }
             Write-Output 'Optional unavailable flag preview rejected before token issuance.'
         }
+        }
+    }
+    finally {
+        Stop-JsonLineProcess -Process $script:HostProcess
+        Stop-JsonLineProcess -Process $script:WorkerProcess
     }
 }
-finally {
-    Stop-JsonLineProcess -Process $script:HostProcess
-    Stop-JsonLineProcess -Process $script:WorkerProcess
-}
+
+Invoke-Main

--- a/scripts/live-test-update-tag-safety.ps1
+++ b/scripts/live-test-update-tag-safety.ps1
@@ -270,7 +270,8 @@ function Invoke-McpRequest {
     $id = ++$script:NextRequestId
     Send-JsonLine -Process $script:HostProcess -Message @{ jsonrpc = '2.0'; id = $id; method = $Method; params = $Params }
     $response = Read-JsonLine -Process $script:HostProcess -ExpectedId $id
-    if ($null -ne $response.error) {
+    $errorProperty = $response.PSObject.Properties['error']
+    if ($null -ne $errorProperty -and $null -ne $errorProperty.Value) {
         throw "MCP request '$Method' failed: $($response.error | ConvertTo-Json -Compress -Depth 20)"
     }
     return $response.result

--- a/scripts/live-test-update-tag-safety.ps1
+++ b/scripts/live-test-update-tag-safety.ps1
@@ -304,8 +304,7 @@ function Invoke-McpTool {
         throw "MCP tool '$Name' returned no result."
     }
     if ((Test-McpToolResultIsError -Result $result) -and -not $AllowApplicationError) {
-        $errorText = if ($null -ne $result.content -and @($result.content).Count -gt 0) { [string]$result.content[0].text } else { 'no error content' }
-        throw "MCP tool '$Name' returned an application error: $errorText"
+        throw "MCP tool '$Name' returned an application error."
     }
     $text = if ($null -ne $result.content -and @($result.content).Count -gt 0) { [string]$result.content[0].text } else { $null }
     $document = if ([string]::IsNullOrWhiteSpace($text)) { $null } else { $text | ConvertFrom-Json -Depth 100 }
@@ -570,7 +569,7 @@ function Invoke-Main {
             $probeOperation = New-UpdateTagOperation -Snapshot $probeSnapshot -FlagName $ProbeFlagName -Value $true -OperationId 'update-tag-unavailable-flag-probe'
             $probePreview = Invoke-McpTool -Name 'preview_write_batch' -Arguments @{ operations = @($probeOperation) } -AllowApplicationError
             if ((Test-McpToolResultIsError -Result $probePreview.Result) -or $null -eq $probePreview.Document) {
-                throw "Optional unavailable probe did not return the expected validation document: $($probePreview.Text)"
+                throw 'Optional unavailable probe did not return the expected validation document.'
             }
             $probeSuccess = $probePreview.Document.PSObject.Properties['success']
             $probeFailureCategory = $probePreview.Document.PSObject.Properties['failureCategory']
@@ -578,7 +577,7 @@ function Invoke-Main {
             if ($null -eq $probeSuccess -or $probeSuccess.Value -isnot [bool] -or [bool]$probeSuccess.Value -or
                 $null -eq $probeFailureCategory -or [string]$probeFailureCategory.Value -ne 'validation_error' -or
                 $null -ne $probeToken) {
-                throw "Optional unavailable probe did not return success:false, failureCategory validation_error, and no safety token: $($probePreview.Text)"
+                throw 'Optional unavailable probe did not return success:false, failureCategory validation_error, and no safety token.'
             }
             Write-Output 'Optional unavailable flag preview rejected before token issuance.'
         }


### PR DESCRIPTION
## Summary

- add an exact, typed update_tag safety snapshot with identity-required SafetyRead capability and strict worker payload validation
- bind preview/apply state hashing to the resolved PLC, table, folder, tag, mutable values, and requested external-flag availability
- add registered-path, FakeWorker, worker-client, harness, documentation, and live-acceptance coverage while preserving the legacy public list_tag_tables response

## Verification

- serial reference-stub build: 0 warnings, 0 errors
- complete test suite: 2,634 passed, 0 failed, 0 skipped
- focused live-harness contract suite: 20 passed
- live TIA V21: Read and PreviewDrift passed; authorized ExternalVisible drift changed True to False; the stale token was rejected with state_changed; restoration and an independent final read confirmed True
- optional unavailable-flag live probe: NOT RUN because no distinct authorized target exposed an unavailable flag; required offline and registered coverage passed

## Live-project state

The disposable project remains open with isModified=true after the restored transient write. No save, close, or discard operation was performed.