### PR TITLE
feat(batch): narrow tag operation safety scopes

### DIFF
--- a/TiaMcpServer.Contracts/OperationPolicyCatalog.cs
+++ b/TiaMcpServer.Contracts/OperationPolicyCatalog.cs
@@ -92,6 +92,13 @@ public static class OperationPolicyCatalog
 
             // SafetyRead (read-only safe, but requires a verified expected identity)
             ["read_update_tag_safety_snapshot"] = OperationCapability.SafetyRead,
+            ["read_create_tag_table_safety_snapshot"] = OperationCapability.SafetyRead,
+            ["read_delete_tag_table_safety_snapshot"] = OperationCapability.SafetyRead,
+            ["read_create_tag_safety_snapshot"] = OperationCapability.SafetyRead,
+            ["read_delete_tag_safety_snapshot"] = OperationCapability.SafetyRead,
+            ["read_create_user_constant_safety_snapshot"] = OperationCapability.SafetyRead,
+            ["read_update_user_constant_safety_snapshot"] = OperationCapability.SafetyRead,
+            ["read_delete_user_constant_safety_snapshot"] = OperationCapability.SafetyRead,
 
             // TemporaryExport (read-only safe, temporary files with cleanup)
             ["get_block_content"] = OperationCapability.TemporaryExport,

--- a/TiaMcpServer.Contracts/TagOperationSafetySnapshotInfo.cs
+++ b/TiaMcpServer.Contracts/TagOperationSafetySnapshotInfo.cs
@@ -1,81 +1,83 @@
+using System.Text.Json.Serialization;
+
 namespace TiaMcpServer.Contracts;
 
 public sealed record TagTableSafetyIdentityInfo(
-    string PlcName,
-    string FolderPath,
-    string TableName,
-    string CanonicalPath);
+    [property: JsonRequired] string PlcName,
+    [property: JsonRequired] string FolderPath,
+    [property: JsonRequired] string TableName,
+    [property: JsonRequired] string CanonicalPath);
 
 public sealed record TagSafetyIdentityInfo(
-    string PlcName,
-    string FolderPath,
-    string TableName,
-    string TagName,
-    string CanonicalPath,
-    string DataType,
+    [property: JsonRequired] string PlcName,
+    [property: JsonRequired] string FolderPath,
+    [property: JsonRequired] string TableName,
+    [property: JsonRequired] string TagName,
+    [property: JsonRequired] string CanonicalPath,
+    [property: JsonRequired] string DataType,
     string? LogicalAddress,
     bool? ExternalAccessible,
     bool? ExternalVisible,
     bool? ExternalWritable);
 
 public sealed record UserConstantSafetyIdentityInfo(
-    string PlcName,
-    string FolderPath,
-    string TableName,
-    string ConstantName,
-    string CanonicalPath,
-    string DataType,
-    string Value);
+    [property: JsonRequired] string PlcName,
+    [property: JsonRequired] string FolderPath,
+    [property: JsonRequired] string TableName,
+    [property: JsonRequired] string ConstantName,
+    [property: JsonRequired] string CanonicalPath,
+    [property: JsonRequired] string DataType,
+    [property: JsonRequired] string Value);
 
 public sealed record TagCollisionProbeInfo(
-    string Kind,
-    string CandidateName,
-    string CanonicalPath,
+    [property: JsonRequired] string Kind,
+    [property: JsonRequired] string CandidateName,
+    [property: JsonRequired] string CanonicalPath,
     string? LogicalAddress,
-    bool IsTarget);
+    [property: JsonRequired] bool IsTarget);
 
 public sealed record CreateTagTableSafetySnapshotInfo(
-    string PlcName,
-    string FolderPath,
-    string RequestedTableName,
-    IReadOnlyList<TagCollisionProbeInfo> TableNameCollisions);
+    [property: JsonRequired] string PlcName,
+    [property: JsonRequired] string FolderPath,
+    [property: JsonRequired] string RequestedTableName,
+    [property: JsonRequired] IReadOnlyList<TagCollisionProbeInfo> TableNameCollisions);
 
 public sealed record DeleteTagTableSafetySnapshotInfo(
-    TagTableSafetyIdentityInfo TargetTable,
-    string ExportedSimaticMl,
-    string ExportSha256,
-    int CharacterCount);
+    [property: JsonRequired] TagTableSafetyIdentityInfo TargetTable,
+    [property: JsonRequired] string ExportedSimaticMl,
+    [property: JsonRequired] string ExportSha256,
+    [property: JsonRequired] int CharacterCount);
 
 public sealed record CreateTagSafetySnapshotInfo(
-    TagTableSafetyIdentityInfo TargetTable,
-    string EffectiveName,
+    [property: JsonRequired] TagTableSafetyIdentityInfo TargetTable,
+    [property: JsonRequired] string EffectiveName,
     string? EffectiveLogicalAddress,
-    IReadOnlyList<TagCollisionProbeInfo> NameCollisions,
-    IReadOnlyList<TagCollisionProbeInfo> AddressCollisions);
+    [property: JsonRequired] IReadOnlyList<TagCollisionProbeInfo> NameCollisions,
+    [property: JsonRequired] IReadOnlyList<TagCollisionProbeInfo> AddressCollisions);
 
 public sealed record UpdateTagSafetySnapshotInfo(
-    TagTableSafetyIdentityInfo TargetTable,
-    TagSafetyIdentityInfo TargetTag,
-    string EffectiveName,
+    [property: JsonRequired] TagTableSafetyIdentityInfo TargetTable,
+    [property: JsonRequired] TagSafetyIdentityInfo TargetTag,
+    [property: JsonRequired] string EffectiveName,
     string? EffectiveLogicalAddress,
-    IReadOnlyList<TagCollisionProbeInfo> NameCollisions,
-    IReadOnlyList<TagCollisionProbeInfo> AddressCollisions);
+    [property: JsonRequired] IReadOnlyList<TagCollisionProbeInfo> NameCollisions,
+    [property: JsonRequired] IReadOnlyList<TagCollisionProbeInfo> AddressCollisions);
 
 public sealed record DeleteTagSafetySnapshotInfo(
-    TagTableSafetyIdentityInfo TargetTable,
-    TagSafetyIdentityInfo TargetTag);
+    [property: JsonRequired] TagTableSafetyIdentityInfo TargetTable,
+    [property: JsonRequired] TagSafetyIdentityInfo TargetTag);
 
 public sealed record CreateUserConstantSafetySnapshotInfo(
-    TagTableSafetyIdentityInfo TargetTable,
-    string EffectiveName,
-    IReadOnlyList<TagCollisionProbeInfo> NameCollisions);
+    [property: JsonRequired] TagTableSafetyIdentityInfo TargetTable,
+    [property: JsonRequired] string EffectiveName,
+    [property: JsonRequired] IReadOnlyList<TagCollisionProbeInfo> NameCollisions);
 
 public sealed record UpdateUserConstantSafetySnapshotInfo(
-    TagTableSafetyIdentityInfo TargetTable,
-    UserConstantSafetyIdentityInfo TargetConstant,
-    string EffectiveName,
-    IReadOnlyList<TagCollisionProbeInfo> NameCollisions);
+    [property: JsonRequired] TagTableSafetyIdentityInfo TargetTable,
+    [property: JsonRequired] UserConstantSafetyIdentityInfo TargetConstant,
+    [property: JsonRequired] string EffectiveName,
+    [property: JsonRequired] IReadOnlyList<TagCollisionProbeInfo> NameCollisions);
 
 public sealed record DeleteUserConstantSafetySnapshotInfo(
-    TagTableSafetyIdentityInfo TargetTable,
-    UserConstantSafetyIdentityInfo TargetConstant);
+    [property: JsonRequired] TagTableSafetyIdentityInfo TargetTable,
+    [property: JsonRequired] UserConstantSafetyIdentityInfo TargetConstant);

--- a/TiaMcpServer.Contracts/TagOperationSafetySnapshotInfo.cs
+++ b/TiaMcpServer.Contracts/TagOperationSafetySnapshotInfo.cs
@@ -1,0 +1,81 @@
+namespace TiaMcpServer.Contracts;
+
+public sealed record TagTableSafetyIdentityInfo(
+    string PlcName,
+    string FolderPath,
+    string TableName,
+    string CanonicalPath);
+
+public sealed record TagSafetyIdentityInfo(
+    string PlcName,
+    string FolderPath,
+    string TableName,
+    string TagName,
+    string CanonicalPath,
+    string DataType,
+    string? LogicalAddress,
+    bool? ExternalAccessible,
+    bool? ExternalVisible,
+    bool? ExternalWritable);
+
+public sealed record UserConstantSafetyIdentityInfo(
+    string PlcName,
+    string FolderPath,
+    string TableName,
+    string ConstantName,
+    string CanonicalPath,
+    string DataType,
+    string Value);
+
+public sealed record TagCollisionProbeInfo(
+    string Kind,
+    string CandidateName,
+    string CanonicalPath,
+    string? LogicalAddress,
+    bool IsTarget);
+
+public sealed record CreateTagTableSafetySnapshotInfo(
+    string PlcName,
+    string FolderPath,
+    string RequestedTableName,
+    IReadOnlyList<TagCollisionProbeInfo> TableNameCollisions);
+
+public sealed record DeleteTagTableSafetySnapshotInfo(
+    TagTableSafetyIdentityInfo TargetTable,
+    string ExportedSimaticMl,
+    string ExportSha256,
+    int CharacterCount);
+
+public sealed record CreateTagSafetySnapshotInfo(
+    TagTableSafetyIdentityInfo TargetTable,
+    string EffectiveName,
+    string? EffectiveLogicalAddress,
+    IReadOnlyList<TagCollisionProbeInfo> NameCollisions,
+    IReadOnlyList<TagCollisionProbeInfo> AddressCollisions);
+
+public sealed record UpdateTagSafetySnapshotInfo(
+    TagTableSafetyIdentityInfo TargetTable,
+    TagSafetyIdentityInfo TargetTag,
+    string EffectiveName,
+    string? EffectiveLogicalAddress,
+    IReadOnlyList<TagCollisionProbeInfo> NameCollisions,
+    IReadOnlyList<TagCollisionProbeInfo> AddressCollisions);
+
+public sealed record DeleteTagSafetySnapshotInfo(
+    TagTableSafetyIdentityInfo TargetTable,
+    TagSafetyIdentityInfo TargetTag);
+
+public sealed record CreateUserConstantSafetySnapshotInfo(
+    TagTableSafetyIdentityInfo TargetTable,
+    string EffectiveName,
+    IReadOnlyList<TagCollisionProbeInfo> NameCollisions);
+
+public sealed record UpdateUserConstantSafetySnapshotInfo(
+    TagTableSafetyIdentityInfo TargetTable,
+    UserConstantSafetyIdentityInfo TargetConstant,
+    string EffectiveName,
+    IReadOnlyList<TagCollisionProbeInfo> NameCollisions);
+
+public sealed record DeleteUserConstantSafetySnapshotInfo(
+    TagTableSafetyIdentityInfo TargetTable,
+    UserConstantSafetyIdentityInfo TargetConstant);

--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -65,6 +65,14 @@ var tagUpdateTargetDriftMutationCount = 0;
 var tagUpdateStrictSnapshotFailureBroadReadCount = 0;
 var tagUpdateInvalidSnapshotBroadReadCount = 0;
 var tagSafetyDedupReadCount = 0;
+var tagSafetySnapshotReadCount = 0;
+var tagSafetyMutationCount = 0;
+var tagSafetySnapshotReadsAtMutation = 0;
+var tagSafetyBroadReadCount = 0;
+var tagSafetyTargetExists = true;
+var tagSafetyTargetTagName = "Start";
+var tagSafetySiblingTag = new TagSafetyIdentityInfo("PLC_1", "/", "Outputs", "Before",
+    "PLC_1/Tag tables/Outputs/Before", "Bool", "%Q0.0", true, true, false);
 var hardwarePaginationScenarioCalls = new Dictionary<string, int>(StringComparer.Ordinal);
 var hardwarePaginationIdentityDrift = false;
 
@@ -288,6 +296,20 @@ while ((line = Console.In.ReadLine()) is not null)
                 ? """{"success":true,"payload":"{\"isOpen\":true}"}"""
                 : TagSafetyRouteResponse(line, scenario == "tag-safety-invalid-routes",
                     invalidCollision: scenario == "tag-safety-private-collision-kind"));
+            break;
+        case "tag-safety-same-object-drift":
+        case @"C:\FakeWorker\tag-safety-same-object-drift.ap21":
+        case "tag-safety-collision-drift":
+        case @"C:\FakeWorker\tag-safety-collision-drift.ap21":
+        case "tag-safety-unrelated-sibling":
+        case @"C:\FakeWorker\tag-safety-unrelated-sibling.ap21":
+        case "tag-safety-delete-table-export-drift":
+        case @"C:\FakeWorker\tag-safety-delete-table-export-drift.ap21":
+        case "tag-safety-reread":
+        case @"C:\FakeWorker\tag-safety-reread.ap21":
+        case "tag-safety-authorized-apply":
+        case @"C:\FakeWorker\tag-safety-authorized-apply.ap21":
+            Respond(TagSafetyBehaviorResponse(line, Path.GetFileNameWithoutExtension(scenario)));
             break;
         case "tag-safety-route-proof":
         case @"C:\FakeWorker\tag-safety-route-proof.ap21":
@@ -1033,6 +1055,121 @@ ProjectStatusInfo StatusWithMetadataFixture() => new()
 };
 
 // Exact-route fixtures reject wrong selectors before returning each operation's typed payload.
+string TagSafetyBehaviorResponse(string requestLine, string scenario)
+{
+    var method = ReadMethod(requestLine);
+    if (method == "get_project_status")
+    {
+        // Read-only observation: bootstrap and assertions never advance the snapshot phase.
+        return Success(ToCamelCaseJson(new
+        {
+            isOpen = true,
+            snapshotReadCount = tagSafetySnapshotReadCount,
+            mutationCount = tagSafetyMutationCount,
+            snapshotReadsAtMutation = tagSafetySnapshotReadsAtMutation,
+            broadReadCount = tagSafetyBroadReadCount,
+            targetExists = tagSafetyTargetExists,
+            targetTagName = tagSafetyTargetTagName,
+            siblingTableName = tagSafetySiblingTag.TableName,
+            siblingTagName = tagSafetySiblingTag.TagName
+        }));
+    }
+    if (method == "list_tag_tables")
+    {
+        tagSafetyBroadReadCount++;
+        return """{"success":false,"error":"wrong route: list_tag_tables"}""";
+    }
+
+    var expectedWrite = scenario switch
+    {
+        "tag-safety-same-object-drift" or "tag-safety-authorized-apply" => "update_tag",
+        "tag-safety-collision-drift" => "create_tag",
+        "tag-safety-unrelated-sibling" => "delete_tag",
+        "tag-safety-delete-table-export-drift" => "delete_tag_table",
+        "tag-safety-reread" => "create_user_constant",
+        _ => throw new InvalidOperationException("Unknown tag safety behavior scenario.")
+    };
+    var requestedName = ReadField(requestLine, "name");
+    if (ReadField(requestLine, "plcName") != "PLC_1" ||
+        ReadField(requestLine, "tableName") != "Inputs" ||
+        ReadField(requestLine, "folderPath") is not (null or "" or "/") ||
+        (expectedWrite is "update_tag" or "delete_tag" && requestedName != "Start") ||
+        (expectedWrite == "update_tag" && ReadField(requestLine, "newName") != "Start_1") ||
+        (expectedWrite == "create_tag" && (requestedName is not ("Start_1" or "AddressOnly") ||
+            ReadField(requestLine, "dataType") != "Bool" || ReadField(requestLine, "logicalAddress") != "%I0.1")) ||
+        (expectedWrite == "create_user_constant" && requestedName != "DebounceMs"))
+    {
+        return """{"success":false,"error":"wrong tag safety behavior selector"}""";
+    }
+    if (method == expectedWrite)
+    {
+        // Count every mutation attempt, including one the host should have rejected.
+        tagSafetyMutationCount++;
+        tagSafetySnapshotReadsAtMutation = tagSafetySnapshotReadCount;
+        if (expectedWrite == "update_tag")
+            tagSafetyTargetTagName = ReadField(requestLine, "newName")!;
+        if (expectedWrite is "delete_tag" or "delete_tag_table")
+            tagSafetyTargetExists = false;
+        return Success("{}");
+    }
+    if (method != $"read_{expectedWrite}_safety_snapshot")
+        return """{"success":false,"error":"unexpected tag safety behavior method"}""";
+
+    // Only an exact selector read advances state. The second read is apply, before mutation.
+    var applyPhase = ++tagSafetySnapshotReadCount > 1;
+    var table = new TagTableSafetyIdentityInfo("PLC_1", "/", "Inputs", "PLC_1/Tag tables/Inputs");
+    var tag = new TagSafetyIdentityInfo("PLC_1", "/", "Inputs", tagSafetyTargetTagName,
+        table.CanonicalPath + "/" + tagSafetyTargetTagName, "Bool", "%I0.0", true, true, false);
+    var empty = Array.Empty<TagCollisionProbeInfo>();
+    object payload;
+    switch (scenario)
+    {
+        case "tag-safety-same-object-drift":
+        case "tag-safety-authorized-apply":
+            if (applyPhase && scenario == "tag-safety-same-object-drift")
+                tag = tag with { ExternalVisible = false };
+            payload = new UpdateTagSafetySnapshotInfo(table, tag, "Start_1", "%I0.0", empty,
+                new[] { new TagCollisionProbeInfo("logical-address", tag.TagName, tag.CanonicalPath, "%I0.0", true) });
+            break;
+        case "tag-safety-collision-drift":
+            // Independent variants: same name at another address, or another name at the same address.
+            var nameCollisions = applyPhase && requestedName == "Start_1"
+                ? new[] { new TagCollisionProbeInfo("tag-name", "Start_1", table.CanonicalPath + "/Start_1", "%I0.2", false) }
+                : empty;
+            var addressCollisions = applyPhase && requestedName == "AddressOnly"
+                ? new[] { new TagCollisionProbeInfo("logical-address", "Other", table.CanonicalPath + "/Other", "%I0.1", false) }
+                : empty;
+            payload = new CreateTagSafetySnapshotInfo(table, requestedName!, "%I0.1", nameCollisions, addressCollisions);
+            break;
+        case "tag-safety-unrelated-sibling":
+            if (applyPhase)
+            {
+                // This Outputs-table tag would appear in the old broad inventory. It is outside
+                // the Inputs/Start selector, so the exact target snapshot remains byte-identical.
+                tagSafetySiblingTag = tagSafetySiblingTag with
+                {
+                    TagName = "After", CanonicalPath = "PLC_1/Tag tables/Outputs/After"
+                };
+            }
+            payload = new DeleteTagSafetySnapshotInfo(table, tag);
+            break;
+        case "tag-safety-delete-table-export-drift":
+            var xml = $"<Document><SW.Tags.PlcTagTable><Name>Inputs</Name><Comment>{(applyPhase ? "B" : "A")}</Comment></SW.Tags.PlcTagTable></Document>";
+            var digest = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(xml))).ToLowerInvariant();
+            payload = new DeleteTagTableSafetySnapshotInfo(table, xml, digest, xml.Length);
+            break;
+        case "tag-safety-reread":
+            var constantCollisions = applyPhase
+                ? new[] { new TagCollisionProbeInfo("user-constant-name", "DebounceMs", table.CanonicalPath + "/DebounceMs", null, false) }
+                : empty;
+            payload = new CreateUserConstantSafetySnapshotInfo(table, "DebounceMs", constantCollisions);
+            break;
+        default:
+            throw new InvalidOperationException("Unknown tag safety snapshot scenario.");
+    }
+    return Success(ToCamelCaseJson(payload));
+}
+
 string TagSafetyRouteResponse(string requestLine, bool malformed, bool invalidCollision = false)
 {
     var method = ReadMethod(requestLine);

--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -283,9 +283,11 @@ while ((line = Console.In.ReadLine()) is not null)
             break;
         case "tag-safety-all-routes":
         case "tag-safety-invalid-routes":
+        case "tag-safety-private-collision-kind":
             Respond(ReadMethod(line) == "get_project_status"
                 ? """{"success":true,"payload":"{\"isOpen\":true}"}"""
-                : TagSafetyRouteResponse(line, scenario == "tag-safety-invalid-routes"));
+                : TagSafetyRouteResponse(line, scenario == "tag-safety-invalid-routes",
+                    invalidCollision: scenario == "tag-safety-private-collision-kind"));
             break;
         case "tag-safety-route-proof":
         case @"C:\FakeWorker\tag-safety-route-proof.ap21":
@@ -1031,7 +1033,7 @@ ProjectStatusInfo StatusWithMetadataFixture() => new()
 };
 
 // Exact-route fixtures reject wrong selectors before returning each operation's typed payload.
-string TagSafetyRouteResponse(string requestLine, bool malformed)
+string TagSafetyRouteResponse(string requestLine, bool malformed, bool invalidCollision = false)
 {
     var method = ReadMethod(requestLine);
     if (ReadField(requestLine, "plcName") != "PLC_1" ||
@@ -1061,6 +1063,16 @@ string TagSafetyRouteResponse(string requestLine, bool malformed)
     if (payload is null || (!method!.Contains("tag_table", StringComparison.Ordinal) && ReadField(requestLine, "name") != "Start"))
     {
         return """{"success":false,"error":"wrong route or effective tag safety selector"}""";
+    }
+    if (invalidCollision && payload is UpdateTagSafetySnapshotInfo update)
+    {
+        payload = update with
+        {
+            NameCollisions = new[]
+            {
+                new TagCollisionProbeInfo("PRIVATE_SNAPSHOT_SENTINEL", "Run", "PLC_1/Area/Inputs/Run", null, false)
+            }
+        };
     }
     return Success(malformed ? "{}" : ToCamelCaseJson(payload));
 }

--- a/TiaMcpServer.FakeWorker/Program.cs
+++ b/TiaMcpServer.FakeWorker/Program.cs
@@ -60,10 +60,11 @@ var updateBlockPostconditionAttempt = 0;
 var createBlockPostconditionAttempt = 0;
 var orderedTypeWriteCount = 0;
 var tagUpdateFlagDriftSnapshotReadCount = 0;
-var tagUpdateBroadDriftReadCount = 0;
-var tagUpdateBroadDriftMutationCount = 0;
+var tagUpdateTargetDriftReadCount = 0;
+var tagUpdateTargetDriftMutationCount = 0;
 var tagUpdateStrictSnapshotFailureBroadReadCount = 0;
 var tagUpdateInvalidSnapshotBroadReadCount = 0;
+var tagSafetyDedupReadCount = 0;
 var hardwarePaginationScenarioCalls = new Dictionary<string, int>(StringComparer.Ordinal);
 var hardwarePaginationIdentityDrift = false;
 
@@ -269,10 +270,39 @@ while ((line = Console.In.ReadLine()) is not null)
         case "hang":
             Thread.Sleep(Timeout.Infinite);
             break;
+        case "batch-preview-tag-safety":
+            Respond(ReadMethod(line) == "read_create_tag_table_safety_snapshot"
+                ? Success(ToCamelCaseJson(new CreateTagTableSafetySnapshotInfo(
+                    "PLC_1", "", "Inputs", Array.Empty<TagCollisionProbeInfo>())))
+                : Success(line));
+            break;
         case "echo":
             // Returns the received request verbatim so tests can assert which fields survived
             // the BatchOperationRequest -> WorkerRequest hop.
             Respond(JsonSerializer.Serialize(new { success = true, payload = line }));
+            break;
+        case "tag-safety-all-routes":
+        case "tag-safety-invalid-routes":
+            Respond(ReadMethod(line) == "get_project_status"
+                ? """{"success":true,"payload":"{\"isOpen\":true}"}"""
+                : TagSafetyRouteResponse(line, scenario == "tag-safety-invalid-routes"));
+            break;
+        case "tag-safety-route-proof":
+        case @"C:\FakeWorker\tag-safety-route-proof.ap21":
+        case "tag-safety-dedup-proof":
+        case @"C:\FakeWorker\tag-safety-dedup-proof.ap21":
+            Respond(ReadMethod(line) switch
+            {
+                "get_project_status" => """{"success":true,"payload":"{\"isOpen\":true}"}""",
+                "list_tag_tables" => """{"success":false,"error":"wrong route: list_tag_tables"}""",
+                "read_delete_tag_safety_snapshot" when scenario.Contains("tag-safety-dedup-proof", StringComparison.Ordinal) && ++tagSafetyDedupReadCount > 1
+                    => """{"success":false,"error":"dedup missing: repeated read_delete_tag_safety_snapshot"}""",
+                "read_delete_tag_safety_snapshot" => Success(JsonSerializer.Serialize(new DeleteTagSafetySnapshotInfo(
+                    new("PLC_1", "", "Inputs", "PLC_1/Inputs"),
+                    new("PLC_1", "", "Inputs", "Start", "PLC_1/Inputs/Start", "Bool", "%I0.0", true, true, false)),
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })),
+                _ => """{"success":false,"error":"unexpected tag safety route-proof method"}"""
+            });
             break;
         case "tag-update-snapshot-unavailable-visible":
             Respond(ReadMethod(line) switch
@@ -280,7 +310,7 @@ while ((line = Console.In.ReadLine()) is not null)
                 "get_project_status" => """{"success":true,"payload":"{\"isOpen\":true}"}""",
                 "list_tag_tables" => """{"success":true,"payload":"{\"tables\":[]}"}""",
                 "update_tag" => """{"success":true,"payload":"{}"}""",
-                "read_update_tag_safety_snapshot" => """{"success":true,"payload":"{\"plcName\":\"ResolvedPLC\",\"folderPath\":\"/\",\"tableName\":\"Default tag table\",\"tagName\":\"MotorReady\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I0.0\",\"externalAccessible\":false,\"externalVisible\":null,\"externalWritable\":false}"}""",
+                "read_update_tag_safety_snapshot" => Success(ToCamelCaseJson(TagUpdateSnapshot(externalVisible: null))),
                 _ => $$"""{"success":false,"error":"unexpected update-tag safety fixture method '{{ReadMethod(line)}}'"}"""
             });
             break;
@@ -290,7 +320,7 @@ while ((line = Console.In.ReadLine()) is not null)
                 "get_project_status" => """{"success":true,"payload":"{\"isOpen\":true}"}""",
                 "list_tag_tables" => """{"success":true,"payload":"{\"tables\":[]}"}""",
                 "update_tag" => """{"success":true,"payload":"{}"}""",
-                "read_update_tag_safety_snapshot" => """{"success":true,"payload":"{\"plcName\":\"ResolvedPLC\",\"folderPath\":\"/\",\"tableName\":\"Default tag table\",\"tagName\":\"MotorReady\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I0.0\",\"externalAccessible\":null,\"externalVisible\":null,\"externalWritable\":null}"}""",
+                "read_update_tag_safety_snapshot" => Success(ToCamelCaseJson(TagUpdateSnapshot(null, null, null))),
                 _ => $$"""{"success":false,"error":"unexpected all-unavailable update-tag fixture method '{{ReadMethod(line)}}'"}"""
             });
             break;
@@ -304,24 +334,24 @@ while ((line = Console.In.ReadLine()) is not null)
                 _ => $$"""{"success":false,"error":"unexpected update-tag safety fixture method '{{ReadMethod(line)}}'"}"""
             });
             break;
-        case "tag-update-broad-drift":
+        case "tag-update-target-drift":
             switch (ReadMethod(line))
             {
                 case "get_project_status":
-                    Respond($$"""{"success":true,"payload":"{\"isOpen\":true,\"broadDriftMutationCount\":{{tagUpdateBroadDriftMutationCount}}}"}""");
+                    Respond($$"""{"success":true,"payload":"{\"isOpen\":true,\"targetDriftMutationCount\":{{tagUpdateTargetDriftMutationCount}}}"}""");
                     break;
                 case "read_update_tag_safety_snapshot":
-                    Respond("""{"success":true,"payload":"{\"plcName\":\"ResolvedPLC\",\"folderPath\":\"/\",\"tableName\":\"Default tag table\",\"tagName\":\"MotorReady\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I0.0\",\"externalAccessible\":false,\"externalVisible\":true,\"externalWritable\":false}"}""");
+                    Respond(Success(ToCamelCaseJson(TagUpdateSnapshot(dataType: ++tagUpdateTargetDriftReadCount == 1 ? "Bool" : "DInt"))));
                     break;
                 case "list_tag_tables":
-                    Respond(TagUpdateBroadDriftResponse(++tagUpdateBroadDriftReadCount));
+                    Respond("""{"success":false,"error":"wrong route: list_tag_tables"}""");
                     break;
                 case "update_tag":
-                    tagUpdateBroadDriftMutationCount++;
+                    tagUpdateTargetDriftMutationCount++;
                     Respond("""{"success":true,"payload":"{}"}""");
                     break;
                 default:
-                    Respond("""{"success":false,"error":"unexpected broad-drift update-tag fixture method"}""");
+                    Respond("""{"success":false,"error":"unexpected target-drift update-tag fixture method"}""");
                     break;
             }
             break;
@@ -365,19 +395,19 @@ while ((line = Console.In.ReadLine()) is not null)
             Respond(ReadMethod(line) switch
             {
                 "get_project_status" => """{"success":true,"payload":"{\"isOpen\":true}"}""",
-                "read_update_tag_safety_snapshot" => """{"success":true,"payload":"{\"plcName\":\"ResolvedPLC\",\"folderPath\":\"/\",\"tableName\":\"Default tag table\",\"tagName\":\"MotorReady\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I0.0\",\"externalAccessible\":false,\"externalVisible\":true,\"externalWritable\":false}"}""",
+                "read_update_tag_safety_snapshot" => Success(ToCamelCaseJson(TagUpdateSnapshot())),
                 "list_tag_tables" => """{"success":true,"payload":"{\"tables\":[]}","warnings":["Skipping unrelated tag table: access denied."]}""",
                 "update_tag" => """{"success":true,"payload":"{}"}""",
                 _ => """{"success":false,"error":"unexpected update-tag broad-omission fixture method"}"""
             });
             break;
-        case "tag-update-broad-malformed-payload":
+        case "tag-update-exact-malformed-payload":
             Respond(ReadMethod(line) switch
             {
                 "get_project_status" => """{"success":true,"payload":"{\"isOpen\":true}"}""",
-                "read_update_tag_safety_snapshot" => """{"success":true,"payload":"{\"plcName\":\"ResolvedPLC\",\"folderPath\":\"/\",\"tableName\":\"Default tag table\",\"tagName\":\"MotorReady\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I0.0\",\"externalAccessible\":false,\"externalVisible\":true,\"externalWritable\":false}"}""",
-                "list_tag_tables" => """{"success":true,"payload":"{not valid json"}""",
-                _ => """{"success":false,"error":"unexpected update-tag malformed-broad fixture method"}"""
+                "read_update_tag_safety_snapshot" => Success("{not valid json"),
+                "list_tag_tables" => """{"success":false,"error":"wrong route: list_tag_tables"}""",
+                _ => """{"success":false,"error":"unexpected update-tag malformed-exact fixture method"}"""
             });
             break;
         case "network-read-warnings":
@@ -999,6 +1029,41 @@ ProjectStatusInfo StatusWithMetadataFixture() => new()
         },
     },
 };
+
+// Exact-route fixtures reject wrong selectors before returning each operation's typed payload.
+string TagSafetyRouteResponse(string requestLine, bool malformed)
+{
+    var method = ReadMethod(requestLine);
+    if (ReadField(requestLine, "plcName") != "PLC_1" ||
+        ReadField(requestLine, "tableName") != "Inputs" ||
+        ReadField(requestLine, "folderPath") != "Area")
+    {
+        return """{"success":false,"error":"wrong tag safety selector"}""";
+    }
+    var table = new TagTableSafetyIdentityInfo("PLC_1", "Area", "Inputs", "PLC_1/Area/Inputs");
+    var tag = new TagSafetyIdentityInfo("PLC_1", "Area", "Inputs", "Start", "PLC_1/Area/Inputs/Start", "Bool", "%I0.0", true, true, false);
+    var constant = new UserConstantSafetyIdentityInfo("PLC_1", "Area", "Inputs", "Start", "PLC_1/Area/Inputs/Start", "Bool", "true");
+    var collisions = Array.Empty<TagCollisionProbeInfo>();
+    object? payload = method switch
+    {
+        "read_create_tag_table_safety_snapshot" => new CreateTagTableSafetySnapshotInfo("PLC_1", "Area", "Inputs", collisions),
+        "read_delete_tag_table_safety_snapshot" => new DeleteTagTableSafetySnapshotInfo(table, "<Document />", new string('a', 64), 12),
+        "read_create_tag_safety_snapshot" when ReadField(requestLine, "logicalAddress") == "%I1.0" && ReadField(requestLine, "dataType") == "Bool"
+            => new CreateTagSafetySnapshotInfo(table, "Start", "%I1.0", collisions, collisions),
+        "read_update_tag_safety_snapshot" when ReadField(requestLine, "newName") == "Run" && ReadField(requestLine, "logicalAddress") == "%I1.0"
+            => new UpdateTagSafetySnapshotInfo(table, tag, "Run", "%I1.0", collisions, collisions),
+        "read_delete_tag_safety_snapshot" => new DeleteTagSafetySnapshotInfo(table, tag),
+        "read_create_user_constant_safety_snapshot" => new CreateUserConstantSafetySnapshotInfo(table, "Start", collisions),
+        "read_update_user_constant_safety_snapshot" => new UpdateUserConstantSafetySnapshotInfo(table, constant, "Start", collisions),
+        "read_delete_user_constant_safety_snapshot" => new DeleteUserConstantSafetySnapshotInfo(table, constant),
+        _ => null
+    };
+    if (payload is null || (!method!.Contains("tag_table", StringComparison.Ordinal) && ReadField(requestLine, "name") != "Start"))
+    {
+        return """{"success":false,"error":"wrong route or effective tag safety selector"}""";
+    }
+    return Success(malformed ? "{}" : ToCamelCaseJson(payload));
+}
 
 // Wraps a payload document as a successful worker response. Serializing beats hand-escaping once a
 // payload is more than a few members: the escaping is what a hand-written literal gets wrong, and a
