### PR TITLE
feat: add structured preview diffs for write batches

### DIFF
--- a/TiaMcpServer.Tests/Batch/BatchPreviewDiffTests.cs
+++ b/TiaMcpServer.Tests/Batch/BatchPreviewDiffTests.cs
@@ -1,0 +1,167 @@
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.OperationBatches;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class BatchPreviewDiffTests
+{
+    private static BatchOperationRequest BlockOp(string id, string path, string requested, string? format = null)
+        => new()
+        {
+            OperationId = id,
+            Operation = "update_block_logic",
+            BlockPath = path,
+            YamlContent = requested,
+            Format = format,
+        };
+
+    private static BatchOperationRequest TypeOp(string id, string path, string requested, string? format = null)
+        => new()
+        {
+            OperationId = id,
+            Operation = "update_type_content",
+            TypePath = path,
+            SourceContent = requested,
+            Format = format,
+        };
+
+    private static OperationBatchCurrentState State(BatchOperationRequest op, string current)
+        => new(op.OperationId, op.Operation, current);
+
+    private static string Sha256(string value)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
+
+    [Fact]
+    public void Build_ReturnsNullWhenBatchHasNoEligibleTextReplacement()
+    {
+        var operations = new[]
+        {
+            new BatchOperationRequest
+            {
+                OperationId = "tag-1",
+                Operation = "create_tag_table",
+                TableName = "Inputs",
+            }
+        };
+
+        var states = new[]
+        {
+            new OperationBatchCurrentState("tag-1", "create_tag_table", "{\"table\":\"Inputs\"}")
+        };
+
+        Assert.Null(BatchPreviewDiff.Build(operations, states));
+    }
+
+    [Fact]
+    public void Build_UsesNormalizedWriteFormatAndRawHashesForEligibleOperations()
+    {
+        const string current = "DATA_BLOCK \"Recipe\"\r\nBEGIN\r\nEND_DATA_BLOCK\r\n";
+        const string requested = "DATA_BLOCK \"Recipe\"\r\nBEGIN\r\n  Value := 1;\r\nEND_DATA_BLOCK\r\n";
+        var op = BlockOp("block-1", "PLC_1/Blocks/Recipe_DB", requested, SourceFormatNames.Source);
+
+        var diff = BatchPreviewDiff.Build(new[] { op }, new[] { State(op, current) })!;
+        var entry = Assert.Single(diff.Operations);
+
+        Assert.Equal(SourceFormatNames.Source, entry.Format);
+        Assert.Equal(Sha256(current), entry.Current.Sha256);
+        Assert.Equal(Sha256(requested), entry.Requested.Sha256);
+    }
+
+    [Fact]
+    public void Build_IdenticalContent_ProducesEmptyExcerptsAndZeroChangedSpans()
+    {
+        const string content = "TYPE \"A\"\r\nSTRUCT\r\nEND_STRUCT;\r\nEND_TYPE\r\n";
+        var op = TypeOp("type-1", "PLC_1/Types/A", content);
+
+        var diff = BatchPreviewDiff.Build(new[] { op }, new[] { State(op, content) })!;
+        var entry = Assert.Single(diff.Operations);
+
+        Assert.True(entry.RawTextEqual);
+        Assert.True(entry.NormalizedLinesEqual);
+        Assert.False(entry.LineEndingOnly);
+        Assert.Equal(0, entry.CurrentChangedLineCount);
+        Assert.Equal(0, entry.RequestedChangedLineCount);
+        Assert.Empty(entry.Current.Excerpt.Lines);
+        Assert.Empty(entry.Requested.Excerpt.Lines);
+    }
+
+    [Fact]
+    public void Build_DetectsLineEndingOnlyDifference()
+    {
+        const string current = "TYPE \"A\"\r\nSTRUCT\r\nEND_STRUCT;\r\nEND_TYPE\r\n";
+        const string requested = "TYPE \"A\"\nSTRUCT\nEND_STRUCT;\nEND_TYPE\n";
+        var op = TypeOp("type-1", "PLC_1/Types/A", requested);
+
+        var diff = BatchPreviewDiff.Build(new[] { op }, new[] { State(op, current) })!;
+        var entry = Assert.Single(diff.Operations);
+
+        Assert.False(entry.RawTextEqual);
+        Assert.True(entry.NormalizedLinesEqual);
+        Assert.True(entry.LineEndingOnly);
+    }
+
+    [Fact]
+    public void Build_TruncatesChangedSpanToFirstAndLastTwentyLinesPerSide()
+    {
+        var current = string.Join("\r\n", Enumerable.Range(1, 60).Select(i => $"OLD {i}")) + "\r\n";
+        var requested = string.Join("\r\n", Enumerable.Range(1, 60).Select(i => $"NEW {i}")) + "\r\n";
+        var op = TypeOp("type-1", "PLC_1/Types/A", requested);
+
+        var diff = BatchPreviewDiff.Build(new[] { op }, new[] { State(op, current) })!;
+        var entry = Assert.Single(diff.Operations);
+
+        Assert.Equal(40, entry.Current.Excerpt.Lines.Count);
+        Assert.Equal(40, entry.Requested.Excerpt.Lines.Count);
+        Assert.Equal("OLD 1", entry.Current.Excerpt.Lines[0].Text);
+        Assert.Equal("OLD 60", entry.Current.Excerpt.Lines[^1].Text);
+        Assert.Equal("NEW 1", entry.Requested.Excerpt.Lines[0].Text);
+        Assert.Equal("NEW 60", entry.Requested.Excerpt.Lines[^1].Text);
+        Assert.Equal(20, entry.Current.Excerpt.OmittedLineCount);
+        Assert.Equal(20, entry.Requested.Excerpt.OmittedLineCount);
+    }
+
+    [Fact]
+    public void Build_TruncatesLongLinesAndReportsOmittedCharacters()
+    {
+        var longLine = new string('x', BatchPreviewDiff.MaxExcerptCharsPerLine + 37);
+        var current = "TYPE \"A\"\r\nEND_TYPE\r\n";
+        var requested = $"TYPE \"A\"\r\n{longLine}\r\nEND_TYPE\r\n";
+        var op = TypeOp("type-1", "PLC_1/Types/A", requested);
+
+        var diff = BatchPreviewDiff.Build(new[] { op }, new[] { State(op, current) })!;
+        var line = diff.Operations[0].Requested.Excerpt.Lines.Single(x => x.LineNumber == 2);
+
+        Assert.Equal(BatchPreviewDiff.MaxExcerptCharsPerLine, line.Text.Length);
+        Assert.Equal(37, line.OmittedCharacterCount);
+        Assert.Equal(37, diff.Operations[0].Requested.Excerpt.OmittedCharacterCount);
+    }
+
+    [Fact]
+    public void Build_ExhaustsTheWholeBatchLineBudgetAtTheFifthEligibleOperation_AndLaterEntriesKeepHashesAndCounts()
+    {
+        var current = string.Join("\r\n", Enumerable.Range(1, 60).Select(i => $"OLD {i}")) + "\r\n";
+        var requested = string.Join("\r\n", Enumerable.Range(1, 60).Select(i => $"NEW {i}")) + "\r\n";
+        var operations = Enumerable.Range(1, 6)
+            .Select(i => TypeOp($"type-{i}", $"PLC_1/Types/T{i}", requested))
+            .ToArray();
+        var states = operations.Select(op => State(op, current)).ToArray();
+
+        var diff = BatchPreviewDiff.Build(operations, states)!;
+
+        Assert.All(diff.Operations.Take(4), entry => Assert.NotEmpty(entry.Requested.Excerpt.Lines));
+        Assert.True(diff.Operations[4].BatchBudgetExhausted);
+        Assert.Empty(diff.Operations[4].Current.Excerpt.Lines);
+        Assert.Empty(diff.Operations[4].Requested.Excerpt.Lines);
+        Assert.True(diff.Operations[5].BatchBudgetExhausted);
+        Assert.Empty(diff.Operations[5].Current.Excerpt.Lines);
+        Assert.Empty(diff.Operations[5].Requested.Excerpt.Lines);
+        Assert.NotEmpty(diff.Operations[5].Requested.Sha256);
+        Assert.True(diff.Operations[5].Requested.LineCount > 0);
+        Assert.True(diff.Operations[5].Requested.CharacterCount > 0);
+    }
+}

--- a/TiaMcpServer.Tests/Batch/BatchPreviewDiffTests.cs
+++ b/TiaMcpServer.Tests/Batch/BatchPreviewDiffTests.cs
@@ -128,7 +128,7 @@ public sealed class BatchPreviewDiffTests
     [Fact]
     public void Build_TruncatesLongLinesAndReportsOmittedCharacters()
     {
-        var longLine = new string('x', BatchPreviewDiff.MaxExcerptCharsPerLine + 37);
+        var longLine = new string('x', 549);
         var current = "TYPE \"A\"\r\nEND_TYPE\r\n";
         var requested = $"TYPE \"A\"\r\n{longLine}\r\nEND_TYPE\r\n";
         var op = TypeOp("type-1", "PLC_1/Types/A", requested);
@@ -136,9 +136,46 @@ public sealed class BatchPreviewDiffTests
         var diff = BatchPreviewDiff.Build(new[] { op }, new[] { State(op, current) })!;
         var line = diff.Operations[0].Requested.Excerpt.Lines.Single(x => x.LineNumber == 2);
 
-        Assert.Equal(BatchPreviewDiff.MaxExcerptCharsPerLine, line.Text.Length);
+        Assert.Equal(512, line.Text.Length);
         Assert.Equal(37, line.OmittedCharacterCount);
         Assert.Equal(37, diff.Operations[0].Requested.Excerpt.OmittedCharacterCount);
+    }
+
+    [Fact]
+    public void Build_UsesLiteral8192CharacterPerSideLimit()
+    {
+        var current = string.Join("\r\n", Enumerable.Range(1, 16).Select(i => $"OLD {i}"));
+        var requested = string.Join("\r\n", Enumerable.Repeat(new string('x', 600), 16));
+        var op = TypeOp("type-1", "PLC_1/Types/A", requested);
+
+        var diff = BatchPreviewDiff.Build(new[] { op }, new[] { State(op, current) })!;
+        var excerpt = Assert.Single(diff.Operations).Requested.Excerpt;
+
+        Assert.Equal(16, excerpt.Lines.Count);
+        Assert.All(excerpt.Lines, line => Assert.Equal(512, line.Text.Length));
+        Assert.Equal(8_192, excerpt.Lines.Sum(line => line.Text.Length));
+        Assert.Equal(1_408, excerpt.OmittedCharacterCount);
+    }
+
+    [Fact]
+    public void Build_ExhaustsAtLiteral32768CharacterBatchLimit()
+    {
+        var current = string.Join("\r\n", Enumerable.Repeat(new string('a', 600), 16));
+        var requested = string.Join("\r\n", Enumerable.Repeat(new string('b', 600), 16));
+        var operations = Enumerable.Range(1, 3)
+            .Select(i => TypeOp($"type-{i}", $"PLC_1/Types/T{i}", requested))
+            .ToArray();
+        var states = operations.Select(op => State(op, current)).ToArray();
+
+        var diff = BatchPreviewDiff.Build(operations, states)!;
+
+        Assert.All(diff.Operations.Take(2), entry => Assert.False(entry.BatchBudgetExhausted));
+        Assert.Equal(32_768, diff.Operations.Take(2).Sum(entry =>
+            entry.Current.Excerpt.Lines.Sum(line => line.Text.Length)
+            + entry.Requested.Excerpt.Lines.Sum(line => line.Text.Length)));
+        Assert.True(diff.Operations[2].BatchBudgetExhausted);
+        Assert.Empty(diff.Operations[2].Current.Excerpt.Lines);
+        Assert.Empty(diff.Operations[2].Requested.Excerpt.Lines);
     }
 
     [Fact]
@@ -160,8 +197,15 @@ public sealed class BatchPreviewDiffTests
         Assert.True(diff.Operations[5].BatchBudgetExhausted);
         Assert.Empty(diff.Operations[5].Current.Excerpt.Lines);
         Assert.Empty(diff.Operations[5].Requested.Excerpt.Lines);
-        Assert.NotEmpty(diff.Operations[5].Requested.Sha256);
-        Assert.True(diff.Operations[5].Requested.LineCount > 0);
-        Assert.True(diff.Operations[5].Requested.CharacterCount > 0);
+        var exhausted = diff.Operations[5];
+        Assert.Equal(Sha256(current), exhausted.Current.Sha256);
+        Assert.Equal(current.Length, exhausted.Current.CharacterCount);
+        Assert.Equal(61, exhausted.Current.LineCount);
+        Assert.Equal(Sha256(requested), exhausted.Requested.Sha256);
+        Assert.Equal(requested.Length, exhausted.Requested.CharacterCount);
+        Assert.Equal(61, exhausted.Requested.LineCount);
+        Assert.False(exhausted.RawTextEqual);
+        Assert.False(exhausted.NormalizedLinesEqual);
+        Assert.False(exhausted.LineEndingOnly);
     }
 }

--- a/TiaMcpServer.Tests/Batch/BatchPreviewDiffTests.cs
+++ b/TiaMcpServer.Tests/Batch/BatchPreviewDiffTests.cs
@@ -144,17 +144,17 @@ public sealed class BatchPreviewDiffTests
     [Fact]
     public void Build_UsesLiteral8192CharacterPerSideLimit()
     {
-        var current = string.Join("\r\n", Enumerable.Range(1, 16).Select(i => $"OLD {i}"));
-        var requested = string.Join("\r\n", Enumerable.Repeat(new string('x', 600), 16));
+        var current = string.Join("\r\n", Enumerable.Range(1, 32).Select(i => $"OLD {i}"));
+        var requested = string.Join("\r\n", Enumerable.Repeat(new string('x', 512), 32));
         var op = TypeOp("type-1", "PLC_1/Types/A", requested);
 
         var diff = BatchPreviewDiff.Build(new[] { op }, new[] { State(op, current) })!;
         var excerpt = Assert.Single(diff.Operations).Requested.Excerpt;
 
-        Assert.Equal(16, excerpt.Lines.Count);
-        Assert.All(excerpt.Lines, line => Assert.Equal(512, line.Text.Length));
+        Assert.Equal(32, excerpt.Lines.Count);
+        Assert.All(excerpt.Lines, line => Assert.Equal(256, line.Text.Length));
         Assert.Equal(8_192, excerpt.Lines.Sum(line => line.Text.Length));
-        Assert.Equal(1_408, excerpt.OmittedCharacterCount);
+        Assert.Equal(8_192, excerpt.OmittedCharacterCount);
     }
 
     [Fact]

--- a/TiaMcpServer.Tests/Batch/BatchSafetyTokenTests.cs
+++ b/TiaMcpServer.Tests/Batch/BatchSafetyTokenTests.cs
@@ -170,4 +170,60 @@ public class BatchSafetyTokenTests
 
         Assert.False(result.IsValid);
     }