@@ -2047,19 +2112,18 @@ string HandleSecondItemFailureWrite(string requestLine, List<SubnetLifecycleSubn
         : $$"""{"success":false,"error":"deliberate second-item failure for network-subnet-lifecycle-second-item-failure"}""";
 }
 
-string TagUpdateDriftSnapshotResponse(int readCount)
+UpdateTagSafetySnapshotInfo TagUpdateSnapshot(
+    bool? externalAccessible = false, bool? externalVisible = true, bool? externalWritable = false, string dataType = "Bool")
 {
-    var externalAccessible = readCount == 1 ? "false" : "true";
-    return $$"""{"success":true,"payload":"{\"plcName\":\"ResolvedPLC\",\"folderPath\":\"/\",\"tableName\":\"Default tag table\",\"tagName\":\"MotorReady\",\"dataType\":\"Bool\",\"logicalAddress\":\"%I0.0\",\"externalAccessible\":{{externalAccessible}},\"externalVisible\":true,\"externalWritable\":false}"}""";
+    return new(
+        new("ResolvedPLC", "/", "Default tag table", "ResolvedPLC/Default tag table"),
+        new("ResolvedPLC", "/", "Default tag table", "MotorReady", "ResolvedPLC/Default tag table/MotorReady",
+            dataType, "%I0.0", externalAccessible, externalVisible, externalWritable),
+        "MotorReady", "%I0.0", Array.Empty<TagCollisionProbeInfo>(), Array.Empty<TagCollisionProbeInfo>());
 }
 
-string TagUpdateBroadDriftResponse(int readCount)
-{
-    var payload = readCount == 1
-        ? """{"tables":[]}"""
-        : """{"tables":[{"name":"Unrelated","folderPath":"/","tags":[],"userConstants":[]}]}""";
-    return Success(payload);
-}
+string TagUpdateDriftSnapshotResponse(int readCount)
+    => Success(ToCamelCaseJson(TagUpdateSnapshot(externalAccessible: readCount != 1)));
 
 string InvalidTagUpdateSnapshotResponse(string requestLine)
 {
@@ -2073,30 +2137,22 @@ string InvalidTagUpdateSnapshotResponse(string requestLine)
         return Success("[]");
     }
 
-    var snapshot = new Dictionary<string, object?>(StringComparer.Ordinal)
-    {
-        ["plcName"] = "ResolvedPLC",
-        ["folderPath"] = "/",
-        ["tableName"] = "Default tag table",
-        ["tagName"] = "MotorReady",
-        ["dataType"] = "Bool",
-        ["logicalAddress"] = "%I0.0",
-        ["externalAccessible"] = false,
-        ["externalVisible"] = true,
-        ["externalWritable"] = false,
-    };
+    var snapshot = JsonNode.Parse(ToCamelCaseJson(TagUpdateSnapshot()))!.AsObject();
+    snapshot["targetTag"]!["dataType"] = "PRIVATE_SNAPSHOT_SENTINEL";
 
     if (variant == "empty")
     {
         snapshot.Clear();
     }
-    else if (variant.StartsWith("missing-", StringComparison.Ordinal))
+    else if (variant.StartsWith("missing-", StringComparison.Ordinal) ||
+             variant.StartsWith("null-", StringComparison.Ordinal) ||
+             variant.StartsWith("wrong-", StringComparison.Ordinal))
     {
-        snapshot.Remove(variant["missing-".Length..]);
-    }
-    else if (variant.StartsWith("wrong-", StringComparison.Ordinal))
-    {
-        snapshot[variant["wrong-".Length..]] = new { unsupported = true };
+        var parts = variant[(variant.IndexOf('-') + 1)..].Split('.');
+        var owner = parts.Length == 1 ? snapshot : snapshot[parts[0]]!.AsObject();
+        if (variant.StartsWith("missing-", StringComparison.Ordinal)) owner.Remove(parts[^1]);
+        else owner[parts[^1]] = variant.StartsWith("null-", StringComparison.Ordinal)
+            ? null : JsonValue.Create(123);
     }
 
     if (variant == "unknown-member")
@@ -2107,7 +2163,7 @@ string InvalidTagUpdateSnapshotResponse(string requestLine)
     var payload = JsonSerializer.Serialize(snapshot);
     if (variant == "duplicate-member")
     {
-        payload = payload.Insert(1, "\"plcName\":\"Duplicate\",");
+        payload = payload.Insert(1, "\"effectiveName\":\"Duplicate\",");
     }
     return Success(payload);
 }

--- a/TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotBuilder.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotBuilder.cs
@@ -54,13 +54,14 @@ internal static class TagOperationSafetySnapshotBuilder
     internal static IReadOnlyList<TagCollisionProbeInfo> SelectCollisions(
         string kind, IEnumerable<TagCollisionProbeInfo> candidates, string? requestedValue, string? targetPath)
         => string.IsNullOrEmpty(requestedValue) ? Array.Empty<TagCollisionProbeInfo>() :
-            OrderCollisions(candidates.Where(x => string.Equals(
+            OrderCollisions(candidates.Where(x => (kind != "logical-address" || x.Kind == "tag-name") && string.Equals(
                     kind == "logical-address" ? x.LogicalAddress : x.CandidateName,
                     requestedValue, StringComparison.OrdinalIgnoreCase))
                 .Select(x => x with
                 {
-                    Kind = kind,
-                    IsTarget = string.Equals(x.CanonicalPath, targetPath, StringComparison.Ordinal)
+                    Kind = kind == "logical-address" ? kind : x.Kind,
+                    IsTarget = (kind == "logical-address" ? x.Kind == "tag-name" : x.Kind == kind) &&
+                        string.Equals(x.CanonicalPath, targetPath, StringComparison.Ordinal)
                 }));
 
     internal static DeleteTagTableSafetySnapshotInfo BuildDeleteTagTableSnapshot(TagTableSafetyIdentityInfo table, string xml)

--- a/TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotBuilder.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotBuilder.cs
@@ -1,0 +1,60 @@
+using System.Security.Cryptography;
+using System.Text;
+using TiaMcpServer.Contracts;
+
+namespace TiaMcpServer.OpennessWorker.Openness;
+
+// Siemens-free shaping: no parsing, rewriting, or removal of exported XML content.
+internal static class TagOperationSafetySnapshotBuilder
+{
+    internal static string NormalizeFolderPath(string? folderPath)
+    {
+        var parts = (folderPath ?? string.Empty).Trim().Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length == 0 ? "/" : "/" + string.Join("/", parts);
+    }
+
+    internal static TagTableSafetyIdentityInfo BuildTableIdentity(string plcName, string? folderPath, string tableName)
+    {
+        var folder = NormalizeFolderPath(folderPath);
+        var path = plcName + "/Tag tables" + (folder == "/" ? "/" : folder + "/") + tableName;
+        return new TagTableSafetyIdentityInfo(plcName, folder, tableName, path);
+    }
+
+    internal static TagSafetyIdentityInfo BuildTagIdentity(
+        TagTableSafetyIdentityInfo table, string name, string dataType, string? logicalAddress,
+        bool? externalAccessible, bool? externalVisible, bool? externalWritable)
+        => new(table.PlcName, table.FolderPath, table.TableName, name, table.CanonicalPath + "/" + name,
+            dataType, logicalAddress, externalAccessible, externalVisible, externalWritable);
+
+    internal static UserConstantSafetyIdentityInfo BuildConstantIdentity(
+        TagTableSafetyIdentityInfo table, string name, string dataType, string value)
+        => new(table.PlcName, table.FolderPath, table.TableName, name, table.CanonicalPath + "/" + name, dataType, value);
+
+    internal static IReadOnlyList<TagCollisionProbeInfo> OrderCollisions(IEnumerable<TagCollisionProbeInfo> collisions)
+        => collisions.OrderBy(x => x.CanonicalPath, StringComparer.Ordinal)
+            .ThenBy(x => x.Kind, StringComparer.Ordinal)
+            .ThenBy(x => x.CandidateName, StringComparer.Ordinal)
+            .ThenBy(x => x.LogicalAddress, StringComparer.Ordinal)
+            .ThenBy(x => x.IsTarget).ToArray();
+
+    internal static IReadOnlyList<TagCollisionProbeInfo> SelectCollisions(
+        string kind, IEnumerable<TagCollisionProbeInfo> candidates, string? requestedValue, string? targetPath)
+        => string.IsNullOrEmpty(requestedValue) ? Array.Empty<TagCollisionProbeInfo>() :
+            OrderCollisions(candidates.Where(x => string.Equals(
+                    kind == "logical-address" ? x.LogicalAddress : x.CandidateName,
+                    requestedValue, StringComparison.OrdinalIgnoreCase))
+                .Select(x => x with
+                {
+                    Kind = kind,
+                    IsTarget = string.Equals(x.CanonicalPath, targetPath, StringComparison.Ordinal)
+                }));
+
+    internal static DeleteTagTableSafetySnapshotInfo BuildDeleteTagTableSnapshot(TagTableSafetyIdentityInfo table, string xml)
+    {
+        if (string.IsNullOrWhiteSpace(xml))
+            throw new InvalidOperationException("The tag-table export is empty.");
+        using var sha = SHA256.Create();
+        var hash = BitConverter.ToString(sha.ComputeHash(Encoding.UTF8.GetBytes(xml))).Replace("-", "").ToLowerInvariant();
+        return new DeleteTagTableSafetySnapshotInfo(table, xml, hash, xml.Length);
+    }
+}

--- a/TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotBuilder.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotBuilder.cs
@@ -7,6 +7,20 @@ namespace TiaMcpServer.OpennessWorker.Openness;
 // Siemens-free shaping: no parsing, rewriting, or removal of exported XML content.
 internal static class TagOperationSafetySnapshotBuilder
 {
+    // Consume discovery past the first match: a later match or discovery error must fail closed.
+    internal static T ResolveUniquePlc<T>(IEnumerable<T> matches)
+    {
+        using var enumerator = matches.GetEnumerator();
+        if (!enumerator.MoveNext())
+            throw new InvalidOperationException("No PLC software matched the safety-read selector.");
+
+        var match = enumerator.Current;
+        if (enumerator.MoveNext())
+            throw new InvalidOperationException("Multiple PLC software instances matched the safety-read selector. Specify an unambiguous PLC selector.");
+
+        return match;
+    }
+
     internal static string NormalizeFolderPath(string? folderPath)
     {
         var parts = (folderPath ?? string.Empty).Trim().Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);

--- a/TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotReader.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotReader.cs
@@ -1,4 +1,7 @@
 using Siemens.Engineering;
+using Siemens.Engineering.HW;
+using Siemens.Engineering.HW.Features;
+using Siemens.Engineering.SW;
 using Siemens.Engineering.SW.Tags;
 using TiaMcpServer.Contracts;
 
@@ -155,7 +158,8 @@ internal static class TagOperationSafetySnapshotReader
 
     private static ResolvedGroup ResolveGroup(Project project, WorkerRequest request)
     {
-        var plc = PlcSoftwareLocator.Find(project, request.PlcName);
+        var plc = TagOperationSafetySnapshotBuilder.ResolveUniquePlc(
+            DiscoverPlcSoftwareStrict(project, request.PlcName));
         PlcTagTableGroup group = plc.TagTableGroup;
         var actualSegments = new List<string>();
         foreach (var segment in TagOperationSafetySnapshotBuilder.NormalizeFolderPath(request.FolderPath)
@@ -167,6 +171,34 @@ internal static class TagOperationSafetySnapshotReader
         }
         return new ResolvedGroup(plc.Name, plc.TagTableGroup, group,
             actualSegments.Count == 0 ? "/" : "/" + string.Join("/", actualSegments));
+    }
+
+    private static IEnumerable<PlcSoftware> DiscoverPlcSoftwareStrict(Project project, string? plcName)
+    {
+        // Includes grouped devices and propagates incomplete-discovery errors.
+        foreach (var device in ProjectDeviceEnumerator.Enumerate(project))
+        {
+            foreach (var software in DiscoverPlcSoftwareStrict(device.DeviceItems))
+            {
+                if (plcName is null ||
+                    string.Equals(software.Name, plcName, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(device.Name, plcName, StringComparison.OrdinalIgnoreCase))
+                    yield return software;
+            }
+        }
+    }
+
+    private static IEnumerable<PlcSoftware> DiscoverPlcSoftwareStrict(DeviceItemComposition items)
+    {
+        foreach (DeviceItem item in items)
+        {
+            var container = item.GetService<SoftwareContainer>();
+            if (container?.Software is PlcSoftware software)
+                yield return software;
+
+            foreach (var child in DiscoverPlcSoftwareStrict(item.DeviceItems))
+                yield return child;
+        }
     }
 
     private static void RequireName(string? value, string field)

--- a/TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotReader.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotReader.cs
@@ -2,6 +2,7 @@ using Siemens.Engineering;
 using Siemens.Engineering.HW;
 using Siemens.Engineering.HW.Features;
 using Siemens.Engineering.SW;
+using Siemens.Engineering.SW.Blocks;
 using Siemens.Engineering.SW.Tags;
 using TiaMcpServer.Contracts;
 
@@ -14,11 +15,12 @@ internal static class TagOperationSafetySnapshotReader
     {
         RequireName(request.TableName, "TableName");
         var group = ResolveGroup(project, request);
-        var occupied = group.Group.TagTables.Find(request.TableName!);
-        var collisions = occupied is null ? Array.Empty<TagCollisionProbeInfo>() :
-            new[] { new TagCollisionProbeInfo("table-name", occupied.Name,
-                TagOperationSafetySnapshotBuilder.BuildTableIdentity(group.PlcName, group.FolderPath, occupied.Name).CanonicalPath,
-                null, false) };
+        var candidates = EnumerateTables(group.RootGroup, "/").Select(item =>
+            new TagCollisionProbeInfo("table-name", item.Table.Name,
+                TagOperationSafetySnapshotBuilder.BuildTableIdentity(group.PlcName, item.FolderPath, item.Table.Name).CanonicalPath,
+                null, false));
+        var collisions = TagOperationSafetySnapshotBuilder.SelectCollisions(
+            "table-name", candidates, request.TableName, null);
         return new CreateTagTableSafetySnapshotInfo(group.PlcName, group.FolderPath, request.TableName!, collisions);
     }
 
@@ -45,7 +47,7 @@ internal static class TagOperationSafetySnapshotReader
         RequireName(request.DataType, "DataType");
         var resolved = ResolveTable(project, request);
         var address = request.LogicalAddress ?? string.Empty;
-        var candidates = TagCandidates(resolved).ToArray();
+        var candidates = SymbolCandidates(resolved).ToArray();
         return new CreateTagSafetySnapshotInfo(resolved.Identity, request.Name!, address,
             TagOperationSafetySnapshotBuilder.SelectCollisions("tag-name", candidates, request.Name, null),
             TagOperationSafetySnapshotBuilder.SelectCollisions("logical-address", candidates, address, null));
@@ -57,7 +59,7 @@ internal static class TagOperationSafetySnapshotReader
         var target = ReadTag(resolved, request.Name);
         var name = string.IsNullOrWhiteSpace(request.NewName) ? target.TagName : request.NewName!;
         var address = request.LogicalAddress ?? target.LogicalAddress;
-        var candidates = TagCandidates(resolved).ToArray();
+        var candidates = SymbolCandidates(resolved).ToArray();
         return new UpdateTagSafetySnapshotInfo(resolved.Identity, target, name, address,
             TagOperationSafetySnapshotBuilder.SelectCollisions("tag-name", candidates, name, target.CanonicalPath),
             TagOperationSafetySnapshotBuilder.SelectCollisions("logical-address", candidates, address, target.CanonicalPath));
@@ -74,7 +76,7 @@ internal static class TagOperationSafetySnapshotReader
         RequireName(request.Name, "Name");
         var resolved = ResolveTable(project, request);
         return new CreateUserConstantSafetySnapshotInfo(resolved.Identity, request.Name!,
-            TagOperationSafetySnapshotBuilder.SelectCollisions("user-constant-name", ConstantCandidates(resolved), request.Name, null));
+            TagOperationSafetySnapshotBuilder.SelectCollisions("user-constant-name", SymbolCandidates(resolved), request.Name, null));
     }
 
     internal static UpdateUserConstantSafetySnapshotInfo ReadUpdateUserConstant(Project project, WorkerRequest request)
@@ -82,7 +84,7 @@ internal static class TagOperationSafetySnapshotReader
         var resolved = ResolveTable(project, request);
         var target = ReadConstant(resolved, request.Name);
         return new UpdateUserConstantSafetySnapshotInfo(resolved.Identity, target, target.ConstantName,
-            TagOperationSafetySnapshotBuilder.SelectCollisions("user-constant-name", ConstantCandidates(resolved), target.ConstantName, target.CanonicalPath));
+            TagOperationSafetySnapshotBuilder.SelectCollisions("user-constant-name", SymbolCandidates(resolved), target.ConstantName, target.CanonicalPath));
     }
 
     internal static DeleteUserConstantSafetySnapshotInfo ReadDeleteUserConstant(Project project, WorkerRequest request)
@@ -117,24 +119,43 @@ internal static class TagOperationSafetySnapshotReader
         catch (NotSupportedException) { return null; }
     }
 
-    private static IEnumerable<TagCollisionProbeInfo> TagCandidates(ResolvedTable resolved)
+    private static IEnumerable<TagCollisionProbeInfo> SymbolCandidates(ResolvedTable resolved)
     {
         foreach (var item in EnumerateTables(resolved.Group.RootGroup, "/"))
         {
             var table = TagOperationSafetySnapshotBuilder.BuildTableIdentity(resolved.Identity.PlcName, item.FolderPath, item.Table.Name);
             foreach (PlcTag tag in item.Table.Tags)
                 yield return new TagCollisionProbeInfo("tag-name", tag.Name, table.CanonicalPath + "/" + tag.Name, tag.LogicalAddress, false);
-        }
-    }
-
-    private static IEnumerable<TagCollisionProbeInfo> ConstantCandidates(ResolvedTable resolved)
-    {
-        foreach (var item in EnumerateTables(resolved.Group.RootGroup, "/"))
-        {
-            var table = TagOperationSafetySnapshotBuilder.BuildTableIdentity(resolved.Identity.PlcName, item.FolderPath, item.Table.Name);
             foreach (PlcUserConstant constant in item.Table.UserConstants)
                 yield return new TagCollisionProbeInfo("user-constant-name", constant.Name, table.CanonicalPath + "/" + constant.Name, null, false);
         }
+
+        // These operations address the unqualified CPU namespace. Software-unit
+        // namespaces require separate effective-name resolution and are not guessed here.
+        foreach (var block in BlockCandidates(resolved.Group.Plc.BlockGroup, resolved.Identity.PlcName + "/Program blocks"))
+            yield return block;
+    }
+
+    private static IEnumerable<TagCollisionProbeInfo> BlockCandidates(PlcBlockGroup group, string path)
+    {
+        foreach (PlcBlock block in group.Blocks)
+            yield return new TagCollisionProbeInfo("block-name", block.Name, path + "/" + block.Name, null, false);
+        foreach (PlcBlockGroup child in group.Groups)
+            foreach (var block in BlockCandidates(child, path + "/" + child.Name))
+                yield return block;
+        if (group is PlcBlockSystemGroup root)
+            foreach (PlcSystemBlockGroup child in root.SystemBlockGroups)
+                foreach (var block in SystemBlockCandidates(child, path + "/System blocks/" + child.Name))
+                    yield return block;
+    }
+
+    private static IEnumerable<TagCollisionProbeInfo> SystemBlockCandidates(PlcSystemBlockGroup group, string path)
+    {
+        foreach (PlcBlock block in group.Blocks)
+            yield return new TagCollisionProbeInfo("block-name", block.Name, path + "/" + block.Name, null, false);
+        foreach (PlcSystemBlockGroup child in group.Groups)
+            foreach (var block in SystemBlockCandidates(child, path + "/" + child.Name))
+                yield return block;
     }
 
     private static IEnumerable<TableInFolder> EnumerateTables(PlcTagTableGroup group, string folderPath)
@@ -169,7 +190,7 @@ internal static class TagOperationSafetySnapshotReader
                 ?? throw new InvalidOperationException($"Tag table folder '{request.FolderPath}' was not found.");
             actualSegments.Add(group.Name);
         }
-        return new ResolvedGroup(plc.Name, plc.TagTableGroup, group,
+        return new ResolvedGroup(plc.Name, plc.TagTableGroup, plc, group,
             actualSegments.Count == 0 ? "/" : "/" + string.Join("/", actualSegments));
     }
 
@@ -207,7 +228,8 @@ internal static class TagOperationSafetySnapshotReader
             throw new InvalidOperationException(field + " is required.");
     }
 
-    private sealed record ResolvedGroup(string PlcName, PlcTagTableGroup RootGroup, PlcTagTableGroup Group, string FolderPath);
+    private sealed record ResolvedGroup(string PlcName, PlcTagTableGroup RootGroup, PlcSoftware Plc,
+        PlcTagTableGroup Group, string FolderPath);
     private sealed record ResolvedTable(ResolvedGroup Group, PlcTagTable Table, TagTableSafetyIdentityInfo Identity);
     private sealed record TableInFolder(PlcTagTable Table, string FolderPath);
 }

--- a/TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotReader.cs
+++ b/TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotReader.cs
@@ -1,0 +1,181 @@
+using Siemens.Engineering;
+using Siemens.Engineering.SW.Tags;
+using TiaMcpServer.Contracts;
+
+namespace TiaMcpServer.OpennessWorker.Openness;
+
+// Strict safety reads: failures propagate. Public TagTableReader remains best-effort.
+internal static class TagOperationSafetySnapshotReader
+{
+    internal static CreateTagTableSafetySnapshotInfo ReadCreateTagTable(Project project, WorkerRequest request)
+    {
+        RequireName(request.TableName, "TableName");
+        var group = ResolveGroup(project, request);
+        var occupied = group.Group.TagTables.Find(request.TableName!);
+        var collisions = occupied is null ? Array.Empty<TagCollisionProbeInfo>() :
+            new[] { new TagCollisionProbeInfo("table-name", occupied.Name,
+                TagOperationSafetySnapshotBuilder.BuildTableIdentity(group.PlcName, group.FolderPath, occupied.Name).CanonicalPath,
+                null, false) };
+        return new CreateTagTableSafetySnapshotInfo(group.PlcName, group.FolderPath, request.TableName!, collisions);
+    }
+
+    internal static DeleteTagTableSafetySnapshotInfo ReadDeleteTagTable(Project project, WorkerRequest request)
+    {
+        var resolved = ResolveTable(project, request);
+        var exportPath = Path.Combine(Path.GetTempPath(), "tia-mcp-tag-safety-" + Guid.NewGuid().ToString("N") + ".xml");
+        try
+        {
+            // Verified in installed V21 Base.xml and Step7.xml: None exports no document info.
+            resolved.Table.Export(new FileInfo(exportPath), ExportOptions.None, DocumentInfoOptions.None);
+            return TagOperationSafetySnapshotBuilder.BuildDeleteTagTableSnapshot(resolved.Identity, File.ReadAllText(exportPath));
+        }
+        finally
+        {
+            if (File.Exists(exportPath))
+                File.Delete(exportPath);
+        }
+    }
+
+    internal static CreateTagSafetySnapshotInfo ReadCreateTag(Project project, WorkerRequest request)
+    {
+        RequireName(request.Name, "Name");
+        RequireName(request.DataType, "DataType");
+        var resolved = ResolveTable(project, request);
+        var address = request.LogicalAddress ?? string.Empty;
+        var candidates = TagCandidates(resolved).ToArray();
+        return new CreateTagSafetySnapshotInfo(resolved.Identity, request.Name!, address,
+            TagOperationSafetySnapshotBuilder.SelectCollisions("tag-name", candidates, request.Name, null),
+            TagOperationSafetySnapshotBuilder.SelectCollisions("logical-address", candidates, address, null));
+    }
+
+    internal static UpdateTagSafetySnapshotInfo ReadUpdateTag(Project project, WorkerRequest request)
+    {
+        var resolved = ResolveTable(project, request);
+        var target = ReadTag(resolved, request.Name);
+        var name = string.IsNullOrWhiteSpace(request.NewName) ? target.TagName : request.NewName!;
+        var address = request.LogicalAddress ?? target.LogicalAddress;
+        var candidates = TagCandidates(resolved).ToArray();
+        return new UpdateTagSafetySnapshotInfo(resolved.Identity, target, name, address,
+            TagOperationSafetySnapshotBuilder.SelectCollisions("tag-name", candidates, name, target.CanonicalPath),
+            TagOperationSafetySnapshotBuilder.SelectCollisions("logical-address", candidates, address, target.CanonicalPath));
+    }
+
+    internal static DeleteTagSafetySnapshotInfo ReadDeleteTag(Project project, WorkerRequest request)
+    {
+        var resolved = ResolveTable(project, request);
+        return new DeleteTagSafetySnapshotInfo(resolved.Identity, ReadTag(resolved, request.Name));
+    }
+
+    internal static CreateUserConstantSafetySnapshotInfo ReadCreateUserConstant(Project project, WorkerRequest request)
+    {
+        RequireName(request.Name, "Name");
+        var resolved = ResolveTable(project, request);
+        return new CreateUserConstantSafetySnapshotInfo(resolved.Identity, request.Name!,
+            TagOperationSafetySnapshotBuilder.SelectCollisions("user-constant-name", ConstantCandidates(resolved), request.Name, null));
+    }
+
+    internal static UpdateUserConstantSafetySnapshotInfo ReadUpdateUserConstant(Project project, WorkerRequest request)
+    {
+        var resolved = ResolveTable(project, request);
+        var target = ReadConstant(resolved, request.Name);
+        return new UpdateUserConstantSafetySnapshotInfo(resolved.Identity, target, target.ConstantName,
+            TagOperationSafetySnapshotBuilder.SelectCollisions("user-constant-name", ConstantCandidates(resolved), target.ConstantName, target.CanonicalPath));
+    }
+
+    internal static DeleteUserConstantSafetySnapshotInfo ReadDeleteUserConstant(Project project, WorkerRequest request)
+    {
+        var resolved = ResolveTable(project, request);
+        return new DeleteUserConstantSafetySnapshotInfo(resolved.Identity, ReadConstant(resolved, request.Name));
+    }
+
+    private static TagSafetyIdentityInfo ReadTag(ResolvedTable resolved, string? name)
+    {
+        RequireName(name, "Name");
+        var tag = resolved.Table.Tags.Find(name!)
+            ?? throw new InvalidOperationException($"Tag '{name}' was not found in tag table '{resolved.Table.Name}'.");
+        return TagOperationSafetySnapshotBuilder.BuildTagIdentity(resolved.Identity, tag.Name, tag.DataTypeName, tag.LogicalAddress,
+            ReadOptionalFlag(() => tag.ExternalAccessible),
+            ReadOptionalFlag(() => tag.ExternalVisible),
+            ReadOptionalFlag(() => tag.ExternalWritable));
+    }
+
+    private static UserConstantSafetyIdentityInfo ReadConstant(ResolvedTable resolved, string? name)
+    {
+        RequireName(name, "Name");
+        var constant = resolved.Table.UserConstants.Find(name!)
+            ?? throw new InvalidOperationException($"User constant '{name}' was not found in tag table '{resolved.Table.Name}'.");
+        return TagOperationSafetySnapshotBuilder.BuildConstantIdentity(resolved.Identity, constant.Name, constant.DataTypeName,
+            constant.Value?.ToString() ?? throw new InvalidOperationException("The target user-constant value is unavailable."));
+    }
+
+    private static bool? ReadOptionalFlag(Func<bool> read)
+    {
+        try { return read(); }
+        catch (NotSupportedException) { return null; }
+    }
+
+    private static IEnumerable<TagCollisionProbeInfo> TagCandidates(ResolvedTable resolved)
+    {
+        foreach (var item in EnumerateTables(resolved.Group.RootGroup, "/"))
+        {
+            var table = TagOperationSafetySnapshotBuilder.BuildTableIdentity(resolved.Identity.PlcName, item.FolderPath, item.Table.Name);
+            foreach (PlcTag tag in item.Table.Tags)
+                yield return new TagCollisionProbeInfo("tag-name", tag.Name, table.CanonicalPath + "/" + tag.Name, tag.LogicalAddress, false);
+        }
+    }
+
+    private static IEnumerable<TagCollisionProbeInfo> ConstantCandidates(ResolvedTable resolved)
+    {
+        foreach (var item in EnumerateTables(resolved.Group.RootGroup, "/"))
+        {
+            var table = TagOperationSafetySnapshotBuilder.BuildTableIdentity(resolved.Identity.PlcName, item.FolderPath, item.Table.Name);
+            foreach (PlcUserConstant constant in item.Table.UserConstants)
+                yield return new TagCollisionProbeInfo("user-constant-name", constant.Name, table.CanonicalPath + "/" + constant.Name, null, false);
+        }
+    }
+
+    private static IEnumerable<TableInFolder> EnumerateTables(PlcTagTableGroup group, string folderPath)
+    {
+        foreach (PlcTagTable table in group.TagTables)
+            yield return new TableInFolder(table, folderPath);
+        foreach (PlcTagTableGroup child in group.Groups)
+            foreach (var item in EnumerateTables(child, (folderPath == "/" ? "/" : folderPath + "/") + child.Name))
+                yield return item;
+    }
+
+    private static ResolvedTable ResolveTable(Project project, WorkerRequest request)
+    {
+        RequireName(request.TableName, "TableName");
+        var group = ResolveGroup(project, request);
+        var table = group.Group.TagTables.Find(request.TableName!)
+            ?? throw new InvalidOperationException($"Tag table '{request.TableName}' was not found in '{group.FolderPath}'.");
+        return new ResolvedTable(group, table,
+            TagOperationSafetySnapshotBuilder.BuildTableIdentity(group.PlcName, group.FolderPath, table.Name));
+    }
+
+    private static ResolvedGroup ResolveGroup(Project project, WorkerRequest request)
+    {
+        var plc = PlcSoftwareLocator.Find(project, request.PlcName);
+        PlcTagTableGroup group = plc.TagTableGroup;
+        var actualSegments = new List<string>();
+        foreach (var segment in TagOperationSafetySnapshotBuilder.NormalizeFolderPath(request.FolderPath)
+            .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            group = group.Groups.Find(segment)
+                ?? throw new InvalidOperationException($"Tag table folder '{request.FolderPath}' was not found.");
+            actualSegments.Add(group.Name);
+        }
+        return new ResolvedGroup(plc.Name, plc.TagTableGroup, group,
+            actualSegments.Count == 0 ? "/" : "/" + string.Join("/", actualSegments));
+    }
+
+    private static void RequireName(string? value, string field)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new InvalidOperationException(field + " is required.");
+    }
+
+    private sealed record ResolvedGroup(string PlcName, PlcTagTableGroup RootGroup, PlcTagTableGroup Group, string FolderPath);
+    private sealed record ResolvedTable(ResolvedGroup Group, PlcTagTable Table, TagTableSafetyIdentityInfo Identity);
+    private sealed record TableInFolder(PlcTagTable Table, string FolderPath);
+}

--- a/TiaMcpServer.OpennessWorker/Program.cs
+++ b/TiaMcpServer.OpennessWorker/Program.cs
@@ -164,6 +164,13 @@ internal static class Program
                 "update_type_content" => UpdateTypeContent(request),
                 "list_tag_tables"     => ListTagTables(request),
                 "read_update_tag_safety_snapshot" => ReadUpdateTagSafetySnapshot(request),
+                "read_create_tag_table_safety_snapshot" => ReadCreateTagTableSafetySnapshot(request),
+                "read_delete_tag_table_safety_snapshot" => ReadDeleteTagTableSafetySnapshot(request),
+                "read_create_tag_safety_snapshot" => ReadCreateTagSafetySnapshot(request),
+                "read_delete_tag_safety_snapshot" => ReadDeleteTagSafetySnapshot(request),
+                "read_create_user_constant_safety_snapshot" => ReadCreateUserConstantSafetySnapshot(request),
+                "read_update_user_constant_safety_snapshot" => ReadUpdateUserConstantSafetySnapshot(request),
+                "read_delete_user_constant_safety_snapshot" => ReadDeleteUserConstantSafetySnapshot(request),
                 "compile_check"       => CompileCheck(request),
                 "create_tag_table"    => CreateTagTable(request),
                 "delete_tag_table"    => DeleteTagTable(request),
@@ -862,12 +869,49 @@ internal static class Program
     private static WorkerResponse ReadUpdateTagSafetySnapshot(WorkerRequest request)
     {
         return WithProject(request, project => Success(
-            TagUpdateSafetySnapshotReader.Read(
-                project,
-                request.PlcName,
-                request.TableName!,
-                request.FolderPath,
-                request.Name!)));
+            TagOperationSafetySnapshotReader.ReadUpdateTag(project, request)));
+    }
+
+    private static WorkerResponse ReadCreateTagTableSafetySnapshot(WorkerRequest request)
+    {
+        return WithProject(request, project => Success(
+            TagOperationSafetySnapshotReader.ReadCreateTagTable(project, request)));
+    }
+
+    private static WorkerResponse ReadDeleteTagTableSafetySnapshot(WorkerRequest request)
+    {
+        return WithProject(request, project => Success(
+            TagOperationSafetySnapshotReader.ReadDeleteTagTable(project, request)));
+    }
+
+    private static WorkerResponse ReadCreateTagSafetySnapshot(WorkerRequest request)
+    {
+        return WithProject(request, project => Success(
+            TagOperationSafetySnapshotReader.ReadCreateTag(project, request)));
+    }
+
+    private static WorkerResponse ReadDeleteTagSafetySnapshot(WorkerRequest request)
+    {
+        return WithProject(request, project => Success(
+            TagOperationSafetySnapshotReader.ReadDeleteTag(project, request)));
+    }
+
+    private static WorkerResponse ReadCreateUserConstantSafetySnapshot(WorkerRequest request)
+    {
+        return WithProject(request, project => Success(
+            TagOperationSafetySnapshotReader.ReadCreateUserConstant(project, request)));
+    }
+
+    private static WorkerResponse ReadUpdateUserConstantSafetySnapshot(WorkerRequest request)
+    {
+        return WithProject(request, project => Success(
+            TagOperationSafetySnapshotReader.ReadUpdateUserConstant(project, request)));
+    }
+
+    private static WorkerResponse ReadDeleteUserConstantSafetySnapshot(WorkerRequest request)
+    {
+        return WithProject(request, project => Success(
+            TagOperationSafetySnapshotReader.ReadDeleteUserConstant(project, request)));
     }
 
     private static WorkerResponse CompileCheck(WorkerRequest request)

--- a/TiaMcpServer.Tests/Batch/BatchSafetySnapshotTests.cs
+++ b/TiaMcpServer.Tests/Batch/BatchSafetySnapshotTests.cs
@@ -25,13 +25,20 @@ public class BatchSafetySnapshotTests
     }
 
     [Fact]
-    public void DescribeOperation_DescribesTagCreateWithNameAndTable()
+    public void DescribeOperation_DescribesTagAndUserConstantOperationsWithNameAndTable()
     {
-        var summary = BatchSafetySnapshot.DescribeOperation(
+        var tagSummary = BatchSafetySnapshot.DescribeOperation(
             Op("a", "create_tag", r => { r.TableName = "Inputs"; r.Name = "Start"; r.DataType = "Bool"; }));
+        var tableSummary = BatchSafetySnapshot.DescribeOperation(
+            Op("b", "delete_tag_table", r => r.TableName = "Inputs"));
+        var constantSummary = BatchSafetySnapshot.DescribeOperation(
+            Op("c", "create_user_constant", r => { r.TableName = "Inputs"; r.Name = "MaxSpeed"; }));
 
-        Assert.Contains("Start", summary);
-        Assert.Contains("Inputs", summary);
+        Assert.Contains("Start", tagSummary);
+        Assert.Contains("Inputs", tagSummary);
+        Assert.Contains("Inputs", tableSummary);
+        Assert.Contains("MaxSpeed", constantSummary);
+        Assert.Contains("Inputs", constantSummary);
     }
 
     [Fact]
@@ -41,12 +48,13 @@ public class BatchSafetySnapshotTests
         {
             Op("first", "create_tag_table", r => r.TableName = "T1"),
             Op("second", "delete_tag_table", r => r.TableName = "T2"),
+            Op("third", "create_user_constant", r => { r.TableName = "T2"; r.Name = "MaxSpeed"; }),
         };
 
         var targets = BatchSafetySnapshot.BuildTargets(operations);
 
-        Assert.Equal(new[] { "first", "second" }, targets.Select(t => t.OperationId).ToArray());
-        Assert.Equal(new[] { "create_tag_table", "delete_tag_table" }, targets.Select(t => t.Operation).ToArray());
+        Assert.Equal(new[] { "first", "second", "third" }, targets.Select(t => t.OperationId).ToArray());
+        Assert.Equal(new[] { "create_tag_table", "delete_tag_table", "create_user_constant" }, targets.Select(t => t.Operation).ToArray());
         Assert.Equal(BatchSafetySnapshot.DescribeOperation(operations[0]), targets[0].Summary);
     }
 