+
+    [Fact]
+    public void DisplayDiff_IsNotRequiredForTokenValidation()
+    {
+        using var audit = new TempAuditDirectory();
+        var service = audit.CreateSafety();
+        var (ops, states) = TwoItemBatch();
+        var targets = BatchSafetySnapshot.BuildTargets(ops);
+        var combined = BatchSafetySnapshot.CombineCurrentState(
+            ops.Select((o, i) => new OperationBatchCurrentState(o.OperationId, o.Operation, states[i])).ToList());
+        var project = BatchSafetySnapshot.ResolveProjectPath(ops);
+
+        var preview = service.CreatePreview(
+            ApplyToolName,
+            project,
+            targets,
+            "summary",
+            ops,
+            combined,
+            diff: new { operations = new[] { new { operationId = "b", operation = "update_block_logic" } } });
+        var token = JsonDocument.Parse(preview).RootElement.GetProperty("safetyToken").GetString()!;
+
+        Assert.True(service.ValidateAndConsume(token, ApplyToolName, project, targets, ops, combined).IsValid);
+    }
+
+    [Fact]
+    public void DifferentDisplayDiffs_IssueTokensThatValidateAgainstTheSameState()
+    {
+        using var audit = new TempAuditDirectory();
+        var service = audit.CreateSafety();
+        var (ops, states) = TwoItemBatch();
+        var targets = BatchSafetySnapshot.BuildTargets(ops);
+        var combined = BatchSafetySnapshot.CombineCurrentState(
+            ops.Select((o, i) => new OperationBatchCurrentState(o.OperationId, o.Operation, states[i])).ToList());
+        var project = BatchSafetySnapshot.ResolveProjectPath(ops);
+
+        var first = JsonDocument.Parse(service.CreatePreview(
+            ApplyToolName,
+            project,
+            targets,
+            "summary",
+            ops,
+            combined,
+            diff: new { version = 1 }));
+        var second = JsonDocument.Parse(service.CreatePreview(
+            ApplyToolName,
+            project,
+            targets,
+            "summary",
+            ops,
+            combined,
+            diff: new { version = 2, extra = true }));
+
+        Assert.True(service.ValidateEnvelope(first.RootElement.GetProperty("safetyToken").GetString(), ApplyToolName, project, targets, ops).IsValid);
+        Assert.True(service.ValidateEnvelope(second.RootElement.GetProperty("safetyToken").GetString(), ApplyToolName, project, targets, ops).IsValid);
+    }
 }

--- a/TiaMcpServer.Tests/Batch/WriteBatchPreviewDiffIntegrationTests.cs
+++ b/TiaMcpServer.Tests/Batch/WriteBatchPreviewDiffIntegrationTests.cs
@@ -202,6 +202,35 @@ public sealed class WriteBatchPreviewDiffIntegrationTests
     }
 
     [Fact]
+    public async Task PreviewWriteBatch_BatchBudgetExhaustionSuppressesAllLaterEligibleExcerpts()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "type-content-roundtrip");
+        using (client)
+        {
+            var oversized = string.Join("\r\n", Enumerable.Range(1, 60).Select(_ => "x")) + "\r\n";
+            var operations = Enumerable.Range(1, 8).Select(i => new BatchOperationRequest
+            {
+                OperationId = $"oversized-{i}", Operation = "update_type_content", ProjectPath = "type-content-roundtrip", TypePath = "PLC_1/Types/AnalogInputSettings", SourceContent = oversized
+            }).Append(new BatchOperationRequest
+            {
+                OperationId = "small-after-exhaustion", Operation = "update_type_content", ProjectPath = "type-content-roundtrip", TypePath = "PLC_1/Types/AnalogInputSettings", SourceContent = "TYPE AnalogInputSettings STRUCT Value : Int; END_STRUCT END_TYPE"
+            }).ToArray();
+
+            var result = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+            using var doc = JsonDocument.Parse(result);
+            var diffOperations = doc.RootElement.GetProperty("diff").GetProperty("operations").EnumerateArray().ToArray();
+            var exhausted = diffOperations[7];
+            var later = diffOperations[8];
+
+            Assert.True(exhausted.GetProperty("batchBudgetExhausted").GetBoolean());
+            Assert.True(later.GetProperty("batchBudgetExhausted").GetBoolean());
+            Assert.Empty(later.GetProperty("current").GetProperty("excerpt").GetProperty("lines").EnumerateArray());
+            Assert.Empty(later.GetProperty("requested").GetProperty("excerpt").GetProperty("lines").EnumerateArray());
+        }
+    }
+
+    [Fact]
     public async Task PreviewWriteBatch_AllIneligibleWrites_ReturnsNullDiff()
     {
         using var audit = new TempAuditDirectory();

--- a/TiaMcpServer.Tests/Batch/WriteBatchPreviewDiffIntegrationTests.cs
+++ b/TiaMcpServer.Tests/Batch/WriteBatchPreviewDiffIntegrationTests.cs
@@ -195,7 +195,9 @@ public sealed class WriteBatchPreviewDiffIntegrationTests
             Assert.True(diffOperations[8].GetProperty("batchBudgetExhausted").GetBoolean());
             Assert.Empty(diffOperations[8].GetProperty("current").GetProperty("excerpt").GetProperty("lines").EnumerateArray());
             Assert.Empty(diffOperations[8].GetProperty("requested").GetProperty("excerpt").GetProperty("lines").EnumerateArray());
-            Assert.NotEmpty(diffOperations[8].GetProperty("requested").GetProperty("sha256").GetString());
+            var requestedSha256 = diffOperations[8].GetProperty("requested").GetProperty("sha256").GetString();
+            Assert.NotNull(requestedSha256);
+            Assert.NotEmpty(requestedSha256);
             Assert.True(diffOperations[8].GetProperty("requested").GetProperty("lineCount").GetInt32() > 0);
             Assert.True(diffOperations[8].GetProperty("requested").GetProperty("characterCount").GetInt32() > 0);
         }

--- a/TiaMcpServer.Tests/Batch/WriteBatchPreviewDiffIntegrationTests.cs
+++ b/TiaMcpServer.Tests/Batch/WriteBatchPreviewDiffIntegrationTests.cs
@@ -1,0 +1,219 @@
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tests.Worker;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class WriteBatchPreviewDiffIntegrationTests
+{
+    private const string SourceBlockCurrent =
+        "DATA_BLOCK \"Recipe\"\r\nSTRUCT\r\nEND_STRUCT;\r\nBEGIN\r\nEND_DATA_BLOCK\r\n";
+    private const string TypeCurrent =
+        "TYPE AnalogInputSettings STRUCT Value : Real; END_STRUCT END_TYPE";
+
+    private static OpennessWorkerClient CreateClient(ProjectSessionBinding binding)
+        => new(binding, logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+
+    private static WriteSafetyService CreateSafety(TempAuditDirectory audit, ProjectSessionBinding binding)
+        => new(binding, () => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, audit.Path);
+
+    private static async Task<(OpennessWorkerClient Client, WriteSafetyService Safety, ProjectSessionBinding Binding)> BoundAsync(
+        TempAuditDirectory audit,
+        string projectPath)
+    {
+        var binding = new ProjectSessionBinding(null);
+        var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, projectPath);
+        return (client, CreateSafety(audit, binding), binding);
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_UpdateBlockLogicWithSourceFormat_EmitsStructuredDiff()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "block-source-roundtrip");
+        using (client)
+        {
+            var result = await WriteBatchTools.PreviewWriteBatch(client, safety, new[]
+            {
+                new BatchOperationRequest { OperationId = "block-source", Operation = "update_block_logic", ProjectPath = "block-source-roundtrip", BlockPath = "PLC_1/Blocks/Recipe_DB", Format = SourceFormatNames.Source, YamlContent = "DATA_BLOCK \"Recipe\"\r\nSTRUCT\r\n  Value : Int;\r\nEND_STRUCT;\r\nBEGIN\r\nEND_DATA_BLOCK\r\n" }
+            });
+            using var doc = JsonDocument.Parse(result);
+            var entry = doc.RootElement.GetProperty("diff").GetProperty("operations")[0];
+            Assert.Equal("block-source", entry.GetProperty("operationId").GetString());
+            Assert.Equal(SourceFormatNames.Source, entry.GetProperty("format").GetString());
+            Assert.True(entry.GetProperty("requested").GetProperty("excerpt").GetProperty("lines").GetArrayLength() > 0);
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_UpdateBlockLogicWithoutFormat_DefaultsToXmlAndEmitsStructuredDiff()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "echo");
+        using (client)
+        {
+            var result = await WriteBatchTools.PreviewWriteBatch(client, safety, new[]
+            {
+                new BatchOperationRequest { OperationId = "block-default", Operation = "update_block_logic", ProjectPath = "echo", BlockPath = "PLC_1/Blocks/Main", YamlContent = "--- FILE: Main.xml\r\n<Document />\r\n" }
+            });
+            using var doc = JsonDocument.Parse(result);
+            var entry = doc.RootElement.GetProperty("diff").GetProperty("operations")[0];
+            Assert.Equal("block-default", entry.GetProperty("operationId").GetString());
+            Assert.Equal(SourceFormatNames.Xml, entry.GetProperty("format").GetString());
+            Assert.True(entry.GetProperty("current").GetProperty("characterCount").GetInt32() > 0);
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_UpdateBlockLogicWithExplicitXmlFormat_EmitsStructuredDiff()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "echo");
+        using (client)
+        {
+            var result = await WriteBatchTools.PreviewWriteBatch(client, safety, new[]
+            {
+                new BatchOperationRequest { OperationId = "block-xml", Operation = "update_block_logic", ProjectPath = "echo", BlockPath = "PLC_1/Blocks/Main", Format = SourceFormatNames.Xml, YamlContent = "--- FILE: Main.xml\r\n<Document Id=\"next\" />\r\n" }
+            });
+            using var doc = JsonDocument.Parse(result);
+            var entry = doc.RootElement.GetProperty("diff").GetProperty("operations")[0];
+            Assert.Equal("block-xml", entry.GetProperty("operationId").GetString());
+            Assert.Equal(SourceFormatNames.Xml, entry.GetProperty("format").GetString());
+            Assert.True(entry.GetProperty("requested").GetProperty("characterCount").GetInt32() > 0);
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_UpdateTypeContent_EmitsStructuredDiff()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "type-content-roundtrip");
+        using (client)
+        {
+            var result = await WriteBatchTools.PreviewWriteBatch(client, safety, new[]
+            {
+                new BatchOperationRequest { OperationId = "type-source", Operation = "update_type_content", ProjectPath = "type-content-roundtrip", TypePath = "PLC_1/Types/AnalogInputSettings", SourceContent = "TYPE AnalogInputSettings STRUCT Value : Int; END_STRUCT END_TYPE" }
+            });
+            using var doc = JsonDocument.Parse(result);
+            var entry = doc.RootElement.GetProperty("diff").GetProperty("operations")[0];
+            Assert.Equal("type-source", entry.GetProperty("operationId").GetString());
+            Assert.True(entry.GetProperty("current").GetProperty("characterCount").GetInt32() > 0);
+            Assert.True(entry.GetProperty("requested").GetProperty("excerpt").GetProperty("lines").GetArrayLength() > 0);
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_MixedEligibleAndIneligibleWrites_PreservesEligibleRequestOrder()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "echo");
+        using (client)
+        {
+            var result = await WriteBatchTools.PreviewWriteBatch(client, safety, new[]
+            {
+                new BatchOperationRequest { OperationId = "block-1", Operation = "update_block_logic", ProjectPath = "echo", BlockPath = "PLC_1/Blocks/Main", YamlContent = "--- FILE: Main.xml\r\n<Document />\r\n" },
+                new BatchOperationRequest { OperationId = "tag-1", Operation = "create_tag_table", ProjectPath = "echo", TableName = "Inputs" },
+                new BatchOperationRequest { OperationId = "type-3", Operation = "update_type_content", ProjectPath = "echo", TypePath = "PLC_1/Types/AnalogInputSettings", SourceContent = "TYPE AnalogInputSettings STRUCT Value : Int; END_STRUCT END_TYPE" }
+            });
+            using var doc = JsonDocument.Parse(result);
+            var operations = doc.RootElement.GetProperty("diff").GetProperty("operations");
+            Assert.Equal(new[] { "block-1", "type-3" }, operations.EnumerateArray().Select(x => x.GetProperty("operationId").GetString()).ToArray());
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_IdenticalContent_ReportsRawAndNormalizedEqualityWithNoChangedExcerpt()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "block-source-roundtrip");
+        using (client)
+        {
+            var result = await WriteBatchTools.PreviewWriteBatch(client, safety, new[]
+            {
+                new BatchOperationRequest { OperationId = "block-same", Operation = "update_block_logic", ProjectPath = "block-source-roundtrip", BlockPath = "PLC_1/Blocks/Recipe_DB", Format = SourceFormatNames.Source, YamlContent = SourceBlockCurrent }
+            });
+            using var doc = JsonDocument.Parse(result);
+            var entry = doc.RootElement.GetProperty("diff").GetProperty("operations")[0];
+            Assert.True(entry.GetProperty("rawTextEqual").GetBoolean());
+            Assert.True(entry.GetProperty("normalizedLinesEqual").GetBoolean());
+            Assert.False(entry.GetProperty("lineEndingOnly").GetBoolean());
+            Assert.Equal(0, entry.GetProperty("currentChangedLineCount").GetInt32());
+            Assert.Equal(0, entry.GetProperty("requestedChangedLineCount").GetInt32());
+            Assert.Equal(0, entry.GetProperty("current").GetProperty("excerpt").GetProperty("lines").GetArrayLength());
+            Assert.Equal(0, entry.GetProperty("requested").GetProperty("excerpt").GetProperty("lines").GetArrayLength());
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_LineEndingOnlyChange_ReportsNormalizedEqualityButNotRawEquality()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "block-source-roundtrip");
+        using (client)
+        {
+            var requested = SourceBlockCurrent.Replace("\r\n", "\n");
+            var result = await WriteBatchTools.PreviewWriteBatch(client, safety, new[]
+            {
+                new BatchOperationRequest { OperationId = "block-eol", Operation = "update_block_logic", ProjectPath = "block-source-roundtrip", BlockPath = "PLC_1/Blocks/Recipe_DB", Format = SourceFormatNames.Source, YamlContent = requested }
+            });
+            using var doc = JsonDocument.Parse(result);
+            var entry = doc.RootElement.GetProperty("diff").GetProperty("operations")[0];
+            Assert.False(entry.GetProperty("rawTextEqual").GetBoolean());
+            Assert.True(entry.GetProperty("normalizedLinesEqual").GetBoolean());
+            Assert.True(entry.GetProperty("lineEndingOnly").GetBoolean());
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_TruncatesOversizedEntriesAndExhaustsTheBatchBudget()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "type-content-roundtrip");
+        using (client)
+        {
+            const int retainedLineLength = 80;
+            var oversizedLine = new string('x', retainedLineLength);
+            var requested = string.Join("\r\n", Enumerable.Range(1, 60).Select(_ => oversizedLine)) + "\r\n";
+            var operations = Enumerable.Range(1, 9).Select(i => new BatchOperationRequest
+            {
+                OperationId = $"type-{i}", Operation = "update_type_content", ProjectPath = "type-content-roundtrip", TypePath = "PLC_1/Types/AnalogInputSettings", SourceContent = requested
+            }).ToArray();
+            var result = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+            using var doc = JsonDocument.Parse(result);
+            var diffOperations = doc.RootElement.GetProperty("diff").GetProperty("operations").EnumerateArray().ToArray();
+            Assert.Equal(40, diffOperations[0].GetProperty("requested").GetProperty("excerpt").GetProperty("lines").GetArrayLength());
+            Assert.Equal(retainedLineLength, diffOperations[0].GetProperty("requested").GetProperty("excerpt").GetProperty("lines")[0].GetProperty("text").GetString()!.Length);
+            Assert.False(diffOperations[6].GetProperty("batchBudgetExhausted").GetBoolean());
+            Assert.True(diffOperations[7].GetProperty("batchBudgetExhausted").GetBoolean());
+            Assert.Empty(diffOperations[7].GetProperty("current").GetProperty("excerpt").GetProperty("lines").EnumerateArray());
+            Assert.Empty(diffOperations[7].GetProperty("requested").GetProperty("excerpt").GetProperty("lines").EnumerateArray());
+            Assert.True(diffOperations[8].GetProperty("batchBudgetExhausted").GetBoolean());
+            Assert.Empty(diffOperations[8].GetProperty("current").GetProperty("excerpt").GetProperty("lines").EnumerateArray());
+            Assert.Empty(diffOperations[8].GetProperty("requested").GetProperty("excerpt").GetProperty("lines").EnumerateArray());
+            Assert.NotEmpty(diffOperations[8].GetProperty("requested").GetProperty("sha256").GetString());
+            Assert.True(diffOperations[8].GetProperty("requested").GetProperty("lineCount").GetInt32() > 0);
+            Assert.True(diffOperations[8].GetProperty("requested").GetProperty("characterCount").GetInt32() > 0);
+        }
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_AllIneligibleWrites_ReturnsNullDiff()
+    {
+        using var audit = new TempAuditDirectory();
+        var (client, safety, _) = await BoundAsync(audit, "echo");
+        using (client)
+        {
+            var result = await WriteBatchTools.PreviewWriteBatch(client, safety, new[]
+            {
+                new BatchOperationRequest { OperationId = "tag-1", Operation = "create_tag_table", ProjectPath = "echo", TableName = "Inputs" }
+            });
+            using var doc = JsonDocument.Parse(result);
+            Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("diff").ValueKind);
+        }
+    }
+}