--- a/TiaMcpServer.Tests/Batch/TagOperationCurrentStateReadFakeWorkerTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationCurrentStateReadFakeWorkerTests.cs
@@ -1,0 +1,219 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.OperationBatches;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tests.Worker;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationCurrentStateReadFakeWorkerTests
+{
+    [Fact]
+    public async Task PreviewWriteBatch_DeleteTag_UsesExactInternalSnapshotRouteInsteadOfListTagTables()
+    {
+        const string path = @"C:\FakeWorker\tag-safety-route-proof.ap21";
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, path);
+        var safety = CreateSafety(audit, binding);
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, new[] { DeleteTag(path, "d1") });
+
+        Assert.True(preview.Contains("\"safetyToken\":", StringComparison.Ordinal), preview);
+        Assert.DoesNotContain("wrong route: list_tag_tables", preview, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_TwoIdenticalDeleteTagSelectors_PerformsOneSnapshotReadAndStillDescribesBothOperations()
+    {
+        const string path = @"C:\FakeWorker\tag-safety-dedup-proof.ap21";
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, path);
+        var safety = CreateSafety(audit, binding);
+        var operations = new[] { DeleteTag(path, "d1"), DeleteTag(path, "d2") };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+
+        Assert.True(preview.Contains("\"safetyToken\":", StringComparison.Ordinal), preview);
+        using var document = JsonDocument.Parse(preview);
+        var descriptions = string.Join("\n", document.RootElement.GetProperty("target")
+            .EnumerateArray().Select(item => item.GetProperty("summary").GetString()));
+        Assert.Equal(2, Regex.Matches(descriptions,
+            Regex.Escape("Delete PLC tag 'Start' from table 'Inputs'."), RegexOptions.CultureInvariant).Count);
+        Assert.Equal(new[] { "d1", "d2" }, document.RootElement.GetProperty("target")
+            .EnumerateArray().Select(item => item.GetProperty("operationId").GetString()));
+    }
+
+    [Fact]
+    public async Task ApplyWriteBatch_DeduplicatedPreview_PerformsFreshSnapshotRead()
+    {
+        const string path = @"C:\FakeWorker\tag-safety-dedup-proof.ap21";
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, path);
+        var safety = CreateSafety(audit, binding);
+        var operations = new[] { DeleteTag(path, "d1"), DeleteTag(path, "d2") };
+        using var preview = JsonDocument.Parse(await WriteBatchTools.PreviewWriteBatch(client, safety, operations));
+
+        var apply = await WriteBatchTools.ApplyWriteBatch(client, safety, operations, confirm: true,
+            safetyToken: preview.RootElement.GetProperty("safetyToken").GetString());
+
+        Assert.Contains("dedup missing: repeated read_delete_tag_safety_snapshot", apply, StringComparison.Ordinal);
+        Assert.Contains("before write", apply, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_RepeatedPreview_PerformsFreshSnapshotRead()
+    {
+        const string path = @"C:\FakeWorker\tag-safety-dedup-proof.ap21";
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, path);
+        var safety = CreateSafety(audit, binding);
+        var operations = new[] { DeleteTag(path, "d1") };
+        var first = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+        Assert.True(first.Contains("\"safetyToken\":", StringComparison.Ordinal), first);
+
+        var second = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+
+        Assert.Contains("dedup missing: repeated read_delete_tag_safety_snapshot", second, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"safetyToken\":", second, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PreviewWriteBatch_SharedUpdateSelector_ValidatesRequestedFlagsForEveryOperation()
+    {
+        const string path = "tag-update-snapshot-unavailable-all";
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, path);
+        var safety = CreateSafety(audit, binding);
+        var operations = new[]
+        {
+            new BatchOperationRequest { OperationId = "u1", Operation = "update_tag", ProjectPath = path,
+                PlcName = "PLC_1", TableName = "Default tag table", Name = "MotorReady", DataType = "DInt" },
+            new BatchOperationRequest { OperationId = "u2", Operation = "update_tag", ProjectPath = path,
+                PlcName = "PLC_1", TableName = "Default tag table", Name = "MotorReady", ExternalVisible = true }
+        };
+
+        var preview = await WriteBatchTools.PreviewWriteBatch(client, safety, operations);
+
+        Assert.Contains("u2", preview, StringComparison.Ordinal);
+        Assert.Contains("externalVisible", preview, StringComparison.Ordinal);
+        Assert.Contains("validation_error", preview, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"safetyToken\":", preview, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("create_tag_table")]
+    [InlineData("delete_tag_table")]
+    [InlineData("create_tag")]
+    [InlineData("update_tag")]
+    [InlineData("delete_tag")]
+    [InlineData("create_user_constant")]
+    [InlineData("update_user_constant")]
+    [InlineData("delete_user_constant")]
+    public async Task PreviewWriteBatch_EachTagOperation_UsesExactTypedRoute(string operation)
+    {
+        var preview = await PreviewRoute(operation, "tag-safety-all-routes");
+        Assert.True(preview.Contains("\"safetyToken\":", StringComparison.Ordinal), preview);
+    }
+
+    [Theory]
+    [InlineData("create_tag_table")]
+    [InlineData("delete_tag_table")]
+    [InlineData("create_tag")]
+    [InlineData("update_tag")]
+    [InlineData("delete_tag")]
+    [InlineData("create_user_constant")]
+    [InlineData("update_user_constant")]
+    [InlineData("delete_user_constant")]
+    public async Task PreviewWriteBatch_EachTagOperation_RejectsMalformedSnapshot(string operation)
+    {
+        var preview = await PreviewRoute(operation, "tag-safety-invalid-routes");
+        Assert.Contains("\"failureCategory\":\"protocol_error\"", preview, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"safetyToken\":", preview, StringComparison.Ordinal);
+    }
+
+    private static async Task<string> PreviewRoute(string operation, string path)
+    {
+        using var audit = new TempAuditDirectory();
+        var binding = new ProjectSessionBinding(null);
+        using var client = CreateClient(binding);
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, path);
+        var op = new BatchOperationRequest
+        {
+            OperationId = "route", Operation = operation, ProjectPath = path,
+            PlcName = "PLC_1", TableName = "Inputs", FolderPath = "Area"
+        };
+        if (!operation.EndsWith("tag_table", StringComparison.Ordinal)) op.Name = "Start";
+        if (operation is "create_tag" or "create_user_constant") op.DataType = "Bool";
+        if (operation == "create_user_constant") op.Value = "true";
+        if (operation is "create_tag" or "update_tag") op.LogicalAddress = "%I1.0";
+        if (operation == "update_tag") op.NewName = "Run";
+        return await WriteBatchTools.PreviewWriteBatch(client, CreateSafety(audit, binding), new[] { op });
+    }
+
+    [Fact]
+    public void StateComposer_CanRepeatIdenticalCurrentStateForDifferentOperationsWithoutLosingOrder()
+    {
+        var combined = OperationBatchStateComposer.CombineCurrentState(new[]
+        {
+            new OperationBatchCurrentState("u1", "update_tag", "{\"k\":1}"),
+            new OperationBatchCurrentState("d1", "delete_tag", "{\"k\":1}")
+        });
+
+        Assert.Contains("u1::update_tag", combined, StringComparison.Ordinal);
+        Assert.Contains("d1::delete_tag", combined, StringComparison.Ordinal);
+        Assert.True(combined.IndexOf("u1::update_tag", StringComparison.Ordinal) <
+            combined.IndexOf("d1::delete_tag", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TokenValidation_TreatsDuplicatedCurrentStateBodiesAsDistinctWhenOperationIdentityDiffers()
+    {
+        using var audit = new TempAuditDirectory();
+        var service = new WriteSafetyService(() => DateTimeOffset.UtcNow,
+            WriteSafetyService.DefaultTokenLifetime, audit.Path);
+        var operations = new[]
+        {
+            new BatchOperationRequest { OperationId = "u1", Operation = "update_tag" },
+            new BatchOperationRequest { OperationId = "d1", Operation = "delete_tag" }
+        };
+        var states = new[]
+        {
+            new OperationBatchCurrentState("u1", "update_tag", "{\"snapshot\":1}"),
+            new OperationBatchCurrentState("d1", "delete_tag", "{\"snapshot\":1}")
+        };
+        var combined = OperationBatchStateComposer.CombineCurrentState(states);
+        var targets = BatchSafetySnapshot.BuildTargets(operations);
+        using var preview = JsonDocument.Parse(service.CreatePreview("apply_write_batch", null,
+            targets, "Test ordered state", operations, combined));
+        var token = preview.RootElement.GetProperty("safetyToken").GetString();
+
+        var result = service.ValidateAndConsume(token, "apply_write_batch", null, targets, operations, combined);
+        Assert.True(result.IsValid, result.Error);
+    }
+
+    private static BatchOperationRequest DeleteTag(string path, string id) => new()
+    {
+        OperationId = id, Operation = "delete_tag", ProjectPath = path,
+        PlcName = "PLC_1", TableName = "Inputs", Name = "Start"
+    };
+
+    private static OpennessWorkerClient CreateClient(ProjectSessionBinding binding)
+        => new(binding, logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+
+    private static WriteSafetyService CreateSafety(TempAuditDirectory audit, ProjectSessionBinding binding)
+        => new(binding, () => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, audit.Path);
+}

--- a/TiaMcpServer.Tests/Batch/TagOperationCurrentStateReadFakeWorkerTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationCurrentStateReadFakeWorkerTests.cs
@@ -145,6 +145,18 @@ public sealed class TagOperationCurrentStateReadFakeWorkerTests
         Assert.DoesNotContain("\"safetyToken\":", preview, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task PreviewWriteBatch_InvalidCollisionKind_DoesNotEchoRejectedPayloadValue()
+    {
+        var preview = await PreviewRoute("update_tag", "tag-safety-private-collision-kind");
+
+        using var document = JsonDocument.Parse(preview);
+        Assert.Equal(WorkerFailureCategories.ProtocolError,
+            document.RootElement.GetProperty("failureCategory").GetString());
+        Assert.False(document.RootElement.TryGetProperty("safetyToken", out _));
+        Assert.DoesNotContain("PRIVATE_SNAPSHOT_SENTINEL", preview, StringComparison.Ordinal);
+    }
+
     private static async Task<string> PreviewRoute(string operation, string path)
     {
         using var audit = new TempAuditDirectory();

--- a/TiaMcpServer.Tests/Batch/TagOperationFakeWorkerTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationFakeWorkerTests.cs
@@ -1,0 +1,208 @@
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Tests.Worker;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationFakeWorkerTests
+{
+    [Fact]
+    public async Task ApplyWriteBatch_UpdateTag_SameObjectDriftFailsWithStateChanged()
+    {
+        await AssertDriftRejected("tag-safety-same-object-drift", new()
+        {
+            OperationId = "u1", Operation = "update_tag", Name = "Start", NewName = "Start_1"
+        });
+    }
+
+    [Theory]
+    [InlineData("Start_1")]
+    [InlineData("AddressOnly")]
+    public async Task ApplyWriteBatch_CreateTag_RelevantCollisionDriftFailsWithStateChanged(string name)
+    {
+        await AssertDriftRejected("tag-safety-collision-drift", new()
+        {
+            OperationId = "c1", Operation = "create_tag", Name = name,
+            DataType = "Bool", LogicalAddress = "%I0.1"
+        });
+    }
+
+    [Fact]
+    public async Task ApplyWriteBatch_DeleteTag_IgnoresUnrelatedSiblingTableDrift()
+    {
+        using var fixture = await Fixture.Create("tag-safety-unrelated-sibling");
+        var operations = fixture.Operations(new()
+        {
+            OperationId = "d1", Operation = "delete_tag", Name = "Start"
+        });
+        var preview = await WriteBatchTools.PreviewWriteBatch(fixture.Client, fixture.Safety, operations);
+        var token = ExtractToken(preview);
+        var before = await fixture.Observe();
+        Assert.Equal(0, before.GetProperty("mutationCount").GetInt32());
+        Assert.Equal(1, before.GetProperty("snapshotReadCount").GetInt32());
+        Assert.Equal("Outputs", before.GetProperty("siblingTableName").GetString());
+        Assert.Equal("Before", before.GetProperty("siblingTagName").GetString());
+
+        var apply = await WriteBatchTools.ApplyWriteBatch(fixture.Client, fixture.Safety, operations,
+            confirm: true, safetyToken: token);
+
+        AssertSucceeded(apply, "d1");
+        var after = await fixture.Observe();
+        Assert.Equal("After", after.GetProperty("siblingTagName").GetString());
+        Assert.Equal(2, after.GetProperty("snapshotReadCount").GetInt32());
+        Assert.Equal(0, after.GetProperty("broadReadCount").GetInt32());
+        Assert.Equal(1, after.GetProperty("mutationCount").GetInt32());
+        Assert.Equal(2, after.GetProperty("snapshotReadsAtMutation").GetInt32());
+        Assert.False(after.GetProperty("targetExists").GetBoolean());
+    }
+
+    [Fact]
+    public async Task ApplyWriteBatch_DeleteTagTable_ExportDriftFailsWithStateChanged()
+    {
+        await AssertDriftRejected("tag-safety-delete-table-export-drift", new()
+        {
+            OperationId = "t1", Operation = "delete_tag_table"
+        });
+    }
+
+    [Fact]
+    public async Task ApplyWriteBatch_CreateUserConstant_ReReadsOnApplyInsteadOfReusingPreviewCache()
+    {
+        await AssertDriftRejected("tag-safety-reread", new()
+        {
+            OperationId = "uc1", Operation = "create_user_constant", Name = "DebounceMs",
+            DataType = "Int", Value = "50"
+        });
+    }
+
+    [Fact]
+    public async Task ApplyWriteBatch_UpdateTag_StableStateSucceedsOnceThenRejectsReplay()
+    {
+        using var fixture = await Fixture.Create("tag-safety-authorized-apply");
+        var operations = fixture.Operations(new()
+        {
+            OperationId = "u1", Operation = "update_tag", Name = "Start", NewName = "Start_1"
+        });
+        var preview = await WriteBatchTools.PreviewWriteBatch(fixture.Client, fixture.Safety, operations);
+        var token = ExtractToken(preview);
+        var before = await fixture.Observe();
+        Assert.Equal(1, before.GetProperty("snapshotReadCount").GetInt32());
+        Assert.Equal(0, before.GetProperty("mutationCount").GetInt32());
+
+        var apply = await WriteBatchTools.ApplyWriteBatch(fixture.Client, fixture.Safety, operations,
+            confirm: true, safetyToken: token);
+        AssertSucceeded(apply, "u1");
+        var after = await fixture.Observe();
+        Assert.Equal(2, after.GetProperty("snapshotReadCount").GetInt32());
+        Assert.Equal(2, after.GetProperty("snapshotReadsAtMutation").GetInt32());
+        Assert.Equal("Start_1", after.GetProperty("targetTagName").GetString());
+        Assert.Equal(1, after.GetProperty("mutationCount").GetInt32());
+
+        var replay = await WriteBatchTools.ApplyWriteBatch(fixture.Client, fixture.Safety, operations,
+            confirm: true, safetyToken: token);
+        using var document = JsonDocument.Parse(replay);
+        Assert.False(document.RootElement.GetProperty("success").GetBoolean());
+        // The existing cheap envelope rejection returns success/error without a category.
+        Assert.Contains("expired, consumed, or unknown", document.RootElement.GetProperty("error").GetString());
+        var replayState = await fixture.Observe();
+        Assert.Equal(1, replayState.GetProperty("mutationCount").GetInt32());
+        Assert.Equal(2, replayState.GetProperty("snapshotReadCount").GetInt32());
+        Assert.Equal(0, replayState.GetProperty("broadReadCount").GetInt32());
+    }
+
+    private static async Task AssertDriftRejected(string scenario, BatchOperationRequest operation)
+    {
+        using var fixture = await Fixture.Create(scenario);
+        var operations = fixture.Operations(operation);
+        var preview = await WriteBatchTools.PreviewWriteBatch(fixture.Client, fixture.Safety, operations);
+        var token = ExtractToken(preview);
+        var before = await fixture.Observe();
+        Assert.Equal(1, before.GetProperty("snapshotReadCount").GetInt32());
+        Assert.Equal(0, before.GetProperty("mutationCount").GetInt32());
+
+        var apply = await WriteBatchTools.ApplyWriteBatch(fixture.Client, fixture.Safety, operations,
+            confirm: true, safetyToken: token);
+
+        Assert.Contains("\"failureCategory\":\"state_changed\"", apply, StringComparison.Ordinal);
+        using var document = JsonDocument.Parse(apply);
+        Assert.False(document.RootElement.GetProperty("success").GetBoolean());
+        var after = await fixture.Observe();
+        Assert.Equal(2, after.GetProperty("snapshotReadCount").GetInt32());
+        Assert.Equal(0, after.GetProperty("mutationCount").GetInt32());
+        Assert.Equal(0, after.GetProperty("broadReadCount").GetInt32());
+    }
+
+    private static string ExtractToken(string preview)
+    {
+        using var document = JsonDocument.Parse(preview);
+        Assert.True(document.RootElement.TryGetProperty("safetyToken", out var token), preview);
+        Assert.False(string.IsNullOrWhiteSpace(token.GetString()));
+        return token.GetString()!;
+    }
+
+    private static void AssertSucceeded(string apply, string operationId)
+    {
+        using var document = JsonDocument.Parse(apply);
+        Assert.True(document.RootElement.GetProperty("success").GetBoolean(), apply);
+        var operation = Assert.Single(document.RootElement.GetProperty("operations").EnumerateArray());
+        Assert.Equal(operationId, operation.GetProperty("operationId").GetString());
+        Assert.Equal("succeeded", operation.GetProperty("status").GetString());
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        private readonly TempAuditDirectory audit = new();
+        private readonly string projectPath;
+        public OpennessWorkerClient Client { get; }
+        public WriteSafetyService Safety { get; }
+
+        private Fixture(string scenario, ProjectSessionBinding binding)
+        {
+            projectPath = $@"C:\FakeWorker\{scenario}.ap21";
+            Client = new(binding, logger: null, workerExecutablePath: FakeWorkerLocator.Locate());
+            Safety = new(binding, () => DateTimeOffset.UtcNow, WriteSafetyService.DefaultTokenLifetime, audit.Path);
+        }
+
+        public static async Task<Fixture> Create(string scenario)
+        {
+            var binding = new ProjectSessionBinding(null);
+            var fixture = new Fixture(scenario, binding);
+            try
+            {
+                await FakeWorkerBinding.BindVerifiedAsync(fixture.Client, binding, fixture.projectPath);
+                return fixture;
+            }
+            catch
+            {
+                fixture.Dispose();
+                throw;
+            }
+        }
+
+        public BatchOperationRequest[] Operations(BatchOperationRequest operation)
+        {
+            operation.ProjectPath = projectPath;
+            operation.PlcName = "PLC_1";
+            operation.TableName = "Inputs";
+            return new[] { operation };
+        }
+
+        public async Task<JsonElement> Observe()
+        {
+            var result = await Client.GetProjectStatusAsync(projectPath);
+            Assert.True(result.Success, result.Error);
+            using var document = JsonDocument.Parse(result.Payload);
+            return document.RootElement.Clone();
+        }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            audit.Dispose();
+        }
+    }
+}

--- a/TiaMcpServer.Tests/Batch/TagOperationPrerequisiteBaselineTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationPrerequisiteBaselineTests.cs
@@ -1,0 +1,34 @@
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationPrerequisiteBaselineTests
+{
+    [Fact]
+    public void Program_RegistersWriteBatchTools()
+    {
+        var text = File.ReadAllText(Source("TiaMcpServer/Program.cs"));
+
+        Assert.Contains(".WithTools<WriteBatchTools>()", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UpdateTag_BaselineStillCarriesPr3MutableFlagsThroughTheRegisteredWritePath()
+    {
+        var capability = File.ReadAllText(Source("TiaMcpServer.Contracts/OperationCapability.cs"));
+        var catalog = File.ReadAllText(Source("TiaMcpServer/Batch/BatchOperationCatalog.cs"));
+        var invoker = File.ReadAllText(Source("TiaMcpServer/Batch/BatchWorkerInvoker.cs"));
+
+        Assert.Contains("SafetyRead", capability, StringComparison.Ordinal);
+        Assert.Contains("\"externalAccessible\"", catalog, StringComparison.Ordinal);
+        Assert.Contains("\"externalVisible\"", catalog, StringComparison.Ordinal);
+        Assert.Contains("\"externalWritable\"", catalog, StringComparison.Ordinal);
+        Assert.Contains(
+            "client.UpdateTagAsync(op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.NewName, op.DataType, op.LogicalAddress, op.ExternalAccessible, op.ExternalVisible, op.ExternalWritable, op.IsSafety, op.ProjectPath)",
+            invoker,
+            StringComparison.Ordinal);
+    }
+
+    private static string Source(string relative)
+        => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", relative));
+}

--- a/TiaMcpServer.Tests/Batch/TagOperationSafetyBuilderTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationSafetyBuilderTests.cs
@@ -6,6 +6,45 @@ namespace TiaMcpServer.Tests.Batch;
 
 public sealed class TagOperationSafetyBuilderTests
 {
+    [Fact]
+    public void StrictPlcResolution_RejectsZeroMatches()
+    {
+        Assert.Throws<InvalidOperationException>(() => ResolveUniquePlc(Array.Empty<object>()));
+    }
+
+    [Fact]
+    public void StrictPlcResolution_ReturnsTheOnlyMatch()
+    {
+        var expected = new object();
+        Assert.Same(expected, ResolveUniquePlc(new[] { expected }));
+    }
+
+    [Fact]
+    public void StrictPlcResolution_RejectsMultipleMatchesInsteadOfSelectingTheFirst()
+    {
+        Assert.Throws<InvalidOperationException>(() => ResolveUniquePlc(new[] { new object(), new object() }));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StrictPlcResolution_PropagatesDiscoveryFailureEvenAfterOneMatch(bool yieldMatchFirst)
+    {
+        var failure = new IOException("Discovery could not inspect a device item.");
+        var actual = Assert.Throws<IOException>(() => ResolveUniquePlc(FailingDiscovery()));
+        Assert.Same(failure, actual);
+
+        IEnumerable<object> FailingDiscovery()
+        {
+            if (yieldMatchFirst)
+                yield return new object();
+            throw failure;
+        }
+    }
+
+    private static object ResolveUniquePlc(IEnumerable<object> matches)
+        => TagOperationSafetySnapshotBuilder.ResolveUniquePlc(matches);
+
     [Theory]
     [InlineData(null, "/", "PLC_1/Tag tables/Inputs")]
     [InlineData(" /Area//Signals/ ", "/Area/Signals", "PLC_1/Tag tables/Area/Signals/Inputs")]

--- a/TiaMcpServer.Tests/Batch/TagOperationSafetyBuilderTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationSafetyBuilderTests.cs
@@ -1,0 +1,82 @@
+using TiaMcpServer.Contracts;
+using TiaMcpServer.OpennessWorker.Openness;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationSafetyBuilderTests
+{
+    [Theory]
+    [InlineData(null, "/", "PLC_1/Tag tables/Inputs")]
+    [InlineData(" /Area//Signals/ ", "/Area/Signals", "PLC_1/Tag tables/Area/Signals/Inputs")]
+    public void TableIdentity_NormalizesFolderSeparators(string? folder, string expectedFolder, string expectedPath)
+    {
+        var table = TagOperationSafetySnapshotBuilder.BuildTableIdentity("PLC_1", folder, "Inputs");
+        Assert.Equal(expectedFolder, table.FolderPath);
+        Assert.Equal(expectedPath, table.CanonicalPath);
+    }
+
+    [Fact]
+    public void DeleteSnapshot_PreservesCompleteExportAndHashesExactContent()
+    {
+        var table = new TagTableSafetyIdentityInfo("PLC_1", "/", "Inputs", "PLC_1/Tag tables/Inputs");
+        var snapshot = TagOperationSafetySnapshotBuilder.BuildDeleteTagTableSnapshot(table, "<Document />");
+        Assert.Equal("<Document />", snapshot.ExportedSimaticMl);
+        Assert.Equal(12, snapshot.CharacterCount);
+        Assert.Same(table, snapshot.TargetTable);
+        Assert.Equal("f0a79fec323a922b8967d8bfee43ade7c6e12520a50c3fc6dd46fd58135a0a3e", snapshot.ExportSha256);
+        const string detailed = "<Document GeneratedOn=\"preserve\"><Unknown ID=\"7\"> \r\n<!--keep-->x</Unknown></Document>";
+        Assert.Equal(detailed, TagOperationSafetySnapshotBuilder.BuildDeleteTagTableSnapshot(table, detailed).ExportedSimaticMl);
+    }
+
+    [Fact]
+    public void CollisionSelection_BindsOnlyRequestedValuesAcrossTablesAndMarksTheTarget()
+    {
+        var target = new TagCollisionProbeInfo("tag-name", "Start", "PLC_1/Tag tables/A/Start", "%I0.0", false);
+        var sibling = new TagCollisionProbeInfo("tag-name", "Start", "PLC_1/Tag tables/B/Start", "%I0.1", false);
+        var unrelated = new TagCollisionProbeInfo("tag-name", "Other", "PLC_1/Tag tables/C/Other", "%I0.2", false);
+        var candidates = new[] { unrelated, sibling, target };
+        var names = TagOperationSafetySnapshotBuilder.SelectCollisions("tag-name", candidates, "Start", target.CanonicalPath);
+        Assert.Equal(new[] { target with { IsTarget = true }, sibling }, names);
+        var addresses = TagOperationSafetySnapshotBuilder.SelectCollisions("logical-address", candidates, "%I0.1", target.CanonicalPath);
+        Assert.Equal(new[] { sibling with { Kind = "logical-address" } }, addresses);
+        Assert.Empty(TagOperationSafetySnapshotBuilder.SelectCollisions("logical-address", candidates, null, null));
+    }
+
+    [Fact]
+    public void CollisionOrdering_IsOrdinalAndIndependentOfEnumerationOrder()
+    {
+        var a = new TagCollisionProbeInfo("tag-name", "Start", "PLC_1/Tag tables/A/Start", "%I0.0", false);
+        var b = new TagCollisionProbeInfo("tag-name", "Start", "PLC_1/Tag tables/B/Start", "%I0.0", true);
+        Assert.Equal(new[] { a, b }, TagOperationSafetySnapshotBuilder.OrderCollisions(new[] { b, a }));
+        Assert.Equal(new[] { a, b }, TagOperationSafetySnapshotBuilder.OrderCollisions(new[] { a, b }));
+    }
+
+    [Fact]
+    public void TagIdentity_PreservesExternalFlagsIncludingUnavailableValues()
+    {
+        var table = TagOperationSafetySnapshotBuilder.BuildTableIdentity("PLC_1", "/", "Inputs");
+        var tag = TagOperationSafetySnapshotBuilder.BuildTagIdentity(table, "Start", "Bool", "%I0.0", false, null, true);
+        Assert.Equal("PLC_1/Tag tables/Inputs/Start", tag.CanonicalPath);
+        Assert.False(tag.ExternalAccessible);
+        Assert.Null(tag.ExternalVisible);
+        Assert.True(tag.ExternalWritable);
+        var constant = TagOperationSafetySnapshotBuilder.BuildConstantIdentity(table, "DebounceMs", "Int", "25");
+        Assert.Equal("PLC_1/Tag tables/Inputs/DebounceMs", constant.CanonicalPath);
+        Assert.Equal("25", constant.Value);
+    }
+
+    [Fact]
+    public void DeleteTagTableSnapshot_UsesTheVerifiedTimestampFreeExportCallFirst()
+    {
+        var path = Source("TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotReader.cs");
+        Assert.True(File.Exists(path), "The deterministic tag-table safety reader must exist.");
+        var text = File.ReadAllText(path);
+        Assert.Contains("ExportOptions.None", text, StringComparison.Ordinal);
+        Assert.Contains(".Export(new FileInfo(", text, StringComparison.Ordinal);
+        Assert.Contains("DocumentInfoOptions.None", text, StringComparison.Ordinal);
+    }
+
+    private static string Source(string relative)
+        => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", relative));
+}

--- a/TiaMcpServer.Tests/Batch/TagOperationSafetyLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationSafetyLiveHarnessContractTests.cs
@@ -90,6 +90,23 @@ public sealed class TagOperationSafetyLiveHarnessContractTests
         Assert.DoesNotContain("Remove-Item -LiteralPath $ProjectPath", text, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Script_DriftScenariosRetainMutationsUntilFinalDiscard()
+    {
+        var text = File.ReadAllText(ScriptPath);
+        var driftStart = text.IndexOf("function Test-Drift(", StringComparison.Ordinal);
+        var driftEnd = text.IndexOf("function Stop-McpHost", driftStart, StringComparison.Ordinal);
+        var driftCheck = text[driftStart..driftEnd];
+
+        Assert.DoesNotContain("$Restoration", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("reset-constant", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("remove-collision", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Invoke-AuthorizedChange", driftCheck, StringComparison.Ordinal);
+        Assert.DoesNotMatch(new Regex(
+            @"New-Operation[^\r\n]*'update_user_constant'[^\r\n]*value\s*=\s*\$(constant|siblingConstant)\.value"), text);
+        Assert.Contains("saveBeforeClose = $false", text, StringComparison.Ordinal);
+    }
+
     private static readonly string ScriptPath = Path.GetFullPath(
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "scripts", "live-test-tag-operation-safety-scopes.ps1"));
 

--- a/TiaMcpServer.Tests/Batch/TagOperationSafetyLiveHarnessContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationSafetyLiveHarnessContractTests.cs
@@ -1,0 +1,98 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationSafetyLiveHarnessContractTests
+{
+    [Fact]
+    public void Script_IsPresent_RequiresPowerShell7AndStrictMode_AndDefaultsToNonMutatingMode()
+    {
+        var text = File.ReadAllText(ScriptPath);
+
+        Assert.Matches(new Regex(@"^\s*#Requires\s+-Version\s+7(\.\d+)?\s*$", RegexOptions.Multiline), text);
+        Assert.Contains("Set-StrictMode -Version Latest", text, StringComparison.Ordinal);
+        Assert.Contains("$ErrorActionPreference = 'Stop'", text, StringComparison.Ordinal);
+        Assert.Contains("[ValidateSet('PreviewOnly','DriftAndRestore','ApplyAndRestore')]", text, StringComparison.Ordinal);
+        Assert.Contains("$Mode = 'PreviewOnly'", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_UsesTheHostRequiresExplicitMutationModeAndNeverRunsFromOrdinaryTests()
+    {
+        var text = File.ReadAllText(ScriptPath);
+
+        Assert.Contains("TiaMcpServer", text, StringComparison.Ordinal);
+        Assert.Contains("if ($Mode -eq 'ApplyAndRestore')", text, StringComparison.Ordinal);
+        Assert.Contains("disposable project copy", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("OpennessWorker.exe", text, StringComparison.Ordinal);
+
+        var testDirectory = Path.Combine(GetRepositoryRoot(), "TiaMcpServer.Tests");
+        var thisFile = Path.Combine(testDirectory, "Batch", "TagOperationSafetyLiveHarnessContractTests.cs");
+        var offendingFiles = Directory
+            .EnumerateFiles(testDirectory, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !string.Equals(Path.GetFullPath(path), Path.GetFullPath(thisFile), StringComparison.OrdinalIgnoreCase))
+            .Where(path => File.ReadAllText(path).Contains("live-test-tag-operation-safety-scopes.ps1", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Empty(offendingFiles);
+    }
+
+    [Fact]
+    public void Script_UsesFinallyCleanupArtifactHygieneAndTokenRedaction()
+    {
+        var text = File.ReadAllText(ScriptPath);
+
+        Assert.Contains("try {", text, StringComparison.Ordinal);
+        Assert.Contains("finally {", text, StringComparison.Ordinal);
+        Assert.Contains("Stop-McpHost", text, StringComparison.Ordinal);
+        Assert.Contains("artifact", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("failure.json", text, StringComparison.Ordinal);
+        Assert.Contains("Redact-SafetyToken", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Write-Host \"safetyToken:", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_UsesAsyncStdoutReadsBoundedByTheRemainingDeadline()
+    {
+        var text = File.ReadAllText(ScriptPath);
+
+        Assert.DoesNotContain("StandardOutput.ReadLine()", text, StringComparison.Ordinal);
+        Assert.Contains("StandardOutput.ReadLineAsync()", text, StringComparison.Ordinal);
+        Assert.Contains("$remaining = $deadline - (Get-Date)", text, StringComparison.Ordinal);
+        Assert.Contains("$readTask.WaitAsync($remaining)", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_CoversAllRequiredPr5LiveClaims()
+    {
+        var text = File.ReadAllText(ScriptPath);
+
+        Assert.Contains("same-object drift", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("relevant collision", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("unrelated sibling", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("restore or discard", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Script_MutationGateRequiresDisposableCopyAndUsesGuardedNoSaveDiscard()
+    {
+        var text = File.ReadAllText(ScriptPath);
+
+        Assert.Contains("[switch] $ConfirmDisposableCopy", text, StringComparison.Ordinal);
+        Assert.Contains("$AllowMutation -and $ConfirmDisposableCopy", text, StringComparison.Ordinal);
+        Assert.Contains("function Assert-MutationAuthorization", text, StringComparison.Ordinal);
+        Assert.Contains("$AuthorizedProjectPath, $ProjectPath", text, StringComparison.Ordinal);
+        Assert.Contains("$initialProject.isModified -eq $false", text, StringComparison.Ordinal);
+        Assert.Contains("saveBeforeClose = $false", text, StringComparison.Ordinal);
+        Assert.Contains("$closedPayload.project.isOpen -eq $false", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("'save_project'", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Remove-Item -LiteralPath $ProjectPath", text, StringComparison.Ordinal);
+    }
+
+    private static readonly string ScriptPath = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "scripts", "live-test-tag-operation-safety-scopes.ps1"));
+
+    private static string GetRepositoryRoot()
+        => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+}

--- a/TiaMcpServer.Tests/Batch/TagOperationSafetyReaderTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationSafetyReaderTests.cs
@@ -1,0 +1,254 @@
+using System.Text.Json;
+using Siemens.Engineering;
+using Siemens.Engineering.HW;
+using Siemens.Engineering.HW.Features;
+using Siemens.Engineering.SW;
+using Siemens.Engineering.SW.Blocks;
+using Siemens.Engineering.SW.Tags;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Json;
+using TiaMcpServer.OpennessWorker.Openness;
+using TiaMcpServer.Safety;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationSafetyReaderTests
+{
+    public static TheoryData<string, string, bool> SymbolDriftCases()
+    {
+        var cases = new TheoryData<string, string, bool>();
+        foreach (var operation in new[] { "create_tag", "update_tag", "create_user_constant", "update_user_constant" })
+        foreach (var kind in new[] { operation.EndsWith("user_constant") ? "tag" : "constant", "block" })
+        foreach (var relevant in new[] { true, false })
+            cases.Add(operation, kind, relevant);
+        return cases;
+    }
+
+    [Theory]
+    [MemberData(nameof(SymbolDriftCases))]
+    public void NameDriftAcrossSymbolKinds_ChangesTokenOnlyForTheRequestedName(
+        string operation, string kind, bool relevant)
+    {
+        var fixture = new Fixture(operation);
+        var result = ValidateAfterDrift(fixture, () =>
+            fixture.AddSymbol(kind, relevant ? "rEQUESTED" : "Unrelated"));
+        Assert.Equal(!relevant, result.IsValid);
+        if (relevant)
+            Assert.Equal(WorkerFailureCategories.StateChanged, result.FailureCategory);
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    public void CreateTable_SiblingOrNestedOccupancy_ChangesTokenOnlyForRequestedName(bool nested, bool relevant)
+    {
+        var fixture = new Fixture("create_tag_table");
+        var folder = new PlcTagTableGroup { Name = "Elsewhere" };
+        fixture.Plc.TagTableGroup.Groups.Items.Add(folder);
+        if (nested)
+        {
+            var child = new PlcTagTableGroup { Name = "Nested" };
+            folder.Groups.Items.Add(child);
+            folder = child;
+        }
+        var result = ValidateAfterDrift(fixture, () =>
+            folder.TagTables.Items.Add(new PlcTagTable { Name = relevant ? "rEQUESTED" : "Unrelated" }));
+        Assert.Equal(!relevant, result.IsValid);
+        if (relevant)
+        {
+            Assert.Equal(WorkerFailureCategories.StateChanged, result.FailureCategory);
+            var snapshot = (CreateTagTableSafetySnapshotInfo)fixture.Read();
+            Assert.Equal("/Destination", snapshot.FolderPath);
+            Assert.Equal(nested ? "PLC_1/Tag tables/Elsewhere/Nested/rEQUESTED" :
+                "PLC_1/Tag tables/Elsewhere/rEQUESTED", Assert.Single(snapshot.TableNameCollisions).CanonicalPath);
+        }
+    }
+
+    [Theory]
+    [InlineData("user")]
+    [InlineData("system")]
+    [InlineData("nested-system")]
+    public void NestedBlockNameDrift_InvalidatesToken(string hierarchy)
+    {
+        var fixture = new Fixture("create_tag");
+        var group = new PlcBlockGroup { Name = "Area" };
+        fixture.Plc.BlockGroup.Groups.Items.Add(group);
+        var system = new PlcSystemBlockGroup { Name = "System" };
+        fixture.Plc.BlockGroup.SystemBlockGroups.Items.Add(system);
+        var child = new PlcSystemBlockGroup { Name = "Nested" };
+        system.Groups.Items.Add(child);
+        var blocks = hierarchy switch
+        {
+            "user" => group.Blocks,
+            "system" => system.Blocks,
+            _ => child.Blocks
+        };
+        var result = ValidateAfterDrift(fixture, () => blocks.Items.Add(new PlcBlock { Name = "Requested" }));
+        Assert.False(result.IsValid);
+        Assert.Equal(WorkerFailureCategories.StateChanged, result.FailureCategory);
+    }
+
+    [Fact]
+    public void NameProbes_PreserveKindsAndMarkOnlyTheExactTargetWhileAddressesRemainTagOnly()
+    {
+        var fixture = new Fixture("update_user_constant");
+        fixture.Target.Tags.Items.Add(new PlcTag { Name = "Requested" });
+        fixture.AddSymbol("block", "Requested");
+        var snapshot = (UpdateUserConstantSafetySnapshotInfo)fixture.Read();
+        Assert.Equal(new[] { "block-name", "tag-name", "user-constant-name" },
+            snapshot.NameCollisions.Select(x => x.Kind).OrderBy(x => x, StringComparer.Ordinal));
+        var target = Assert.Single(snapshot.NameCollisions.Where(x => x.IsTarget));
+        Assert.Equal("user-constant-name", target.Kind);
+
+        var tagFixture = new Fixture("create_tag");
+        tagFixture.AddSymbol("constant", "Requested");
+        tagFixture.AddSymbol("block", "Requested");
+        tagFixture.AddSymbol("tag", "AddressOccupant");
+        var tagSnapshot = (CreateTagSafetySnapshotInfo)tagFixture.Read();
+        var address = Assert.Single(tagSnapshot.AddressCollisions);
+        Assert.Equal("AddressOccupant", address.CandidateName);
+        Assert.Equal("logical-address", address.Kind);
+    }
+
+    [Theory]
+    [InlineData("create_tag_table", "tables")]
+    [InlineData("create_tag", "constants")]
+    [InlineData("create_user_constant", "tags")]
+    [InlineData("create_tag", "blocks")]
+    [InlineData("create_user_constant", "system-blocks")]
+    public void CollisionTraversalFailure_PropagatesAfterRelevantEvidence(string operation, string failureAt)
+    {
+        var fixture = new Fixture(operation);
+        fixture.AddSymbol("tag", "Requested");
+        fixture.AddSymbol("constant", "Requested");
+        fixture.AddSymbol("block", "Requested");
+        var failure = new IOException("Cannot complete collision discovery.");
+        switch (failureAt)
+        {
+            case "tables":
+                fixture.Sibling.Name = "Requested";
+                fixture.Plc.TagTableGroup.Groups.EnumerationFailure = failure;
+                break;
+            case "constants": fixture.Sibling.UserConstants.EnumerationFailure = failure; break;
+            case "tags": fixture.Sibling.Tags.EnumerationFailure = failure; break;
+            case "blocks": fixture.Plc.BlockGroup.Blocks.EnumerationFailure = failure; break;
+            default: fixture.Plc.BlockGroup.SystemBlockGroups.EnumerationFailure = failure; break;
+        }
+        Assert.Same(failure, Assert.Throws<IOException>(() => fixture.Read()));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(2)]
+    public void PlcResolution_RejectsMissingAndAmbiguousMatches(int count)
+    {
+        var fixture = new Fixture("create_tag_table");
+        fixture.Project.Devices.Items.Clear();
+        for (var i = 0; i < count; i++)
+            fixture.AddPlc(new PlcSoftware { Name = "PLC_1" });
+        Assert.Throws<InvalidOperationException>(() => fixture.Read());
+    }
+
+    [Theory]
+    [InlineData("create_tag_table")]
+    [InlineData("delete_tag")]
+    [InlineData("delete_user_constant")]
+    public void SelectorsWithoutSymbolNameProbes_DoNotReadTheBlockRoot(string operation)
+    {
+        var fixture = new Fixture(operation);
+        fixture.Plc.BlockGroupFailure = new IOException("Block state is unrelated to this selector.");
+        Assert.NotNull(fixture.Read());
+    }
+
+    [Fact]
+    public void PlcResolution_PropagatesDiscoveryFailureAfterOneMatch()
+    {
+        var fixture = new Fixture("create_tag_table");
+        var failure = new IOException("Cannot inspect remaining devices.");
+        fixture.Project.DeviceGroups.EnumerationFailure = failure;
+        Assert.Same(failure, Assert.Throws<IOException>(() => fixture.Read()));
+    }
+
+    private static WriteSafetyValidationResult ValidateAfterDrift(Fixture fixture, Action drift)
+    {
+        var safety = new WriteSafetyService();
+        var before = Decode(fixture);
+        using var preview = JsonDocument.Parse(safety.CreatePreview("apply_write_batch", null,
+            fixture.Request.TableName!, fixture.Operation, fixture.Request, before));
+        var token = preview.RootElement.GetProperty("safetyToken").GetString();
+        drift();
+        return safety.ValidateAndConsume(token, "apply_write_batch", null,
+            fixture.Request.TableName!, fixture.Request, Decode(fixture));
+    }
+
+    private static string Decode(Fixture fixture)
+    {
+        var decoded = TiaMcpServer.Batch.TagOperationSafetySnapshotContract.Decode(
+            fixture.Operation, CanonicalJson.Serialize(fixture.Read()));
+        Assert.True(decoded.Success, decoded.Error);
+        return decoded.CanonicalState;
+    }
+
+    private sealed class Fixture
+    {
+        public string Operation { get; }
+        public Siemens.Engineering.Project Project { get; } = new();
+        public PlcSoftware Plc { get; } = new() { Name = "PLC_1" };
+        public PlcTagTable Target { get; } = new() { Name = "Inputs" };
+        public PlcTagTable Sibling { get; } = new() { Name = "OtherTable" };
+        public WorkerRequest Request { get; }
+
+        public Fixture(string operation)
+        {
+            Operation = operation;
+            AddPlc(Plc);
+            var destination = new PlcTagTableGroup { Name = "Destination" };
+            Plc.TagTableGroup.Groups.Items.Add(destination);
+            destination.TagTables.Items.Add(Target);
+            Plc.TagTableGroup.TagTables.Items.Add(Sibling);
+            Target.Tags.Items.Add(new PlcTag { Name = "Original", LogicalAddress = "%I0.0" });
+            if (operation is "update_user_constant" or "delete_user_constant")
+                Target.UserConstants.Items.Add(new PlcUserConstant { Name = "Requested" });
+            Request = new WorkerRequest
+            {
+                PlcName = "PLC_1", FolderPath = "/Destination",
+                TableName = operation == "create_tag_table" ? "Requested" : "Inputs",
+                Name = operation is "update_tag" or "delete_tag" ? "Original" : "Requested",
+                NewName = operation == "update_tag" ? "Requested" : null,
+                DataType = "Bool", LogicalAddress = "%I0.1"
+            };
+        }
+
+        public void AddPlc(PlcSoftware software)
+        {
+            var device = new Device { Name = "Device" };
+            device.DeviceItems.Items.Add(new DeviceItem { Container = new SoftwareContainer { Software = software } });
+            Project.Devices.Items.Add(device);
+        }
+
+        public void AddSymbol(string kind, string name)
+        {
+            switch (kind)
+            {
+                case "tag": Sibling.Tags.Items.Add(new PlcTag { Name = name, LogicalAddress = "%I0.1" }); break;
+                case "constant": Sibling.UserConstants.Items.Add(new PlcUserConstant { Name = name }); break;
+                default: Plc.BlockGroup.Blocks.Items.Add(new PlcBlock { Name = name }); break;
+            }
+        }
+
+        public object Read() => Operation switch
+        {
+            "create_tag_table" => TagOperationSafetySnapshotReader.ReadCreateTagTable(Project, Request),
+            "create_tag" => TagOperationSafetySnapshotReader.ReadCreateTag(Project, Request),
+            "update_tag" => TagOperationSafetySnapshotReader.ReadUpdateTag(Project, Request),
+            "delete_tag" => TagOperationSafetySnapshotReader.ReadDeleteTag(Project, Request),
+            "create_user_constant" => TagOperationSafetySnapshotReader.ReadCreateUserConstant(Project, Request),
+            "update_user_constant" => TagOperationSafetySnapshotReader.ReadUpdateUserConstant(Project, Request),
+            "delete_user_constant" => TagOperationSafetySnapshotReader.ReadDeleteUserConstant(Project, Request),
+            _ => throw new InvalidOperationException(Operation)
+        };
+    }
+}

--- a/TiaMcpServer.Tests/Batch/TagOperationSafetySelectorTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationSafetySelectorTests.cs
@@ -1,0 +1,53 @@
+using TiaMcpServer.Batch;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationSafetySelectorTests
+{
+    [Fact]
+    public void Build_UpdateTag_UsesRequestedRenameAndLogicalAddress()
+    {
+        var key = TagOperationSafetySelector.Build(new BatchOperationRequest
+        {
+            OperationId = "u1",
+            Operation = "update_tag",
+            ProjectPath = @"C:\Plant\Demo.ap21",
+            PlcName = "PLC_1",
+            TableName = "Inputs",
+            Name = "Start",
+            NewName = "Start_1",
+            LogicalAddress = "%I0.1"
+        });
+
+        Assert.Equal("update_tag", key.SelectorKind);
+        Assert.Equal(@"C:\Plant\Demo.ap21", key.NormalizedProjectPath);
+        Assert.Equal("Start_1", key.EffectiveName);
+        Assert.Equal("%I0.1", key.EffectiveLogicalAddress);
+    }
+
+    [Fact]
+    public void Build_DeleteTag_DoesNotCollapseIntoUpdateTagKey()
+    {
+        var update = TagOperationSafetySelector.Build(new BatchOperationRequest
+        {
+            OperationId = "u1",
+            Operation = "update_tag",
+            ProjectPath = @"C:\Plant\Demo.ap21",
+            PlcName = "PLC_1",
+            TableName = "Inputs",
+            Name = "Start"
+        });
+        var delete = TagOperationSafetySelector.Build(new BatchOperationRequest
+        {
+            OperationId = "d1",
+            Operation = "delete_tag",
+            ProjectPath = @"C:\Plant\Demo.ap21",
+            PlcName = "PLC_1",
+            TableName = "Inputs",
+            Name = "Start"
+        });
+
+        Assert.NotEqual(update.SelectorKind, delete.SelectorKind);
+    }
+}

--- a/TiaMcpServer.Tests/Batch/TagOperationSafetySelectorTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationSafetySelectorTests.cs
@@ -50,4 +50,30 @@ public sealed class TagOperationSafetySelectorTests
 
         Assert.NotEqual(update.SelectorKind, delete.SelectorKind);
     }
+
+    [Fact]
+    public void Build_EquivalentProjectPathSpellings_UsesOneNormalizedKey()
+    {
+        var canonical = TagOperationSafetySelector.Build(new BatchOperationRequest
+        {
+            OperationId = "u1",
+            Operation = "update_tag",
+            ProjectPath = @"C:\Plant\Demo.ap21",
+            PlcName = "PLC_1",
+            TableName = "Inputs",
+            Name = "Start"
+        });
+        var equivalent = TagOperationSafetySelector.Build(new BatchOperationRequest
+        {
+            OperationId = "u2",
+            Operation = "update_tag",
+            ProjectPath = @" C:\Plant\.\Demo.ap21 ",
+            PlcName = "PLC_1",
+            TableName = "Inputs",
+            Name = "Start"
+        });
+
+        Assert.Equal(canonical.NormalizedProjectPath, equivalent.NormalizedProjectPath);
+        Assert.Equal(canonical, equivalent);
+    }
 }

--- a/TiaMcpServer.Tests/Batch/TagOperationSafetySnapshotContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationSafetySnapshotContractTests.cs
@@ -103,4 +103,27 @@ public sealed class TagOperationSafetySnapshotContractTests
         Assert.Empty(result.CanonicalState);
         Assert.Equal(WorkerFailureCategories.ProtocolError, result.FailureCategory);
     }
+
+    [Theory]
+    [InlineData("create_user_constant")]
+    [InlineData("update_user_constant")]
+    [InlineData("create_tag_table")]
+    public void UnknownCollisionKind_IsRejectedForConstantsAndTables(string operation)
+    {
+        var table = new TagTableSafetyIdentityInfo("PLC_1", "/", "Inputs", "PLC_1/Tag tables/Inputs");
+        var collisions = new[] { new TagCollisionProbeInfo("unexpected", "Start", "opaque", null, false) };
+        object snapshot = operation switch
+        {
+            "create_tag_table" => new CreateTagTableSafetySnapshotInfo("PLC_1", "/", "Inputs", collisions),
+            "create_user_constant" => new CreateUserConstantSafetySnapshotInfo(table, "Start", collisions),
+            _ => new UpdateUserConstantSafetySnapshotInfo(table,
+                new UserConstantSafetyIdentityInfo("PLC_1", "/", "Inputs", "Start", "PLC_1/Tag tables/Inputs/Start", "Int", "25"),
+                "Start", collisions)
+        };
+        var result = TagOperationSafetySnapshotContract.Decode(operation,
+            TiaMcpServer.Json.CanonicalJson.Serialize(snapshot));
+        Assert.False(result.Success);
+        Assert.Empty(result.CanonicalState);
+        Assert.Equal(WorkerFailureCategories.ProtocolError, result.FailureCategory);
+    }
 }

--- a/TiaMcpServer.Tests/Batch/TagOperationSafetySnapshotContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationSafetySnapshotContractTests.cs
@@ -58,4 +58,49 @@ public sealed class TagOperationSafetySnapshotContractTests
         Assert.False(result.Success);
         Assert.Equal(WorkerFailureCategories.ProtocolError, result.FailureCategory);
     }
+
+    [Fact]
+    public void OmittedRequiredSnapshotMembers_FailClosedAsProtocolError()
+    {
+        var result = TagOperationSafetySnapshotContract.Decode("create_tag", "{}");
+
+        Assert.False(result.Success);
+        Assert.Empty(result.CanonicalState);
+        Assert.Equal(WorkerFailureCategories.ProtocolError, result.FailureCategory);
+    }
+
+    [Fact]
+    public void ExplicitNullRequiredSnapshotMember_FailsClosedAsProtocolError()
+    {
+        var result = TagOperationSafetySnapshotContract.Decode("delete_tag_table", """
+        {
+          "targetTable":null,
+          "exportedSimaticMl":"<Document />",
+          "exportSha256":"abc123",
+          "characterCount":12
+        }
+        """);
+
+        Assert.False(result.Success);
+        Assert.Empty(result.CanonicalState);
+        Assert.Equal(WorkerFailureCategories.ProtocolError, result.FailureCategory);
+    }
+
+    [Fact]
+    public void UnsupportedCollisionKind_FailsClosedAsProtocolError()
+    {
+        var result = TagOperationSafetySnapshotContract.Decode("create_tag", """
+        {
+          "targetTable":{"plcName":"PLC_1","folderPath":"","tableName":"Inputs","canonicalPath":"PLC_1/Tag tables/Inputs"},
+          "effectiveName":"Start",
+          "effectiveLogicalAddress":null,
+          "nameCollisions":[{"kind":"unexpected","candidateName":"Start","canonicalPath":"PLC_1/Tag tables/Inputs/Start","logicalAddress":null,"isTarget":false}],
+          "addressCollisions":[]
+        }
+        """);
+
+        Assert.False(result.Success);
+        Assert.Empty(result.CanonicalState);
+        Assert.Equal(WorkerFailureCategories.ProtocolError, result.FailureCategory);
+    }
 }

--- a/TiaMcpServer.Tests/Batch/TagOperationSafetySnapshotContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationSafetySnapshotContractTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using TiaMcpServer.Batch;
+using TiaMcpServer.Contracts;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationSafetySnapshotContractTests
+{
+    [Fact]
+    public void UpdateTagSnapshot_PreservesFalseFlagsAndEffectiveRename()
+    {
+        var payload = """
+        {
+          "targetTable":{"plcName":"PLC_1","folderPath":"","tableName":"Inputs","canonicalPath":"PLC_1/Tag tables/Inputs"},
+          "targetTag":{"plcName":"PLC_1","folderPath":"","tableName":"Inputs","tagName":"Start","canonicalPath":"PLC_1/Tag tables/Inputs/Start","dataType":"Bool","logicalAddress":"%I0.0","externalAccessible":false,"externalVisible":false,"externalWritable":false},
+          "effectiveName":"Start_1",
+          "effectiveLogicalAddress":"%I0.1",
+          "nameCollisions":[{"kind":"tag-name","candidateName":"Start_1","canonicalPath":"PLC_1/Tag tables/Inputs/Start_1","logicalAddress":"%I0.1","isTarget":false}],
+          "addressCollisions":[{"kind":"logical-address","candidateName":"Other","canonicalPath":"PLC_1/Tag tables/Inputs/Other","logicalAddress":"%I0.1","isTarget":false}]
+        }
+        """;
+
+        var result = TagOperationSafetySnapshotContract.Decode("update_tag", payload);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Contains("\"externalAccessible\":false", result.CanonicalState, StringComparison.Ordinal);
+        Assert.Contains("\"externalVisible\":false", result.CanonicalState, StringComparison.Ordinal);
+        Assert.Contains("\"externalWritable\":false", result.CanonicalState, StringComparison.Ordinal);
+        Assert.Contains("\"effectiveName\":\"Start_1\"", result.CanonicalState, StringComparison.Ordinal);
+        Assert.Contains("\"effectiveLogicalAddress\":\"%I0.1\"", result.CanonicalState, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeleteTagTableSnapshot_RequiresFullExport()
+    {
+        var payload = """
+        {
+          "targetTable":{"plcName":"PLC_1","folderPath":"","tableName":"Inputs","canonicalPath":"PLC_1/Tag tables/Inputs"},
+          "exportedSimaticMl":"<Document />",
+          "exportSha256":"abc123",
+          "characterCount":12
+        }
+        """;
+
+        var result = TagOperationSafetySnapshotContract.Decode("delete_tag_table", payload);
+
+        Assert.True(result.Success, result.Error);
+        using var canonical = JsonDocument.Parse(result.CanonicalState);
+        Assert.Equal("<Document />", canonical.RootElement.GetProperty("exportedSimaticMl").GetString());
+    }
+
+    [Fact]
+    public void MalformedPayload_FailsClosedAsProtocolError()
+    {
+        var result = TagOperationSafetySnapshotContract.Decode("create_tag", "{\"targetTable\":42}");
+
+        Assert.False(result.Success);
+        Assert.Equal(WorkerFailureCategories.ProtocolError, result.FailureCategory);
+    }
+}

--- a/TiaMcpServer.Tests/Batch/TagOperationSafetyWorkerSourceContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationSafetyWorkerSourceContractTests.cs
@@ -1,0 +1,37 @@
+using Xunit;
+
+namespace TiaMcpServer.Tests.Batch;
+
+public sealed class TagOperationSafetyWorkerSourceContractTests
+{
+    [Fact]
+    public void Program_DispatchesEveryInternalTagSafetyRead()
+    {
+        var text = File.ReadAllText(Source("TiaMcpServer.OpennessWorker/Program.cs"));
+        Assert.Contains("\"read_create_tag_table_safety_snapshot\" => ReadCreateTagTableSafetySnapshot(request)", text, StringComparison.Ordinal);
+        Assert.Contains("\"read_delete_tag_table_safety_snapshot\" => ReadDeleteTagTableSafetySnapshot(request)", text, StringComparison.Ordinal);
+        Assert.Contains("\"read_create_tag_safety_snapshot\" => ReadCreateTagSafetySnapshot(request)", text, StringComparison.Ordinal);
+        Assert.Contains("\"read_update_tag_safety_snapshot\" => ReadUpdateTagSafetySnapshot(request)", text, StringComparison.Ordinal);
+        Assert.Contains("\"read_delete_tag_safety_snapshot\" => ReadDeleteTagSafetySnapshot(request)", text, StringComparison.Ordinal);
+        Assert.Contains("\"read_create_user_constant_safety_snapshot\" => ReadCreateUserConstantSafetySnapshot(request)", text, StringComparison.Ordinal);
+        Assert.Contains("\"read_update_user_constant_safety_snapshot\" => ReadUpdateUserConstantSafetySnapshot(request)", text, StringComparison.Ordinal);
+        Assert.Contains("\"read_delete_user_constant_safety_snapshot\" => ReadDeleteUserConstantSafetySnapshot(request)", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OperationPolicyCatalog_RegistersTagSafetyReadersAsSafetyReads()
+    {
+        var text = File.ReadAllText(Source("TiaMcpServer.Contracts/OperationPolicyCatalog.cs"));
+        Assert.Contains("[\"read_create_tag_table_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+        Assert.Contains("[\"read_delete_tag_table_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+        Assert.Contains("[\"read_create_tag_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+        Assert.Contains("[\"read_update_tag_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+        Assert.Contains("[\"read_delete_tag_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+        Assert.Contains("[\"read_create_user_constant_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+        Assert.Contains("[\"read_update_user_constant_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+        Assert.Contains("[\"read_delete_user_constant_safety_snapshot\"] = OperationCapability.SafetyRead", text, StringComparison.Ordinal);
+    }
+
+    private static string Source(string relative)
+        => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", relative));
+}

--- a/TiaMcpServer.Tests/Batch/TagOperationSafetyWorkerSourceContractTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagOperationSafetyWorkerSourceContractTests.cs
@@ -5,6 +5,17 @@ namespace TiaMcpServer.Tests.Batch;
 public sealed class TagOperationSafetyWorkerSourceContractTests
 {
     [Fact]
+    public void SafetyReader_UsesCompleteStrictDiscoveryAndTheTestedUniqueSelection()
+    {
+        var text = File.ReadAllText(Source("TiaMcpServer.OpennessWorker/Openness/TagOperationSafetySnapshotReader.cs"));
+        Assert.Contains("TagOperationSafetySnapshotBuilder.ResolveUniquePlc(", text, StringComparison.Ordinal);
+        Assert.Contains("ProjectDeviceEnumerator.Enumerate(project)", text, StringComparison.Ordinal);
+        Assert.Contains("item.GetService<SoftwareContainer>()", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("PlcSoftwareLocator.Find", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("catch (EngineeringException", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Program_DispatchesEveryInternalTagSafetyRead()
     {
         var text = File.ReadAllText(Source("TiaMcpServer.OpennessWorker/Program.cs"));

--- a/TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs
+++ b/TiaMcpServer.Tests/Batch/TagUpdateCurrentStateFakeWorkerTests.cs
@@ -125,20 +125,19 @@ public class TagUpdateCurrentStateFakeWorkerTests
         };
         foreach (var member in new[]
         {
-            "plcName",
-            "folderPath",
-            "tableName",
-            "tagName",
-            "dataType",
-            "logicalAddress",
-            "externalAccessible",
-            "externalVisible",
-            "externalWritable",
+            "targetTable", "targetTag", "effectiveName", "nameCollisions", "addressCollisions",
+            "targetTable.plcName", "targetTable.folderPath", "targetTable.tableName", "targetTable.canonicalPath",
+            "targetTag.plcName", "targetTag.folderPath", "targetTag.tableName", "targetTag.tagName",
+            "targetTag.canonicalPath", "targetTag.dataType",
         })
         {
             cases.Add($"missing-{member}");
+            cases.Add($"null-{member}");
             cases.Add($"wrong-{member}");
         }
+        foreach (var member in new[] { "logicalAddress", "externalAccessible", "externalVisible", "externalWritable" })
+            cases.Add($"wrong-targetTag.{member}");
+        cases.Add("wrong-effectiveLogicalAddress");
         return cases;
     }
 
@@ -165,6 +164,7 @@ public class TagUpdateCurrentStateFakeWorkerTests
             WorkerFailureCategories.ProtocolError,
             previewDocument.RootElement.GetProperty("failureCategory").GetString());
         Assert.False(previewDocument.RootElement.TryGetProperty("safetyToken", out _));
+        Assert.DoesNotContain("PRIVATE_SNAPSHOT_SENTINEL", preview, StringComparison.Ordinal);
         Assert.True(observedState.Success, observedState.Error);
         using var stateDocument = JsonDocument.Parse(observedState.Payload);
         Assert.Equal(0, stateDocument.RootElement.GetProperty("invalidSnapshotBroadReadCount").GetInt32());
@@ -190,9 +190,9 @@ public class TagUpdateCurrentStateFakeWorkerTests
     }
 
     [Fact]
-    public async Task ApplyWriteBatch_UpdateTagBroadOnlyDriftFailsWithStateChangedBeforeMutation()
+    public async Task ApplyWriteBatch_UpdateTagTargetDataTypeDriftFailsWithStateChangedBeforeMutation()
     {
-        const string scenario = "tag-update-broad-drift";
+        const string scenario = "tag-update-target-drift";
         using var audit = new TempAuditDirectory();
         var binding = new ProjectSessionBinding(null);
         var safety = CreateSafety(audit, binding);
@@ -219,7 +219,7 @@ public class TagUpdateCurrentStateFakeWorkerTests
             applyDocument.RootElement.GetProperty("failureCategory").GetString());
         Assert.True(observedState.Success, observedState.Error);
         using var stateDocument = JsonDocument.Parse(observedState.Payload);
-        Assert.Equal(0, stateDocument.RootElement.GetProperty("broadDriftMutationCount").GetInt32());
+        Assert.Equal(0, stateDocument.RootElement.GetProperty("targetDriftMutationCount").GetInt32());
     }
 
     [Fact]
@@ -259,9 +259,9 @@ public class TagUpdateCurrentStateFakeWorkerTests
     }
 
     [Fact]
-    public async Task PreviewWriteBatch_UpdateTagMalformedBroadPayloadFailsClosedWithProtocolError()
+    public async Task PreviewWriteBatch_UpdateTagMalformedExactPayloadFailsClosedWithProtocolError()
     {
-        const string scenario = "tag-update-broad-malformed-payload";
+        const string scenario = "tag-update-exact-malformed-payload";
         using var audit = new TempAuditDirectory();
         var binding = new ProjectSessionBinding(null);
         var safety = CreateSafety(audit, binding);

--- a/TiaMcpServer.Tests/Batch/WriteBatchPreviewDiffIntegrationTests.cs
+++ b/TiaMcpServer.Tests/Batch/WriteBatchPreviewDiffIntegrationTests.cs
@@ -111,14 +111,14 @@ public sealed class WriteBatchPreviewDiffIntegrationTests
     public async Task PreviewWriteBatch_MixedEligibleAndIneligibleWrites_PreservesEligibleRequestOrder()
     {
         using var audit = new TempAuditDirectory();
-        var (client, safety, _) = await BoundAsync(audit, "echo");
+        var (client, safety, _) = await BoundAsync(audit, "batch-preview-tag-safety");
         using (client)
         {
             var result = await WriteBatchTools.PreviewWriteBatch(client, safety, new[]
             {
-                new BatchOperationRequest { OperationId = "block-1", Operation = "update_block_logic", ProjectPath = "echo", BlockPath = "PLC_1/Blocks/Main", YamlContent = "--- FILE: Main.xml\r\n<Document />\r\n" },
-                new BatchOperationRequest { OperationId = "tag-1", Operation = "create_tag_table", ProjectPath = "echo", TableName = "Inputs" },
-                new BatchOperationRequest { OperationId = "type-3", Operation = "update_type_content", ProjectPath = "echo", TypePath = "PLC_1/Types/AnalogInputSettings", SourceContent = "TYPE AnalogInputSettings STRUCT Value : Int; END_STRUCT END_TYPE" }
+                new BatchOperationRequest { OperationId = "block-1", Operation = "update_block_logic", ProjectPath = "batch-preview-tag-safety", BlockPath = "PLC_1/Blocks/Main", YamlContent = "--- FILE: Main.xml\r\n<Document />\r\n" },
+                new BatchOperationRequest { OperationId = "tag-1", Operation = "create_tag_table", ProjectPath = "batch-preview-tag-safety", TableName = "Inputs" },
+                new BatchOperationRequest { OperationId = "type-3", Operation = "update_type_content", ProjectPath = "batch-preview-tag-safety", TypePath = "PLC_1/Types/AnalogInputSettings", SourceContent = "TYPE AnalogInputSettings STRUCT Value : Int; END_STRUCT END_TYPE" }
             });
             using var doc = JsonDocument.Parse(result);
             var operations = doc.RootElement.GetProperty("diff").GetProperty("operations");
@@ -236,12 +236,12 @@ public sealed class WriteBatchPreviewDiffIntegrationTests
     public async Task PreviewWriteBatch_AllIneligibleWrites_ReturnsNullDiff()
     {
         using var audit = new TempAuditDirectory();
-        var (client, safety, _) = await BoundAsync(audit, "echo");
+        var (client, safety, _) = await BoundAsync(audit, "batch-preview-tag-safety");
         using (client)
         {
             var result = await WriteBatchTools.PreviewWriteBatch(client, safety, new[]
             {
-                new BatchOperationRequest { OperationId = "tag-1", Operation = "create_tag_table", ProjectPath = "echo", TableName = "Inputs" }
+                new BatchOperationRequest { OperationId = "tag-1", Operation = "create_tag_table", ProjectPath = "batch-preview-tag-safety", TableName = "Inputs" }
             });
             using var doc = JsonDocument.Parse(result);
             Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("diff").ValueKind);

--- a/TiaMcpServer.Tests/Safety/TagOperationSafetyReadPolicyTests.cs
+++ b/TiaMcpServer.Tests/Safety/TagOperationSafetyReadPolicyTests.cs
@@ -1,0 +1,23 @@
+using TiaMcpServer.Contracts;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Safety;
+
+public sealed class TagOperationSafetyReadPolicyTests
+{
+    [Theory]
+    [InlineData("read_create_tag_table_safety_snapshot")]
+    [InlineData("read_delete_tag_table_safety_snapshot")]
+    [InlineData("read_create_tag_safety_snapshot")]
+    [InlineData("read_update_tag_safety_snapshot")]
+    [InlineData("read_delete_tag_safety_snapshot")]
+    [InlineData("read_create_user_constant_safety_snapshot")]
+    [InlineData("read_update_user_constant_safety_snapshot")]
+    [InlineData("read_delete_user_constant_safety_snapshot")]
+    public void EveryTagSafetyReader_UsesTheSafetyReadIdentityBoundPolicy(string operation)
+    {
+        Assert.Equal(OperationCapability.SafetyRead, OperationPolicyCatalog.GetCapability(operation));
+        Assert.True(OperationPolicyCatalog.RequiresExpectedSessionIdentity(operation));
+        Assert.True(OperationPolicyCatalog.IsAllowed(McpAccessMode.ReadOnly, operation));
+    }
+}

--- a/TiaMcpServer.Tests/TestUtilities/TagSafetySiemensDoubles.cs
+++ b/TiaMcpServer.Tests/TestUtilities/TagSafetySiemensDoubles.cs
@@ -1,0 +1,129 @@
+// Offline boundary doubles for the source-linked safety reader. These model only the
+// Siemens object access it consumes; no Openness assemblies or processes are loaded.
+using System.Collections;
+
+namespace Siemens.Engineering
+{
+    internal abstract class NamedObject
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    internal class Composition<T> : IEnumerable<T> where T : NamedObject
+    {
+        public List<T> Items { get; } = new();
+        public Exception? EnumerationFailure { get; set; }
+        public T? Find(string name) => this.FirstOrDefault(x =>
+            string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase));
+        public IEnumerator<T> GetEnumerator()
+        {
+            foreach (var item in Items)
+                yield return item;
+            if (EnumerationFailure is not null)
+                throw EnumerationFailure;
+        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    internal sealed class Project
+    {
+        public Composition<HW.Device> Devices { get; } = new();
+        public Composition<HW.DeviceUserGroup> DeviceGroups { get; } = new();
+    }
+
+    internal enum ExportOptions { None }
+    internal enum DocumentInfoOptions { None }
+}
+
+namespace Siemens.Engineering.HW
+{
+    internal sealed class Device : NamedObject
+    {
+        public DeviceItemComposition DeviceItems { get; } = new();
+    }
+    internal sealed class DeviceUserGroup : NamedObject
+    {
+        public Composition<Device> Devices { get; } = new();
+        public Composition<DeviceUserGroup> Groups { get; } = new();
+    }
+    internal sealed class DeviceItemComposition : Composition<DeviceItem> { }
+    internal sealed class DeviceItem : NamedObject
+    {
+        public DeviceItemComposition DeviceItems { get; } = new();
+        public Features.SoftwareContainer? Container { get; set; }
+        public Exception? ServiceFailure { get; set; }
+        public T? GetService<T>() where T : class
+        {
+            if (ServiceFailure is not null)
+                throw ServiceFailure;
+            return Container as T;
+        }
+    }
+}
+
+namespace Siemens.Engineering.HW.Features
+{
+    internal sealed class SoftwareContainer
+    {
+        public object? Software { get; set; }
+    }
+}
+
+namespace Siemens.Engineering.SW
+{
+    internal sealed class PlcSoftware : NamedObject
+    {
+        private readonly Blocks.PlcBlockSystemGroup blockGroup = new();
+        public Tags.PlcTagTableGroup TagTableGroup { get; } = new();
+        public Exception? BlockGroupFailure { get; set; }
+        public Blocks.PlcBlockSystemGroup BlockGroup => BlockGroupFailure is null ? blockGroup : throw BlockGroupFailure;
+    }
+}
+
+namespace Siemens.Engineering.SW.Tags
+{
+    internal sealed class PlcTagTableGroup : NamedObject
+    {
+        public Composition<PlcTagTable> TagTables { get; } = new();
+        public Composition<PlcTagTableGroup> Groups { get; } = new();
+    }
+    internal sealed class PlcTagTable : NamedObject
+    {
+        public Composition<PlcTag> Tags { get; } = new();
+        public Composition<PlcUserConstant> UserConstants { get; } = new();
+        public void Export(FileInfo path, ExportOptions options, DocumentInfoOptions documentInfo)
+            => throw new NotSupportedException("Export is outside this offline collision fixture.");
+    }
+    internal sealed class PlcTag : NamedObject
+    {
+        public string DataTypeName { get; set; } = "Bool";
+        public string LogicalAddress { get; set; } = "%I0.0";
+        public bool ExternalAccessible { get; set; }
+        public bool ExternalVisible { get; set; }
+        public bool ExternalWritable { get; set; }
+    }
+    internal sealed class PlcUserConstant : NamedObject
+    {
+        public string DataTypeName { get; set; } = "Int";
+        public object Value { get; set; } = "25";
+    }
+}
+
+namespace Siemens.Engineering.SW.Blocks
+{
+    internal sealed class PlcBlock : NamedObject { }
+    internal class PlcBlockGroup : NamedObject
+    {
+        public Composition<PlcBlock> Blocks { get; } = new();
+        public Composition<PlcBlockGroup> Groups { get; } = new();
+    }
+    internal sealed class PlcBlockSystemGroup : PlcBlockGroup
+    {
+        public Composition<PlcSystemBlockGroup> SystemBlockGroups { get; } = new();
+    }
+    internal sealed class PlcSystemBlockGroup : NamedObject
+    {
+        public Composition<PlcBlock> Blocks { get; } = new();
+        public Composition<PlcSystemBlockGroup> Groups { get; } = new();
+    }
+}

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -76,6 +76,10 @@
       Link="Host\Batch\BatchSafetySnapshot.cs" />
     <Compile Include="..\TiaMcpServer\Batch\BatchPreviewDiff.cs"
       Link="Host\Batch\BatchPreviewDiff.cs" />
+    <Compile Include="..\TiaMcpServer\Batch\TagOperationSafetySnapshotContract.cs"
+      Link="Host\Batch\TagOperationSafetySnapshotContract.cs" />
+    <Compile Include="..\TiaMcpServer\Batch\TagOperationSafetySelector.cs"
+      Link="Host\Batch\TagOperationSafetySelector.cs" />
     <Compile Include="..\TiaMcpServer\OperationBatches\IOperationBatchItem.cs" Link="Host\OperationBatches\IOperationBatchItem.cs" />
     <Compile Include="..\TiaMcpServer\OperationBatches\OperationBatchResult.cs" Link="Host\OperationBatches\OperationBatchResult.cs" />
     <Compile Include="..\TiaMcpServer\OperationBatches\OperationBatchExecutionEngine.cs" Link="Host\OperationBatches\OperationBatchExecutionEngine.cs" />

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="Batch\TagOperationPrerequisiteBaselineTests.cs" />
     <ProjectReference Include="..\TiaMcpServer.Contracts\TiaMcpServer.Contracts.csproj" />
     <ProjectReference Include="..\TiaMcpServer.FakeWorker\TiaMcpServer.FakeWorker.csproj"
       ReferenceOutputAssembly="false" />

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -26,6 +26,8 @@
 
   <ItemGroup>
     <Compile Update="Batch\TagOperationPrerequisiteBaselineTests.cs" />
+    <Compile Include="..\TiaMcpServer.OpennessWorker\Openness\TagOperationSafetySnapshotBuilder.cs"
+      Link="Linked\Openness\TagOperationSafetySnapshotBuilder.cs" />
     <ProjectReference Include="..\TiaMcpServer.Contracts\TiaMcpServer.Contracts.csproj" />
     <ProjectReference Include="..\TiaMcpServer.FakeWorker\TiaMcpServer.FakeWorker.csproj"
       ReferenceOutputAssembly="false" />

--- a/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -28,6 +28,10 @@
     <Compile Update="Batch\TagOperationPrerequisiteBaselineTests.cs" />
     <Compile Include="..\TiaMcpServer.OpennessWorker\Openness\TagOperationSafetySnapshotBuilder.cs"
       Link="Linked\Openness\TagOperationSafetySnapshotBuilder.cs" />
+    <Compile Include="..\TiaMcpServer.OpennessWorker\Openness\TagOperationSafetySnapshotReader.cs"
+      Link="Linked\Openness\TagOperationSafetySnapshotReader.cs" />
+    <Compile Include="..\TiaMcpServer.OpennessWorker\Openness\ProjectDeviceEnumerator.cs"
+      Link="Linked\Openness\ProjectDeviceEnumerator.cs" />
     <ProjectReference Include="..\TiaMcpServer.Contracts\TiaMcpServer.Contracts.csproj" />
     <ProjectReference Include="..\TiaMcpServer.FakeWorker\TiaMcpServer.FakeWorker.csproj"
       ReferenceOutputAssembly="false" />

--- a/TiaMcpServer.Tests/Worker/HardwarePageWorkerClientTests.cs
+++ b/TiaMcpServer.Tests/Worker/HardwarePageWorkerClientTests.cs
@@ -334,6 +334,10 @@ public sealed class HardwarePageWorkerClientTests
 
     private sealed class ScriptedIdentityWorker : IDisposable
     {
+        // Starting Windows PowerShell under CI coverage instrumentation can exceed the ordinary
+        // five-second worker budget. These tests exercise identity envelopes, not timeout policy.
+        private static readonly TimeSpan ScriptedWorkerTimeout = TimeSpan.FromSeconds(15);
+
         private readonly string _tempDirectory;
 
         private ScriptedIdentityWorker(string tempDirectory, OpennessWorkerClient client)
@@ -356,7 +360,7 @@ public sealed class HardwarePageWorkerClientTests
             var scriptPath = Path.Combine(tempDirectory, "worker.ps1");
             await File.WriteAllTextAsync(scriptPath, WorkerScript, new UTF8Encoding(false));
 
-            var client = new OpennessWorkerClient(binding, requestTimeout: TimeSpan.FromSeconds(5));
+            var client = new OpennessWorkerClient(binding, requestTimeout: ScriptedWorkerTimeout);
             InjectTransport(client, CreateTransport(scriptPath, mode, projectPath));
             return new ScriptedIdentityWorker(tempDirectory, client);
         }
@@ -395,7 +399,7 @@ public sealed class HardwarePageWorkerClientTests
                 QuoteArgument(projectPath));
             return new PersistentWorkerTransport(
                 powershellPath,
-                requestTimeout: TimeSpan.FromSeconds(5),
+                requestTimeout: ScriptedWorkerTimeout,
                 workerArgs: args);
         }
 

--- a/TiaMcpServer.Tests/Worker/TagOperationSafetyClientIdentityTests.cs
+++ b/TiaMcpServer.Tests/Worker/TagOperationSafetyClientIdentityTests.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Safety;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Worker;
+
+public sealed class TagOperationSafetyClientIdentityTests
+{
+    [Theory]
+    [InlineData("create_tag_table")]
+    [InlineData("delete_tag_table")]
+    [InlineData("create_tag")]
+    [InlineData("update_tag")]
+    [InlineData("delete_tag")]
+    [InlineData("create_user_constant")]
+    [InlineData("update_user_constant")]
+    [InlineData("delete_user_constant")]
+    public async Task EveryTagSafetyClientMethod_SendsExpectedSessionIdentityInTheWorkerRequest(string selectorKind)
+    {
+        var binding = new ProjectSessionBinding(null);
+        using var client = new OpennessWorkerClient(binding, logger: null,
+            workerExecutablePath: FakeWorkerLocator.Locate(),
+            accessPolicy: new OperationAccessPolicy(McpAccessMode.ReadWrite));
+        await FakeWorkerBinding.BindVerifiedAsync(client, binding, "echo");
+        var before = client.BindingSnapshot.ToWorkerIdentity()!;
+        var result = selectorKind switch
+        {
+            "create_tag_table" => await client.ReadCreateTagTableSafetySnapshotAsync("PLC_1", "Inputs", null, "echo"),
+            "delete_tag_table" => await client.ReadDeleteTagTableSafetySnapshotAsync("PLC_1", "Inputs", null, "echo"),
+            "create_tag" => await client.ReadCreateTagSafetySnapshotAsync("PLC_1", "Inputs", null, "Start", "Bool", "%I0.0", "echo"),
+            "update_tag" => await client.ReadUpdateTagSafetySnapshotAsync("PLC_1", "Inputs", null, "Start", "Start_1", "%I0.1", "echo"),
+            "delete_tag" => await client.ReadDeleteTagSafetySnapshotAsync("PLC_1", "Inputs", null, "Start", "echo"),
+            "create_user_constant" => await client.ReadCreateUserConstantSafetySnapshotAsync("PLC_1", "Inputs", null, "DebounceMs", "echo"),
+            "update_user_constant" => await client.ReadUpdateUserConstantSafetySnapshotAsync("PLC_1", "Inputs", null, "DebounceMs", "echo"),
+            "delete_user_constant" => await client.ReadDeleteUserConstantSafetySnapshotAsync("PLC_1", "Inputs", null, "DebounceMs", "echo"),
+            _ => throw new ArgumentOutOfRangeException(nameof(selectorKind))
+        };
+        Assert.True(result.Success, result.Error);
+        using var document = JsonDocument.Parse(result.Payload);
+        var request = document.RootElement;
+        Assert.Equal("read_" + selectorKind + "_safety_snapshot", request.GetProperty("method").GetString());
+        Assert.Equal("PLC_1", request.GetProperty("plcName").GetString());
+        Assert.Equal("Inputs", request.GetProperty("tableName").GetString());
+        var expected = request.GetProperty("expectedSessionIdentity");
+        Assert.Equal(before.WorkerSessionId, expected.GetProperty("workerSessionId").GetString());
+        Assert.Equal(before.SessionGeneration, expected.GetProperty("sessionGeneration").GetInt64());
+        Assert.Equal(before.PortalProcessId, expected.GetProperty("portalProcessId").GetInt32());
+        Assert.Equal(before.ProjectPath, expected.GetProperty("projectPath").GetString());
+        if (selectorKind == "create_tag")
+        {
+            Assert.Equal("Start", request.GetProperty("name").GetString());
+            Assert.Equal("Bool", request.GetProperty("dataType").GetString());
+            Assert.Equal("%I0.0", request.GetProperty("logicalAddress").GetString());
+        }
+        if (selectorKind == "update_tag")
+        {
+            Assert.Equal("Start", request.GetProperty("name").GetString());
+            Assert.Equal("Start_1", request.GetProperty("newName").GetString());
+            Assert.Equal("%I0.1", request.GetProperty("logicalAddress").GetString());
+        }
+        if (selectorKind.Contains("user_constant", StringComparison.Ordinal))
+            Assert.Equal("DebounceMs", request.GetProperty("name").GetString());
+    }
+}

--- a/TiaMcpServer.Tests/Worker/TagOperationSafetyIdentityEnforcementTests.cs
+++ b/TiaMcpServer.Tests/Worker/TagOperationSafetyIdentityEnforcementTests.cs
@@ -1,0 +1,27 @@
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Worker;
+using Xunit;
+
+namespace TiaMcpServer.Tests.Worker;
+
+public sealed class TagOperationSafetyIdentityEnforcementTests
+{
+    [Theory]
+    [InlineData("read_create_tag_table_safety_snapshot")]
+    [InlineData("read_delete_tag_table_safety_snapshot")]
+    [InlineData("read_create_tag_safety_snapshot")]
+    [InlineData("read_update_tag_safety_snapshot")]
+    [InlineData("read_delete_tag_safety_snapshot")]
+    [InlineData("read_create_user_constant_safety_snapshot")]
+    [InlineData("read_update_user_constant_safety_snapshot")]
+    [InlineData("read_delete_user_constant_safety_snapshot")]
+    public async Task EveryTagSafetyReader_RejectsMissingExpectedSessionIdentity(string method)
+    {
+        using var transport = new PersistentWorkerTransport(FakeWorkerLocator.Locate(), TimeSpan.FromSeconds(5));
+        var observed = await transport.SendAsync(new WorkerRequest { Method = "read_hardware_config", ProjectPath = "echo" });
+        Assert.True(observed.Success, observed.Error);
+        var response = await transport.SendAsync(new WorkerRequest { Method = method, ProjectPath = "echo" });
+        Assert.False(response.Success);
+        Assert.Equal(WorkerFailureCategories.BindingConflict, response.FailureCategory);
+    }
+}

--- a/TiaMcpServer/Batch/BatchWorkerInvoker.cs
+++ b/TiaMcpServer/Batch/BatchWorkerInvoker.cs
@@ -69,10 +69,11 @@ public static class BatchWorkerInvoker
         if (!result.Success) return result;
 
         var decoded = TagOperationSafetySnapshotContract.Decode(operation, result.Payload);
+        // Decoder diagnostics can contain rejected payload values; keep them out of public errors.
         return decoded.Success
             ? result with { Payload = decoded.CanonicalState }
             : WorkerCallResult.Fail(WorkerFailureCategories.ProtocolError,
-                $"Could not decode the {operation} safety snapshot. {decoded.Error}", result.Warnings);
+                $"Could not decode the {operation} safety snapshot.", result.Warnings);
     }
 
     // Validation depends on each write's requested flags, which deliberately are not part of

--- a/TiaMcpServer/Batch/BatchWorkerInvoker.cs
+++ b/TiaMcpServer/Batch/BatchWorkerInvoker.cs
@@ -1,5 +1,5 @@
-using System.Text.Json;
 using TiaMcpServer.Contracts;
+using TiaMcpServer.Json;
 using TiaMcpServer.Worker;
 
 namespace TiaMcpServer.Batch;
@@ -32,11 +32,22 @@ public static class BatchWorkerInvoker
         "update_type_content" => WithValidatedFormat(
             () => NormalizeFormat(op),
             format => client.GetTypeContentAsync(op.TypePath!, format, op.ProjectPath)),
-        "update_tag" => ReadUpdateTagCurrentStateAsync(client, op),
-        "create_tag_table" or "delete_tag_table"
-            or "create_tag" or "delete_tag"
-            or "create_user_constant" or "update_user_constant" or "delete_user_constant"
-            => client.ListTagTablesAsync(op.PlcName, op.ProjectPath),
+        "create_tag_table" => ReadTagCurrentStateAsync(op.Operation, client.ReadCreateTagTableSafetySnapshotAsync(
+            op.PlcName, op.TableName!, op.FolderPath, op.ProjectPath)),
+        "delete_tag_table" => ReadTagCurrentStateAsync(op.Operation, client.ReadDeleteTagTableSafetySnapshotAsync(
+            op.PlcName, op.TableName!, op.FolderPath, op.ProjectPath)),
+        "create_tag" => ReadTagCurrentStateAsync(op.Operation, client.ReadCreateTagSafetySnapshotAsync(
+            op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.DataType!, op.LogicalAddress, op.ProjectPath)),
+        "update_tag" => ReadTagCurrentStateAsync(op.Operation, client.ReadUpdateTagSafetySnapshotAsync(
+            op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.NewName, op.LogicalAddress, op.ProjectPath)),
+        "delete_tag" => ReadTagCurrentStateAsync(op.Operation, client.ReadDeleteTagSafetySnapshotAsync(
+            op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.ProjectPath)),
+        "create_user_constant" => ReadTagCurrentStateAsync(op.Operation, client.ReadCreateUserConstantSafetySnapshotAsync(
+            op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.ProjectPath)),
+        "update_user_constant" => ReadTagCurrentStateAsync(op.Operation, client.ReadUpdateUserConstantSafetySnapshotAsync(
+            op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.ProjectPath)),
+        "delete_user_constant" => ReadTagCurrentStateAsync(op.Operation, client.ReadDeleteUserConstantSafetySnapshotAsync(
+            op.PlcName, op.TableName!, op.FolderPath, op.Name!, op.ProjectPath)),
         "create_block" or "create_block_group" or "delete_block_group"
             => client.BrowseProjectTreeAsync(op.ProjectPath),
         // delete_block declares no 'format' field (see BatchOperationCatalog), so there is no
@@ -50,137 +61,33 @@ public static class BatchWorkerInvoker
             $"Unsupported batch write operation '{op.Operation}'.")),
     };
 
-    private static async Task<WorkerCallResult> ReadUpdateTagCurrentStateAsync(
-        OpennessWorkerClient client,
-        BatchOperationRequest op)
+    private static async Task<WorkerCallResult> ReadTagCurrentStateAsync(
+        string operation,
+        Task<WorkerCallResult> read)
     {
-        var strict = await client.ReadUpdateTagSafetySnapshotAsync(
-            op.PlcName,
-            op.TableName!,
-            op.FolderPath,
-            op.Name!,
-            op.ProjectPath).ConfigureAwait(false);
-        if (!strict.Success)
-        {
-            return strict;
-        }
+        var result = await read.ConfigureAwait(false);
+        if (!result.Success) return result;
 
-        if (!TryDecodeUpdateTagSafetySnapshot(strict.Payload, out var snapshot, out var decodeError))
-        {
-            return WorkerCallResult.Fail(WorkerFailureCategories.ProtocolError,
-                $"Could not decode the update_tag safety snapshot. {decodeError}");
-        }
-
-        var unavailableFlag = TagUpdateSafetyCurrentState.ValidateRequestedExternalFlags(op, snapshot);
-        if (unavailableFlag is not null)
-        {
-            return WorkerCallResult.Fail(WorkerFailureCategories.ValidationError,
-                $"The current tag does not expose requested flag '{unavailableFlag}'.");
-        }
-
-        var broad = await client.ListTagTablesAsync(op.PlcName, op.ProjectPath).ConfigureAwait(false);
-        if (!broad.Success)
-        {
-            return broad;
-        }
-
-        string currentState;
-        try
-        {
-            currentState = TagUpdateSafetyCurrentState.Compose(snapshot, broad.Payload);
-        }
-        catch (JsonException ex)
-        {
-            return WorkerCallResult.Fail(
-                WorkerFailureCategories.ProtocolError,
-                $"Could not decode the update_tag broad tag-table safety state. {ex.Message}",
-                broad.Warnings);
-        }
-
-        return WorkerCallResult.Ok(
-            currentState,
-            broad.Warnings) with
-        {
-            ResolvedProjectPath = broad.ResolvedProjectPath,
-            SessionIdentity = broad.SessionIdentity,
-        };
+        var decoded = TagOperationSafetySnapshotContract.Decode(operation, result.Payload);
+        return decoded.Success
+            ? result with { Payload = decoded.CanonicalState }
+            : WorkerCallResult.Fail(WorkerFailureCategories.ProtocolError,
+                $"Could not decode the {operation} safety snapshot. {decoded.Error}", result.Warnings);
     }
 
-    private static bool TryDecodeUpdateTagSafetySnapshot(
-        string payload,
-        out TagUpdateSafetySnapshot snapshot,
-        out string error)
+    // Validation depends on each write's requested flags, which deliberately are not part of
+    // the snapshot selector. Run it for every operation, including reused snapshot payloads.
+    internal static WorkerCallResult ValidateRequestedTagState(BatchOperationRequest op, WorkerCallResult state)
     {
-        snapshot = null!;
-        error = string.Empty;
-        try
-        {
-            using var document = JsonDocument.Parse(payload);
-            if (document.RootElement.ValueKind != JsonValueKind.Object)
-            {
-                error = "Expected one JSON object.";
-                return false;
-            }
-
-            var expectedKinds = new Dictionary<string, JsonValueKind>(StringComparer.Ordinal)
-            {
-                ["plcName"] = JsonValueKind.String,
-                ["folderPath"] = JsonValueKind.String,
-                ["tableName"] = JsonValueKind.String,
-                ["tagName"] = JsonValueKind.String,
-                ["dataType"] = JsonValueKind.String,
-                ["logicalAddress"] = JsonValueKind.String,
-                ["externalAccessible"] = JsonValueKind.True,
-                ["externalVisible"] = JsonValueKind.True,
-                ["externalWritable"] = JsonValueKind.True,
-            };
-            var seen = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var property in document.RootElement.EnumerateObject())
-            {
-                if (!expectedKinds.TryGetValue(property.Name, out var expectedKind))
-                {
-                    error = $"Unsupported member '{property.Name}'.";
-                    return false;
-                }
-                if (!seen.Add(property.Name))
-                {
-                    error = $"Duplicate member '{property.Name}'.";
-                    return false;
-                }
-
-                var actualKind = property.Value.ValueKind;
-                var validKind = expectedKind == JsonValueKind.String
-                    ? actualKind == JsonValueKind.String
-                    : actualKind is JsonValueKind.True or JsonValueKind.False or JsonValueKind.Null;
-                if (!validKind)
-                {
-                    error = $"Member '{property.Name}' has an unsupported JSON type.";
-                    return false;
-                }
-            }
-
-            foreach (var member in expectedKinds.Keys)
-            {
-                if (!seen.Contains(member))
-                {
-                    error = $"Required member '{member}' is missing.";
-                    return false;
-                }
-            }
-
-            snapshot = document.RootElement.Deserialize<TagUpdateSafetySnapshot>()!;
-            if (snapshot is null)
-            {
-                error = "The snapshot object decoded to null.";
-                return false;
-            }
-            return true;
-        }
-        catch (JsonException ex)
-        {
-            error = ex.Message;
-            return false;
-        }
+        if (!state.Success || op.Operation != "update_tag") return state;
+        var tag = CanonicalJson.Deserialize<UpdateTagSafetySnapshotInfo>(state.Payload).TargetTag;
+        var unavailableFlag = op.ExternalAccessible.HasValue && tag.ExternalAccessible is null ? "externalAccessible"
+            : op.ExternalVisible.HasValue && tag.ExternalVisible is null ? "externalVisible"
+            : op.ExternalWritable.HasValue && tag.ExternalWritable is null ? "externalWritable"
+            : null;
+        return unavailableFlag is null ? state
+            : WorkerCallResult.Fail(WorkerFailureCategories.ValidationError,
+                $"The current tag does not expose requested flag '{unavailableFlag}'.");
     }
 
     /// <summary>Executes a single read or write item against the worker.</summary>

--- a/TiaMcpServer/Batch/TagOperationSafetySelector.cs
+++ b/TiaMcpServer/Batch/TagOperationSafetySelector.cs
@@ -1,0 +1,54 @@
+namespace TiaMcpServer.Batch;
+
+internal sealed record TagOperationSafetySelectorKey(
+    string SelectorKind,
+    string? NormalizedProjectPath,
+    string PlcName,
+    string FolderPath,
+    string TableName,
+    string? ObjectName,
+    string? EffectiveName,
+    string? EffectiveLogicalAddress);
+
+internal static class TagOperationSafetySelector
+{
+    public static TagOperationSafetySelectorKey Build(BatchOperationRequest op)
+    {
+        if (!TryBuild(op, out var key))
+        {
+            throw new InvalidOperationException($"Unsupported tag safety operation '{op.Operation}'.");
+        }
+
+        return key;
+    }
+
+    public static bool TryBuild(BatchOperationRequest op, out TagOperationSafetySelectorKey key)
+    {
+        if (op.Operation is not ("create_tag_table" or "delete_tag_table" or "create_tag" or "update_tag" or "delete_tag" or "create_user_constant" or "update_user_constant" or "delete_user_constant"))
+        {
+            key = default!;
+            return false;
+        }
+
+        var effectiveName = op.Operation switch
+        {
+            "update_tag" => string.IsNullOrWhiteSpace(op.NewName) ? op.Name : op.NewName,
+            "update_user_constant" => op.Name,
+            _ => op.Name
+        };
+        var effectiveLogicalAddress = op.Operation is "create_tag" or "update_tag"
+            ? op.LogicalAddress
+            : null;
+
+        key = new(
+            op.Operation,
+            string.IsNullOrWhiteSpace(op.ProjectPath) ? null : op.ProjectPath,
+            op.PlcName ?? string.Empty,
+            op.FolderPath ?? string.Empty,
+            op.TableName ?? string.Empty,
+            op.Operation is "create_tag_table" or "delete_tag_table" ? null : op.Name,
+            effectiveName,
+            effectiveLogicalAddress);
+        return true;
+    }
+}

--- a/TiaMcpServer/Batch/TagOperationSafetySelector.cs
+++ b/TiaMcpServer/Batch/TagOperationSafetySelector.cs
@@ -1,3 +1,5 @@
+using TiaMcpServer.Contracts;
+
 namespace TiaMcpServer.Batch;
 
 internal sealed record TagOperationSafetySelectorKey(
@@ -42,7 +44,7 @@ internal static class TagOperationSafetySelector
 
         key = new(
             op.Operation,
-            string.IsNullOrWhiteSpace(op.ProjectPath) ? null : op.ProjectPath,
+            ProjectPathNormalization.Canonicalize(op.ProjectPath),
             op.PlcName ?? string.Empty,
             op.FolderPath ?? string.Empty,
             op.TableName ?? string.Empty,

--- a/TiaMcpServer/Batch/TagOperationSafetySnapshotContract.cs
+++ b/TiaMcpServer/Batch/TagOperationSafetySnapshotContract.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using TiaMcpServer.Contracts;
+using TiaMcpServer.Json;
+
+namespace TiaMcpServer.Batch;
+
+internal sealed record TagOperationSafetyDecodeResult(
+    bool Success,
+    string CanonicalState,
+    string? Error = null,
+    string? FailureCategory = null);
+
+internal static class TagOperationSafetySnapshotContract
+{
+    public static TagOperationSafetyDecodeResult Decode(string operation, string payload)
+    {
+        try
+        {
+            var canonical = operation switch
+            {
+                "create_tag_table" => CanonicalJson.Serialize(CanonicalJson.Deserialize<CreateTagTableSafetySnapshotInfo>(payload)),
+                "delete_tag_table" => CanonicalJson.Serialize(CanonicalJson.Deserialize<DeleteTagTableSafetySnapshotInfo>(payload)),
+                "create_tag" => CanonicalJson.Serialize(CanonicalJson.Deserialize<CreateTagSafetySnapshotInfo>(payload)),
+                "update_tag" => CanonicalJson.Serialize(CanonicalJson.Deserialize<UpdateTagSafetySnapshotInfo>(payload)),
+                "delete_tag" => CanonicalJson.Serialize(CanonicalJson.Deserialize<DeleteTagSafetySnapshotInfo>(payload)),
+                "create_user_constant" => CanonicalJson.Serialize(CanonicalJson.Deserialize<CreateUserConstantSafetySnapshotInfo>(payload)),
+                "update_user_constant" => CanonicalJson.Serialize(CanonicalJson.Deserialize<UpdateUserConstantSafetySnapshotInfo>(payload)),
+                "delete_user_constant" => CanonicalJson.Serialize(CanonicalJson.Deserialize<DeleteUserConstantSafetySnapshotInfo>(payload)),
+                _ => throw new InvalidOperationException($"Unsupported tag safety operation '{operation}'.")
+            };
+
+            return new(true, canonical);
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
+        {
+            return new(false, string.Empty, ex.Message, WorkerFailureCategories.ProtocolError);
+        }
+    }
+}

--- a/TiaMcpServer/Batch/TagOperationSafetySnapshotContract.cs
+++ b/TiaMcpServer/Batch/TagOperationSafetySnapshotContract.cs
@@ -49,7 +49,7 @@ internal static class TagOperationSafetySnapshotContract
         RequireText(snapshot.PlcName, "PLC name");
         RequireText(snapshot.FolderPath, "folder path", allowEmpty: true);
         RequireText(snapshot.RequestedTableName, "requested table name");
-        RequireCollisions(snapshot.TableNameCollisions, expectedKind: null);
+        RequireCollisions(snapshot.TableNameCollisions, "table-name");
     }
 
     private static void ValidateDeleteTagTable(DeleteTagTableSafetySnapshotInfo snapshot)
@@ -67,7 +67,7 @@ internal static class TagOperationSafetySnapshotContract
     {
         RequireTable(snapshot.TargetTable);
         RequireText(snapshot.EffectiveName, "effective tag name");
-        RequireCollisions(snapshot.NameCollisions, "tag-name");
+        RequireCollisions(snapshot.NameCollisions, "tag-name", "user-constant-name", "block-name");
         RequireCollisions(snapshot.AddressCollisions, "logical-address");
     }
 
@@ -76,7 +76,7 @@ internal static class TagOperationSafetySnapshotContract
         RequireTable(snapshot.TargetTable);
         RequireTag(snapshot.TargetTag, snapshot.TargetTable);
         RequireText(snapshot.EffectiveName, "effective tag name");
-        RequireCollisions(snapshot.NameCollisions, "tag-name");
+        RequireCollisions(snapshot.NameCollisions, "tag-name", "user-constant-name", "block-name");
         RequireCollisions(snapshot.AddressCollisions, "logical-address");
     }
 
@@ -90,7 +90,7 @@ internal static class TagOperationSafetySnapshotContract
     {
         RequireTable(snapshot.TargetTable);
         RequireText(snapshot.EffectiveName, "effective user-constant name");
-        RequireCollisions(snapshot.NameCollisions, expectedKind: null);
+        RequireCollisions(snapshot.NameCollisions, "tag-name", "user-constant-name", "block-name");
     }
 
     private static void ValidateUpdateUserConstant(UpdateUserConstantSafetySnapshotInfo snapshot)
@@ -98,7 +98,7 @@ internal static class TagOperationSafetySnapshotContract
         RequireTable(snapshot.TargetTable);
         RequireConstant(snapshot.TargetConstant, snapshot.TargetTable);
         RequireText(snapshot.EffectiveName, "effective user-constant name");
-        RequireCollisions(snapshot.NameCollisions, expectedKind: null);
+        RequireCollisions(snapshot.NameCollisions, "tag-name", "user-constant-name", "block-name");
     }
 
     private static void ValidateDeleteUserConstant(DeleteUserConstantSafetySnapshotInfo snapshot)
@@ -141,7 +141,7 @@ internal static class TagOperationSafetySnapshotContract
         RequireSameTable(constant.PlcName, constant.FolderPath, constant.TableName, table);
     }
 
-    private static void RequireCollisions(IReadOnlyList<TagCollisionProbeInfo>? collisions, string? expectedKind)
+    private static void RequireCollisions(IReadOnlyList<TagCollisionProbeInfo>? collisions, params string[] allowedKinds)
     {
         ArgumentNullException.ThrowIfNull(collisions);
         foreach (var collision in collisions)
@@ -150,7 +150,7 @@ internal static class TagOperationSafetySnapshotContract
             RequireText(collision.Kind, "collision kind");
             RequireText(collision.CandidateName, "collision candidate name");
             RequireText(collision.CanonicalPath, "collision canonical path");
-            if (expectedKind is not null && !string.Equals(collision.Kind, expectedKind, StringComparison.Ordinal))
+            if (!allowedKinds.Contains(collision.Kind, StringComparer.Ordinal))
             {
                 throw new JsonException($"Unsupported collision kind '{collision.Kind}'.");
             }

--- a/TiaMcpServer/Batch/TagOperationSafetySnapshotContract.cs
+++ b/TiaMcpServer/Batch/TagOperationSafetySnapshotContract.cs
@@ -18,22 +18,160 @@ internal static class TagOperationSafetySnapshotContract
         {
             var canonical = operation switch
             {
-                "create_tag_table" => CanonicalJson.Serialize(CanonicalJson.Deserialize<CreateTagTableSafetySnapshotInfo>(payload)),
-                "delete_tag_table" => CanonicalJson.Serialize(CanonicalJson.Deserialize<DeleteTagTableSafetySnapshotInfo>(payload)),
-                "create_tag" => CanonicalJson.Serialize(CanonicalJson.Deserialize<CreateTagSafetySnapshotInfo>(payload)),
-                "update_tag" => CanonicalJson.Serialize(CanonicalJson.Deserialize<UpdateTagSafetySnapshotInfo>(payload)),
-                "delete_tag" => CanonicalJson.Serialize(CanonicalJson.Deserialize<DeleteTagSafetySnapshotInfo>(payload)),
-                "create_user_constant" => CanonicalJson.Serialize(CanonicalJson.Deserialize<CreateUserConstantSafetySnapshotInfo>(payload)),
-                "update_user_constant" => CanonicalJson.Serialize(CanonicalJson.Deserialize<UpdateUserConstantSafetySnapshotInfo>(payload)),
-                "delete_user_constant" => CanonicalJson.Serialize(CanonicalJson.Deserialize<DeleteUserConstantSafetySnapshotInfo>(payload)),
+                "create_tag_table" => Decode<CreateTagTableSafetySnapshotInfo>(payload, ValidateCreateTagTable),
+                "delete_tag_table" => Decode<DeleteTagTableSafetySnapshotInfo>(payload, ValidateDeleteTagTable),
+                "create_tag" => Decode<CreateTagSafetySnapshotInfo>(payload, ValidateCreateTag),
+                "update_tag" => Decode<UpdateTagSafetySnapshotInfo>(payload, ValidateUpdateTag),
+                "delete_tag" => Decode<DeleteTagSafetySnapshotInfo>(payload, ValidateDeleteTag),
+                "create_user_constant" => Decode<CreateUserConstantSafetySnapshotInfo>(payload, ValidateCreateUserConstant),
+                "update_user_constant" => Decode<UpdateUserConstantSafetySnapshotInfo>(payload, ValidateUpdateUserConstant),
+                "delete_user_constant" => Decode<DeleteUserConstantSafetySnapshotInfo>(payload, ValidateDeleteUserConstant),
                 _ => throw new InvalidOperationException($"Unsupported tag safety operation '{operation}'.")
             };
 
             return new(true, canonical);
         }
-        catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
+        catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException or ArgumentException)
         {
             return new(false, string.Empty, ex.Message, WorkerFailureCategories.ProtocolError);
+        }
+    }
+
+    private static string Decode<T>(string payload, Action<T> validate)
+    {
+        var snapshot = CanonicalJson.Deserialize<T>(payload);
+        validate(snapshot);
+        return CanonicalJson.Serialize(snapshot);
+    }
+
+    private static void ValidateCreateTagTable(CreateTagTableSafetySnapshotInfo snapshot)
+    {
+        RequireText(snapshot.PlcName, "PLC name");
+        RequireText(snapshot.FolderPath, "folder path", allowEmpty: true);
+        RequireText(snapshot.RequestedTableName, "requested table name");
+        RequireCollisions(snapshot.TableNameCollisions, expectedKind: null);
+    }
+
+    private static void ValidateDeleteTagTable(DeleteTagTableSafetySnapshotInfo snapshot)
+    {
+        RequireTable(snapshot.TargetTable);
+        RequireText(snapshot.ExportedSimaticMl, "exported Simatic ML");
+        RequireText(snapshot.ExportSha256, "export SHA-256");
+        if (snapshot.CharacterCount < 0 || snapshot.CharacterCount != snapshot.ExportedSimaticMl.Length)
+        {
+            throw new JsonException("The tag-table export character count is invalid.");
+        }
+    }
+
+    private static void ValidateCreateTag(CreateTagSafetySnapshotInfo snapshot)
+    {
+        RequireTable(snapshot.TargetTable);
+        RequireText(snapshot.EffectiveName, "effective tag name");
+        RequireCollisions(snapshot.NameCollisions, "tag-name");
+        RequireCollisions(snapshot.AddressCollisions, "logical-address");
+    }
+
+    private static void ValidateUpdateTag(UpdateTagSafetySnapshotInfo snapshot)
+    {
+        RequireTable(snapshot.TargetTable);
+        RequireTag(snapshot.TargetTag, snapshot.TargetTable);
+        RequireText(snapshot.EffectiveName, "effective tag name");
+        RequireCollisions(snapshot.NameCollisions, "tag-name");
+        RequireCollisions(snapshot.AddressCollisions, "logical-address");
+    }
+
+    private static void ValidateDeleteTag(DeleteTagSafetySnapshotInfo snapshot)
+    {
+        RequireTable(snapshot.TargetTable);
+        RequireTag(snapshot.TargetTag, snapshot.TargetTable);
+    }
+
+    private static void ValidateCreateUserConstant(CreateUserConstantSafetySnapshotInfo snapshot)
+    {
+        RequireTable(snapshot.TargetTable);
+        RequireText(snapshot.EffectiveName, "effective user-constant name");
+        RequireCollisions(snapshot.NameCollisions, expectedKind: null);
+    }
+
+    private static void ValidateUpdateUserConstant(UpdateUserConstantSafetySnapshotInfo snapshot)
+    {
+        RequireTable(snapshot.TargetTable);
+        RequireConstant(snapshot.TargetConstant, snapshot.TargetTable);
+        RequireText(snapshot.EffectiveName, "effective user-constant name");
+        RequireCollisions(snapshot.NameCollisions, expectedKind: null);
+    }
+
+    private static void ValidateDeleteUserConstant(DeleteUserConstantSafetySnapshotInfo snapshot)
+    {
+        RequireTable(snapshot.TargetTable);
+        RequireConstant(snapshot.TargetConstant, snapshot.TargetTable);
+    }
+
+    private static void RequireTable(TagTableSafetyIdentityInfo? table)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        RequireText(table.PlcName, "table PLC name");
+        RequireText(table.FolderPath, "table folder path", allowEmpty: true);
+        RequireText(table.TableName, "table name");
+        RequireText(table.CanonicalPath, "table canonical path");
+    }
+
+    private static void RequireTag(TagSafetyIdentityInfo? tag, TagTableSafetyIdentityInfo table)
+    {
+        ArgumentNullException.ThrowIfNull(tag);
+        RequireText(tag.PlcName, "tag PLC name");
+        RequireText(tag.FolderPath, "tag folder path", allowEmpty: true);
+        RequireText(tag.TableName, "tag table name");
+        RequireText(tag.TagName, "tag name");
+        RequireText(tag.CanonicalPath, "tag canonical path");
+        RequireText(tag.DataType, "tag data type");
+        RequireSameTable(tag.PlcName, tag.FolderPath, tag.TableName, table);
+    }
+
+    private static void RequireConstant(UserConstantSafetyIdentityInfo? constant, TagTableSafetyIdentityInfo table)
+    {
+        ArgumentNullException.ThrowIfNull(constant);
+        RequireText(constant.PlcName, "user-constant PLC name");
+        RequireText(constant.FolderPath, "user-constant folder path", allowEmpty: true);
+        RequireText(constant.TableName, "user-constant table name");
+        RequireText(constant.ConstantName, "user-constant name");
+        RequireText(constant.CanonicalPath, "user-constant canonical path");
+        RequireText(constant.DataType, "user-constant data type");
+        RequireText(constant.Value, "user-constant value", allowEmpty: true);
+        RequireSameTable(constant.PlcName, constant.FolderPath, constant.TableName, table);
+    }
+
+    private static void RequireCollisions(IReadOnlyList<TagCollisionProbeInfo>? collisions, string? expectedKind)
+    {
+        ArgumentNullException.ThrowIfNull(collisions);
+        foreach (var collision in collisions)
+        {
+            ArgumentNullException.ThrowIfNull(collision);
+            RequireText(collision.Kind, "collision kind");
+            RequireText(collision.CandidateName, "collision candidate name");
+            RequireText(collision.CanonicalPath, "collision canonical path");
+            if (expectedKind is not null && !string.Equals(collision.Kind, expectedKind, StringComparison.Ordinal))
+            {
+                throw new JsonException($"Unsupported collision kind '{collision.Kind}'.");
+            }
+        }
+    }
+
+    private static void RequireSameTable(string plcName, string folderPath, string tableName, TagTableSafetyIdentityInfo table)
+    {
+        if (!string.Equals(plcName, table.PlcName, StringComparison.Ordinal) ||
+            !string.Equals(folderPath, table.FolderPath, StringComparison.Ordinal) ||
+            !string.Equals(tableName, table.TableName, StringComparison.Ordinal))
+        {
+            throw new JsonException("The target object does not belong to the target tag table.");
+        }
+    }
+
+    private static void RequireText(string? value, string name, bool allowEmpty = false)
+    {
+        if (value is null || (!allowEmpty && string.IsNullOrWhiteSpace(value)))
+        {
+            throw new JsonException($"The snapshot {name} is required.");
         }
     }
 }

--- a/TiaMcpServer/Batch/WriteBatchTools.cs
+++ b/TiaMcpServer/Batch/WriteBatchTools.cs
@@ -194,10 +194,26 @@ public class WriteBatchTools
         OpennessWorkerClient workerClient,
         BatchOperationRequest[] operations)
     {
+        // This cache belongs to one read phase only. Preview and apply each create a fresh map.
+        var dedup = new Dictionary<TagOperationSafetySelectorKey, Task<WorkerCallResult>>();
         var states = new List<OperationBatchCurrentState>(operations.Length);
         foreach (var op in operations)
         {
-            var state = await BatchWorkerInvoker.ReadCurrentStateAsync(workerClient, op).ConfigureAwait(false);
+            WorkerCallResult state;
+            if (TagOperationSafetySelector.TryBuild(op, out var key))
+            {
+                if (!dedup.TryGetValue(key, out var read))
+                {
+                    read = BatchWorkerInvoker.ReadCurrentStateAsync(workerClient, op);
+                    dedup.Add(key, read);
+                }
+                state = await read.ConfigureAwait(false);
+                state = BatchWorkerInvoker.ValidateRequestedTagState(op, state);
+            }
+            else
+            {
+                state = await BatchWorkerInvoker.ReadCurrentStateAsync(workerClient, op).ConfigureAwait(false);
+            }
             if (!state.Success)
             {
                 return (

--- a/TiaMcpServer/Worker/OpennessWorkerClient.cs
+++ b/TiaMcpServer/Worker/OpennessWorkerClient.cs
@@ -749,6 +749,154 @@ public class OpennessWorkerClient : IDisposable
             "{}");
     }
 
+    public Task<WorkerCallResult> ReadCreateTagTableSafetySnapshotAsync(
+        string? plcName,
+        string tableName,
+        string? folderPath,
+        string? projectPath)
+        => SendBoundProjectRequestAsync(
+            "read_create_tag_table_safety_snapshot",
+            projectPath,
+            request =>
+            {
+                request.PlcName = plcName;
+                request.TableName = tableName;
+                request.FolderPath = folderPath;
+            },
+            "{}");
+
+    public Task<WorkerCallResult> ReadDeleteTagTableSafetySnapshotAsync(
+        string? plcName,
+        string tableName,
+        string? folderPath,
+        string? projectPath)
+        => SendBoundProjectRequestAsync(
+            "read_delete_tag_table_safety_snapshot",
+            projectPath,
+            request =>
+            {
+                request.PlcName = plcName;
+                request.TableName = tableName;
+                request.FolderPath = folderPath;
+            },
+            "{}");
+
+    public Task<WorkerCallResult> ReadCreateTagSafetySnapshotAsync(
+        string? plcName,
+        string tableName,
+        string? folderPath,
+        string name,
+        string dataType,
+        string? logicalAddress,
+        string? projectPath)
+        => SendBoundProjectRequestAsync(
+            "read_create_tag_safety_snapshot",
+            projectPath,
+            request =>
+            {
+                request.PlcName = plcName;
+                request.TableName = tableName;
+                request.FolderPath = folderPath;
+                request.Name = name;
+                request.DataType = dataType;
+                request.LogicalAddress = logicalAddress;
+            },
+            "{}");
+
+    public Task<WorkerCallResult> ReadUpdateTagSafetySnapshotAsync(
+        string? plcName,
+        string tableName,
+        string? folderPath,
+        string name,
+        string? newName,
+        string? logicalAddress,
+        string? projectPath)
+        => SendBoundProjectRequestAsync(
+            "read_update_tag_safety_snapshot",
+            projectPath,
+            request =>
+            {
+                request.PlcName = plcName;
+                request.TableName = tableName;
+                request.FolderPath = folderPath;
+                request.Name = name;
+                request.NewName = newName;
+                request.LogicalAddress = logicalAddress;
+            },
+            "{}");
+
+    public Task<WorkerCallResult> ReadDeleteTagSafetySnapshotAsync(
+        string? plcName,
+        string tableName,
+        string? folderPath,
+        string name,
+        string? projectPath)
+        => SendBoundProjectRequestAsync(
+            "read_delete_tag_safety_snapshot",
+            projectPath,
+            request =>
+            {
+                request.PlcName = plcName;
+                request.TableName = tableName;
+                request.FolderPath = folderPath;
+                request.Name = name;
+            },
+            "{}");
+
+    public Task<WorkerCallResult> ReadCreateUserConstantSafetySnapshotAsync(
+        string? plcName,
+        string tableName,
+        string? folderPath,
+        string name,
+        string? projectPath)
+        => SendBoundProjectRequestAsync(
+            "read_create_user_constant_safety_snapshot",
+            projectPath,
+            request =>
+            {
+                request.PlcName = plcName;
+                request.TableName = tableName;
+                request.FolderPath = folderPath;
+                request.Name = name;
+            },
+            "{}");
+
+    public Task<WorkerCallResult> ReadUpdateUserConstantSafetySnapshotAsync(
+        string? plcName,
+        string tableName,
+        string? folderPath,
+        string name,
+        string? projectPath)
+        => SendBoundProjectRequestAsync(
+            "read_update_user_constant_safety_snapshot",
+            projectPath,
+            request =>
+            {
+                request.PlcName = plcName;
+                request.TableName = tableName;
+                request.FolderPath = folderPath;
+                request.Name = name;
+            },
+            "{}");
+
+    public Task<WorkerCallResult> ReadDeleteUserConstantSafetySnapshotAsync(
+        string? plcName,
+        string tableName,
+        string? folderPath,
+        string name,
+        string? projectPath)
+        => SendBoundProjectRequestAsync(
+            "read_delete_user_constant_safety_snapshot",
+            projectPath,
+            request =>
+            {
+                request.PlcName = plcName;
+                request.TableName = tableName;
+                request.FolderPath = folderPath;
+                request.Name = name;
+            },
+            "{}");
+
     public Task<WorkerCallResult> CompileCheckAsync(string? blockPath, string? plcName, string? projectPath)
     {
         return SendBoundProjectRequestAsync(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -578,14 +578,17 @@ failures, and unrelated-name tolerance. They pass those snapshots through the re
 and token validator without loading Openness assemblies. Offline and FakeWorker tests also cover
 typed selectors, ordered expansion, within-phase deduplication,
 fresh apply reads, same-object/collision drift rejection, unrelated sibling tolerance, authorized
-apply, and replay rejection. Mandatory live TIA Portal V21 acceptance is still pending. The
-[guarded live harness](../scripts/live-test-tag-operation-safety-scopes.ps1) defaults to
-`PreviewOnly`; neither that mode nor either mutation mode has been run for PR 5. Static contracts
-and parser checks do not substitute for live evidence.
+apply, and replay rejection. The
+[guarded live TIA Portal V21 acceptance](superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md)
+completed against the exact recorded host, PID, disposable copy, and fixtures: all eight previews
+and ordered duplicate selection passed; same-object and name/address collision drift returned
+`state_changed`; unrelated sibling drift preserved the original token; one authorized unchanged-token
+apply succeeded; no-save discard preserved the saved baseline; and the clean source project was
+restored open. Static/offline and bounded live evidence remain separate, complementary claims.
 
 PR 5 explicitly defers multilingual per-tag comment binding, public `list_tag_tables`
-completeness changes, broader snapshot narrowing, and PLC `start_plc` / `stop_plc` safety work.
-The public table list remains best-effort and unchanged.
+completeness changes, broader snapshot narrowing, Software Unit namespace-aware collisions, and
+PLC `start_plc` / `stop_plc` safety work. The public table list remains best-effort and unchanged.
 
 Internal exact-target selectors use the shared `SafetyRead` capability. A `SafetyRead` is
 side-effect-free and allowed in read-only mode, but it is not an ordinary observe: every request

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -531,19 +531,31 @@ The eight tag/table/user-constant writes bind typed, operation-specific safety s
 of the full `list_tag_tables` payload. All identities retain the resolved PLC, folder, table,
 and canonical object path. Collision probes retain matching candidate identity, kind, name,
 logical address where applicable, and whether the candidate is the target; unrelated candidate
-state is excluded. Table-name collisions are scoped to the selected parent folder. Tag-name,
-logical-address, and user-constant-name collisions search the selected PLC's tag tables and bind
-only relevant matches in deterministic order.
+state is excluded. Table-name collisions search the selected PLC's complete tag-table hierarchy,
+including sibling and nested folders, while retaining the exact destination-folder identity.
+Tag and user-constant name probes compare names case-insensitively across PLC tags, user constants,
+and blocks in the selected PLC's unqualified CPU namespace. They traverse all tag-table folders
+and the ordinary program-block hierarchy, including nested user groups and system-block groups.
+Each matching candidate retains its actual kind (`tag-name`, `user-constant-name`, or `block-name`)
+and canonical path; target marking requires both the kind and exact path. Logical-address probes
+remain tag-only. All probes bind only matching names/addresses in deterministic order, and traversal
+or discovery errors propagate even after a match has been found.
+
+These scopes follow the Siemens V21 rules for [PLC tag and tag-table names](https://docs.tia.siemens.cloud/r/en-us/v21/declaring-plc-tags/rules-for-plc-tags/valid-names-of-plc-tags)
+and [global user-constant names](https://docs.tia.siemens.cloud/r/en-us/v21/declaring-plc-tags/declaring-global-constants/rules-for-global-user-constants).
+Software Unit namespace resolution is not modeled by these operations: unit-local block names are
+not folded into the unqualified CPU namespace. Namespace-aware coverage remains a design/live
+qualification follow-up.
 
 | Operation / exact selector | Bound current state |
 | --- | --- |
-| `create_tag_table` | Resolved PLC and parent folder, requested table name, and same-folder table-name collisions |
+| `create_tag_table` | Resolved PLC and destination folder, requested table name, and matching table-name occupancy throughout that PLC's tag-table hierarchy |
 | `delete_tag_table` | Exact target-table identity and its normalized Simatic ML export, SHA-256, and character count |
-| `create_tag` | Exact target-table identity, effective name/address, and matching name/address collision probes |
-| `update_tag` | Exact target-table and tag identity/state, effective name/address, and matching name/address collision probes |
+| `create_tag` | Exact target-table identity, effective name/address, matching tag/constant/block names, and tag-only address probes |
+| `update_tag` | Exact target-table and tag identity/state, effective name/address, matching tag/constant/block names, and tag-only address probes |
 | `delete_tag` | Exact target-table and tag identity/state |
-| `create_user_constant` | Exact target-table identity, effective constant name, and matching constant-name collision probes |
-| `update_user_constant` | Exact target-table and constant identity/state, effective constant name, and matching constant-name collision probes |
+| `create_user_constant` | Exact target-table identity, effective constant name, and matching tag/constant/block names |
+| `update_user_constant` | Exact target-table and constant identity/state, effective constant name, and matching tag/constant/block names |
 | `delete_user_constant` | Exact target-table and constant identity/state |
 
 Tag state includes data type, logical address, and the three external access flags. Constant state
@@ -560,7 +572,11 @@ operation order before composing the combined state. Operation IDs and list orde
 The map is local to that one phase: **there is no cross-phase cache**. Apply always reads fresh
 state under the pinned binding lease. Deduplication does not make the sequential reads atomic.
 
-Offline and FakeWorker tests cover typed selectors, ordered expansion, within-phase deduplication,
+Offline tests execute the safety reader against test-only Siemens object graphs, including
+cross-kind name drift, nested user/system blocks, CPU-wide table-name occupancy, strict traversal
+failures, and unrelated-name tolerance. They pass those snapshots through the real typed decoder
+and token validator without loading Openness assemblies. Offline and FakeWorker tests also cover
+typed selectors, ordered expansion, within-phase deduplication,
 fresh apply reads, same-object/collision drift rejection, unrelated sibling tolerance, authorized
 apply, and replay rejection. Mandatory live TIA Portal V21 acceptance is still pending. The
 [guarded live harness](../scripts/live-test-tag-operation-safety-scopes.ps1) defaults to

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -527,12 +527,49 @@ reuse causes rejection. Completed writes are appended to the audit log under
 Read-only mode is categorically stronger than this token flow: confirmation and
 a valid token cannot override the access policy.
 
-For `update_tag`, the preview state currently composes two complementary reads: one strict,
-exact-target `TagUpdateSafetySnapshot` and the legacy broad tag-table payload retained until PR 5
-narrows the remaining tag-operation scopes. The strict snapshot records the resolved PLC name
-(rather than a caller-supplied selector), folder, table, tag, and every property the mutator can
-change. In particular, a requested external flag whose current value is unreadable causes preview
-to fail before token issuance. The public `list_tag_tables` read remains best-effort and unchanged.
+The eight tag/table/user-constant writes bind typed, operation-specific safety snapshots instead
+of the full `list_tag_tables` payload. All identities retain the resolved PLC, folder, table,
+and canonical object path. Collision probes retain matching candidate identity, kind, name,
+logical address where applicable, and whether the candidate is the target; unrelated candidate
+state is excluded. Table-name collisions are scoped to the selected parent folder. Tag-name,
+logical-address, and user-constant-name collisions search the selected PLC's tag tables and bind
+only relevant matches in deterministic order.
+
+| Operation / exact selector | Bound current state |
+| --- | --- |
+| `create_tag_table` | Resolved PLC and parent folder, requested table name, and same-folder table-name collisions |
+| `delete_tag_table` | Exact target-table identity and its normalized Simatic ML export, SHA-256, and character count |
+| `create_tag` | Exact target-table identity, effective name/address, and matching name/address collision probes |
+| `update_tag` | Exact target-table and tag identity/state, effective name/address, and matching name/address collision probes |
+| `delete_tag` | Exact target-table and tag identity/state |
+| `create_user_constant` | Exact target-table identity, effective constant name, and matching constant-name collision probes |
+| `update_user_constant` | Exact target-table and constant identity/state, effective constant name, and matching constant-name collision probes |
+| `delete_user_constant` | Exact target-table and constant identity/state |
+
+Tag state includes data type, logical address, and the three external access flags. Constant state
+includes data type and value. A requested external flag whose current value is unreadable still
+fails before token issuance; unreadable required evidence or a malformed typed worker payload
+fails closed. Table deletion binds the selected table's export, including exported content that
+the public table list does not expose; it does not bind sibling-table exports.
+
+Within one preview or apply read phase, identical tag selectors share one worker read. The key
+contains operation kind, canonical project path, PLC selector, folder, table, object name,
+effective name, and requested logical address; request fields conservatively distinguish keys.
+The shared result is validated for each requesting operation and expanded back into the original
+operation order before composing the combined state. Operation IDs and list order remain bound.
+The map is local to that one phase: **there is no cross-phase cache**. Apply always reads fresh
+state under the pinned binding lease. Deduplication does not make the sequential reads atomic.
+
+Offline and FakeWorker tests cover typed selectors, ordered expansion, within-phase deduplication,
+fresh apply reads, same-object/collision drift rejection, unrelated sibling tolerance, authorized
+apply, and replay rejection. Mandatory live TIA Portal V21 acceptance is still pending. The
+[guarded live harness](../scripts/live-test-tag-operation-safety-scopes.ps1) defaults to
+`PreviewOnly`; neither that mode nor either mutation mode has been run for PR 5. Static contracts
+and parser checks do not substitute for live evidence.
+
+PR 5 explicitly defers multilingual per-tag comment binding, public `list_tag_tables`
+completeness changes, broader snapshot narrowing, and PLC `start_plc` / `stop_plc` safety work.
+The public table list remains best-effort and unchanged.
 
 Internal exact-target selectors use the shared `SafetyRead` capability. A `SafetyRead` is
 side-effect-free and allowed in read-only mode, but it is not an ordinary observe: every request

--- a/docs/IMPROVEMENT_LOG.md
+++ b/docs/IMPROVEMENT_LOG.md
@@ -8,27 +8,6 @@ plus manual verification of the highest-stakes claims. Test suite at authoring t
 (pure-logic tests only; no integration coverage of the worker or IPC layer). As of 2026-07-20 the
 suite is 341/341 green and does cover the worker/IPC layer via the fake-worker harness.
 
-## PR 5 tag-operation safety scopes - live acceptance pending
-
-The [implementation plan](superpowers/plans/2026-09-01-pr5-tag-operation-safety-scopes.md) now
-has typed exact selectors for all eight tag/table/user-constant write operations, relevant
-collision probes, phase-local read deduplication with ordered expansion, and fresh apply reads
-without a cross-phase cache. Offline/FakeWorker checks cover drift rejection, unrelated sibling
-tolerance, successful authorized apply, and replay behavior. This is development evidence only.
-
-The [guarded live harness](../scripts/live-test-tag-operation-safety-scopes.ps1) and its static
-contracts are prepared. No PR 5 live harness mode has been executed and no live acceptance report
-exists. PR 5 remains open until separately authorized mandatory TIA Portal V21 acceptance produces
-reviewed evidence. The default is non-mutating `PreviewOnly`. Explicit mutation modes require a
-clean saved disposable copy, exact-path authorization, and the `Discard` cleanup strategy: guarded
-no-save close, with no filesystem deletion. Cleanup failure fails the run; live acceptance must
-verify the on-disk copy remains clean. This does not claim inverse restoration or plant acceptance.
-
-Deferred scope remains: multilingual per-tag comment binding; public `list_tag_tables`
-completeness changes; broader snapshot narrowing; and PLC `start_plc` / `stop_plc` safety work.
-The older PR 3 entry below records its historical scope; the public table-list contract remains
-unchanged by PR 5 as well.
-
 ## Overall verdict
 
 Solid foundation: the batch-tool consolidation (45 → 16 tools), typed batch item schema with
@@ -432,6 +411,26 @@ failures, malformed worker payloads, process-key invalidation, and byte-for-byte
 equivalence. A separately authorized read-only acceptance procedure was contract-tested but was
 not executed against live TIA Portal V21 before its removal; live pagination acceptance remains
 unverified.
+
+## PR 5 tag-operation safety scopes — mandatory live acceptance completed (2026-09-05)
+
+Typed exact selectors now cover all eight tag/table/user-constant write operations with relevant
+cross-kind/name/address collision probes, phase-local read deduplication and ordered expansion,
+fresh apply reads, and no cross-phase cache. Focused tests passed 83/83, current-state FakeWorker
+tests 24/24, harness contracts 7/7, the full offline suite 2691/2691, and both stub and real V21
+builds completed with 0 warnings/errors.
+
+The [guarded live acceptance report](superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md)
+records successful `PreviewOnly`, `DriftAndRestore`, and `ApplyAndRestore` modes against the exact
+disposable copy. Same-object and relevant name/address collision drift rejected stale tokens with
+`state_changed`; unrelated sibling drift preserved the original target token; one unchanged-token
+apply succeeded and observed `heaterStages=4`; no-save discard preserved the saved baseline; and
+the clean source project was restored open. The initial sandbox visibility failure and two
+deterministic lifecycle binding conflicts occurred before mutation and were not uncertain writes.
+
+Deferred scope remains explicit: multilingual per-tag comment binding; public `list_tag_tables`
+completeness changes; broader snapshot narrowing; Software Unit namespace-aware collisions; and
+PLC `start_plc` / `stop_plc` safety work. This bounded evidence is not plant acceptance.
 
 ## PR 3 update_tag exact safety snapshot — mandatory live acceptance completed (2026-09-05)
 

--- a/docs/IMPROVEMENT_LOG.md
+++ b/docs/IMPROVEMENT_LOG.md
@@ -8,6 +8,27 @@ plus manual verification of the highest-stakes claims. Test suite at authoring t
 (pure-logic tests only; no integration coverage of the worker or IPC layer). As of 2026-07-20 the
 suite is 341/341 green and does cover the worker/IPC layer via the fake-worker harness.
 
+## PR 5 tag-operation safety scopes - live acceptance pending
+
+The [implementation plan](superpowers/plans/2026-09-01-pr5-tag-operation-safety-scopes.md) now
+has typed exact selectors for all eight tag/table/user-constant write operations, relevant
+collision probes, phase-local read deduplication with ordered expansion, and fresh apply reads
+without a cross-phase cache. Offline/FakeWorker checks cover drift rejection, unrelated sibling
+tolerance, successful authorized apply, and replay behavior. This is development evidence only.
+
+The [guarded live harness](../scripts/live-test-tag-operation-safety-scopes.ps1) and its static
+contracts are prepared. No PR 5 live harness mode has been executed and no live acceptance report
+exists. PR 5 remains open until separately authorized mandatory TIA Portal V21 acceptance produces
+reviewed evidence. The default is non-mutating `PreviewOnly`. Explicit mutation modes require a
+clean saved disposable copy, exact-path authorization, and the `Discard` cleanup strategy: guarded
+no-save close, with no filesystem deletion. Cleanup failure fails the run; live acceptance must
+verify the on-disk copy remains clean. This does not claim inverse restoration or plant acceptance.
+
+Deferred scope remains: multilingual per-tag comment binding; public `list_tag_tables`
+completeness changes; broader snapshot narrowing; and PLC `start_plc` / `stop_plc` safety work.
+The older PR 3 entry below records its historical scope; the public table-list contract remains
+unchanged by PR 5 as well.
+
 ## Overall verdict
 
 Solid foundation: the batch-tool consolidation (45 → 16 tools), typed batch item schema with

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,3 +62,7 @@ its [PR 1 project enumeration completeness plan](superpowers/plans/2026-08-28-pr
 the [PR 2 hardware pagination plan](superpowers/plans/2026-08-29-hardware-pagination.md),
 [PR #29 binding findings repair design](superpowers/specs/2026-08-28-pr29-binding-findings-repair-design.md),
 and its [implementation plan](superpowers/plans/2026-08-28-pr29-binding-findings-repair.md).
+
+PR 5 has offline/FakeWorker evidence and a statically checked guarded harness, but no live run
+or acceptance report yet. See the [current tag-safety acceptance boundary](SupportedOperations/PLC_OPERATIONS_SUMMARY.md#tag-safety-acceptance-boundary)
+before any separately authorized live V21 work.

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ with separate plans for [PR 1 explicit MCP tool annotations](superpowers/plans/2
 [PR 4 bounded structured preview diffs](superpowers/plans/2026-09-01-pr4-structured-preview-diff.md),
 [its completed live Preview and authorized Apply/restore/compile acceptance report (2026-09-05)](superpowers/acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md),
 [PR 5 tag-operation safety scopes](superpowers/plans/2026-09-01-pr5-tag-operation-safety-scopes.md),
+[its completed mandatory live acceptance report (2026-09-05)](superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md),
 and [PR 6 project-tree safety scopes](superpowers/plans/2026-09-01-pr6-project-tree-safety-scopes.md);
 [project completeness and hardware pagination design](superpowers/specs/2026-08-28-issue-31-project-completeness-pagination-design.md),
 its [PR 1 project enumeration completeness plan](superpowers/plans/2026-08-28-project-enumeration-completeness.md),
@@ -63,6 +64,7 @@ the [PR 2 hardware pagination plan](superpowers/plans/2026-08-29-hardware-pagina
 [PR #29 binding findings repair design](superpowers/specs/2026-08-28-pr29-binding-findings-repair-design.md),
 and its [implementation plan](superpowers/plans/2026-08-28-pr29-binding-findings-repair.md).
 
-PR 5 has offline/FakeWorker evidence and a statically checked guarded harness, but no live run
-or acceptance report yet. See the [current tag-safety acceptance boundary](SupportedOperations/PLC_OPERATIONS_SUMMARY.md#tag-safety-acceptance-boundary)
-before any separately authorized live V21 work.
+PR 5's [current tag-safety acceptance boundary](SupportedOperations/PLC_OPERATIONS_SUMMARY.md#tag-safety-acceptance-boundary)
+now links its completed guarded live V21 result while keeping public table-list completeness,
+broader snapshots, Software Unit namespace collisions, multilingual comments, PLC control, and
+plant acceptance explicitly outside the accepted scope.

--- a/docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md
+++ b/docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md
@@ -68,11 +68,15 @@ The operations below run through `preview_write_batch` and `apply_write_batch`.
 
 ## Tag safety acceptance boundary
 
-PR 5 has offline/FakeWorker evidence and a statically checked
-[guarded live harness](../../scripts/live-test-tag-operation-safety-scopes.ps1). Mandatory live
-TIA Portal V21 acceptance remains pending; the harness has not been executed in any mode.
-Public previews expose hashes and ordered targets, so successful previews alone do not prove
-internal typed snapshot contents, worker read counts, or apply behavior.
+PR 5 has completed offline/FakeWorker, static harness-contract, and guarded live TIA Portal V21
+evidence. The
+[live acceptance report](../superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md)
+records the exact host, PID, disposable copy, fixtures, artifacts, and saved-baseline/source cleanup.
+All eight operation previews and the ordered duplicate-selector check passed; same-object and
+name/address collision drift returned `state_changed`; unrelated sibling drift preserved the
+original target token; and one authorized unchanged-token apply succeeded. Public previews still
+expose hashes and ordered targets rather than internal typed snapshot contents or worker read
+counts, so those internal claims remain offline/FakeWorker evidence rather than live observations.
 
 The harness requires PowerShell 7.2 or later, the built net8 host, an already-open exact
 disposable project copy, and explicit PLC/table/tag/user-constant fixture names and values.
@@ -86,12 +90,15 @@ and no save is issued. Scenario mutations remain until that final discard; no in
 writes restore constants or delete collision tags between checks. Acceptance must verify the
 on-disk copy remains clean. A failed or
 unconfirmed discard fails the run and requires manual no-save cleanup of the isolated copy.
-Each run retains redacted MCP and failure/cleanup JSON in a dedicated artifact directory; it does
-not automatically create a live acceptance report. Ordinary tests only inspect the script as text.
+Each run retains redacted MCP and failure/cleanup JSON in a dedicated artifact directory. The
+completed report confirms that both mutation modes performed guarded no-save discard, the saved
+copy returned to its exact baseline, and the original source was left open and unmodified. The
+initial sandbox visibility failure and two deterministic lifecycle binding conflicts occurred
+before mutation and were not uncertain writes. Ordinary tests only inspect the script as text.
 
 Explicitly deferred: multilingual per-tag comment binding; public `list_tag_tables` completeness
-changes; broader snapshot narrowing; and PLC `start_plc` / `stop_plc` safety work. Existing PLC
-start/stop operations are not changed or qualified by PR 5.
+changes; broader snapshot narrowing; Software Unit namespace-aware collisions; and PLC `start_plc`
+and `stop_plc` safety work. Existing PLC start/stop operations are not changed or qualified by PR 5.
 
 ## Current limits
 

--- a/docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md
+++ b/docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md
@@ -71,7 +71,9 @@ authorized feature apply. Both mutation modes require `-AllowMutation`, `-Confir
 `-AuthorizedProjectPath` equal to `-ProjectPath`, and `-CleanupStrategy Discard`, plus a pre-saved
 unmodified copy. The implemented cleanup is guarded `close_project` with `saveBeforeClose=false`;
 the mode names do not imply an implemented inverse-restore strategy. No project files are deleted
-and no save is issued. Acceptance must verify the on-disk copy remains clean. A failed or
+and no save is issued. Scenario mutations remain until that final discard; no inverse fixture
+writes restore constants or delete collision tags between checks. Acceptance must verify the
+on-disk copy remains clean. A failed or
 unconfirmed discard fails the run and requires manual no-save cleanup of the isolated copy.
 Each run retains redacted MCP and failure/cleanup JSON in a dedicated artifact directory; it does
 not automatically create a live acceptance report. Ordinary tests only inspect the script as text.

--- a/docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md
+++ b/docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md
@@ -50,6 +50,17 @@ The operations below run through `preview_write_batch` and `apply_write_batch`.
   bind the exact object's current state. See the [eight selector shapes](../ARCHITECTURE.md#8-write-safety)
   for the complete contract. Identical selectors share reads only within one phase and expand
   back into the original operation order; apply reads fresh state with no cross-phase cache.
+- Tag and user-constant create/update name probes include case-insensitive matches against PLC
+  tags, user constants, and blocks in the selected PLC's unqualified CPU namespace. Matching blocks
+  include nested user and system-block groups; each probe retains its symbol kind and exact path.
+  Logical-address probes remain tag-only. Table creation retains the exact destination folder but
+  probes matching table names across the PLC's entire tag-table hierarchy, including sibling and
+  nested folders. Unrelated names remain outside the snapshot; incomplete traversal fails closed.
+  These scopes follow Siemens V21's [tag-name rules](https://docs.tia.siemens.cloud/r/en-us/v21/declaring-plc-tags/rules-for-plc-tags/valid-names-of-plc-tags),
+  [constant-name rules](https://docs.tia.siemens.cloud/r/en-us/v21/declaring-plc-tags/declaring-global-constants/rules-for-global-user-constants),
+  and [table-creation rules](https://docs.tia.siemens.cloud/r/en-us/v21/declaring-plc-tags/creating-and-managing-plc-tag-tables/creating-plc-tag-tables).
+  Software Unit namespace-aware block collision coverage remains a design/live qualification
+  follow-up; these operations do not treat unit-local names as unqualified CPU-global names.
 - If an `update_tag` requests `externalAccessible`, `externalVisible`, or
   `externalWritable` and that selected flag cannot be read for the exact tag, preview fails before
   token issuance. This safety condition does not change the public `list_tag_tables` contract:

--- a/docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md
+++ b/docs/SupportedOperations/PLC_OPERATIONS_SUMMARY.md
@@ -43,11 +43,42 @@ The operations below run through `preview_write_batch` and `apply_write_batch`.
 - Import/update operations modify existing objects only. They do not create, rename, delete, or upsert the addressed object.
 - Deletes and PLC start/stop operations use the same confirmed write flow as other data writes.
 - A write batch is applied in order and stops on the first failure. Completed mutations are not rolled back.
-- `update_tag` preview combines its existing broad tag-table state with a strict exact-target
-  snapshot. If an update requests `externalAccessible`, `externalVisible`, or
+- Tag-related writes bind exact targets plus scoped name/address collision probes, replacing
+  the full table-list safety payload. Table deletion binds the exact table's normalized Simatic ML
+  export and digest; tag deletion binds exact tag state; constant deletion binds exact constant
+  state. Create operations bind the parent/table identity and relevant collisions. Updates also
+  bind the exact object's current state. See the [eight selector shapes](../ARCHITECTURE.md#8-write-safety)
+  for the complete contract. Identical selectors share reads only within one phase and expand
+  back into the original operation order; apply reads fresh state with no cross-phase cache.
+- If an `update_tag` requests `externalAccessible`, `externalVisible`, or
   `externalWritable` and that selected flag cannot be read for the exact tag, preview fails before
   token issuance. This safety condition does not change the public `list_tag_tables` contract:
   that read remains best-effort and may retain its existing skipped-read behavior.
+
+## Tag safety acceptance boundary
+
+PR 5 has offline/FakeWorker evidence and a statically checked
+[guarded live harness](../../scripts/live-test-tag-operation-safety-scopes.ps1). Mandatory live
+TIA Portal V21 acceptance remains pending; the harness has not been executed in any mode.
+Public previews expose hashes and ordered targets, so successful previews alone do not prove
+internal typed snapshot contents, worker read counts, or apply behavior.
+
+The harness requires PowerShell 7.2 or later, the built net8 host, an already-open exact
+disposable project copy, and explicit PLC/table/tag/user-constant fixture names and values.
+`PreviewOnly` is the non-mutating default. `DriftAndRestore` covers same-object drift, relevant
+name/address collision drift, and unrelated sibling tolerance. `ApplyAndRestore` performs one
+authorized feature apply. Both mutation modes require `-AllowMutation`, `-ConfirmDisposableCopy`, an
+`-AuthorizedProjectPath` equal to `-ProjectPath`, and `-CleanupStrategy Discard`, plus a pre-saved
+unmodified copy. The implemented cleanup is guarded `close_project` with `saveBeforeClose=false`;
+the mode names do not imply an implemented inverse-restore strategy. No project files are deleted
+and no save is issued. Acceptance must verify the on-disk copy remains clean. A failed or
+unconfirmed discard fails the run and requires manual no-save cleanup of the isolated copy.
+Each run retains redacted MCP and failure/cleanup JSON in a dedicated artifact directory; it does
+not automatically create a live acceptance report. Ordinary tests only inspect the script as text.
+
+Explicitly deferred: multilingual per-tag comment binding; public `list_tag_tables` completeness
+changes; broader snapshot narrowing; and PLC `start_plc` / `stop_plc` safety work. Existing PLC
+start/stop operations are not changed or qualified by PR 5.
 
 ## Current limits
 

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -59,16 +59,17 @@ Task-level implementation plans derived from the specs above.
 
 ## Acceptance reports
 
-PR 5 tag-operation safety scopes has a prepared harness and offline/FakeWorker evidence only.
-No harness mode has run, and no PR 5 live acceptance report exists. The existing plan link above
-is retained; add an acceptance-report entry only after the authorized live run and report review.
-See the [current acceptance boundary](../SupportedOperations/PLC_OPERATIONS_SUMMARY.md#tag-safety-acceptance-boundary).
+PR 5 tag-operation safety scopes completed its offline/FakeWorker, static harness-contract, and
+guarded live TIA Portal V21 acceptance. The report records all three successful modes, exact
+saved-baseline verification, source restoration, and the bounded deferred scope. See the
+[current acceptance boundary](../SupportedOperations/PLC_OPERATIONS_SUMMARY.md#tag-safety-acceptance-boundary).
 
 Evidence from completed live runs against TIA Portal V21, plus prepared reports whose live gate is
 explicitly pending.
 
 | Date | Document |
 | --- | --- |
+| 2026-09-05 | [PR 5 — tag-operation safety scopes — mandatory live PASS](acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md) |
 | 2026-09-05 | [PR 3 — exact `update_tag` safety snapshot — mandatory live PASS](acceptance/reports/2026-09-01-pr3-update-tag-safety-snapshot-live.md) |
 | 2026-09-05 | [PR 4 — structured preview diff — live Preview and authorized Apply/restore/compile acceptance completed](acceptance/reports/2026-09-01-pr4-structured-preview-diff-live.md) |
 | 2026-09-01 | [PR 2 — registered-tool delegation — live](acceptance/reports/2026-09-01-pr2-registered-tool-delegation-live.md) |

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -59,6 +59,11 @@ Task-level implementation plans derived from the specs above.
 
 ## Acceptance reports
 
+PR 5 tag-operation safety scopes has a prepared harness and offline/FakeWorker evidence only.
+No harness mode has run, and no PR 5 live acceptance report exists. The existing plan link above
+is retained; add an acceptance-report entry only after the authorized live run and report review.
+See the [current acceptance boundary](../SupportedOperations/PLC_OPERATIONS_SUMMARY.md#tag-safety-acceptance-boundary).
+
 Evidence from completed live runs against TIA Portal V21, plus prepared reports whose live gate is
 explicitly pending.
 

--- a/docs/superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md
+++ b/docs/superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md
@@ -125,13 +125,13 @@ not written to this report or the artifacts.
 
 - Proven: for repository revision `2d6d071`, the host SHA-256 and TIA V21/PID/project identities
   above, all eight tag/table/user-constant operations produced stable exact-selector previews;
-  same-object, cross-kind name, and logical-address collision drift invalidated stale tokens;
+  same-object, tag-name, and logical-address collision drift invalidated stale tokens;
   unrelated sibling drift did not invalidate the scoped target; one unchanged-token apply
   succeeded; mutation-mode cleanup used confirmed no-save discard; the saved disposable baseline
   was intact; and the source project was restored open and unmodified. Offline tests separately
   prove typed snapshot shapes, exact worker dispatch, guarded `SafetyRead` identity policy,
-  phase-local deduplication with ordered expansion, fresh apply reads, and deterministic
-  delete-table export behavior.
+  cross-kind tag/constant/block name-collision candidates, phase-local deduplication with ordered
+  expansion, fresh apply reads, and deterministic delete-table export behavior.
 - Not proven: this is not plant or production acceptance and does not qualify physical PLC
   behavior. Multilingual per-tag comment binding remains deferred. Public `list_tag_tables`
   completeness and best-effort behavior remain unchanged. Broader snapshot narrowing beyond the

--- a/docs/superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md
+++ b/docs/superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md
@@ -1,0 +1,144 @@
+# PR 5 Tag Operation Safety Scopes Live Acceptance
+
+Acceptance date: 2026-09-05 UTC
+
+Result: **PASS** for the exact offline build, host binary, TIA Portal session, disposable project
+copy, fixtures, guarded calls, cleanup, and saved-baseline checks recorded here.
+
+## Environment
+
+- TIA Portal version: the live status payload reported `Totally Integrated Automation Portal V21`
+  and `STEP 7 Professional V21`. Separately, project history recorded that the copy was last saved
+  by V21 Update 2 Hotfix 1; that history entry is not treated as the runtime-version probe.
+- Harness script path:
+  [`scripts/live-test-tag-operation-safety-scopes.ps1`](../../../../scripts/live-test-tag-operation-safety-scopes.ps1),
+  run with PowerShell 7.6.5.
+- Repository revision: `2d6d071` on `feat/tag-operation-safety-scopes`.
+- Host DLL: `TiaMcpServer/bin/Debug/net8.0/TiaMcpServer.dll`, SHA-256
+  `3EA42029CE1797085851DAC73CA72B2126DD778CE2EF5E2C92BB277B65B88028`.
+- Disposable project copy:
+  `C:\Users\LCZ\AppData\Local\Temp\TIA_PR5_20260905T222714Z\TIA_PR5_20260905T222714Z.ap21`.
+- Source project:
+  `C:\Users\LCZ\Desktop\RnD\plc-prompt-injections\SimpleProject\SimpleProject.ap21`.
+- PLC identity: `PLC_LAD`.
+- Target table / sibling table: `Default tag table` at `/` / `Inputs` at `/`.
+- Target tag / collision tag / user constant: `AlwaysTRUE` (`Bool`, baseline `%M1.2`) /
+  `PR5_CollisionTag_20260905` with collision address `%M10.0` / `heaterStages` (`USInt`,
+  baseline `3`, live applied value `4`). The sibling constant was `PR5_Sibling_USInt`
+  (`USInt`, baseline `5`, drift value `6`); unused creation fixtures were
+  `PR5_NewConstant_20260905` and `PR5_NewTable_20260905`.
+- Portal identity: PID `54096` throughout. Each harness process had its own worker session:
+  `c07c38b6390948eebe7a3e2d62cb5aa5` for `PreviewOnly`,
+  `dfeabc17b9f948c4bf8c0c05cf8c46ba` for `DriftAndRestore`, and
+  `8aebe1d8ea394c1fb52eadbf3c70704a` for `ApplyAndRestore`, each at generation `2`
+  and bound to the exact disposable path. Final source verification used direct worker
+  `72043e5a1a2f448b9148a4ae3c1d1b8f`, generation `8`, PID `54096`.
+
+## Calls Performed
+
+- Preview-only checks: `PreviewOnly` ran all eight operation-specific previews twice and ran one
+  ordered duplicate-selector preview. The eight operations were `create_tag_table`,
+  `delete_tag_table`, `create_tag`, `update_tag`, `delete_tag`, `create_user_constant`,
+  `update_user_constant`, and `delete_user_constant`. The project stayed open and unmodified.
+- Drift-and-restore checks: `DriftAndRestore` previewed the same-object target, name collision,
+  address collision, and unrelated-sibling target before guarded mutations. It applied only to the
+  authorized disposable copy, retained scenario mutations until cleanup, and closed the copy with
+  `saveBeforeClose=false`; the mode name does not imply an inverse-write restore.
+- Apply-and-restore checks: `ApplyAndRestore` used the unchanged issued token for one authorized
+  `update_user_constant`, observed `heaterStages=4`, and closed the copy with
+  `saveBeforeClose=false`.
+- Post-run registered calls: after a read-only binding reconciliation, a fresh
+  `open_project(forceRebind=true)` preview/apply reopened the disposable copy. Registered
+  `get_project_status` and `list_tag_tables` reads proved the saved baseline. A fresh
+  `close_project(saveBeforeClose=false)` preview/apply closed the copy, then a fresh
+  `open_project(forceRebind=true)` preview/apply reopened the source project and a final status
+  read verified it clean.
+
+The successful redacted artifact directories are:
+
+| Mode | Artifact directory | Files |
+| --- | --- | ---: |
+| `PreviewOnly` | `tia-tag-safety-20260905T223842Z-9a69e824bbef4ab18198439a9b609914` | 82 |
+| `DriftAndRestore` | `tia-tag-safety-20260905T224041Z-70aa5cc842d2437aa6282642d9231a2d` | 178 |
+| `ApplyAndRestore` | `tia-tag-safety-20260905T224355Z-eb51691b7ae1434b9ad363a06aa6123c` | 98 |
+
+All three successful runs used the artifact root
+`.superpowers/sdd/2026-09-01-pr5-tag-operation-safety-scopes/live-artifacts`.
+
+## Evidence
+
+- Same-object drift result: **PASS**. The target constant changed after token issuance; the stale
+  token was rejected with `state_changed`, and rejection did not change the target state.
+- Relevant collision result: **PASS**. Creating `PR5_CollisionTag_20260905` at `%M10.0` invalidated
+  both the stale name-collision token and the stale logical-address-collision token. Both applies
+  were rejected with `state_changed`. Together with same-object drift, the run contained exactly
+  three `state_changed` responses and no other failure category.
+- Unrelated sibling tolerance result: **PASS**. Changing `PR5_Sibling_USInt` from `5` to `6` did
+  not change the target snapshot hash; the original token remained valid and created the requested
+  target-table constant.
+- Successful apply result: **PASS**. `ApplyAndRestore` applied one unchanged issued token and a
+  registered read observed `heaterStages` as `USInt` value `4` before discard.
+- Restore or discard result: **PASS**. Both mutation modes closed the exact disposable copy through
+  guarded `close_project(saveBeforeClose=false)` preview/apply. The later saved-copy read proved
+  `heaterStages=3`, `PR5_Sibling_USInt=5`, and `AlwaysTRUE=Bool %M1.2`; the collision tag and
+  `%M10.0` address, new constant, and new table were absent. The copy was unmodified and was closed
+  again without saving. The exact source project was then reopened, verified `isModified=false`,
+  and left open.
+- Artifact hygiene result: **PASS**. Recursive parsing found 78 safety-token fields, all 78 stored
+  as `[REDACTED]`; no raw token, unexpected file, unexpected nested directory, or JSON parse failure
+  was found. The expected first-connect status advisory in each successful harness named PID
+  `54096` and the exact disposable path; no batch operation returned warnings.
+- Offline and build evidence: focused PR5 tests passed 83/83; current-state FakeWorker tests passed
+  24/24; live-harness contracts passed 7/7; the PowerShell parser reported 0 errors; the stub build
+  and real TIA V21 build both completed with 0 warnings and 0 errors; the full offline suite passed
+  2691/2691. `git diff --check` passed.
+
+### Failed and reconciled attempts
+
+Before the harness runs, the first direct status call emitted its expected first-connect advisory.
+The controller accepted only that advisory because its PID `54096` and exact disposable path
+matched the complete verified status identity; it was not treated as permission to ignore any
+operation warning.
+
+The first sandboxed `PreviewOnly` launch could not see the desktop TIA instance and stopped at
+`get_project_status` with `worker_operation_failed`: `No running TIA Portal V21 instance found`.
+Its artifact directory,
+`tia-tag-safety-20260905T223749Z-98107d2a263040e9967a1913e37653d8`, records
+`mutationAttempted=false`, no token, no warning, and successful host/transient cleanup. The exact
+read-only command was rerun through the approved desktop-access path. This was a pre-mutation
+sandbox visibility failure, not an uncertain write.
+
+After `ApplyAndRestore` closed the copy from a separate harness process, the first direct
+`open_project` apply was rejected with `binding_conflict`: its preview expected direct-worker
+generation `4` and the disposable path, while apply observed generation `5` and no open project.
+The controller ruled this a deterministic pre-mutation rejection. A required read-only status call
+then invalidated the stale binding and returned the same deterministic `binding_conflict`; it did
+not mutate TIA. One authorized fresh preview/apply after reconciliation succeeded, producing
+direct-worker generation `6` on the disposable copy. Neither binding conflict was an uncertain
+write, and neither was automatically retried before reconciliation.
+
+Two earlier lifecycle preview tokens were issued but never retained or applied after the live
+controller initially expected a `success` field that lifecycle previews do not contain. They were
+not written to this report or the artifacts.
+
+## Verification Boundary
+
+- Proven: for repository revision `2d6d071`, the host SHA-256 and TIA V21/PID/project identities
+  above, all eight tag/table/user-constant operations produced stable exact-selector previews;
+  same-object, cross-kind name, and logical-address collision drift invalidated stale tokens;
+  unrelated sibling drift did not invalidate the scoped target; one unchanged-token apply
+  succeeded; mutation-mode cleanup used confirmed no-save discard; the saved disposable baseline
+  was intact; and the source project was restored open and unmodified. Offline tests separately
+  prove typed snapshot shapes, exact worker dispatch, guarded `SafetyRead` identity policy,
+  phase-local deduplication with ordered expansion, fresh apply reads, and deterministic
+  delete-table export behavior.
+- Not proven: this is not plant or production acceptance and does not qualify physical PLC
+  behavior. Multilingual per-tag comment binding remains deferred. Public `list_tag_tables`
+  completeness and best-effort behavior remain unchanged. Broader snapshot narrowing beyond the
+  eight PR5 operations remains deferred. Software Unit namespace-aware collision handling remains
+  deferred; unit-local block names were not treated as unqualified CPU-global collisions. PLC
+  `start_plc` and `stop_plc` were neither changed nor live-qualified. No claim is made about those
+  deferred areas from static, offline, FakeWorker, or this bounded live evidence.
+
+The implementation plan for this evidence is
+[`2026-09-01-pr5-tag-operation-safety-scopes.md`](../../plans/2026-09-01-pr5-tag-operation-safety-scopes.md).

--- a/docs/superpowers/plans/2026-09-01-pr5-tag-operation-safety-scopes.md
+++ b/docs/superpowers/plans/2026-09-01-pr5-tag-operation-safety-scopes.md
@@ -10,6 +10,19 @@
 
 **Spec:** [`docs/superpowers/specs/2026-09-01-write-safety-hardening-design.md`](../specs/2026-09-01-write-safety-hardening-design.md)
 
+**Final-review scope correction (2026-09-05):** The exact destination folder is an identity,
+not the boundary of table-name uniqueness. `create_tag_table` must probe matching names throughout
+the selected PLC's tag-table hierarchy. Tag/user-constant create and update probes must include
+matching PLC tags, user constants, and ordinary program blocks (nested user and system-block
+groups), preserving actual kind plus canonical identity. Names compare case-insensitively;
+logical-address probes remain tag-only. This corrects any parent-only or same-kind interpretation
+of the original plan using Siemens V21's [PLC tag/table naming rules](https://docs.tia.siemens.cloud/r/en-us/v21/declaring-plc-tags/rules-for-plc-tags/valid-names-of-plc-tags)
+and [global constant naming rules](https://docs.tia.siemens.cloud/r/en-us/v21/declaring-plc-tags/declaring-global-constants/rules-for-global-user-constants).
+Software Unit namespace resolution is outside these existing unqualified selectors; unit-local
+block names must not be guessed into the CPU-global collision scope. Namespace-aware coverage
+remains a design/live follow-up. No public schema, token, audit, or failure-category change is
+authorized by this correction.
+
 ## Global Constraints
 
 - Implement PR 5 only on top of the approved PR 2 and PR 3 baseline. If the branch still carries the pre-PR2 duplicated write path in `TiaMcpServer/Batch/BatchTools.cs`, merge or rebase the prerequisite first instead of backporting PR 5 into the old wrapper shape.
@@ -807,12 +820,13 @@ Use the exact Step 1-verified three-parameter export overload and the exact Step
 
 In `TagOperationSafetySnapshotReader.cs`, resolve exact targets through Siemens objects and produce the typed records from Task 1. Follow these rules:
 
-- `create_tag_table`: resolve the exact PLC and parent folder, then return only occupancy probes for the requested table name.
+- `create_tag_table`: resolve the exact PLC and destination folder, then traverse that PLC's complete tag-table hierarchy and return only occupancy probes for the requested table name, retaining each matching table's folder identity. Traversal failures must propagate even after a matching table is found.
 - `delete_tag_table`: resolve the exact table, export the full table through the Step 1-verified `PlcTagTable.Export(FileInfo, ExportOptions, ...)` overload with the Step 1-verified timestamp-free/document-info-free option, preserve that full Simatic ML content byte-for-byte unless current evidence proves one specific unavoidable non-semantic field remains, hash the exact preserved content, and return that content plus counts.
-- `create_tag`: resolve the exact table and collision probes for the requested effective name and logical address.
-- `update_tag`: resolve the exact current target tag, preserve the PR 3 flag fields, and probe collisions for the effective requested rename/address.
+- `create_tag`: resolve the exact table; probe the requested effective name across tags, user constants, and blocks in the selected PLC's unqualified CPU namespace, and probe the logical address against tags only.
+- `update_tag`: resolve the exact current target tag, preserve the PR 3 flag fields, and probe the effective requested rename/address with the same cross-kind name and tag-only address scope. Target marking requires exact kind and identity.
 - `delete_tag`: bind the exact current target tag and table identity only.
-- `create/update/delete user constant`: resolve the exact table, the exact current constant when it exists, and only name-collision probes for the existing requested/current name. Do not add rename semantics to `update_user_constant`.
+- `create/update user constant`: resolve the exact table and current constant for update, and probe only the requested/current name across tags, user constants, and ordinary program blocks including nested user/system groups. Preserve each candidate's actual kind and exact identity. Do not add rename semantics to `update_user_constant`.
+- `delete_user_constant`: bind only the exact current constant and table identity, without collision probes.
 
 Consume the existing PR 3 `SafetyRead` policy in `OperationPolicyCatalog.cs` so these eight internal methods are not ordinary `Observe` reads:
 

--- a/scripts/live-test-tag-operation-safety-scopes.ps1
+++ b/scripts/live-test-tag-operation-safety-scopes.ps1
@@ -1,0 +1,496 @@
+#Requires -Version 7
+<#
+.SYNOPSIS
+    Separately authorized PR5 acceptance through the net8 TiaMcpServer host.
+.DESCRIPTION
+    Never invoke from ordinary tests or CI. PreviewOnly performs reads and previews only.
+    The exact disposable project copy must already be open in TIA Portal V21. Mutation modes
+    require a saved, unmodified copy, -AllowMutation, -ConfirmDisposableCopy,
+    -AuthorizedProjectPath matching that exact path, and -CleanupStrategy Discard.
+    Discard closes without saving; it does not delete
+    project files. An inverse-restore strategy is not implemented. Live acceptance must also
+    verify that the on-disk copy remains clean. Do not edit the project concurrently.
+
+    Supply existing target/sibling tables, target tag, and target/sibling user constants.
+    NewTableName, CollisionTagName, and NewConstantName must be unused fixture names.
+    CollisionLogicalAddress must be an unused Bool memory address. ChangedConstantValue and
+    ChangedSiblingConstantValue must be valid, distinct values in the existing constant types,
+    expressed exactly as TIA returns them. All feature and cleanup writes use preview/token/apply.
+
+    Artifacts are redacted MCP requests/responses plus manifest, checks, cleanup, and failure JSON.
+    Tokens remain in memory. Public previews expose hashes and ordered targets, not internal
+    typed snapshots or worker call counts; offline tests cover those separate contract claims.
+    No live acceptance markdown report is created automatically. Review every run artifact.
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('PreviewOnly','DriftAndRestore','ApplyAndRestore')]
+    [string] $Mode = 'PreviewOnly',
+    [Parameter(Mandatory)] [string] $ProjectPath,
+    [Parameter(Mandatory)] [string] $PlcName,
+    [Parameter(Mandatory)] [string] $TargetTable,
+    [Parameter(Mandatory)] [string] $SiblingTable,
+    [Parameter(Mandatory)] [string] $TargetTagName,
+    [Parameter(Mandatory)] [string] $CollisionTagName,
+    [Parameter(Mandatory)] [string] $TargetConstantName,
+    [Parameter(Mandatory)] [string] $SiblingConstantName,
+    [Parameter(Mandatory)] [string] $NewConstantName,
+    [Parameter(Mandatory)] [string] $NewTableName,
+    [Parameter(Mandatory)] [ValidatePattern('^%M[0-9]+\.[0-7]$')] [string] $CollisionLogicalAddress,
+    [Parameter(Mandatory)] [string] $ChangedConstantValue,
+    [Parameter(Mandatory)] [string] $ChangedSiblingConstantValue,
+    [string] $TargetFolder = '/',
+    [string] $SiblingFolder = '/',
+    [switch] $AllowMutation,
+    [switch] $ConfirmDisposableCopy,
+    [string] $AuthorizedProjectPath,
+    [ValidateSet('Discard')] [string] $CleanupStrategy,
+    [string] $HostDllPath = 'TiaMcpServer/bin/Debug/net8.0/TiaMcpServer.dll',
+    [string] $ArtifactRoot = [IO.Path]::GetTempPath(),
+    [ValidateRange(10,600)] [int] $TimeoutSeconds = 180
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$utf8 = [Text.UTF8Encoding]::new($false, $true)
+$script:HostProcess = $null
+$script:StderrTask = $null
+$script:RequestId = 0
+$script:InitialIdentity = $null
+$script:InitialBinding = $null
+$script:MutationAuthorized = $false
+$script:MutationAttempted = $false
+$script:TransportHealthy = $true
+$script:Tokens = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+$checks = [Collections.Generic.List[object]]::new()
+$failures = [Collections.Generic.List[object]]::new()
+$cleanup = [ordered]@{ strategy = $CleanupStrategy; discard = 'NOT REQUIRED'; hostStopped = $false; transientRemoved = $false }
+$runName = 'tia-tag-safety-' + [DateTime]::UtcNow.ToString('yyyyMMddTHHmmssZ') + '-' + [Guid]::NewGuid().ToString('N')
+$artifactDirectory = Join-Path ([IO.Path]::GetFullPath($ArtifactRoot)) $runName
+[void][IO.Directory]::CreateDirectory($artifactDirectory)
+$transientDirectory = Join-Path $artifactDirectory 'transient'
+[void][IO.Directory]::CreateDirectory($transientDirectory)
+
+function Assert-Condition([bool] $Condition, [string] $Message) {
+    if (-not $Condition) { throw $Message }
+}
+
+function Redact-SafetyToken($Value) {
+    if ($null -eq $Value) { return $null }
+    if ($Value -is [Collections.IDictionary]) {
+        $copy = [ordered]@{}
+        foreach ($key in $Value.Keys) {
+            if ([string]::Equals([string]$key, 'safetyToken', [StringComparison]::OrdinalIgnoreCase)) {
+                if ($Value[$key] -is [string] -and -not [string]::IsNullOrEmpty($Value[$key])) {
+                    [void]$script:Tokens.Add($Value[$key])
+                }
+                $copy[$key] = '[REDACTED]'
+            }
+            else { $copy[$key] = Redact-SafetyToken $Value[$key] }
+        }
+        return $copy
+    }
+    if ($Value -is [string]) {
+        $text = $Value
+        if ($text.TrimStart().StartsWith('{') -or $text.TrimStart().StartsWith('[')) {
+            $parsed = $null
+            try { $parsed = ConvertFrom-Json -InputObject $text -AsHashtable -ErrorAction Stop } catch { }
+            if ($null -ne $parsed) { $text = ConvertTo-Json -InputObject (Redact-SafetyToken $parsed) -Depth 100 -Compress }
+        }
+        foreach ($token in $script:Tokens) { $text = $text.Replace($token, '[REDACTED]') }
+        return [regex]::Replace($text, '(?i)("safetyToken"\s*:\s*")[^"]*', '$1[REDACTED]')
+    }
+    if ($Value -is [Collections.IEnumerable]) {
+        $items = @($Value | ForEach-Object { Redact-SafetyToken $_ })
+        return ,$items
+    }
+    return $Value
+}
+
+function Write-Artifact([string] $Name, $Value) {
+    $safe = Redact-SafetyToken $Value
+    $json = ConvertTo-Json -InputObject $safe -Depth 100
+    [IO.File]::WriteAllText((Join-Path $artifactDirectory $Name), $json, $utf8)
+}
+
+function Write-Failure([string] $Stage, [string] $Message) {
+    $failures.Add(@{ stage = $Stage; error = $Message; utc = [DateTime]::UtcNow.ToString('o') })
+    Write-Artifact 'failure.json' @{ failures = $failures; checks = $checks; cleanup = $cleanup; mutationAttempted = $script:MutationAttempted }
+}
+
+function Invoke-Mcp([string] $Method, [hashtable] $Parameters) {
+    Assert-Condition ($null -ne $script:HostProcess -and $script:TransportHealthy) 'MCP host transport is unavailable; outcome may be unknown.'
+    $script:RequestId++
+    $id = $script:RequestId
+    $request = @{ jsonrpc = '2.0'; id = $id; method = $Method; params = $Parameters }
+    Write-Artifact ('{0:D4}-request.json' -f $id) $request
+    try {
+        $script:HostProcess.StandardInput.WriteLine((ConvertTo-Json -InputObject $request -Depth 100 -Compress))
+        $script:HostProcess.StandardInput.Flush()
+        $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+        $notificationIndex = 0
+        $result = $null
+        while ($null -eq $result) {
+            $remaining = $deadline - (Get-Date)
+            Assert-Condition ($remaining -gt [TimeSpan]::Zero) "MCP response timed out for $Method; state may be unknown."
+            $readTask = $script:HostProcess.StandardOutput.ReadLineAsync()
+            $line = $readTask.WaitAsync($remaining).GetAwaiter().GetResult()
+            Assert-Condition ($null -ne $line) "Host closed stdout during $Method."
+            $response = ConvertFrom-Json -InputObject $line -AsHashtable
+            Assert-Condition ($null -ne $response -and $response -is [Collections.IDictionary]) 'Invalid MCP response document.'
+            if (-not $response.ContainsKey('id')) {
+                $notificationIndex++
+                Write-Artifact ('{0:D4}-notification-{1:D4}.json' -f $id, $notificationIndex) $response
+                continue
+            }
+            Write-Artifact ('{0:D4}-response.json' -f $id) $response
+            Assert-Condition ($response.id -eq $id) 'Unexpected MCP response id.'
+            Assert-Condition (-not $response.ContainsKey('error')) "MCP $Method failed; see redacted response."
+            Assert-Condition ($response.ContainsKey('result') -and $null -ne $response.result) 'MCP response has no result.'
+            $result = $response.result
+        }
+    }
+    catch {
+        # A timed-out ReadLineAsync may still own stdout. Do not issue cleanup through that pipe.
+        $script:TransportHealthy = $false
+        throw
+    }
+    return $result
+}
+
+function Invoke-Tool([string] $Name, [hashtable] $Arguments, [switch] $AllowFailure) {
+    # Central deny gate also guards future call sites and lifecycle cleanup.
+    if ($Name -in @('apply_write_batch', 'close_project')) {
+        Assert-MutationAuthorization
+    }
+    Assert-Condition ($Name -in @('get_project_status','execute_read_batch','preview_write_batch','apply_write_batch','close_project')) 'Tool is outside the harness allowlist.'
+    $result = Invoke-Mcp 'tools/call' @{ name = $Name; arguments = $Arguments }
+    Assert-Condition (-not ($result.ContainsKey('isError') -and $result.isError)) "MCP tool $Name failed; see redacted response."
+    Assert-Condition ($result.ContainsKey('content') -and $null -ne $result.content) 'Missing MCP content.'
+    $items = @($result.content | Where-Object { $null -ne $_ -and $_.type -eq 'text' })
+    Assert-Condition ($items.Count -eq 1) "$Name must return exactly one text document."
+    $document = ConvertFrom-Json -InputObject $items[0].text -AsHashtable
+    Assert-Condition ($null -ne $document -and $document -is [Collections.IDictionary]) 'Invalid tool JSON document.'
+    if (-not $AllowFailure) {
+        Assert-Condition (-not ($document.ContainsKey('success') -and $document.success -ne $true)) "$Name reported failure; see redacted response."
+    }
+    return $document
+}
+
+function Read-Binding {
+    $status = Invoke-Tool 'get_project_status' @{ projectPath = $ProjectPath }
+    Assert-Condition ($status.success -eq $true -and $null -ne $status.payload -and $null -ne $status.sessionIdentity) 'Missing project status/identity.'
+    $payload = ConvertFrom-Json -InputObject $status.payload -AsHashtable
+    Assert-Condition ($null -ne $payload -and $null -ne $payload.project) 'Missing project status payload.'
+    Assert-Condition ($payload.success -eq $true -and $payload.project.isOpen -eq $true) 'Explicit target project is not open.'
+    $identity = $status.sessionIdentity
+    foreach ($path in @($payload.projectPath, $payload.project.path, $identity.projectPath)) {
+        Assert-Condition (-not [string]::IsNullOrWhiteSpace($path)) 'Missing project path.'
+        Assert-Condition ([string]::Equals([IO.Path]::GetFullPath($path), $ProjectPath, [StringComparison]::OrdinalIgnoreCase)) 'Active project differs from exact disposable project copy.'
+    }
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace($identity.workerSessionId)) 'Missing worker session id.'
+    Assert-Condition ($identity.sessionGeneration -gt 0 -and $identity.portalProcessId -gt 0) 'Incomplete session identity.'
+    $signature = '{0}/{1}/{2}' -f $identity.workerSessionId, $identity.sessionGeneration, $identity.portalProcessId
+    if ($null -ne $script:InitialIdentity) {
+        Assert-Condition ($signature -ceq $script:InitialIdentity) 'Project session changed; refusing further work.'
+    }
+    $script:InitialIdentity = $signature
+    return $payload.project
+}
+
+function Assert-PreviewBinding($Preview) {
+    Assert-Condition ($null -ne $Preview -and $null -ne $Preview.projectBinding) 'Preview binding missing.'
+    $binding = $Preview.projectBinding
+    Assert-Condition ($binding.state -eq 'verified' -and $binding.revision -gt 0 -and -not [string]::IsNullOrWhiteSpace($binding.bindingId)) 'Preview binding is not verified.'
+    $identity = '{0}/{1}/{2}' -f $binding.workerSessionId, $binding.sessionGeneration, $binding.portalProcessId
+    Assert-Condition ($identity -ceq $script:InitialIdentity -and [string]::Equals($binding.projectPath, $ProjectPath, [StringComparison]::OrdinalIgnoreCase)) 'Preview session differs from exact target.'
+    $signature = '{0}/{1}' -f $binding.bindingId, $binding.revision
+    if ($null -ne $script:InitialBinding) {
+        Assert-Condition ($signature -ceq $script:InitialBinding) 'Host binding changed during acceptance.'
+    }
+    $script:InitialBinding = $signature
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace($Preview.safetyToken)) 'Preview did not issue a token.'
+}
+
+function Get-Preview([array] $Operations) {
+    $null = Read-Binding
+    $preview = Invoke-Tool 'preview_write_batch' @{ operations = $Operations }
+    Assert-PreviewBinding $preview
+    Assert-Condition ($preview.currentStateHash -match '^[0-9a-fA-F]{64}$' -and $preview.requestedInputHash -match '^[0-9a-fA-F]{64}$') 'Preview hashes missing.'
+    Assert-Condition ($null -ne $preview.target -and $preview.target.Count -eq $Operations.Count) 'Preview target count differs.'
+    for ($i = 0; $i -lt $Operations.Count; $i++) {
+        Assert-Condition ($preview.target[$i].operationId -ceq $Operations[$i].operationId -and $preview.target[$i].operation -ceq $Operations[$i].operation) 'Preview target order or operation differs.'
+    }
+    return $preview
+}
+
+function New-Operation([string] $Id, [string] $Operation, [string] $Table, [string] $Folder, [hashtable] $Fields = @{}) {
+    $result = @{ operationId = $Id; operation = $Operation; projectPath = $ProjectPath; plcName = $PlcName; tableName = $Table; folderPath = $Folder }
+    foreach ($key in $Fields.Keys) { $result[$key] = $Fields[$key] }
+    return $result
+}
+
+function Read-Tables {
+    $operation = @{ operationId = 'fixture-read'; operation = 'list_tag_tables'; projectPath = $ProjectPath; plcName = $PlcName }
+    $read = Invoke-Tool 'execute_read_batch' @{ operations = @($operation) }
+    Assert-Condition ($read.success -eq $true -and $null -ne $read.operations -and $read.operations.Count -eq 1) 'Fixture read failed.'
+    $item = $read.operations[0]
+    Assert-Condition ($item.status -eq 'succeeded' -and $item.operationId -ceq 'fixture-read') 'Fixture read identity/status mismatch.'
+    Assert-Condition (@($item.warnings | Where-Object { $null -ne $_ }).Count -eq 0) 'Fixture read has warnings; refusing incomplete evidence.'
+    Assert-Condition ($item.result -is [string] -and $item.result -notmatch '\[(TRUNCATED|OMITTED)') 'Fixture read missing/truncated.'
+    $tables = ConvertFrom-Json -InputObject $item.result -AsHashtable
+    Assert-Condition ($null -ne $tables) 'No fixture tables returned.'
+    return ,@($tables)
+}
+
+function Find-Table([array] $Tables, [string] $Name, [string] $Folder) {
+    $matches = @($Tables | Where-Object { $null -ne $_ -and $_.name -ceq $Name -and $_.folderPath -ceq $Folder })
+    Assert-Condition ($matches.Count -eq 1) 'Fixture table must resolve exactly once at its explicit folder/name.'
+    return $matches[0]
+}
+
+function Find-Constant($Table, [string] $Name) {
+    Assert-Condition ($null -ne $Table -and $null -ne $Table.userConstants) 'User constant collection missing.'
+    $matches = @($Table.userConstants | Where-Object { $null -ne $_ -and $_.name -ceq $Name })
+    Assert-Condition ($matches.Count -eq 1) 'Fixture user constant must resolve exactly once.'
+    return $matches[0]
+}
+
+function Assert-MutationAuthorization {
+    Assert-Condition ($Mode -ne 'PreviewOnly' -and $AllowMutation -and $ConfirmDisposableCopy -and $script:MutationAuthorized -and $CleanupStrategy -ceq 'Discard') 'Mutation requires an explicitly authorized mode and restore or discard strategy.'
+    Assert-Condition ([string]::Equals($AuthorizedProjectPath, $ProjectPath, [StringComparison]::OrdinalIgnoreCase)) 'Mutation authorization does not match the exact disposable project copy.'
+}
+
+function Invoke-Apply([array] $Operations, $Preview, [switch] $ExpectStateChanged) {
+    Assert-MutationAuthorization
+    $null = Read-Binding
+    Assert-PreviewBinding $Preview
+    $script:MutationAttempted = $true
+    $result = Invoke-Tool 'apply_write_batch' @{ operations = $Operations; confirm = $true; safetyToken = $Preview.safetyToken } -AllowFailure
+    if ($ExpectStateChanged) {
+        Assert-Condition ($result.success -eq $false -and $result.failureCategory -ceq 'state_changed') 'Stale token did not reject with state_changed.'
+    }
+    else {
+        Assert-Condition ($result.success -eq $true -and $result.succeeded -eq $Operations.Count -and $result.failed -eq 0) 'Authorized apply failed.'
+    }
+    return $result
+}
+
+function Invoke-AuthorizedChange([array] $Operations) {
+    $preview = Get-Preview $Operations
+    $null = Invoke-Apply $Operations $preview
+}
+
+function Test-Drift([string] $Claim, [array] $Target, [array] $Mutation, [array] $Restoration) {
+    $before = Get-Preview $Target
+    Invoke-AuthorizedChange $Mutation
+    $after = Get-Preview $Target
+    Assert-Condition ($before.currentStateHash -cne $after.currentStateHash) "$Claim did not change the bound state hash."
+    $null = Invoke-Apply $Target $before -ExpectStateChanged
+    $rejected = Get-Preview $Target
+    Assert-Condition ($after.currentStateHash -ceq $rejected.currentStateHash) "$Claim rejection changed target state."
+    $checks.Add(@{ claim = $Claim; result = 'PASS'; rejection = 'state_changed'; beforeHash = $before.currentStateHash; driftHash = $after.currentStateHash; unchangedAfterRejection = $true })
+    # Best-effort inverse fixture reset for the next scenario; final cleanup still discards the copy.
+    Invoke-AuthorizedChange $Restoration
+}
+
+function Stop-McpHost {
+    if ($null -ne $script:HostProcess) {
+        try {
+            try {
+                if (-not $script:HostProcess.HasExited) {
+                    $script:HostProcess.StandardInput.Close()
+                    [void]$script:HostProcess.WaitForExit(5000)
+                }
+            }
+            finally {
+                if (-not $script:HostProcess.HasExited) {
+                    $script:HostProcess.Kill($true)
+                    Assert-Condition ($script:HostProcess.WaitForExit(5000)) 'Host did not stop after termination.'
+                }
+                $cleanup.hostStopped = $script:HostProcess.HasExited
+            }
+            if ($null -ne $script:StderrTask) {
+                $stderr = $script:StderrTask.WaitAsync([TimeSpan]::FromSeconds(5)).GetAwaiter().GetResult()
+                Write-Artifact 'host-stderr.json' @{ text = $stderr }
+            }
+        }
+        finally {
+            $script:HostProcess.Dispose()
+            $script:HostProcess = $null
+        }
+    }
+    $cleanup.hostStopped = $true
+}
+
+try {
+    Assert-Condition ($PSVersionTable.PSVersion -ge [Version]'7.2') 'PowerShell 7.2 or later is required for Task.WaitAsync.'
+    Assert-Condition ([IO.Path]::IsPathFullyQualified($ProjectPath)) 'ProjectPath must be absolute.'
+    $ProjectPath = (Resolve-Path -LiteralPath $ProjectPath).ProviderPath
+    Assert-Condition ([IO.Path]::GetExtension($ProjectPath) -ieq '.ap21') 'ProjectPath must identify a TIA Portal V21 .ap21 file.'
+    foreach ($name in @($PlcName,$TargetTable,$SiblingTable,$TargetTagName,$CollisionTagName,$TargetConstantName,$SiblingConstantName,$NewConstantName,$NewTableName)) {
+        Assert-Condition (-not [string]::IsNullOrWhiteSpace($name)) 'Fixture names must be explicit and nonempty.'
+    }
+    Assert-Condition ($TargetTable -cne $SiblingTable -or $TargetFolder -cne $SiblingFolder) 'Unrelated sibling must be a different table.'
+    if ($Mode -eq 'PreviewOnly') {
+        Assert-Condition (-not $AllowMutation -and -not $ConfirmDisposableCopy -and [string]::IsNullOrEmpty($AuthorizedProjectPath) -and [string]::IsNullOrEmpty($CleanupStrategy)) 'PreviewOnly must not carry mutation authorization.'
+    }
+    else {
+        Assert-Condition ($AllowMutation -and $ConfirmDisposableCopy -and $CleanupStrategy -ceq 'Discard') 'Explicit mutation modes require -AllowMutation, -ConfirmDisposableCopy, and -CleanupStrategy Discard.'
+        Assert-Condition (-not [string]::IsNullOrWhiteSpace($AuthorizedProjectPath) -and [IO.Path]::IsPathFullyQualified($AuthorizedProjectPath)) 'Authorize the exact absolute disposable project copy path.'
+        $AuthorizedProjectPath = (Resolve-Path -LiteralPath $AuthorizedProjectPath).ProviderPath
+        Assert-Condition ([string]::Equals($AuthorizedProjectPath, $ProjectPath, [StringComparison]::OrdinalIgnoreCase)) 'AuthorizedProjectPath must equal ProjectPath.'
+    }
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    if (-not [IO.Path]::IsPathFullyQualified($HostDllPath)) { $HostDllPath = Join-Path $repoRoot $HostDllPath }
+    $HostDllPath = (Resolve-Path -LiteralPath $HostDllPath).ProviderPath
+    Assert-Condition ([IO.Path]::GetFileName($HostDllPath) -ceq 'TiaMcpServer.dll') 'Launch the net8 TiaMcpServer host DLL.'
+    $hostHash = (Get-FileHash -LiteralPath $HostDllPath -Algorithm SHA256).Hash
+    Write-Artifact 'manifest.json' @{ mode = $Mode; projectPath = $ProjectPath; plcName = $PlcName; targetTable = $TargetTable; targetFolder = $TargetFolder; siblingTable = $SiblingTable; siblingFolder = $SiblingFolder; hostDllPath = $HostDllPath; hostSha256 = $hostHash; cleanupStrategy = $CleanupStrategy; authorizedProjectPath = $AuthorizedProjectPath; disposableCopyConfirmed = [bool]$ConfirmDisposableCopy; evidenceBoundary = 'Live host observations for this run only; no automatic PR5 acceptance report or plant acceptance.' }
+
+    $startInfo = [Diagnostics.ProcessStartInfo]::new('dotnet')
+    foreach ($argument in @($HostDllPath, '--read-write', '--project', $ProjectPath)) { $startInfo.ArgumentList.Add($argument) }
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardInput = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.StandardInputEncoding = $utf8
+    $startInfo.StandardOutputEncoding = $utf8
+    $script:HostProcess = [Diagnostics.Process]::Start($startInfo)
+    Assert-Condition ($null -ne $script:HostProcess) 'Host failed to start.'
+    $script:StderrTask = $script:HostProcess.StandardError.ReadToEndAsync()
+    $initialize = Invoke-Mcp 'initialize' @{ protocolVersion = '2024-11-05'; capabilities = @{}; clientInfo = @{ name = 'tag-operation-safety-acceptance'; version = '1.0' } }
+    Assert-Condition ($initialize.protocolVersion -ceq '2024-11-05') 'Unexpected negotiated MCP protocol version.'
+    $notification = @{ jsonrpc = '2.0'; method = 'notifications/initialized' }
+    Write-Artifact 'initialized-notification.json' $notification
+    $script:HostProcess.StandardInput.WriteLine((ConvertTo-Json -InputObject $notification -Depth 10 -Compress))
+    $script:HostProcess.StandardInput.Flush()
+    $initialProject = Read-Binding
+    if ($Mode -ne 'PreviewOnly') {
+        Assert-Condition ($initialProject.isModified -eq $false) 'Mutation requires a pre-saved clean disposable project copy.'
+        $script:MutationAuthorized = $true
+    }
+    $tables = Read-Tables
+    $target = Find-Table $tables $TargetTable $TargetFolder
+    $sibling = Find-Table $tables $SiblingTable $SiblingFolder
+    $constant = Find-Constant $target $TargetConstantName
+    $siblingConstant = Find-Constant $sibling $SiblingConstantName
+    $tags = @($target.tags | Where-Object { $null -ne $_ -and $_.name -ceq $TargetTagName })
+    Assert-Condition ($tags.Count -eq 1) 'Target tag must resolve exactly once.'
+    Assert-Condition ($constant.value -cne $ChangedConstantValue -and $siblingConstant.value -cne $ChangedSiblingConstantValue) 'Changed constant values must differ from their baselines.'
+    Assert-Condition (@($tables | Where-Object { $_.name -ceq $NewTableName -and $_.folderPath -ceq $TargetFolder }).Count -eq 0) 'NewTableName already exists.'
+    $allTags = @($tables | ForEach-Object { $_.tags })
+    $allConstants = @($tables | ForEach-Object { $_.userConstants })
+    Assert-Condition (@($allTags | Where-Object { $null -ne $_ -and ($_.name -ceq $CollisionTagName -or $_.logicalAddress -ieq $CollisionLogicalAddress) }).Count -eq 0) 'Collision fixture name/address must be unused.'
+    Assert-Condition (@($allConstants | Where-Object { $null -ne $_ -and $_.name -ceq $NewConstantName }).Count -eq 0) 'NewConstantName must be unused.'
+    Write-Artifact 'baseline.json' @{ project = $initialProject; tables = $tables; limitation = 'Public list_tag_tables remains best-effort; strict safety reads and guarded applies remain authoritative.' }
+
+    $updateConstant = New-Operation 'update-constant' 'update_user_constant' $TargetTable $TargetFolder @{ name = $TargetConstantName; value = $ChangedConstantValue }
+    $resetConstant = New-Operation 'reset-constant' 'update_user_constant' $TargetTable $TargetFolder @{ name = $TargetConstantName; value = $constant.value }
+    $createTag = New-Operation 'create-tag' 'create_tag' $TargetTable $TargetFolder @{ name = $CollisionTagName; dataType = 'Bool' }
+    $deleteCollision = New-Operation 'remove-collision' 'delete_tag' $TargetTable $TargetFolder @{ name = $CollisionTagName }
+    $operations = @(
+        (New-Operation 'create-table' 'create_tag_table' $NewTableName $TargetFolder),
+        (New-Operation 'delete-table' 'delete_tag_table' $TargetTable $TargetFolder),
+        $createTag,
+        (New-Operation 'update-tag' 'update_tag' $TargetTable $TargetFolder @{ name = $TargetTagName; logicalAddress = $CollisionLogicalAddress }),
+        (New-Operation 'delete-tag' 'delete_tag' $TargetTable $TargetFolder @{ name = $TargetTagName }),
+        (New-Operation 'create-constant' 'create_user_constant' $TargetTable $TargetFolder @{ name = $NewConstantName; dataType = $constant.dataType; value = $constant.value }),
+        $updateConstant,
+        (New-Operation 'delete-constant' 'delete_user_constant' $TargetTable $TargetFolder @{ name = $TargetConstantName })
+    )
+    foreach ($operation in $operations) {
+        $preview = Get-Preview @($operation)
+        $repeat = Get-Preview @($operation)
+        Assert-Condition ($preview.currentStateHash -ceq $repeat.currentStateHash -and $preview.requestedInputHash -ceq $repeat.requestedInputHash) 'Repeated exact selector preview differs.'
+        $checks.Add(@{ claim = $operation.operation; result = 'PREVIEW PASS'; currentStateHash = $preview.currentStateHash; requestedInputHash = $preview.requestedInputHash })
+    }
+    # Repeated selectors in one ordered batch exercise expansion without claiming live read counts.
+    $duplicate = New-Operation 'update-constant-second' 'update_user_constant' $TargetTable $TargetFolder @{ name = $TargetConstantName; value = $ChangedConstantValue }
+    $null = Get-Preview @($updateConstant, $duplicate)
+    $checks.Add(@{ claim = 'ordered duplicate selector preview'; result = 'PASS'; limitation = 'Within-phase worker read count is offline/FakeWorker evidence only.' })
+
+    if ($Mode -eq 'DriftAndRestore') {
+        Test-Drift 'same-object drift' @($resetConstant) @($updateConstant) @($resetConstant)
+        Test-Drift 'relevant collision: name' @($createTag) @($createTag) @($deleteCollision)
+        $addressMutation = New-Operation 'create-address-collision' 'create_tag' $TargetTable $TargetFolder @{ name = $CollisionTagName; dataType = 'Bool'; logicalAddress = $CollisionLogicalAddress }
+        Test-Drift 'relevant collision: address' @($operations[3]) @($addressMutation) @($deleteCollision)
+        $tolerant = Get-Preview @($updateConstant)
+        $siblingMutation = New-Operation 'change-sibling' 'update_user_constant' $SiblingTable $SiblingFolder @{ name = $SiblingConstantName; value = $ChangedSiblingConstantValue }
+        Invoke-AuthorizedChange @($siblingMutation)
+        $afterSibling = Find-Constant (Find-Table (Read-Tables) $SiblingTable $SiblingFolder) $SiblingConstantName
+        Assert-Condition ($afterSibling.value -ceq $ChangedSiblingConstantValue) 'Sibling mutation was not observed.'
+        $after = Get-Preview @($updateConstant)
+        Assert-Condition ($tolerant.currentStateHash -ceq $after.currentStateHash) 'Unrelated sibling invalidated the target snapshot.'
+        $null = Invoke-Apply @($updateConstant) $tolerant
+        $checks.Add(@{ claim = 'unrelated sibling tolerance'; result = 'PASS'; unchangedTargetHash = $after.currentStateHash; originalTokenApplied = $true })
+    }
+    if ($Mode -eq 'ApplyAndRestore') {
+        $preview = Get-Preview @($updateConstant)
+        $null = Invoke-Apply @($updateConstant) $preview
+        $checks.Add(@{ claim = 'one authorized apply'; result = 'PASS'; unchangedIssuedToken = $true })
+    }
+    if ($Mode -ne 'PreviewOnly') {
+        $observed = Find-Constant (Find-Table (Read-Tables) $TargetTable $TargetFolder) $TargetConstantName
+        Assert-Condition ($observed.value -ceq $ChangedConstantValue) 'Authorized target value was not observed.'
+    }
+    $null = Read-Binding
+    Write-Artifact 'checks.json' $checks
+}
+catch {
+    Write-Failure 'checks' $_.Exception.Message
+    throw (Redact-SafetyToken $_.Exception.Message)
+}
+finally {
+    try {
+        if ($script:MutationAttempted) {
+            $cleanup.discard = 'ATTEMPTED'
+            Assert-Condition $script:TransportHealthy 'Transport failed; discard cannot be confirmed. Keep the copy isolated and close without saving manually.'
+            $null = Read-Binding
+            $arguments = @{ projectPath = $ProjectPath; saveBeforeClose = $false }
+            $preview = Invoke-Tool 'close_project' $arguments
+            Assert-PreviewBinding $preview
+            $applyArguments = $arguments.Clone()
+            $applyArguments.confirm = $true
+            $applyArguments.safetyToken = $preview.safetyToken
+            $closed = Invoke-Tool 'close_project' $applyArguments
+            Assert-Condition ($closed.success -eq $true) 'Discard close did not succeed.'
+            Assert-Condition (-not [string]::IsNullOrWhiteSpace($closed.operationResult)) 'Discard close operation result missing.'
+            $closedPayload = ConvertFrom-Json -InputObject $closed.operationResult -AsHashtable
+            Assert-Condition ($null -ne $closedPayload -and $null -ne $closedPayload.project) 'Discard close payload is missing project state.'
+            Assert-Condition ($closedPayload.success -eq $true -and $closedPayload.project.isOpen -eq $false) 'Discard close was not confirmed by its payload.'
+            Assert-Condition ([string]::Equals($closedPayload.projectPath, $ProjectPath, [StringComparison]::OrdinalIgnoreCase) -and [string]::Equals($closedPayload.project.path, $ProjectPath, [StringComparison]::OrdinalIgnoreCase)) 'Discard close payload names a different project.'
+            $cleanup.discard = 'PASS: exact copy closed with saveBeforeClose=false; on-disk clean-copy verification remains a live acceptance obligation'
+        }
+    }
+    catch {
+        $cleanup.discard = 'FAILED: manual no-save discard required; keep the copy isolated'
+        Write-Failure 'discard' $_.Exception.Message
+        throw (Redact-SafetyToken $_.Exception.Message)
+    }
+    finally {
+        try { Stop-McpHost }
+        catch {
+            Write-Failure 'host cleanup' $_.Exception.Message
+            throw (Redact-SafetyToken $_.Exception.Message)
+        }
+        finally {
+            try {
+                # Only this run's dedicated empty transient directory is removed. Worker-owned
+                # temporary safety exports use the worker reader's own finally cleanup.
+                if (Test-Path -LiteralPath $transientDirectory) { Remove-Item -LiteralPath $transientDirectory -ErrorAction Stop }
+                $cleanup.transientRemoved = $true
+            }
+            catch {
+                Write-Failure 'transient cleanup' $_.Exception.Message
+                throw (Redact-SafetyToken $_.Exception.Message)
+            }
+            finally {
+                Write-Artifact 'cleanup.json' $cleanup
+                $script:Tokens.Clear()
+                Write-Host "Redacted run artifacts: $artifactDirectory"
+            }
+        }
+    }
+}

--- a/scripts/live-test-tag-operation-safety-scopes.ps1
+++ b/scripts/live-test-tag-operation-safety-scopes.ps1
@@ -281,17 +281,13 @@ function Invoke-AuthorizedChange([array] $Operations) {
     $null = Invoke-Apply $Operations $preview
 }
 
-function Test-Drift([string] $Claim, [array] $Target, [array] $Mutation, [array] $Restoration) {
-    $before = Get-Preview $Target
-    Invoke-AuthorizedChange $Mutation
+function Test-Drift([string] $Claim, [array] $Target, $Before) {
     $after = Get-Preview $Target
-    Assert-Condition ($before.currentStateHash -cne $after.currentStateHash) "$Claim did not change the bound state hash."
-    $null = Invoke-Apply $Target $before -ExpectStateChanged
+    Assert-Condition ($Before.currentStateHash -cne $after.currentStateHash) "$Claim did not change the bound state hash."
+    $null = Invoke-Apply $Target $Before -ExpectStateChanged
     $rejected = Get-Preview $Target
     Assert-Condition ($after.currentStateHash -ceq $rejected.currentStateHash) "$Claim rejection changed target state."
-    $checks.Add(@{ claim = $Claim; result = 'PASS'; rejection = 'state_changed'; beforeHash = $before.currentStateHash; driftHash = $after.currentStateHash; unchangedAfterRejection = $true })
-    # Best-effort inverse fixture reset for the next scenario; final cleanup still discards the copy.
-    Invoke-AuthorizedChange $Restoration
+    $checks.Add(@{ claim = $Claim; result = 'PASS'; rejection = 'state_changed'; beforeHash = $Before.currentStateHash; driftHash = $after.currentStateHash; unchangedAfterRejection = $true })
 }
 
 function Stop-McpHost {
@@ -387,9 +383,7 @@ try {
     Write-Artifact 'baseline.json' @{ project = $initialProject; tables = $tables; limitation = 'Public list_tag_tables remains best-effort; strict safety reads and guarded applies remain authoritative.' }
 
     $updateConstant = New-Operation 'update-constant' 'update_user_constant' $TargetTable $TargetFolder @{ name = $TargetConstantName; value = $ChangedConstantValue }
-    $resetConstant = New-Operation 'reset-constant' 'update_user_constant' $TargetTable $TargetFolder @{ name = $TargetConstantName; value = $constant.value }
     $createTag = New-Operation 'create-tag' 'create_tag' $TargetTable $TargetFolder @{ name = $CollisionTagName; dataType = 'Bool' }
-    $deleteCollision = New-Operation 'remove-collision' 'delete_tag' $TargetTable $TargetFolder @{ name = $CollisionTagName }
     $operations = @(
         (New-Operation 'create-table' 'create_tag_table' $NewTableName $TargetFolder),
         (New-Operation 'delete-table' 'delete_tag_table' $TargetTable $TargetFolder),
@@ -412,18 +406,33 @@ try {
     $checks.Add(@{ claim = 'ordered duplicate selector preview'; result = 'PASS'; limitation = 'Within-phase worker read count is offline/FakeWorker evidence only.' })
 
     if ($Mode -eq 'DriftAndRestore') {
-        Test-Drift 'same-object drift' @($resetConstant) @($updateConstant) @($resetConstant)
-        Test-Drift 'relevant collision: name' @($createTag) @($createTag) @($deleteCollision)
+        # Leave every mutation in the disposable copy until the final no-save discard.
+        $sameObjectPreview = Get-Preview @($updateConstant)
+        Invoke-AuthorizedChange @($updateConstant)
+        Test-Drift 'same-object drift' @($updateConstant) $sameObjectPreview
+
+        # One tag creation supplies both collisions. Both tokens precede that creation,
+        # so the address scenario does not need a tag deletion or a second fixture name.
+        $namePreview = Get-Preview @($createTag)
+        $addressPreview = Get-Preview @($operations[3])
         $addressMutation = New-Operation 'create-address-collision' 'create_tag' $TargetTable $TargetFolder @{ name = $CollisionTagName; dataType = 'Bool'; logicalAddress = $CollisionLogicalAddress }
-        Test-Drift 'relevant collision: address' @($operations[3]) @($addressMutation) @($deleteCollision)
-        $tolerant = Get-Preview @($updateConstant)
+        Invoke-AuthorizedChange @($addressMutation)
+        Test-Drift 'relevant collision: name' @($createTag) $namePreview
+        Test-Drift 'relevant collision: address' @($operations[3]) $addressPreview
+
+        # A new constant gives the tolerance apply a real mutation without resetting
+        # the existing constant that already demonstrated same-object drift.
+        $siblingTarget = @($operations[5])
+        $tolerant = Get-Preview $siblingTarget
         $siblingMutation = New-Operation 'change-sibling' 'update_user_constant' $SiblingTable $SiblingFolder @{ name = $SiblingConstantName; value = $ChangedSiblingConstantValue }
         Invoke-AuthorizedChange @($siblingMutation)
         $afterSibling = Find-Constant (Find-Table (Read-Tables) $SiblingTable $SiblingFolder) $SiblingConstantName
         Assert-Condition ($afterSibling.value -ceq $ChangedSiblingConstantValue) 'Sibling mutation was not observed.'
-        $after = Get-Preview @($updateConstant)
+        $after = Get-Preview $siblingTarget
         Assert-Condition ($tolerant.currentStateHash -ceq $after.currentStateHash) 'Unrelated sibling invalidated the target snapshot.'
-        $null = Invoke-Apply @($updateConstant) $tolerant
+        $null = Invoke-Apply $siblingTarget $tolerant
+        $created = Find-Constant (Find-Table (Read-Tables) $TargetTable $TargetFolder) $NewConstantName
+        Assert-Condition ($created.value -ceq $constant.value) 'Tolerance apply did not create the requested new constant.'
         $checks.Add(@{ claim = 'unrelated sibling tolerance'; result = 'PASS'; unchangedTargetHash = $after.currentStateHash; originalTokenApplied = $true })
     }
     if ($Mode -eq 'ApplyAndRestore') {


### PR DESCRIPTION
## Summary

- replace blanket `list_tag_tables` write-safety state with typed, operation-specific tag table, PLC tag, and user-constant snapshots resolved by the Openness worker
- add exact collision probes, deterministic full-table export hashing for deletion, and phase-local selector deduplication while preserving ordered per-operation state composition
- retain the existing public tool schemas, token lifetime and single-use behavior, failure categories, audit format, and pinned apply-time binding semantics
- add the guarded PowerShell live harness and publish the completed TIA Portal V21 acceptance report

## Safety properties

- safety-only worker reads require the complete verified session identity and remain allowed in read-only mode
- create/update snapshots track relevant CPU-wide tag, constant, ordinary block-name, and logical-address collisions without treating unrelated sibling drift as target drift
- snapshot payloads are strictly decoded and malformed or ambiguous worker results fail closed as `protocol_error`
- preview and apply phases never share cached state; every apply performs fresh reads under the pinned binding lease

## Verification

- `dotnet test TiaMcpServer.Tests --no-restore --nologo` — 2,691 passed, 0 failed
- focused PR 5 tests — 83 passed
- fresh-read FakeWorker scenarios — 24 passed
- live-harness contract tests — 7 passed
- stub solution build — 0 warnings, 0 errors
- real TIA Portal V21 solution build — 0 warnings, 0 errors
- live `PreviewOnly`, `DriftAndRestore`, and `ApplyAndRestore` modes — passed on a pre-saved disposable copy
- live drift run — exactly three expected `state_changed` rejections; unrelated sibling drift tolerated
- live apply run — `heaterStages` observed changing from `3` to `4`, followed by guarded no-save discard and saved-baseline verification

Full live evidence: [`docs/superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md`](https://github.com/Czarnak/tia-portal-mcp/blob/feat/tag-operation-safety-scopes/docs/superpowers/acceptance/reports/2026-09-01-pr5-tag-operation-safety-scopes-live.md)

## Deferred

- namespace-aware Software Unit block-name collision coverage remains a follow-up because the current public selectors do not carry a Software Unit or namespace identity