--- a/TiaMcpServer.Tests/Batch/WritePreviewDiffLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/WritePreviewDiffLiveHarnessContractTests.cs
@@ -51,6 +51,19 @@ public sealed class WritePreviewDiffLiveHarnessContractTests
     }
 
     [Fact]
+    public void Script_SourceHashUsesLowercaseHexForCaseSensitivePreviewComparison()
+    {
+        var text = ReadScript();
+        var hashFunction = Regex.Match(text,
+            @"(?ms)^function Get-TextHash\([^\r\n]+\) \{\r?\n(?<body>.*?)^\}");
+        Assert.True(hashFunction.Success, "Expected the source hash helper.");
+        Assert.Contains(
+            "return [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($utf8.GetBytes($Text))).ToLowerInvariant()",
+            hashFunction.Groups["body"].Value, StringComparison.Ordinal);
+        Assert.Contains(".current.sha256 -ceq (Get-TextHash $original[$i])", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Script_DocumentsDisposableProjectScopeAndWritesTheAcceptanceReportPath()
     {
         var text = ReadScript();

--- a/TiaMcpServer.Tests/Batch/WritePreviewDiffLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/WritePreviewDiffLiveHarnessContractTests.cs
@@ -1,9 +1,10 @@
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Xunit;
 
 namespace TiaMcpServer.Tests.Batch;
 
-// Execution-free source checks only. Never start, dot-source, or parse the live harness here.
+// Ordinary tests never invoke the live harness body; helper tests execute only isolated functions.
 public sealed class WritePreviewDiffLiveHarnessContractTests
 {
     private static readonly string ScriptPath = Path.GetFullPath(Path.Combine(
@@ -71,9 +72,118 @@ public sealed class WritePreviewDiffLiveHarnessContractTests
         Assert.Contains("2026-09-01-pr4-structured-preview-diff-live.md", text, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task Script_ProjectVersionEvidenceUsesExplicitFallbackWithoutRunningHarness()
+    {
+        const string fixture = """
+            param([Parameter(Mandatory)] [string] $HarnessPath)
+
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            $tokens = $null
+            $parseErrors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+                $HarnessPath,
+                [ref] $tokens,
+                [ref] $parseErrors)
+            if ($parseErrors.Count -ne 0) {
+                throw "Harness parsing failed: $($parseErrors[0].Message)"
+            }
+
+            foreach ($functionName in @('Assert-Condition', 'Read-Binding')) {
+                $functionAst = $ast.Find({
+                        param($node)
+                        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] `
+                            -and $node.Name -eq $functionName
+                    }, $true)
+                if ($null -eq $functionAst) {
+                    throw "Function '$functionName' was not found."
+                }
+                Invoke-Expression $functionAst.Extent.Text
+            }
+
+            $ProjectPath = Join-Path ([IO.Path]::GetTempPath()) 'preview-diff-fixture.ap21'
+            $script:InitialIdentity = $null
+            $evidence = @{ Binding = ''; TiaVersion = '' }
+            $script:ProjectVersion = $null
+            function Invoke-Tool {
+                $payload = @{
+                    success = $true
+                    projectPath = $ProjectPath
+                    project = @{ isOpen = $true; path = $ProjectPath; version = $script:ProjectVersion }
+                } | ConvertTo-Json -Compress -Depth 10
+                return @{
+                    success = $true
+                    payload = $payload
+                    sessionIdentity = @{
+                        projectPath = $ProjectPath
+                        workerSessionId = 'fixture-worker'
+                        sessionGeneration = 1
+                        portalProcessId = 42
+                    }
+                }
+            }
+            $cases = @(
+                @{ name = 'missing'; value = $null; expected = 'V21 prerequisite; project version not reported' },
+                @{ name = 'blank'; value = '   '; expected = 'V21 prerequisite; project version not reported' },
+                @{ name = 'reported'; value = 'V21 Update 4'; expected = 'V21 prerequisite; project version reported: V21 Update 4' }
+            )
+            foreach ($case in $cases) {
+                $script:ProjectVersion = $case.value
+                $null = Read-Binding
+                $actual = $evidence.TiaVersion
+                if ($actual -cne $case.expected) {
+                    throw "Unexpected $($case.name) evidence: '$actual'."
+                }
+                if ($actual -notmatch '^[\x20-\x7E]+$' -or $actual -match '\s$') {
+                    throw "Evidence must be nonblank ASCII without trailing whitespace: '$actual'."
+                }
+            }
+            Write-Output 'tia-version-evidence-ok'
+            """;
+
+        var result = await RunPowerShellFixtureAsync(fixture);
+
+        Assert.True(result.ExitCode == 0,
+            $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
+        Assert.Contains("tia-version-evidence-ok", result.StandardOutput, StringComparison.Ordinal);
+    }
+
     private static string ReadScript()
     {
         Assert.True(File.Exists(ScriptPath), $"Expected the live harness at '{ScriptPath}'.");
         return File.ReadAllText(ScriptPath);
     }
+
+    private static async Task<PowerShellResult> RunPowerShellFixtureAsync(string fixture)
+    {
+        var fixturePath = Path.Combine(Path.GetTempPath(), $"preview-diff-harness-{Guid.NewGuid():N}.ps1");
+        await File.WriteAllTextAsync(fixturePath, fixture + Environment.NewLine);
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+        foreach (var argument in new[] { "-NoProfile", "-NonInteractive", "-File", fixturePath, "-HarnessPath", ScriptPath })
+            startInfo.ArgumentList.Add(argument);
+
+        try
+        {
+            using var process = new Process { StartInfo = startInfo };
+            Assert.True(process.Start(), "Expected the PowerShell fixture process to start.");
+            var standardOutput = await process.StandardOutput.ReadToEndAsync();
+            var standardError = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+            return new PowerShellResult(process.ExitCode, standardOutput, standardError);
+        }
+        finally
+        {
+            File.Delete(fixturePath);
+        }
+    }
+
+    private sealed record PowerShellResult(int ExitCode, string StandardOutput, string StandardError);
 }

--- a/TiaMcpServer.Tests/Batch/WritePreviewDiffLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/WritePreviewDiffLiveHarnessContractTests.cs
@@ -149,6 +149,77 @@ public sealed class WritePreviewDiffLiveHarnessContractTests
         Assert.Contains("tia-version-evidence-ok", result.StandardOutput, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task Script_ReportNotProvenEvidenceIsModeSpecificWithoutRunningHarness()
+    {
+        const string fixture = """
+            param([Parameter(Mandatory)] [string] $HarnessPath)
+
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+            $tokens = $null
+            $parseErrors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+                $HarnessPath,
+                [ref] $tokens,
+                [ref] $parseErrors)
+            if ($parseErrors.Count -ne 0) {
+                throw "Harness parsing failed: $($parseErrors[0].Message)"
+            }
+
+            $reportAssignment = $ast.Find({
+                    param($node)
+                    $node -is [System.Management.Automation.Language.AssignmentStatementAst] `
+                        -and $node.Left.Extent.Text -ceq '$report'
+                }, $true)
+            if ($null -eq $reportAssignment) {
+                throw "The report assignment was not found."
+            }
+
+            $runTime = 'fixture-time'
+            $HostDllPath = 'fixture-host.dll'
+            $hostHash = 'fixture-hash'
+            $ProjectPath = 'fixture-project.ap21'
+            $BlockPath = 'fixture-block'
+            $TypePath = 'fixture-type'
+            $runDirectory = 'fixture-evidence'
+            $evidence = @{
+                TiaVersion = 'fixture-version'; Binding = 'fixture-binding'
+                Block = 'fixture-block-preview'; Type = 'fixture-type-preview'
+                LineEnding = 'fixture-line-ending'; Oversized = 'fixture-oversized'
+                Authorization = 'fixture-authorization'; Applied = 'fixture-applied'
+                Restore = 'fixture-restore'; Bytes = 'fixture-bytes'; Compile = 'fixture-compile'
+                FinalState = 'fixture-final-state'; Outcome = 'fixture-outcome'
+            }
+            function Render-Report([string] $ModeValue) {
+                $Mode = $ModeValue
+                Invoke-Expression $reportAssignment.Extent.Text
+                return $report
+            }
+
+            $preview = Render-Report 'Preview'
+            $apply = Render-Report 'Apply'
+            $previewLimitation = '- Not proven: checks marked NOT RUN/INCOMPLETE; production or plant acceptance; disk project-byte identity; saved project state; semantic equivalence of replacements. Preview alone cannot qualify apply/restore/compile.'
+            $applyLimitation = '- Not proven: checks marked NOT RUN/INCOMPLETE; production or plant acceptance; disk project-byte identity; saved project state; semantic equivalence beyond the exact exported-text checks performed.'
+            if (-not $preview.Contains($previewLimitation)) {
+                throw 'Preview report lost its Preview-only limitation.'
+            }
+            if (-not $apply.Contains($applyLimitation)) {
+                throw "Apply report used the wrong limitation: '$apply'."
+            }
+            if ($apply.Contains('Preview alone cannot qualify apply/restore/compile.')) {
+                throw 'Apply report retained the Preview-only limitation.'
+            }
+            Write-Output 'mode-specific-not-proven-ok'
+            """;
+
+        var result = await RunPowerShellFixtureAsync(fixture);
+
+        Assert.True(result.ExitCode == 0,
+            $"PowerShell fixture failed with exit code {result.ExitCode}: {result.StandardError}");
+        Assert.Contains("mode-specific-not-proven-ok", result.StandardOutput, StringComparison.Ordinal);
+    }
+
     private static string ReadScript()
     {
         Assert.True(File.Exists(ScriptPath), $"Expected the live harness at '{ScriptPath}'.");

--- a/TiaMcpServer.Tests/Batch/WritePreviewDiffLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/WritePreviewDiffLiveHarnessContractTests.cs
@@ -1,0 +1,66 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+// Execution-free source checks only. Never start, dot-source, or parse the live harness here.
+public sealed class WritePreviewDiffLiveHarnessContractTests
+{
+    private static readonly string ScriptPath = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "..", "scripts", "live-test-preview-write-diff.ps1"));
+
+    [Fact]
+    public void Script_ExistsAndRequiresPowerShell7()
+    {
+        var text = ReadScript();
+        Assert.Matches(new Regex(@"^\s*#Requires\s+-Version\s+7(\.\d+)?\s*$", RegexOptions.Multiline), text);
+        Assert.Contains("$ErrorActionPreference = 'Stop'", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_DefaultsToPreviewAndGuardsApplyBehindAnExplicitSwitch()
+    {
+        var text = ReadScript();
+        Assert.Matches(new Regex(@"\[ValidateSet\(\s*'Preview'\s*,\s*'Apply'\s*\)\]"), text);
+        Assert.Matches(new Regex(@"\[string\]\s*\$Mode\s*=\s*'Preview'"), text);
+        Assert.Matches(new Regex(@"\[switch\]\s*\$AllowApply"), text);
+        Assert.Matches(new Regex(@"if\s*\(\s*\$Mode\s*-eq\s*'Apply'\s*-and\s*-not\s*\$AllowApply\s*\)"), text);
+        Assert.Contains("[switch] $ConfirmApplyForCi", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_UsesTheRealHostLevelMcpProtocolRatherThanDirectWorkerIpc()
+    {
+        var text = ReadScript();
+        foreach (var required in new[] { "TiaMcpServer.dll", "--project", "'initialize'",
+                     "notifications/initialized", "'tools/call'", "get_project_status",
+                     "execute_read_batch", "preview_write_batch", "apply_write_batch" })
+            Assert.Contains(required, text, StringComparison.Ordinal);
+        Assert.DoesNotContain("OpennessWorker.exe", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("open_project", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_ApplyPathRestoresOriginalBytesAndCompilesTheDisposableProject()
+    {
+        var text = ReadScript();
+        Assert.Contains("compile_check", text, StringComparison.Ordinal);
+        Assert.Contains("byte-identical", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("restore", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Read-Host", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_DocumentsDisposableProjectScopeAndWritesTheAcceptanceReportPath()
+    {
+        var text = ReadScript();
+        Assert.Matches(new Regex(@"disposable", RegexOptions.IgnoreCase), text);
+        Assert.Contains("2026-09-01-pr4-structured-preview-diff-live.md", text, StringComparison.Ordinal);
+    }
+
+    private static string ReadScript()
+    {
+        Assert.True(File.Exists(ScriptPath), $"Expected the live harness at '{ScriptPath}'.");
+        return File.ReadAllText(ScriptPath);
+    }
+}

--- a/TiaMcpServer.Tests/Diagnostics/CiWorkflowTests.cs
+++ b/TiaMcpServer.Tests/Diagnostics/CiWorkflowTests.cs
@@ -198,6 +198,19 @@ public class CiWorkflowTests
         Assert.Contains("SCL `create_block` calls are verified", normalizedReadmeText, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void ImportExportSummary_DocumentsStructuredPreviewDiffBounds()
+    {
+        var text = File.ReadAllText(Path.Combine(GetRepositoryRoot(), "docs", "SupportedOperations", "IMPORT_EXPORT_OPTIONS_SUMMARY.md"));
+
+        Assert.Contains("update_block_logic", text, StringComparison.Ordinal);
+        Assert.Contains("update_type_content", text, StringComparison.Ordinal);
+        Assert.Contains("40 excerpt lines", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("8,192", text, StringComparison.Ordinal);
+        Assert.Contains("32,768", text, StringComparison.Ordinal);
+        Assert.Contains("line-ending-only", text, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static IEnumerable<string> EnumerateWorkflowFiles()
     {
         var workflowsDirectory = Path.Combine(GetRepositoryRoot(), ".github", "workflows");

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -73,6 +73,8 @@
       Link="Host\Batch\BatchOperationCatalog.cs" />
     <Compile Include="..\TiaMcpServer\Batch\BatchSafetySnapshot.cs"
       Link="Host\Batch\BatchSafetySnapshot.cs" />
+    <Compile Include="..\TiaMcpServer\Batch\BatchPreviewDiff.cs"
+      Link="Host\Batch\BatchPreviewDiff.cs" />
     <Compile Include="..\TiaMcpServer\OperationBatches\IOperationBatchItem.cs" Link="Host\OperationBatches\IOperationBatchItem.cs" />
     <Compile Include="..\TiaMcpServer\OperationBatches\OperationBatchResult.cs" Link="Host\OperationBatches\OperationBatchResult.cs" />
     <Compile Include="..\TiaMcpServer\OperationBatches\OperationBatchExecutionEngine.cs" Link="Host\OperationBatches\OperationBatchExecutionEngine.cs" />

--- a/TiaMcpServer/Batch/BatchPreviewDiff.cs
+++ b/TiaMcpServer/Batch/BatchPreviewDiff.cs
@@ -232,7 +232,7 @@ public static class BatchPreviewDiff
         => text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
 
     private static string Sha256(string text)
-        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(text)));
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(text))).ToLowerInvariant();
 
     private sealed record ComparedLines(
         string[] CurrentLines,

--- a/TiaMcpServer/Batch/BatchPreviewDiff.cs
+++ b/TiaMcpServer/Batch/BatchPreviewDiff.cs
@@ -1,0 +1,274 @@
+using System.Security.Cryptography;
+using System.Text;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.OperationBatches;
+
+namespace TiaMcpServer.Batch;
+
+public static class BatchPreviewDiff
+{
+    public const int MaxExcerptLinesPerSide = 40;
+    public const int MaxExcerptCharsPerSide = 8_192;
+    public const int MaxExcerptCharsPerLine = 512;
+    public const int MaxBatchExcerptLines = 320;
+    public const int MaxBatchExcerptChars = 32_768;
+
+    public static BatchPreviewDiffDocument? Build(
+        IReadOnlyList<BatchOperationRequest> operations,
+        IReadOnlyList<OperationBatchCurrentState> states)
+    {
+        if (operations.Count != states.Count)
+        {
+            throw new ArgumentException("Operations and current-state rows must align by index.");
+        }
+
+        var remainingBatchLines = MaxBatchExcerptLines;
+        var remainingBatchChars = MaxBatchExcerptChars;
+        var entries = new List<BatchPreviewDiffEntry>();
+
+        for (var index = 0; index < operations.Count; index++)
+        {
+            var operation = operations[index];
+            if (!IsEligible(operation, out var requestedText, out var normalizedFormat))
+            {
+                continue;
+            }
+
+            var currentText = states[index].CurrentState;
+            var compared = Compare(currentText, requestedText);
+            var currentExcerpt = BuildExcerpt(
+                compared.CurrentLines,
+                compared.FirstChangedCurrentLineIndex,
+                compared.LastChangedCurrentLineIndex);
+            var requestedExcerpt = BuildExcerpt(
+                compared.RequestedLines,
+                compared.FirstChangedRequestedLineIndex,
+                compared.LastChangedRequestedLineIndex);
+
+            var excerptLines = currentExcerpt.Lines.Count + requestedExcerpt.Lines.Count;
+            var excerptChars = CountExcerptCharacters(currentExcerpt) + CountExcerptCharacters(requestedExcerpt);
+            var batchBudgetExhausted = excerptLines > remainingBatchLines || excerptChars > remainingBatchChars;
+            if (batchBudgetExhausted)
+            {
+                currentExcerpt = EmptyExcerpt(compared.CurrentLines, compared.FirstChangedCurrentLineIndex, compared.LastChangedCurrentLineIndex);
+                requestedExcerpt = EmptyExcerpt(compared.RequestedLines, compared.FirstChangedRequestedLineIndex, compared.LastChangedRequestedLineIndex);
+            }
+            else
+            {
+                remainingBatchLines -= excerptLines;
+                remainingBatchChars -= excerptChars;
+            }
+
+            entries.Add(new BatchPreviewDiffEntry(
+                operation.OperationId,
+                operation.Operation,
+                normalizedFormat,
+                new BatchPreviewDiffSide(Sha256(currentText), currentText.Length, CountLines(currentText), currentExcerpt),
+                new BatchPreviewDiffSide(Sha256(requestedText), requestedText.Length, CountLines(requestedText), requestedExcerpt),
+                compared.RawTextEqual,
+                compared.NormalizedLinesEqual,
+                compared.LineEndingOnly,
+                compared.UnchangedPrefixLineCount,
+                compared.UnchangedSuffixLineCount,
+                compared.CurrentChangedLineCount,
+                compared.RequestedChangedLineCount,
+                batchBudgetExhausted));
+        }
+
+        return entries.Count == 0 ? null : new BatchPreviewDiffDocument(entries);
+    }
+
+    private static bool IsEligible(BatchOperationRequest operation, out string requestedText, out string normalizedFormat)
+    {
+        switch (operation.Operation)
+        {
+            case "update_block_logic":
+                requestedText = operation.YamlContent ?? string.Empty;
+                normalizedFormat = NormalizeFormat(operation.Format, SourceFormatNames.Xml);
+                return true;
+            case "update_type_content":
+                requestedText = operation.SourceContent ?? string.Empty;
+                normalizedFormat = NormalizeFormat(operation.Format, SourceFormatNames.Source);
+                return true;
+            default:
+                requestedText = string.Empty;
+                normalizedFormat = string.Empty;
+                return false;
+        }
+    }
+
+    private static string NormalizeFormat(string? format, string defaultFormat)
+        => string.IsNullOrWhiteSpace(format)
+            ? defaultFormat
+            : string.Equals(format, SourceFormatNames.Xml, StringComparison.OrdinalIgnoreCase)
+                ? SourceFormatNames.Xml
+                : SourceFormatNames.Source;
+
+    private static ComparedLines Compare(string currentText, string requestedText)
+    {
+        var currentLines = NormalizeLineEndings(currentText).Split('\n');
+        var requestedLines = NormalizeLineEndings(requestedText).Split('\n');
+        var prefix = 0;
+        var commonLength = Math.Min(currentLines.Length, requestedLines.Length);
+        while (prefix < commonLength && string.Equals(currentLines[prefix], requestedLines[prefix], StringComparison.Ordinal))
+        {
+            prefix++;
+        }
+
+        var suffix = 0;
+        while (suffix < currentLines.Length - prefix
+            && suffix < requestedLines.Length - prefix
+            && string.Equals(
+                currentLines[currentLines.Length - 1 - suffix],
+                requestedLines[requestedLines.Length - 1 - suffix],
+                StringComparison.Ordinal))
+        {
+            suffix++;
+        }
+
+        var normalizedLinesEqual = prefix == currentLines.Length && prefix == requestedLines.Length;
+        var currentChangedLineCount = currentLines.Length - prefix - suffix;
+        var requestedChangedLineCount = requestedLines.Length - prefix - suffix;
+        return new ComparedLines(
+            currentLines,
+            requestedLines,
+            string.Equals(currentText, requestedText, StringComparison.Ordinal),
+            normalizedLinesEqual,
+            !string.Equals(currentText, requestedText, StringComparison.Ordinal) && normalizedLinesEqual,
+            prefix,
+            suffix,
+            currentChangedLineCount,
+            requestedChangedLineCount,
+            currentChangedLineCount == 0 ? -1 : prefix,
+            currentChangedLineCount == 0 ? -1 : currentLines.Length - suffix - 1,
+            requestedChangedLineCount == 0 ? -1 : prefix,
+            requestedChangedLineCount == 0 ? -1 : requestedLines.Length - suffix - 1);
+    }
+
+    private static BatchPreviewDiffExcerpt BuildExcerpt(string[] lines, int firstChangedLineIndex, int lastChangedLineIndex)
+    {
+        if (firstChangedLineIndex < 0)
+        {
+            return new BatchPreviewDiffExcerpt(Array.Empty<BatchPreviewDiffLine>(), 0, 0, false);
+        }
+
+        var selectedIndexes = SelectExcerptLineIndexes(firstChangedLineIndex, lastChangedLineIndex);
+        var charactersPerLine = selectedIndexes.Count == 0
+            ? 0
+            : Math.Min(MaxExcerptCharsPerLine, MaxExcerptCharsPerSide / selectedIndexes.Count);
+        var selected = selectedIndexes
+            .Select(index => ToExcerptLine(lines[index], index, charactersPerLine))
+            .ToArray();
+        var selectedIndexesSet = selectedIndexes.ToHashSet();
+        var omittedLineCount = 0;
+        var omittedCharacterCount = 0;
+        for (var index = firstChangedLineIndex; index <= lastChangedLineIndex; index++)
+        {
+            if (!selectedIndexesSet.Contains(index))
+            {
+                omittedLineCount++;
+                omittedCharacterCount += lines[index].Length;
+            }
+        }
+
+        omittedCharacterCount += selected.Sum(line => line.OmittedCharacterCount);
+        return new BatchPreviewDiffExcerpt(selected, omittedLineCount, omittedCharacterCount, false);
+    }
+
+    private static BatchPreviewDiffExcerpt EmptyExcerpt(string[] lines, int firstChangedLineIndex, int lastChangedLineIndex)
+    {
+        if (firstChangedLineIndex < 0)
+        {
+            return new BatchPreviewDiffExcerpt(Array.Empty<BatchPreviewDiffLine>(), 0, 0, true);
+        }
+
+        var omittedCharacterCount = 0;
+        for (var index = firstChangedLineIndex; index <= lastChangedLineIndex; index++)
+        {
+            omittedCharacterCount += lines[index].Length;
+        }
+
+        return new BatchPreviewDiffExcerpt(
+            Array.Empty<BatchPreviewDiffLine>(),
+            lastChangedLineIndex - firstChangedLineIndex + 1,
+            omittedCharacterCount,
+            true);
+    }
+
+    private static IReadOnlyList<int> SelectExcerptLineIndexes(int firstChangedLineIndex, int lastChangedLineIndex)
+    {
+        var changedLineCount = lastChangedLineIndex - firstChangedLineIndex + 1;
+        if (changedLineCount <= MaxExcerptLinesPerSide)
+        {
+            return Enumerable.Range(firstChangedLineIndex, changedLineCount).ToArray();
+        }
+
+        var firstCount = MaxExcerptLinesPerSide / 2;
+        return Enumerable.Range(firstChangedLineIndex, firstCount)
+            .Concat(Enumerable.Range(lastChangedLineIndex - firstCount + 1, firstCount))
+            .ToArray();
+    }
+
+    private static BatchPreviewDiffLine ToExcerptLine(string text, int zeroBasedLineNumber, int charactersPerLine)
+    {
+        var retainedCharacterCount = Math.Min(text.Length, charactersPerLine);
+        return new BatchPreviewDiffLine(
+            zeroBasedLineNumber + 1,
+            text[..retainedCharacterCount],
+            text.Length - retainedCharacterCount);
+    }
+
+    private static int CountExcerptCharacters(BatchPreviewDiffExcerpt excerpt)
+        => excerpt.Lines.Sum(line => line.Text.Length);
+
+    private static int CountLines(string text)
+        => NormalizeLineEndings(text).Split('\n').Length;
+
+    private static string NormalizeLineEndings(string text)
+        => text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+
+    private static string Sha256(string text)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(text)));
+
+    private sealed record ComparedLines(
+        string[] CurrentLines,
+        string[] RequestedLines,
+        bool RawTextEqual,
+        bool NormalizedLinesEqual,
+        bool LineEndingOnly,
+        int UnchangedPrefixLineCount,
+        int UnchangedSuffixLineCount,
+        int CurrentChangedLineCount,
+        int RequestedChangedLineCount,
+        int FirstChangedCurrentLineIndex,
+        int LastChangedCurrentLineIndex,
+        int FirstChangedRequestedLineIndex,
+        int LastChangedRequestedLineIndex);
+}
+
+public sealed record BatchPreviewDiffDocument(IReadOnlyList<BatchPreviewDiffEntry> Operations);
+
+public sealed record BatchPreviewDiffEntry(
+    string OperationId,
+    string Operation,
+    string Format,
+    BatchPreviewDiffSide Current,
+    BatchPreviewDiffSide Requested,
+    bool RawTextEqual,
+    bool NormalizedLinesEqual,
+    bool LineEndingOnly,
+    int UnchangedPrefixLineCount,
+    int UnchangedSuffixLineCount,
+    int CurrentChangedLineCount,
+    int RequestedChangedLineCount,
+    bool BatchBudgetExhausted);
+
+public sealed record BatchPreviewDiffSide(string Sha256, int CharacterCount, int LineCount, BatchPreviewDiffExcerpt Excerpt);
+
+public sealed record BatchPreviewDiffExcerpt(
+    IReadOnlyList<BatchPreviewDiffLine> Lines,
+    int OmittedLineCount,
+    int OmittedCharacterCount,
+    bool BudgetExhausted);
+
+public sealed record BatchPreviewDiffLine(int LineNumber, string Text, int OmittedCharacterCount);

--- a/TiaMcpServer/Batch/BatchPreviewDiff.cs
+++ b/TiaMcpServer/Batch/BatchPreviewDiff.cs
@@ -24,6 +24,7 @@ public static class BatchPreviewDiff
 
         var remainingBatchLines = MaxBatchExcerptLines;
         var remainingBatchChars = MaxBatchExcerptChars;
+        var batchBudgetExhausted = false;
         var entries = new List<BatchPreviewDiffEntry>();
 
         for (var index = 0; index < operations.Count; index++)
@@ -47,9 +48,12 @@ public static class BatchPreviewDiff
 
             var excerptLines = currentExcerpt.Lines.Count + requestedExcerpt.Lines.Count;
             var excerptChars = CountExcerptCharacters(currentExcerpt) + CountExcerptCharacters(requestedExcerpt);
-            var batchBudgetExhausted = excerptLines > remainingBatchLines || excerptChars > remainingBatchChars;
-            if (batchBudgetExhausted)
+            var entryBudgetExhausted = batchBudgetExhausted
+                || excerptLines > remainingBatchLines
+                || excerptChars > remainingBatchChars;
+            if (entryBudgetExhausted)
             {
+                batchBudgetExhausted = true;
                 currentExcerpt = EmptyExcerpt(compared.CurrentLines, compared.FirstChangedCurrentLineIndex, compared.LastChangedCurrentLineIndex);
                 requestedExcerpt = EmptyExcerpt(compared.RequestedLines, compared.FirstChangedRequestedLineIndex, compared.LastChangedRequestedLineIndex);
             }
@@ -72,7 +76,7 @@ public static class BatchPreviewDiff
                 compared.UnchangedSuffixLineCount,
                 compared.CurrentChangedLineCount,
                 compared.RequestedChangedLineCount,
-                batchBudgetExhausted));
+                entryBudgetExhausted));
         }
 
         return entries.Count == 0 ? null : new BatchPreviewDiffDocument(entries);

--- a/TiaMcpServer/Batch/WriteBatchTools.cs
+++ b/TiaMcpServer/Batch/WriteBatchTools.cs
@@ -62,6 +62,7 @@ public class WriteBatchTools
                 var targets = BatchSafetySnapshot.BuildTargets(operations);
                 var summary = $"Apply {operations.Length} write operation(s) sequentially; stops on first failure (no rollback). "
                     + "The current-state snapshot is read per item and is not an atomic point-in-time view.";
+                var previewDiff = BatchPreviewDiff.Build(operations, snapshot.States);
 
                 return safety.CreatePreview(
                     ApplyToolName,
@@ -70,7 +71,7 @@ public class WriteBatchTools
                     summary,
                     operations,
                     snapshot.CombinedState,
-                    diff: null,
+                    diff: previewDiff,
                     instructions: "Preview only — nothing was changed. To apply, call apply_write_batch with the identical operations list, confirm=true, and this safetyToken.");
             }).ConfigureAwait(false);
         return previewExecution.Success
@@ -189,7 +190,7 @@ public class WriteBatchTools
         return execution.Value!;
     }
 
-    private static async Task<(string CombinedState, string? Error, string? FailureCategory)> ReadCombinedCurrentStateAsync(
+    private static async Task<(IReadOnlyList<OperationBatchCurrentState> States, string CombinedState, string? Error, string? FailureCategory)> ReadCombinedCurrentStateAsync(
         OpennessWorkerClient workerClient,
         BatchOperationRequest[] operations)
     {
@@ -200,6 +201,7 @@ public class WriteBatchTools
             if (!state.Success)
             {
                 return (
+                    Array.Empty<OperationBatchCurrentState>(),
                     string.Empty,
                     $"Could not read current state for operationId '{op.OperationId}' ({op.Operation}). Error: {state.Error}",
                     state.FailureCategory);
@@ -208,6 +210,6 @@ public class WriteBatchTools
             states.Add(new OperationBatchCurrentState(op.OperationId, op.Operation, state.Payload));
         }
 
-        return (BatchSafetySnapshot.CombineCurrentState(states), null, null);
+        return (states, BatchSafetySnapshot.CombineCurrentState(states), null, null);
     }
 }

--- a/TiaMcpServer/Safety/WriteSafetyService.cs
+++ b/TiaMcpServer/Safety/WriteSafetyService.cs
@@ -68,7 +68,7 @@ public sealed partial class WriteSafetyService
        string summary,
        object requestedInput,
        string currentState,
-       string? diff = null,
+       object? diff = null,
        string? instructions = null)
     {
         var issued = IssueToken(

--- a/TiaMcpServer/Safety/WriteSafetyTooling.cs
+++ b/TiaMcpServer/Safety/WriteSafetyTooling.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json;
 using TiaMcpServer.Contracts;
 using TiaMcpServer.Json;
@@ -153,7 +152,7 @@ public static class WriteSafetyTooling
         string summary,
         object requestedInput,
         WorkerCallResult currentState,
-        string? diff = null,
+        object? diff = null,
         string? instructions = null)
     {
         if (!currentState.Success)
@@ -210,38 +209,6 @@ public static class WriteSafetyTooling
                     }
             },
             TiaJson.Presentation);
-    }
-
-    public static string CreateLineDiff(string before, string after)
-    {
-        var beforeLines = before.Replace("\r\n", "\n").Split('\n');
-        var afterLines = after.Replace("\r\n", "\n").Split('\n');
-        var builder = new StringBuilder();
-        builder.AppendLine("--- current");
-        builder.AppendLine("+++ requested");
-
-        var max = Math.Max(beforeLines.Length, afterLines.Length);
-        for (var i = 0; i < max; i++)
-        {
-            var oldLine = i < beforeLines.Length ? beforeLines[i] : null;
-            var newLine = i < afterLines.Length ? afterLines[i] : null;
-            if (string.Equals(oldLine, newLine, StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            if (oldLine is not null)
-            {
-                builder.Append("- ").AppendLine(oldLine);
-            }
-
-            if (newLine is not null)
-            {
-                builder.Append("+ ").AppendLine(newLine);
-            }
-        }
-
-        return builder.ToString();
     }
 
     public static string DescribePathState(string path)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -502,6 +502,10 @@ binding lease, current-state re-read, and audit trail below remain the server-en
    `confirm=true` and the token. The server reads current
    state again and consumes the token only when every bound value still matches.
 
+For `update_block_logic` and `update_type_content`, `preview_write_batch` may include a
+response-only structured `diff` object built from the already-bound exact-format current text and
+the submitted replacement text. This object is outside safety-token issuance and validation.
+
 The complete apply critical section is protected by a pinned binding lease:
 fresh-state read, token validation and consumption, Siemens mutation,
 post-verification, and audit capture all see the same worker id, Portal PID,

--- a/docs/IMPROVEMENT_LOG.md
+++ b/docs/IMPROVEMENT_LOG.md
@@ -154,6 +154,7 @@ Three further follow-ups, all raised by the Phase 3 final review and deliberatel
 
 ## Testing gaps to close alongside
 
+- PR 4 structured preview diff live gate pending.
 - The fake-worker executable test harness now covers the timeout path and persistent-worker restart logic
   through `OpennessWorkerClientIntegrationTests` — DONE 2026-07-16. Stderr propagation, malformed JSON,
   and Win32Exception launch failure are also covered.

--- a/docs/IMPROVEMENT_LOG.md
+++ b/docs/IMPROVEMENT_LOG.md
@@ -154,7 +154,6 @@ Three further follow-ups, all raised by the Phase 3 final review and deliberatel
 
 ## Testing gaps to close alongside
 
-- PR 4 structured preview diff live gate pending.
 - The fake-worker executable test harness now covers the timeout path and persistent-worker restart logic
   through `OpennessWorkerClientIntegrationTests` — DONE 2026-07-16. Stderr propagation, malformed JSON,
   and Win32Exception launch failure are also covered.
@@ -462,3 +461,17 @@ sanitized live evidence is recorded in the
 This completion does not authorize or complete compatibility-wrapper deletion. PLC `start_plc`
 and `stop_plc` safety hardening also remains deferred. No apply, project save, PLC mode change,
 production acceptance, or plant acceptance is claimed.
+
+## PR 4 bounded structured preview diffs — live acceptance completed (2026-09-05)
+
+The [PR 4 acceptance report](superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md)
+records completed live Preview and authorized Apply/restore/compile acceptance against a disposable
+TIA Portal V21 project. The first Apply target exposed TIA canonicalization from `T#1s` to `T#1S`:
+its byte-identity check failed, and guarded no-save close/reopen cleanup recovered the clean disk
+state. A read-only-selected UDT target then passed Preview, temporary Apply, restoration with
+byte-identical public re-exports, and compile with zero errors and zero warnings across two PLCs;
+final guarded no-save close/reopen cleanup returned the project to `isModified=False`.
+
+The close/open lifecycle operations were cleanup and recovery only, not PR 4 feature acceptance.
+The report does not claim plant or production acceptance, disk project-byte identity, saved-project
+acceptance, or semantic equivalence beyond the exact exported-text checks performed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ with separate plans for [PR 1 explicit MCP tool annotations](superpowers/plans/2
 [PR 3 exact `update_tag` safety snapshots](superpowers/plans/2026-09-01-pr3-update-tag-safety-snapshot.md),
 [its completed mandatory live acceptance report](superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md),
 [PR 4 bounded structured preview diffs](superpowers/plans/2026-09-01-pr4-structured-preview-diff.md),
-[its pending live acceptance report](superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md),
+[its completed live Preview and authorized Apply/restore/compile acceptance report (2026-09-05)](superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md),
 [PR 5 tag-operation safety scopes](superpowers/plans/2026-09-01-pr5-tag-operation-safety-scopes.md),
 and [PR 6 project-tree safety scopes](superpowers/plans/2026-09-01-pr6-project-tree-safety-scopes.md);
 [project completeness and hardware pagination design](superpowers/specs/2026-08-28-issue-31-project-completeness-pagination-design.md),

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ with separate plans for [PR 1 explicit MCP tool annotations](superpowers/plans/2
 [PR 3 exact `update_tag` safety snapshots](superpowers/plans/2026-09-01-pr3-update-tag-safety-snapshot.md),
 [its completed mandatory live acceptance report](superpowers/acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md),
 [PR 4 bounded structured preview diffs](superpowers/plans/2026-09-01-pr4-structured-preview-diff.md),
+[its pending live acceptance report](superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md),
 [PR 5 tag-operation safety scopes](superpowers/plans/2026-09-01-pr5-tag-operation-safety-scopes.md),
 and [PR 6 project-tree safety scopes](superpowers/plans/2026-09-01-pr6-project-tree-safety-scopes.md);
 [project completeness and hardware pagination design](superpowers/specs/2026-08-28-issue-31-project-completeness-pagination-design.md),

--- a/docs/SupportedOperations/IMPORT_EXPORT_OPTIONS_SUMMARY.md
+++ b/docs/SupportedOperations/IMPORT_EXPORT_OPTIONS_SUMMARY.md
@@ -50,10 +50,12 @@ outside safety-token issuance and validation.
 - When a changed span exceeds 40 lines, each excerpt contains the first 20 plus last 20 lines.
 - Each displayed line is limited to 512 characters.
 - The complete batch is limited to 320 excerpt lines and 32,768 excerpt characters in request
-  order.
-- The response reports raw SHA-256, raw character count, raw line count, `rawTextEqual`,
-  `normalizedLinesEqual`, and `lineEndingOnly`; a line-ending-only difference has unequal raw text
-  but equal normalized lines.
+  order. After that excerpt budget is exhausted, every eligible entry still retains its raw hashes,
+  counts, and equality flags.
+- Raw SHA-256, raw character count, and raw line count use the original text. For line-window
+  comparison only, line-ending normalization maps CRLF and CR to LF; it performs no other
+  normalization. The response also reports `rawTextEqual`, `normalizedLinesEqual`, and
+  `lineEndingOnly`; a line-ending-only difference has unequal raw text but equal normalized lines.
 - Every other operation has `diff: null`.
 
 ## Format matrix

--- a/docs/SupportedOperations/IMPORT_EXPORT_OPTIONS_SUMMARY.md
+++ b/docs/SupportedOperations/IMPORT_EXPORT_OPTIONS_SUMMARY.md
@@ -39,6 +39,23 @@ Updates are strict updates to an existing object:
 
 For block updates, the worker validates the document, performs the import, compiles the affected scope, and checks the postcondition by re-exporting the block. External-source global DB updates compile the PLC because changing a DB declaration can affect dependent blocks.
 
+### Preview evidence
+
+`preview_write_batch` may include a response-only structured `diff` object for
+`update_block_logic` and `update_type_content`. It compares already-bound exact-format current
+text with the submitted replacement text; it does not predict Siemens post-write state and is
+outside safety-token issuance and validation.
+
+- Each eligible operation has at most 40 excerpt lines and 8,192 excerpt characters per side.
+- When a changed span exceeds 40 lines, each excerpt contains the first 20 plus last 20 lines.
+- Each displayed line is limited to 512 characters.
+- The complete batch is limited to 320 excerpt lines and 32,768 excerpt characters in request
+  order.
+- The response reports raw SHA-256, raw character count, raw line count, `rawTextEqual`,
+  `normalizedLinesEqual`, and `lineEndingOnly`; a line-ending-only difference has unequal raw text
+  but equal normalized lines.
+- Every other operation has `diff: null`.
+
 ## Format matrix
 
 | Capability | Status |

--- a/docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md
+++ b/docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md
@@ -39,6 +39,7 @@ The operations below run through `preview_write_batch` and `apply_write_batch`.
 
 - Block updates validate the supplied document, import it into an existing block, compile the affected PLC scope, and verify the resulting block state through a postcondition/re-export check.
 - Type updates require an existing addressed type and a declaration whose name matches that target.
+- Block/type replacement previews can include bounded structured evidence that is current-versus-requested only, not predicted post-write state.
 - Import/update operations modify existing objects only. They do not create, rename, delete, or upsert the addressed object.
 - Deletes and PLC start/stop operations use the same confirmed write flow as other data writes.
 - A write batch is applied in order and stops on the first failure. Completed mutations are not rolled back.

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -65,6 +65,7 @@ explicitly pending.
 | Date | Document |
 | --- | --- |
 | 2026-09-05 | [PR 3 — exact `update_tag` safety snapshot — mandatory live PASS](acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md) |
+| 2026-09-01 | [PR 4 — structured preview diff — live pending](acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md) |
 | 2026-09-01 | [PR 2 — registered-tool delegation — live](acceptance/reports/2026-09-01-pr2-registered-tool-delegation-live.md) |
 | 2026-09-01 | [PR 1 — explicit MCP tool annotations — live](acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md) |
 | 2026-08-14 | [Structured I/O map defect fixes — live](acceptance/reports/2026-08-14-io-map-defect-fixes-live.md) |

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -65,7 +65,7 @@ explicitly pending.
 | Date | Document |
 | --- | --- |
 | 2026-09-05 | [PR 3 — exact `update_tag` safety snapshot — mandatory live PASS](acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md) |
-| 2026-09-01 | [PR 4 — structured preview diff — live pending](acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md) |
+| 2026-09-05 | [PR 4 — structured preview diff — live Preview and authorized Apply/restore/compile acceptance completed](acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md) |
 | 2026-09-01 | [PR 2 — registered-tool delegation — live](acceptance/reports/2026-09-01-pr2-registered-tool-delegation-live.md) |
 | 2026-09-01 | [PR 1 — explicit MCP tool annotations — live](acceptance/reports/2026-09-01-pr1-explicit-mcp-tool-annotations-live.md) |
 | 2026-08-14 | [Structured I/O map defect fixes — live](acceptance/reports/2026-08-14-io-map-defect-fixes-live.md) |

--- a/docs/superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md
+++ b/docs/superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md
@@ -1,12 +1,24 @@
 # PR 4 Structured Preview Diff Live Acceptance
 
-**PREVIEW PASSED — the dated Preview run below completed through the real host MCP protocol and
-TIA Portal V21. Apply remains pending and requires separate authorization.**
+**LIVE ACCEPTANCE COMPLETE — dated Preview and Apply/restore/compile runs passed through the real
+host MCP protocol and TIA Portal V21 on the disposable project described below.**
 The guarded harness is [live-test-preview-write-diff.ps1](../../../../scripts/live-test-preview-write-diff.ps1).
 Ordinary source contract tests do not invoke the live harness body; isolated helper checks parse
 and execute only the selected functions. The original pre-run scaffold remains below for provenance:
 its pending statements describe the boundary before the dated run, while the appended findings are
-the live Preview evidence.
+the live acceptance evidence. The failed first Apply attempt remains part of that evidence.
+
+## Recovery and Target Selection
+
+- The first Apply attempt against `PLC_LAD/Types/AnalogInputSettings` failed only its final
+  byte-identity check because TIA canonicalized `T#1s` to `T#1S`; all 21 CRLF lines otherwise matched.
+- **Cleanup/recovery only, not PR4 feature acceptance:** guarded `close_project(saveBeforeClose=false)`
+  followed by guarded `open_project` recovered the exact clean disk state with `isModified=False`.
+- Read-only source selection chose `PLC_LAD/Types/HMI_COUNTERS_UDTs/UDT_WORK_CNT`. Preview passed;
+  the subsequent Apply passed both temporary operations, both restoration operations, byte-identical
+  public re-exports, and `compile_check` with zero errors, zero warnings, and two PLCs.
+- **Cleanup/recovery only, not PR4 feature acceptance:** compile left `isModified=True`, so a second
+  guarded no-save close/reopen returned the same project to `isModified=False`.
 
 ## Environment
 
@@ -72,3 +84,178 @@ the live Preview evidence.
 - Outcome: PASS for Preview mode only
 - Proven: only checks marked PASS in this run, through the real host MCP protocol.
 - Not proven: checks marked NOT RUN/INCOMPLETE; production or plant acceptance; disk project-byte identity; saved project state; semantic equivalence of replacements. Preview alone cannot qualify apply/restore/compile.
+
+## Run 2026-09-05T15:34:00.0925519Z (Preview)
+
+### Environment
+
+- Date: 2026-09-05T15:34:00.0925519Z
+- TIA Portal version: V21 prerequisite; project version not reported
+- Host build: C:\Users\LCZ\Desktop\RnD\TIA-Portal\tia-portal-mcp\TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll; SHA256=F02D34DACCF120C63B29DC9A005BD74116D773ADB1C02B9A6017B3DD9FA8A51E
+- Disposable project path: C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21
+- Binding verification: PASS: exact project path and worker/session/Portal identity 4e5a5208a2274fbf9480dc6d4286bc8f/2/54096
+- Block target: PLC_LAD/Blocks/100_Inputs/InputValues_DB
+- Type target: PLC_LAD/Types/AnalogInputSettings
+- Local evidence and original sources: C:\Users\LCZ\AppData\Local\Temp\tia-preview-diff-39eed15de86841b7aa12361196a8df54
+
+### Preview-Only Evidence
+
+- Block preview: PASS: source content change with structured diff
+- Type preview: PASS: source content change with structured diff
+- Line-ending-only preview: PASS: rawTextEqual=false, normalizedLinesEqual=true, lineEndingOnly=true
+- Oversized batch preview: PASS: 512-character line cap; 40-line/8192-character side caps; deterministic exhaustion at zero-based index 3 including later small request
+
+### Apply / Restore / Compile
+
+- Apply authorization: No apply authorized by Preview mode
+- Applied changes: NOT RUN
+- Restore result: NOT RUN
+- Byte-identical re-read: NOT RUN
+- Compile result: NOT RUN
+- Final state: Same verified session; project isModified=False. No save performed.
+
+### Evidence Boundary
+
+- Outcome: PASS for Preview mode only
+- Proven: only checks marked PASS in this run, through the real host MCP protocol.
+- Not proven: checks marked NOT RUN/INCOMPLETE; production or plant acceptance; disk project-byte identity; saved project state; semantic equivalence of replacements. Preview alone cannot qualify apply/restore/compile.
+
+## Run 2026-09-05T15:34:36.0127998Z (Apply)
+
+### Environment
+
+- Date: 2026-09-05T15:34:36.0127998Z
+- TIA Portal version: V21 prerequisite; project version not reported
+- Host build: C:\Users\LCZ\Desktop\RnD\TIA-Portal\tia-portal-mcp\TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll; SHA256=F02D34DACCF120C63B29DC9A005BD74116D773ADB1C02B9A6017B3DD9FA8A51E
+- Disposable project path: C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21
+- Binding verification: PASS: exact project path and worker/session/Portal identity faa274f50b844c4e89a2520415d72e47/2/54096
+- Block target: PLC_LAD/Blocks/100_Inputs/InputValues_DB
+- Type target: PLC_LAD/Types/AnalogInputSettings
+- Local evidence and original sources: C:\Users\LCZ\AppData\Local\Temp\tia-preview-diff-a64709ed5ade421caa1aa4f6f7fcb235
+
+### Preview-Only Evidence
+
+- Block preview: NOT RUN
+- Type preview: NOT RUN
+- Line-ending-only preview: NOT RUN
+- Oversized batch preview: NOT RUN
+
+### Apply / Restore / Compile
+
+- Apply authorization: Explicit -AllowApply and interactive YES
+- Applied changes: PASS: both operations reported success; restoring original text next
+- Restore result: PASS: both original source replacements reported success
+- Byte-identical re-read: NOT RUN
+- Compile result: NOT RUN
+- Final state: NOT READ
+
+### Evidence Boundary
+
+- Outcome: FAILED: Target 1 failed byte-identical restoration.
+- Proven: only checks marked PASS in this run, through the real host MCP protocol.
+- Not proven: checks marked NOT RUN/INCOMPLETE; production or plant acceptance; disk project-byte identity; saved project state; semantic equivalence beyond the exact exported-text checks performed.
+
+## Run 2026-09-05T15:36:47.1841594Z (Preview)
+
+### Environment
+
+- Date: 2026-09-05T15:36:47.1841594Z
+- TIA Portal version: V21 prerequisite; project version not reported
+- Host build: C:\Users\LCZ\Desktop\RnD\TIA-Portal\tia-portal-mcp\TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll; SHA256=F02D34DACCF120C63B29DC9A005BD74116D773ADB1C02B9A6017B3DD9FA8A51E
+- Disposable project path: C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21
+- Binding verification: PASS: exact project path and worker/session/Portal identity ff64b915d5b94d5ea109be92fba4262e/2/54096
+- Block target: PLC_LAD/Blocks/100_Inputs/InputValues_DB
+- Type target: PLC_LAD/Types/AnalogInputSettings
+- Local evidence and original sources: C:\Users\LCZ\AppData\Local\Temp\tia-preview-diff-298646933e5a409ca2455c3d452b863c
+
+### Preview-Only Evidence
+
+- Block preview: PASS: source content change with structured diff
+- Type preview: PASS: source content change with structured diff
+- Line-ending-only preview: PASS: rawTextEqual=false, normalizedLinesEqual=true, lineEndingOnly=true
+- Oversized batch preview: PASS: 512-character line cap; 40-line/8192-character side caps; deterministic exhaustion at zero-based index 3 including later small request
+
+### Apply / Restore / Compile
+
+- Apply authorization: No apply authorized by Preview mode
+- Applied changes: NOT RUN
+- Restore result: NOT RUN
+- Byte-identical re-read: NOT RUN
+- Compile result: NOT RUN
+- Final state: Same verified session; project isModified=True. No save performed.
+
+### Evidence Boundary
+
+- Outcome: PASS for Preview mode only
+- Proven: only checks marked PASS in this run, through the real host MCP protocol.
+- Not proven: checks marked NOT RUN/INCOMPLETE; production or plant acceptance; disk project-byte identity; saved project state; semantic equivalence of replacements. Preview alone cannot qualify apply/restore/compile.
+
+## Run 2026-09-05T15:45:36.7944391Z (Preview)
+
+### Environment
+
+- Date: 2026-09-05T15:45:36.7944391Z
+- TIA Portal version: V21 prerequisite; project version not reported
+- Host build: C:\Users\LCZ\Desktop\RnD\TIA-Portal\tia-portal-mcp\TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll; SHA256=F02D34DACCF120C63B29DC9A005BD74116D773ADB1C02B9A6017B3DD9FA8A51E
+- Disposable project path: C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21
+- Binding verification: PASS: exact project path and worker/session/Portal identity 84467691db48449a9582d9289d1bbe1e/2/54096
+- Block target: PLC_LAD/Blocks/100_Inputs/InputValues_DB
+- Type target: PLC_LAD/Types/HMI_COUNTERS_UDTs/UDT_WORK_CNT
+- Local evidence and original sources: C:\Users\LCZ\AppData\Local\Temp\tia-preview-diff-ad168a023cab4c6ea2b4c9e8d93d32d5
+
+### Preview-Only Evidence
+
+- Block preview: PASS: source content change with structured diff
+- Type preview: PASS: source content change with structured diff
+- Line-ending-only preview: PASS: rawTextEqual=false, normalizedLinesEqual=true, lineEndingOnly=true
+- Oversized batch preview: PASS: 512-character line cap; 40-line/8192-character side caps; deterministic exhaustion at zero-based index 3 including later small request
+
+### Apply / Restore / Compile
+
+- Apply authorization: No apply authorized by Preview mode
+- Applied changes: NOT RUN
+- Restore result: NOT RUN
+- Byte-identical re-read: NOT RUN
+- Compile result: NOT RUN
+- Final state: Same verified session; project isModified=False. No save performed.
+
+### Evidence Boundary
+
+- Outcome: PASS for Preview mode only
+- Proven: only checks marked PASS in this run, through the real host MCP protocol.
+- Not proven: checks marked NOT RUN/INCOMPLETE; production or plant acceptance; disk project-byte identity; saved project state; semantic equivalence of replacements. Preview alone cannot qualify apply/restore/compile.
+
+## Run 2026-09-05T15:45:58.8698473Z (Apply)
+
+### Environment
+
+- Date: 2026-09-05T15:45:58.8698473Z
+- TIA Portal version: V21 prerequisite; project version not reported
+- Host build: C:\Users\LCZ\Desktop\RnD\TIA-Portal\tia-portal-mcp\TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll; SHA256=F02D34DACCF120C63B29DC9A005BD74116D773ADB1C02B9A6017B3DD9FA8A51E
+- Disposable project path: C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21
+- Binding verification: PASS: exact project path and worker/session/Portal identity a37ce5e1aa784019809aa49e7d3cdf7e/2/54096
+- Block target: PLC_LAD/Blocks/100_Inputs/InputValues_DB
+- Type target: PLC_LAD/Types/HMI_COUNTERS_UDTs/UDT_WORK_CNT
+- Local evidence and original sources: C:\Users\LCZ\AppData\Local\Temp\tia-preview-diff-104323d1e9e543ccb83281b6d63a7e68
+
+### Preview-Only Evidence
+
+- Block preview: NOT RUN
+- Type preview: NOT RUN
+- Line-ending-only preview: NOT RUN
+- Oversized batch preview: NOT RUN
+
+### Apply / Restore / Compile
+
+- Apply authorization: Explicit -AllowApply and interactive YES
+- Applied changes: PASS: both operations reported success; restoring original text next
+- Restore result: PASS: both original source replacements reported success
+- Byte-identical re-read: PASS: byte-identical UTF-8 exported text; block SHA256=ef7aff2943a83a5c18e3f02db5da9cda5998db0d0cbc35fc14afca8fa5c759ca; type SHA256=3a6de800e7e82c19e9c134578984decba4e4b2edcca51d1a0cc3e1a0da954ba4
+- Compile result: PASS: zero errors; warnings=0; PLCs=2
+- Final state: Same verified session; project isModified=True. No save performed.
+
+### Evidence Boundary
+
+- Outcome: PASS for Apply mode only
+- Proven: only checks marked PASS in this run, through the real host MCP protocol.
+- Not proven: checks marked NOT RUN/INCOMPLETE; production or plant acceptance; disk project-byte identity; saved project state; semantic equivalence beyond the exact exported-text checks performed.

--- a/docs/superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md
+++ b/docs/superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md
@@ -1,0 +1,37 @@
+# PR 4 Structured Preview Diff Live Acceptance
+
+**PENDING — no live execution has been authorized or performed for this report.**
+The guarded harness is [live-test-preview-write-diff.ps1](../../../../scripts/live-test-preview-write-diff.ps1).
+Its source contract tests read text only. Neither the harness nor a PowerShell parser was run
+as part of implementation. A future separately authorized run appends its dated findings below;
+this pending template is not evidence of a live pass.
+
+## Environment
+
+- Date: Pending live run.
+- TIA Portal version: V21 required; not observed by this task.
+- Host build: Pending exact artifact path and SHA256.
+- Disposable project path: Pending separately authorized target.
+- Binding verification: Pending exact project and worker/session/Portal identity.
+- Block target: Pending source-exportable disposable block.
+- Type target: Pending source-exportable disposable type.
+
+## Preview-Only Evidence
+
+- Block preview: Pending real source change and structured diff.
+- Type preview: Pending real source change and structured diff.
+- Line-ending-only preview: Pending rawTextEqual=false, normalizedLinesEqual=true, lineEndingOnly=true.
+- Oversized batch preview: Pending per-line, per-side and deterministic request-order whole-batch truncation.
+
+## Apply / Restore / Compile
+
+- Apply authorization: Not granted by this report; explicit Apply/AllowApply and interactive confirmation or authorized CI bypass required.
+- Applied changes: Not run.
+- Restore result: Not run.
+- Byte-identical re-read: Not run; compares UTF-8 bytes of exported source text, not the project file.
+- Compile result: Not run; zero errors required. The harness does not save the project.
+
+## Evidence Boundary
+
+- Proven: Prepared harness source and execution-free contract test coverage only; implementation test evidence belongs in the implementation task report.
+- Not proven: PowerShell parsing or runtime behavior, host startup, live MCP/TIA reads or previews, apply/restore/compile, project-file byte identity, saved state, plant or production acceptance. All live gates remain pending.

--- a/docs/superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md
+++ b/docs/superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md
@@ -1,10 +1,12 @@
 # PR 4 Structured Preview Diff Live Acceptance
 
-**PENDING — no live execution has been authorized or performed for this report.**
+**PREVIEW PASSED — the dated Preview run below completed through the real host MCP protocol and
+TIA Portal V21. Apply remains pending and requires separate authorization.**
 The guarded harness is [live-test-preview-write-diff.ps1](../../../../scripts/live-test-preview-write-diff.ps1).
-Its source contract tests read text only. Neither the harness nor a PowerShell parser was run
-as part of implementation. A future separately authorized run appends its dated findings below;
-this pending template is not evidence of a live pass.
+Ordinary source contract tests do not invoke the live harness body; isolated helper checks parse
+and execute only the selected functions. The original pre-run scaffold remains below for provenance:
+its pending statements describe the boundary before the dated run, while the appended findings are
+the live Preview evidence.
 
 ## Environment
 
@@ -35,3 +37,38 @@ this pending template is not evidence of a live pass.
 
 - Proven: Prepared harness source and execution-free contract test coverage only; implementation test evidence belongs in the implementation task report.
 - Not proven: PowerShell parsing or runtime behavior, host startup, live MCP/TIA reads or previews, apply/restore/compile, project-file byte identity, saved state, plant or production acceptance. All live gates remain pending.
+
+## Run 2026-09-05T15:13:41.3889267Z (Preview)
+
+### Environment
+
+- Date: 2026-09-05T15:13:41.3889267Z
+- TIA Portal version: V21 prerequisite; project version not reported
+- Host build: C:\Users\LCZ\Desktop\RnD\TIA-Portal\tia-portal-mcp\TiaMcpServer\bin\Debug\net8.0\TiaMcpServer.dll; SHA256=F02D34DACCF120C63B29DC9A005BD74116D773ADB1C02B9A6017B3DD9FA8A51E
+- Disposable project path: C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21
+- Binding verification: PASS: exact project path and worker/session/Portal identity fc8d88025e684f168d671bfd23d3eab6/2/54096
+- Block target: PLC_LAD/Blocks/100_Inputs/InputValues_DB
+- Type target: PLC_LAD/Types/AnalogInputSettings
+- Local evidence and original sources: C:\Users\LCZ\AppData\Local\Temp\tia-preview-diff-4a121df936384e6a8b0ac3e3370a7ea6
+
+### Preview-Only Evidence
+
+- Block preview: PASS: source content change with structured diff
+- Type preview: PASS: source content change with structured diff
+- Line-ending-only preview: PASS: rawTextEqual=false, normalizedLinesEqual=true, lineEndingOnly=true
+- Oversized batch preview: PASS: 512-character line cap; 40-line/8192-character side caps; deterministic exhaustion at zero-based index 3 including later small request
+
+### Apply / Restore / Compile
+
+- Apply authorization: No apply authorized by Preview mode
+- Applied changes: NOT RUN
+- Restore result: NOT RUN
+- Byte-identical re-read: NOT RUN
+- Compile result: NOT RUN
+- Final state: Same verified session; project isModified=False. No save performed.
+
+### Evidence Boundary
+
+- Outcome: PASS for Preview mode only
+- Proven: only checks marked PASS in this run, through the real host MCP protocol.
+- Not proven: checks marked NOT RUN/INCOMPLETE; production or plant acceptance; disk project-byte identity; saved project state; semantic equivalence of replacements. Preview alone cannot qualify apply/restore/compile.

--- a/scripts/live-test-preview-write-diff.ps1
+++ b/scripts/live-test-preview-write-diff.ps1
@@ -54,7 +54,7 @@ function Assert-Condition([bool] $Condition, [string] $Message) {
 }
 
 function Get-TextHash([string] $Text) {
-    return [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($utf8.GetBytes($Text)))
+    return [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($utf8.GetBytes($Text))).ToLowerInvariant()
 }
 
 function Invoke-Mcp([string] $Method, [hashtable] $Parameters) {

--- a/scripts/live-test-preview-write-diff.ps1
+++ b/scripts/live-test-preview-write-diff.ps1
@@ -1,0 +1,344 @@
+#Requires -Version 7
+<#
+.SYNOPSIS
+    Separately authorized host-level structured preview diff acceptance on a disposable project.
+.DESCRIPTION
+    Requires TIA Portal V21 with the exact disposable project already open, and source-exportable
+    block/type targets. Preview performs reads and previews only. Apply additionally requires
+    -AllowApply and typed confirmation; -ConfirmApplyForCi is ONLY for explicitly authorized CI.
+    Never invoke from ordinary tests or CI. Source contract tests read this file as text only.
+    Source restoration compares UTF-8 bytes of the public exported text, not project-file bytes.
+    Compile may leave the disposable project modified in memory; this harness never saves it.
+    If restoration fails, original source files remain in the run evidence directory for recovery.
+    No transaction or rollback is claimed. Review the report even when this script fails.
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Preview', 'Apply')]
+    [string] $Mode = 'Preview',
+    [Parameter(Mandatory)] [string] $ProjectPath,
+    [Parameter(Mandatory)] [string] $BlockPath,
+    [Parameter(Mandatory)] [string] $TypePath,
+    [switch] $AllowApply,
+    [switch] $ConfirmApplyForCi,
+    [string] $HostDllPath = "TiaMcpServer/bin/Debug/net8.0/TiaMcpServer.dll"
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if ($Mode -eq 'Apply' -and -not $AllowApply) {
+    throw 'Apply mode is disabled by default. Use -AllowApply only for an explicitly authorized disposable project copy.'
+}
+if ($ConfirmApplyForCi -and $Mode -ne 'Apply') { throw '-ConfirmApplyForCi requires Apply mode.' }
+if (-not [IO.Path]::IsPathFullyQualified($ProjectPath)) { throw 'ProjectPath must be an absolute disposable project path.' }
+$ProjectPath = (Resolve-Path -LiteralPath $ProjectPath).ProviderPath
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if (-not [IO.Path]::IsPathFullyQualified($HostDllPath)) { $HostDllPath = Join-Path $repoRoot $HostDllPath }
+$HostDllPath = (Resolve-Path -LiteralPath $HostDllPath).ProviderPath
+$hostHash = (Get-FileHash -LiteralPath $HostDllPath -Algorithm SHA256).Hash
+$reportPath = Join-Path $repoRoot 'docs/superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md'
+$utf8 = [Text.UTF8Encoding]::new($false, $true)
+$script:HostProcess = $null
+$script:RequestId = 0
+$script:InitialIdentity = $null
+$evidence = [ordered]@{
+    Binding = 'PENDING'; Block = 'NOT RUN'; Type = 'NOT RUN'; LineEnding = 'NOT RUN'
+    Oversized = 'NOT RUN'; Authorization = 'No apply authorized by Preview mode'
+    Applied = 'NOT RUN'; Restore = 'NOT RUN'; Bytes = 'NOT RUN'; Compile = 'NOT RUN'
+    FinalState = 'NOT READ'; Outcome = 'INCOMPLETE'; TiaVersion = 'Not observed'
+}
+
+function Assert-Condition([bool] $Condition, [string] $Message) {
+    if (-not $Condition) { throw $Message }
+}
+
+function Get-TextHash([string] $Text) {
+    return [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($utf8.GetBytes($Text)))
+}
+
+function Invoke-Mcp([string] $Method, [hashtable] $Parameters) {
+    $script:RequestId++
+    $request = @{ jsonrpc = '2.0'; id = $script:RequestId; method = $Method; params = $Parameters }
+    $script:HostProcess.StandardInput.WriteLine(($request | ConvertTo-Json -Depth 100 -Compress))
+    $script:HostProcess.StandardInput.Flush()
+    $timer = [Diagnostics.Stopwatch]::StartNew()
+    while ($true) {
+        $remaining = 180000 - [int]$timer.ElapsedMilliseconds
+        Assert-Condition ($remaining -gt 0) "MCP response timed out for $Method; state may be unknown."
+        $read = $script:HostProcess.StandardOutput.ReadLineAsync()
+        Assert-Condition ($read.Wait($remaining)) "MCP response timed out for $Method; state may be unknown."
+        $line = $read.GetAwaiter().GetResult()
+        Assert-Condition ($null -ne $line) "Host closed stdout during $Method."
+        $response = ConvertFrom-Json -InputObject $line -AsHashtable
+        if (-not $response.ContainsKey('id')) { continue }
+        Assert-Condition ($response.id -eq $script:RequestId) 'Unexpected MCP response id.'
+        Assert-Condition (-not $response.ContainsKey('error')) "MCP $Method failed."
+        Assert-Condition ($response.ContainsKey('result')) 'MCP response has no result.'
+        return $response.result
+    }
+}
+
+function Invoke-Tool([string] $Name, [hashtable] $Arguments) {
+    $result = Invoke-Mcp 'tools/call' @{ name = $Name; arguments = $Arguments }
+    Assert-Condition (-not ($result.ContainsKey('isError') -and $result.isError)) "MCP tool $Name failed."
+    $textItems = @($result.content | Where-Object { $_.type -eq 'text' })
+    Assert-Condition ($textItems.Count -eq 1) "$Name must return exactly one text document."
+    $document = ConvertFrom-Json -InputObject $textItems[0].text -AsHashtable
+    Assert-Condition (-not ($document.ContainsKey('success') -and $document.success -ne $true)) "$Name reported failure."
+    return $document
+}
+
+function Read-Binding {
+    $status = Invoke-Tool 'get_project_status' @{ projectPath = $ProjectPath }
+    Assert-Condition ($status.success -eq $true) 'Project status envelope failed.'
+    $payload = ConvertFrom-Json -InputObject $status.payload -AsHashtable
+    Assert-Condition ($payload.success -eq $true -and $payload.project.isOpen -eq $true) 'Target project is not open.'
+    $identity = $status.sessionIdentity
+    foreach ($path in @($payload.projectPath, $payload.project.path, $identity.projectPath)) {
+        Assert-Condition (-not [string]::IsNullOrWhiteSpace($path)) 'Project identity path is missing.'
+        Assert-Condition ([string]::Equals([IO.Path]::GetFullPath($path), $ProjectPath, [StringComparison]::OrdinalIgnoreCase)) 'Active project differs from the explicit disposable target.'
+    }
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace($identity.workerSessionId)) 'Missing worker session id.'
+    Assert-Condition ($identity.sessionGeneration -gt 0 -and $identity.portalProcessId -gt 0) 'Incomplete session identity.'
+    $signature = '{0}/{1}/{2}' -f $identity.workerSessionId, $identity.sessionGeneration, $identity.portalProcessId
+    if ($null -ne $script:InitialIdentity) {
+        Assert-Condition ($signature -ceq $script:InitialIdentity) 'Project session changed during acceptance; refusing further work.'
+    }
+    $script:InitialIdentity = $signature
+    $evidence.Binding = "PASS: exact project path and worker/session/Portal identity $signature"
+    $evidence.TiaVersion = "V21 prerequisite; project version reported: $($payload.project.version)"
+    return $payload.project
+}
+
+function Read-OriginalText {
+    $readOperations = @(
+        @{ operationId = 'read-block'; operation = 'get_block_content'; projectPath = $ProjectPath; blockPath = $BlockPath; format = 'source' },
+        @{ operationId = 'read-type'; operation = 'get_type_content'; projectPath = $ProjectPath; typePath = $TypePath; format = 'source' }
+    )
+    $readResult = Invoke-Tool 'execute_read_batch' @{ operations = $readOperations }
+    Assert-Condition ($readResult.success -eq $true -and $readResult.operations.Count -eq 2) 'Incomplete source read.'
+    $texts = @()
+    for ($i = 0; $i -lt 2; $i++) {
+        $item = $readResult.operations[$i]
+        Assert-Condition ($item.operationId -ceq $readOperations[$i].operationId -and $item.status -eq 'succeeded') 'Source read identity/status mismatch.'
+        Assert-Condition (@($item.warnings | Where-Object { $null -ne $_ }).Count -eq 0) 'Source read has warnings; exact restoration cannot be assumed.'
+        Assert-Condition ($item.result -is [string] -and $item.result.Length -gt 0) 'Source read is empty or invalid.'
+        Assert-Condition ($item.result -notmatch '\[(TRUNCATED|OMITTED)') 'Source read was truncated or omitted.'
+        $texts += $item.result
+    }
+    return ,$texts
+}
+
+function New-BlockOperation([string] $Id, [string] $Text) {
+    return @{ operationId = $Id; operation = 'update_block_logic'; projectPath = $ProjectPath; blockPath = $BlockPath; format = 'source'; yamlContent = $Text }
+}
+function New-TypeOperation([string] $Id, [string] $Text) {
+    return @{ operationId = $Id; operation = 'update_type_content'; projectPath = $ProjectPath; typePath = $TypePath; format = 'source'; sourceContent = $Text }
+}
+
+function Get-Preview([array] $Operations) {
+    $null = Read-Binding
+    $preview = Invoke-Tool 'preview_write_batch' @{ operations = $Operations }
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace($preview.safetyToken)) 'Preview did not issue a safety token.'
+    $binding = $preview.projectBinding
+    Assert-Condition ($binding.state -eq 'verified' -and $binding.revision -gt 0 -and -not [string]::IsNullOrWhiteSpace($binding.bindingId)) 'Preview did not retain a verified host binding.'
+    $signature = '{0}/{1}/{2}' -f $binding.workerSessionId, $binding.sessionGeneration, $binding.portalProcessId
+    Assert-Condition ($signature -ceq $script:InitialIdentity -and [string]::Equals($binding.projectPath, $ProjectPath, [StringComparison]::OrdinalIgnoreCase)) 'Preview binding differs from the verified target session.'
+    Assert-Condition ($preview.diff.operations.Count -eq $Operations.Count) 'Structured diff is missing eligible operations.'
+    for ($i = 0; $i -lt $Operations.Count; $i++) {
+        Assert-Condition ($preview.diff.operations[$i].operationId -ceq $Operations[$i].operationId) 'Diff order differs from request order.'
+    }
+    return $preview
+}
+
+# Keep existing source and bundle headers intact; add a comment inside the first declaration.
+function Add-AcceptanceComment([string] $Text) {
+    $declaration = [regex]::Match($Text, '(?m)^[ \t]*(?:TYPE|DATA_BLOCK|FUNCTION_BLOCK|FUNCTION|ORGANIZATION_BLOCK)\b[^\r\n]*(\r\n|\n)')
+    Assert-Condition ($declaration.Success) 'Target must expose a source declaration with a line terminator.'
+    return $Text.Insert($declaration.Index + $declaration.Length, '// PR4 disposable acceptance comment' + $declaration.Groups[1].Value)
+}
+
+# Report each run separately under the durable report, preserving prior evidence.
+$runTime = [DateTime]::UtcNow.ToString('o')
+$runDirectory = Join-Path ([IO.Path]::GetTempPath()) ('tia-preview-diff-' + [Guid]::NewGuid().ToString('N'))
+[void][IO.Directory]::CreateDirectory($runDirectory)
+try {
+    if ($Mode -eq 'Apply') {
+        Write-Host "Disposable project: $ProjectPath`nBlock: $BlockPath`nType: $TypePath"
+        if (-not $ConfirmApplyForCi) {
+            $typed = Read-Host 'Type YES to apply temporary source comments, restore original text, and compile this disposable project'
+            Assert-Condition ($typed -ceq 'YES') 'Apply was not confirmed.'
+        }
+        $evidence.Authorization = if ($ConfirmApplyForCi) { 'Explicit -AllowApply and -ConfirmApplyForCi (authorized CI only)' } else { 'Explicit -AllowApply and interactive YES' }
+    }
+
+    $startInfo = [Diagnostics.ProcessStartInfo]::new('dotnet')
+    foreach ($argument in @($HostDllPath, '--read-write', '--project', $ProjectPath)) { $startInfo.ArgumentList.Add($argument) }
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardInput = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.StandardInputEncoding = $utf8
+    $startInfo.StandardOutputEncoding = $utf8
+    $script:HostProcess = [Diagnostics.Process]::Start($startInfo)
+    $initialize = Invoke-Mcp 'initialize' @{ protocolVersion = '2024-11-05'; capabilities = @{}; clientInfo = @{ name = 'preview-diff-acceptance'; version = '1.0' } }
+    Assert-Condition ($initialize.protocolVersion -eq '2024-11-05') 'Unexpected negotiated MCP protocol version.'
+    $script:HostProcess.StandardInput.WriteLine('{"jsonrpc":"2.0","method":"notifications/initialized"}')
+    $script:HostProcess.StandardInput.Flush()
+    $null = Read-Binding
+    $original = Read-OriginalText
+    [IO.File]::WriteAllText((Join-Path $runDirectory 'original-block.source.txt'), $original[0], $utf8)
+    [IO.File]::WriteAllText((Join-Path $runDirectory 'original-type.source.txt'), $original[1], $utf8)
+    $changedBlock = Add-AcceptanceComment $original[0]
+    $changedType = Add-AcceptanceComment $original[1]
+
+    if ($Mode -eq 'Preview') {
+        $blockPreview = Get-Preview @(New-BlockOperation 'block-change' $changedBlock)
+        $typePreview = Get-Preview @(New-TypeOperation 'type-change' $changedType)
+        foreach ($preview in @($blockPreview, $typePreview)) {
+            $entry = $preview.diff.operations[0]
+            Assert-Condition ($entry.rawTextEqual -eq $false -and $entry.normalizedLinesEqual -eq $false -and $entry.requested.excerpt.lines.Count -gt 0) 'Expected a real content change and retained structured excerpt.'
+        }
+        $evidence.Block = 'PASS: source content change with structured diff'
+        $evidence.Type = 'PASS: source content change with structured diff'
+        $lf = $original[0].Replace("`r`n", "`n")
+        $eolText = if ($lf -ceq $original[0]) { $lf.Replace("`n", "`r`n") } else { $lf }
+        Assert-Condition ($eolText -cne $original[0]) 'Block needs CRLF or LF line endings for the line-ending-only case.'
+        $eolPreview = Get-Preview @(New-BlockOperation 'line-endings' $eolText)
+        $entry = $eolPreview.diff.operations[0]
+        Assert-Condition ($entry.rawTextEqual -eq $false -and $entry.normalizedLinesEqual -eq $true -and $entry.lineEndingOnly -eq $true) 'Line-ending-only flags are incorrect.'
+        $evidence.LineEnding = 'PASS: rawTextEqual=false, normalizedLinesEqual=true, lineEndingOnly=true'
+
+        # One long changed line proves the 512-character per-line cap independently of the side cap.
+        $linePreview = Get-Preview @(New-TypeOperation 'long-line' ($original[1] + "`n" + ('x' * 1024)))
+        $line = @($linePreview.diff.operations[0].requested.excerpt.lines | Where-Object { $_.text.Length -eq 512 -and $_.omittedCharacterCount -gt 0 })
+        Assert-Condition ($line.Count -gt 0) 'Per-line truncation did not retain 512 characters.'
+        # 60 requested lines of 512 characters exercise both side caps; nine copies exceed
+        # the 32,768-character/320-line whole-batch budgets regardless of small original text.
+        $oversizedText = ((1..60 | ForEach-Object { 'x' * 512 }) -join "`n")
+        $largeOperations = @(1..9 | ForEach-Object { New-TypeOperation "oversized-$_" $oversizedText })
+        $largeOperations += New-TypeOperation 'small-after-exhaustion' $changedType
+        $largePreview = Get-Preview $largeOperations
+        $repeatedPreview = Get-Preview $largeOperations
+        Assert-Condition (($largePreview.diff | ConvertTo-Json -Depth 100 -Compress) -ceq ($repeatedPreview.diff | ConvertTo-Json -Depth 100 -Compress)) 'Repeated ordered preview diff is not deterministic.'
+        $first = $largePreview.diff.operations[0].requested.excerpt
+        Assert-Condition ($first.lines.Count -eq 40 -and $first.omittedLineCount -gt 0 -and $first.omittedCharacterCount -gt 0) 'Per-side truncation evidence missing.'
+        $retainedChars = ($first.lines | ForEach-Object { $_.text.Length } | Measure-Object -Sum).Sum
+        Assert-Condition ($retainedChars -le 8192) 'Per-side character limit exceeded.'
+        $exhausted = $false
+        $firstExhausted = -1
+        for ($i = 0; $i -lt $largePreview.diff.operations.Count; $i++) {
+            $entry = $largePreview.diff.operations[$i]
+            if ($entry.batchBudgetExhausted) {
+                if (-not $exhausted) { $firstExhausted = $i }
+                $exhausted = $true
+            }
+            if ($exhausted) {
+                Assert-Condition ($entry.batchBudgetExhausted -eq $true -and $entry.current.excerpt.lines.Count -eq 0 -and $entry.requested.excerpt.lines.Count -eq 0) 'Later excerpts reappeared after batch exhaustion.'
+                Assert-Condition ($entry.requested.characterCount -gt 0 -and $entry.requested.sha256.Length -eq 64) 'Exhausted entry lost raw-text metadata.'
+            }
+        }
+        Assert-Condition ($exhausted -and $firstExhausted -gt 0) 'Whole-batch exhaustion not demonstrated.'
+        $evidence.Oversized = "PASS: 512-character line cap; 40-line/8192-character side caps; deterministic exhaustion at zero-based index $firstExhausted including later small request"
+        $diffEvidence = @{ block = $blockPreview.diff; type = $typePreview.diff; lineEnding = $eolPreview.diff; longLine = $linePreview.diff; oversized = $largePreview.diff }
+        [IO.File]::WriteAllText((Join-Path $runDirectory 'preview-diffs.json'), ($diffEvidence | ConvertTo-Json -Depth 100), $utf8)
+    }
+    elseif ($Mode -eq 'Apply') {
+        # All confirmed writes are lexically inside this explicitly gated Apply branch.
+        $changes = @((New-BlockOperation 'change-block' $changedBlock), (New-TypeOperation 'change-type' $changedType))
+        $restoration = @((New-BlockOperation 'restore-block' $original[0]), (New-TypeOperation 'restore-type' $original[1]))
+        $changePreview = Get-Preview $changes
+        for ($i = 0; $i -lt 2; $i++) {
+            Assert-Condition ($changePreview.diff.operations[$i].current.sha256 -ceq (Get-TextHash $original[$i])) 'Source changed since original read; refusing apply and restoration of stale text.'
+            Assert-Condition ($changePreview.diff.operations[$i].rawTextEqual -eq $false) 'Temporary comment did not produce a content change.'
+        }
+        $writeAttempted = $false
+        try {
+            $writeAttempted = $true
+            $evidence.Applied = 'ATTEMPTED; outcome not yet verified'
+            $applied = Invoke-Tool 'apply_write_batch' @{ operations = $changes; confirm = $true; safetyToken = $changePreview.safetyToken }
+            Assert-Condition ($applied.success -eq $true -and $applied.succeeded -eq 2) 'Two-item apply did not succeed.'
+            $evidence.Applied = 'PASS: both operations reported success; restoring original text next'
+        }
+        finally {
+            # Also attempt restoration after a partial/failed apply. A changed session fails closed.
+            if ($writeAttempted) {
+                $evidence.Restore = 'ATTEMPTED; final state unknown until re-read'
+                $restorePreview = Get-Preview $restoration
+                $restored = Invoke-Tool 'apply_write_batch' @{ operations = $restoration; confirm = $true; safetyToken = $restorePreview.safetyToken }
+                Assert-Condition ($restored.success -eq $true -and $restored.succeeded -eq 2) 'Restore batch did not succeed; use retained originals for recovery.'
+                $evidence.Restore = 'PASS: both original source replacements reported success'
+                $after = Read-OriginalText
+                for ($i = 0; $i -lt 2; $i++) {
+                    Assert-Condition ([Convert]::ToBase64String($utf8.GetBytes($after[$i])) -ceq [Convert]::ToBase64String($utf8.GetBytes($original[$i]))) "Target $i failed byte-identical restoration."
+                }
+                $evidence.Bytes = "PASS: byte-identical UTF-8 exported text; block SHA256=$(Get-TextHash $after[0]); type SHA256=$(Get-TextHash $after[1])"
+                $null = Read-Binding
+                $compileEnvelope = Invoke-Tool 'compile_check' @{ projectPath = $ProjectPath }
+                $compile = ConvertFrom-Json -InputObject $compileEnvelope.payload -AsHashtable
+                Assert-Condition ($compile.totalErrorCount -eq 0 -and $compile.plcs.Count -gt 0 -and $compile.overallState -ne 'Error') 'Compile must cover at least one PLC and report zero errors.'
+                $evidence.Compile = "PASS: zero errors; warnings=$($compile.totalWarningCount); PLCs=$($compile.plcs.Count)"
+            }
+        }
+    }
+    $finalProject = Read-Binding
+    $evidence.FinalState = "Same verified session; project isModified=$($finalProject.isModified). No save performed."
+    $evidence.Outcome = "PASS for $Mode mode only"
+}
+catch {
+    $evidence.Outcome = 'FAILED: ' + $_.Exception.Message
+    throw
+}
+finally {
+    if ($null -ne $script:HostProcess) {
+        try {
+            $script:HostProcess.StandardInput.Close()
+            if (-not $script:HostProcess.WaitForExit(5000)) { $script:HostProcess.Kill($true) }
+        }
+        catch {
+            $evidence.FinalState += ' Host cleanup failed: ' + $_.Exception.Message
+            Write-Warning 'Host cleanup failed; inspect the acceptance report and child processes.'
+        }
+        finally { $script:HostProcess.Dispose() }
+    }
+    $report = @"
+
+## Run $runTime ($Mode)
+
+### Environment
+
+- Date: $runTime
+- TIA Portal version: $($evidence.TiaVersion)
+- Host build: $HostDllPath; SHA256=$hostHash
+- Disposable project path: $ProjectPath
+- Binding verification: $($evidence.Binding)
+- Block target: $BlockPath
+- Type target: $TypePath
+- Local evidence and original sources: $runDirectory
+
+### Preview-Only Evidence
+
+- Block preview: $($evidence.Block)
+- Type preview: $($evidence.Type)
+- Line-ending-only preview: $($evidence.LineEnding)
+- Oversized batch preview: $($evidence.Oversized)
+
+### Apply / Restore / Compile
+
+- Apply authorization: $($evidence.Authorization)
+- Applied changes: $($evidence.Applied)
+- Restore result: $($evidence.Restore)
+- Byte-identical re-read: $($evidence.Bytes)
+- Compile result: $($evidence.Compile)
+- Final state: $($evidence.FinalState)
+
+### Evidence Boundary
+
+- Outcome: $($evidence.Outcome)
+- Proven: only checks marked PASS in this run, through the real host MCP protocol.
+- Not proven: checks marked NOT RUN/INCOMPLETE; production or plant acceptance; disk project-byte identity; saved project state; semantic equivalence of replacements. Preview alone cannot qualify apply/restore/compile.
+"@
+    [IO.File]::AppendAllText($reportPath, $report + [Environment]::NewLine, $utf8)
+    Write-Host "Acceptance evidence appended to $reportPath"
+}

--- a/scripts/live-test-preview-write-diff.ps1
+++ b/scripts/live-test-preview-write-diff.ps1
@@ -343,7 +343,7 @@ finally {
 
 - Outcome: $($evidence.Outcome)
 - Proven: only checks marked PASS in this run, through the real host MCP protocol.
-- Not proven: checks marked NOT RUN/INCOMPLETE; production or plant acceptance; disk project-byte identity; saved project state; semantic equivalence of replacements. Preview alone cannot qualify apply/restore/compile.
+- Not proven: $(if ($Mode -eq 'Preview') { 'checks marked NOT RUN/INCOMPLETE; production or plant acceptance; disk project-byte identity; saved project state; semantic equivalence of replacements. Preview alone cannot qualify apply/restore/compile.' } else { 'checks marked NOT RUN/INCOMPLETE; production or plant acceptance; disk project-byte identity; saved project state; semantic equivalence beyond the exact exported-text checks performed.' })
 "@
     [IO.File]::AppendAllText($reportPath, $report + [Environment]::NewLine, $utf8)
     Write-Host "Acceptance evidence appended to $reportPath"

--- a/scripts/live-test-preview-write-diff.ps1
+++ b/scripts/live-test-preview-write-diff.ps1
@@ -107,7 +107,13 @@ function Read-Binding {
     }
     $script:InitialIdentity = $signature
     $evidence.Binding = "PASS: exact project path and worker/session/Portal identity $signature"
-    $evidence.TiaVersion = "V21 prerequisite; project version reported: $($payload.project.version)"
+    $projectVersion = $payload.project.version
+    $evidence.TiaVersion = if ([string]::IsNullOrWhiteSpace($projectVersion)) {
+        'V21 prerequisite; project version not reported'
+    }
+    else {
+        "V21 prerequisite; project version reported: $projectVersion"
+    }
     return $payload.project
 }
 


### PR DESCRIPTION
## Summary

- add bounded structured before/after diffs to registered `preview_write_batch` results using the already-read current state
- preserve safety-token inputs, state hashes, validation, auditing, worker behavior, and canonical Network contracts
- document the diff limits and add an explicitly gated host-level live acceptance harness

## Verification

- focused PR4 tests: 30/30 passed
- complete offline suite: 2,664/2,664 passed
- stub build: 0 warnings, 0 errors
- real TIA Portal V21 build: 0 warnings, 0 errors
- documentation link/reachability check: 66 files passed
- final independent whole-branch review and scoped fix re-review: approved

## Live TIA Portal V21 acceptance

- Preview passed for block/type changes, line-ending-only detection, per-line/per-side limits, and deterministic whole-batch exhaustion
- the first authorized Apply exposed TIA canonicalization from `T#1s` to `T#1S`; that failure remains recorded and the disposable project was recovered without saving
- the second authorized Apply passed both mutations, restoration, byte-identical public source re-exports, and compilation with 0 errors, 0 warnings, and 2 PLCs
- final guarded no-save recovery returned the opened project to `isModified=False`

## Evidence boundary

This does not establish plant/production acceptance, saved-project behavior, disk project-byte identity, or semantic equivalence beyond the exact exported-text checks recorded in the acceptance report.